### PR TITLE
add pause and resume methods to storing process.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -257,6 +257,10 @@ UNCOMPILED_JS = [
         <div>
           <button id="storeDeleteButton">Store</button>
           <span id="storeDeleteHelpText"></span>
+          <button id="pauseBtn">Pause</button>
+          <span id="pauseText"></span>
+          <button id="resumeButton">Resume</button>
+          <span id="resumeText"></span>
         </div>
         <div id="progressDiv">
           <span class="label">Progress:</span>

--- a/demo/index.html
+++ b/demo/index.html
@@ -257,10 +257,10 @@ UNCOMPILED_JS = [
         <div>
           <button id="storeDeleteButton">Store</button>
           <span id="storeDeleteHelpText"></span>
-          <button id="pauseBtn">Pause</button>
-          <span id="pauseText"></span>
-          <button id="resumeButton">Resume</button>
-          <span id="resumeText"></span>
+          <button id="pauseDownloadButton">Pause</button>
+          <span id="pauseDownloadText"></span>
+          <button id="resumeDownloadButton">Resume</button>
+          <span id="resumeDownloadText"></span>
         </div>
         <div id="progressDiv">
           <span class="label">Progress:</span>

--- a/demo/offline_section.js
+++ b/demo/offline_section.js
@@ -80,9 +80,9 @@ shakaDemo.updateButtons_ = function(canHide) {
 shakaDemo.setupOffline_ = function() {
   document.getElementById('storeDeleteButton')
       .addEventListener('click', shakaDemo.storeDeleteAsset_);
-  document.getElementById('pauseBtn')
+  document.getElementById('pauseDownloadButton')
       .addEventListener('click', shakaDemo.pauseDownload_);
-  document.getElementById('resumeButton')
+  document.getElementById('resumeDownloadButton')
       .addEventListener('click', shakaDemo.resumeDownload_);
   document.getElementById('assetList')
       .addEventListener('change', shakaDemo.updateButtons_.bind(null, true));
@@ -152,8 +152,8 @@ shakaDemo.setupOfflineAssets_ = function() {
   });
 };
 
-var storage; // eslint-disable-line no-var
-var savedOfflineUri; // eslint-disable-line no-var
+let storage; // eslint-disable-line no-var
+let savedOfflineUri; // eslint-disable-line no-var
 
 /** @private */
 shakaDemo.storeDeleteAsset_ = function() {

--- a/demo/offline_section.js
+++ b/demo/offline_section.js
@@ -230,7 +230,6 @@ shakaDemo.storeDeleteAsset_ = function() {
 };
 
 /**
- * @return {void}
  * @private
  */
 shakaDemo.pauseDownload_ = function() {

--- a/externs/shaka/offline.js
+++ b/externs/shaka/offline.js
@@ -70,7 +70,8 @@ shakaExtern.OfflineConfiguration;
  *   size: number,
  *   expiration: number,
  *   tracks: ?Array.<shakaExtern.Track>,
- *   appMetadata: Object
+ *   appMetadata: Object,
+ *   downloadStatus: ?string
  * }}
  *
  * @property {?string} offlineUri
@@ -91,6 +92,8 @@ shakaExtern.OfflineConfiguration;
  *   Period.
  * @property {Object} appMetadata
  *   The metadata passed to store().
+ *    * @property {string} downloadStatus
+ *   download status
  * @exportDoc
  */
 shakaExtern.StoredContent;
@@ -105,7 +108,8 @@ shakaExtern.StoredContent;
  *   periods: !Array.<shakaExtern.PeriodDB>,
  *   sessionIds: !Array.<string>,
  *   drmInfo: ?shakaExtern.DrmInfo,
- *   appMetadata: Object
+ *   appMetadata: Object,
+ *   downloadStatus: ?string
  * }}
  *
  * @property {string} originalManifestUri
@@ -124,6 +128,8 @@ shakaExtern.StoredContent;
  *   The DRM info used to initialize EME.
  * @property {Object} appMetadata
  *   A metadata object passed from the application.
+ * @property {string} downloadStatus
+ *   download status
  */
 shakaExtern.ManifestDB;
 

--- a/externs/shaka/offline.js
+++ b/externs/shaka/offline.js
@@ -69,7 +69,7 @@ shakaExtern.OfflineConfiguration;
  *   duration: number,
  *   size: number,
  *   expiration: number,
- *   tracks: !Array.<shakaExtern.Track>,
+ *   tracks: ?Array.<shakaExtern.Track>,
  *   appMetadata: Object
  * }}
  *
@@ -86,7 +86,7 @@ shakaExtern.OfflineConfiguration;
  * @property {number} expiration
  *   The time that the encrypted license expires, in milliseconds.  If the media
  *   is clear or the license never expires, this will equal Infinity.
- * @property {!Array.<shakaExtern.Track>} tracks
+ * @property {?Array.<shakaExtern.Track>} tracks
  *   The tracks that are stored.  This only lists those found in the first
  *   Period.
  * @property {Object} appMetadata

--- a/lib/media/segment_reference.js
+++ b/lib/media/segment_reference.js
@@ -47,6 +47,9 @@ shaka.media.InitSegmentReference = function(uris, startByte, endByte) {
 
   /** @const {?number} */
   this.endByte = endByte;
+
+  /** @const {!Array.<string>} */
+  this.uri;
 };
 
 
@@ -137,6 +140,9 @@ shaka.media.SegmentReference = function(
 
   /** @const {?number} */
   this.endByte = endByte;
+
+  /** @const {?number} */
+  this.dataKey;
 };
 
 

--- a/lib/media/segment_reference.js
+++ b/lib/media/segment_reference.js
@@ -143,6 +143,9 @@ shaka.media.SegmentReference = function(
 
   /** @const {?number} */
   this.dataKey = null;
+
+  /** @const {?number} */
+  this.bandwidthSize  = 0;
 };
 
 

--- a/lib/media/segment_reference.js
+++ b/lib/media/segment_reference.js
@@ -49,7 +49,7 @@ shaka.media.InitSegmentReference = function(uris, startByte, endByte) {
   this.endByte = endByte;
 
   /** @const {!Array.<string>} */
-  this.uri;
+  this.uris = [];
 };
 
 
@@ -142,7 +142,7 @@ shaka.media.SegmentReference = function(
   this.endByte = endByte;
 
   /** @const {?number} */
-  this.dataKey;
+  this.dataKey = null;
 };
 
 

--- a/lib/offline/db_engine.js
+++ b/lib/offline/db_engine.js
@@ -229,7 +229,7 @@ shaka.offline.DBEngine.prototype.removeSegments =
     function(keys, onKeyRemoved) {
   return this.remove_(
       shaka.offline.DBEngine.Store.SEGMENT,
-      keys,
+      keys.filter(function(key) { return key !== null; }),
       onKeyRemoved);
 };
 

--- a/lib/offline/db_engine.js
+++ b/lib/offline/db_engine.js
@@ -229,7 +229,7 @@ shaka.offline.DBEngine.prototype.removeSegments =
     function(keys, onKeyRemoved) {
   return this.remove_(
       shaka.offline.DBEngine.Store.SEGMENT,
-      keys.filter(function(key) { return key !== null; }),
+      keys.filter(function(key) { return key != null; }),
       onKeyRemoved);
 };
 

--- a/lib/offline/download_manager.js
+++ b/lib/offline/download_manager.js
@@ -74,6 +74,9 @@ shaka.offline.DownloadManager = function(
 
   /** @private {!Array.<function(number, number)>} */
   this.progressListeners_ = [];
+
+  /** @public {?number} */
+  this.offlineManifestStorageId;
 };
 
 
@@ -147,7 +150,7 @@ shaka.offline.DownloadManager.prototype.addSegment = function(
     type, ref, bandwidthSize, onStore) {
   this.segments_[type] = this.segments_[type] || [];
   this.segments_[type].push({
-    uris: ref.getUris(),
+    uris: ref.uri || ref.getUris(),
     startByte: ref.startByte,
     endByte: ref.endByte,
     bandwidthSize: bandwidthSize,
@@ -166,9 +169,9 @@ shaka.offline.DownloadManager.prototype.addSegment = function(
 shaka.offline.DownloadManager.prototype.downloadAndStore = function(manifest) {
   const MapUtils = shaka.util.MapUtils;
 
-  // Clear any old progress.
-  this.downloadExpected_ = 0;
-  this.downloadActual_ = 0;
+  // Clear any old progress / getting the stored content size
+  this.downloadExpected_ = manifest.size || 0;
+  this.downloadActual_ = manifest.size || 0;
 
   MapUtils.values(this.segments_).forEach(function(segments) {
     segments.forEach(this.markAsPending_.bind(this));
@@ -196,7 +199,10 @@ shaka.offline.DownloadManager.prototype.downloadAndStore = function(manifest) {
   this.segments_ = {};
 
   this.promise_ = Promise.all(async).then(function() {
-    return this.storageEngine_.addManifest(manifest);
+    return this.offlineManifestStorageId ?
+        this.storageEngine_.updateManifest(
+            this.offlineManifestStorageId, manifest) :
+        this.storageEngine_.addManifest(manifest);
   }.bind(this)).then(function(id) {
     this.storedSegmentIds_ = [];
     return id;
@@ -213,6 +219,12 @@ shaka.offline.DownloadManager.prototype.downloadAndStore = function(manifest) {
  * @private
  */
 shaka.offline.DownloadManager.prototype.downloadSegment_ = function(segment) {
+  if (this.manifest_.downloadStatus === 'paused'
+      || (segment.dataKey !== null
+          && typeof segment.dataKey !== 'undefined')) {
+    segment.onStore(segment.dataKey || null);
+    return Promise.resolve();
+  }
   goog.asserts.assert(this.retryParams_,
                       'DownloadManager must not be destroyed');
   const type = shaka.net.NetworkingEngine.RequestType.SEGMENT;
@@ -259,6 +271,12 @@ shaka.offline.DownloadManager.prototype.downloadSegment_ = function(segment) {
       }.bind(this));
 };
 
+/**
+ * @public
+ */
+shaka.offline.DownloadManager.prototype.pause = function() {
+  this.manifest_.downloadStatus = 'paused';
+};
 
 /**
  * @param {!shaka.offline.DownloadManager.Segment} segment

--- a/lib/offline/download_manager.js
+++ b/lib/offline/download_manager.js
@@ -153,7 +153,7 @@ shaka.offline.DownloadManager.prototype.addSegment = function(
     uris: ref.uris && ref.uris.length > 0 ? ref.uris : ref.getUris(),
     startByte: ref.startByte,
     endByte: ref.endByte,
-    bandwidthSize: bandwidthSize,
+    bandwidthSize: bandwidthSize || ref.bandwidthSize || 0,
     onStore: onStore
   });
 };
@@ -171,7 +171,7 @@ shaka.offline.DownloadManager.prototype.downloadAndStore = function(manifest) {
 
   // Clear any old progress / getting the stored content size
   this.downloadExpected_ = manifest.size || 0;
-  this.downloadActual_ = manifest.downloadedBytes || 0;
+  this.downloadActual_ = manifest.size || 0;
 
   MapUtils.values(this.segments_).forEach(function(segments) {
     segments.forEach(this.markAsPending_.bind(this));

--- a/lib/offline/download_manager.js
+++ b/lib/offline/download_manager.js
@@ -76,7 +76,7 @@ shaka.offline.DownloadManager = function(
   this.progressListeners_ = [];
 
   /** @public {?number} */
-  this.offlineManifestStorageId;
+  this.offlineManifestStorageId = null;
 };
 
 
@@ -150,7 +150,7 @@ shaka.offline.DownloadManager.prototype.addSegment = function(
     type, ref, bandwidthSize, onStore) {
   this.segments_[type] = this.segments_[type] || [];
   this.segments_[type].push({
-    uris: ref.uri || ref.getUris(),
+    uris: ref.uris && ref.uris.length > 0 ? ref.uris : ref.getUris(),
     startByte: ref.startByte,
     endByte: ref.endByte,
     bandwidthSize: bandwidthSize,
@@ -219,9 +219,9 @@ shaka.offline.DownloadManager.prototype.downloadAndStore = function(manifest) {
  * @private
  */
 shaka.offline.DownloadManager.prototype.downloadSegment_ = function(segment) {
-  if (this.manifest_.downloadStatus === 'paused'
-      || (segment.dataKey !== null
-          && typeof segment.dataKey !== 'undefined')) {
+  if (this.manifest_.downloadStatus == 'paused'
+      || (segment.dataKey != null
+          && typeof segment.dataKey != 'undefined')) {
     segment.onStore(segment.dataKey || null);
     return Promise.resolve();
   }

--- a/lib/offline/download_manager.js
+++ b/lib/offline/download_manager.js
@@ -171,7 +171,7 @@ shaka.offline.DownloadManager.prototype.downloadAndStore = function(manifest) {
 
   // Clear any old progress / getting the stored content size
   this.downloadExpected_ = manifest.size || 0;
-  this.downloadActual_ = manifest.size || 0;
+  this.downloadActual_ = manifest.downloadedBytes || 0;
 
   MapUtils.values(this.segments_).forEach(function(segments) {
     segments.forEach(this.markAsPending_.bind(this));
@@ -275,6 +275,7 @@ shaka.offline.DownloadManager.prototype.downloadSegment_ = function(segment) {
  * @public
  */
 shaka.offline.DownloadManager.prototype.pause = function() {
+  this.manifest_.downloadedBytes = this.downloadActual_;
   this.manifest_.downloadStatus = 'paused';
 };
 

--- a/lib/offline/offline_manifest_parser.js
+++ b/lib/offline/offline_manifest_parser.js
@@ -155,6 +155,7 @@ shaka.offline.OfflineManifestParser.reconstructManifest = function(manifest) {
     presentationTimeline: timeline,
     minBufferTime: 2,
     offlineSessionIds: manifest.sessionIds,
+    storedPeriods: manifest.periods,
     periods: manifest.periods.map(function(period) {
       return shaka.offline.OfflineUtils.reconstructPeriod(period,
                                                           drmInfos,

--- a/lib/offline/offline_utils.js
+++ b/lib/offline/offline_utils.js
@@ -414,3 +414,23 @@ shaka.offline.OfflineUtils.isText_ = function(stream) {
   const ContentType = shaka.util.ManifestParserUtils.ContentType;
   return stream.contentType == ContentType.TEXT;
 };
+ * @param {!Array.<shakaExtern.PeriodDB>} storedPeriods
+ * @return {void}
+ * @public
+ */
+shaka.offline.OfflineUtils.addDownloadedSegmentsToPeriods =
+    function(periods, storedPeriods) {
+      let storedStreams = storedPeriods[0].streams;
+      periods[0].streams.forEach(function(stream) {
+        const id = stream.id;
+        const matchedStoredStream = storedStreams
+            .filter(function(storedStream) {
+          return storedStream.id === id;
+        });
+        stream.segments = matchedStoredStream[0].segments
+            .filter(function(segment) {
+              return segment.dataKey !== null;
+            });
+      });
+    };
+

--- a/lib/offline/offline_utils.js
+++ b/lib/offline/offline_utils.js
@@ -414,8 +414,9 @@ shaka.offline.OfflineUtils.isText_ = function(stream) {
   const ContentType = shaka.util.ManifestParserUtils.ContentType;
   return stream.contentType == ContentType.TEXT;
 };
+/**
+ * @param {!Array.<shakaExtern.PeriodDB>} periods
  * @param {!Array.<shakaExtern.PeriodDB>} storedPeriods
- * @return {void}
  * @public
  */
 shaka.offline.OfflineUtils.addDownloadedSegmentsToPeriods =
@@ -425,11 +426,11 @@ shaka.offline.OfflineUtils.addDownloadedSegmentsToPeriods =
         const id = stream.id;
         const matchedStoredStream = storedStreams
             .filter(function(storedStream) {
-          return storedStream.id === id;
+          return storedStream.id == id;
         });
         stream.segments = matchedStoredStream[0].segments
             .filter(function(segment) {
-              return segment.dataKey !== null;
+              return segment.dataKey != null;
             });
       });
     };

--- a/lib/offline/offline_utils.js
+++ b/lib/offline/offline_utils.js
@@ -63,7 +63,8 @@ shaka.offline.OfflineUtils.createStoredContentFromManifest = function(
     size: size,
     expiration: expiration,
     tracks: tracks,
-    appMetadata: metadata
+    appMetadata: metadata,
+    downloadStatus: null
   };
 
   return content;
@@ -105,7 +106,8 @@ shaka.offline.OfflineUtils.createStoredContentFromManifestDB = function(
     size: manifestDB.size,
     expiration: manifestDB.expiration,
     tracks: tracks,
-    appMetadata: metadata
+    appMetadata: metadata,
+    downloadStatus: null
   };
 
   return content;
@@ -414,6 +416,8 @@ shaka.offline.OfflineUtils.isText_ = function(stream) {
   const ContentType = shaka.util.ManifestParserUtils.ContentType;
   return stream.contentType == ContentType.TEXT;
 };
+
+
 /**
  * @param {!Array.<shakaExtern.PeriodDB>} periods
  * @param {!Array.<shakaExtern.PeriodDB>} storedPeriods

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -364,6 +364,92 @@ shaka.offline.Storage.prototype.removeByUrl_ = function(offlineUri) {
   }.bind(this));
 };
 
+/**
+ * @return {void}
+ * @export
+ */
+shaka.offline.Storage.prototype.pause = function() {
+  this.downloadManager_.pause();
+};
+
+/**
+ * @param {string} offlineUri
+ * @return {void}
+ * @export
+ */
+shaka.offline.Storage.prototype.resume = function(offlineUri) {
+  this.resume_(offlineUri).then(function() {
+    shaka.log.info('finished resume flow');
+  });
+};
+
+/**
+ * Resume the download after download pause. Adds to the current manifest
+ * the already stored segments,
+ * add to the downloadManager_ the segments that are pending download.
+ * @param {string} offlineUri
+ * @return {!Promise}
+ * @private
+ */
+shaka.offline.Storage.prototype.resume_ = function(offlineUri) {
+  const OfflineUtils = shaka.offline.OfflineUtils;
+  const manifestId = shaka.offline.OfflineUri.uriToManifestId(offlineUri);
+  if (manifestId == null) {
+    return Promise.reject(new shaka.util.Error(
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.STORAGE,
+        shaka.util.Error.Code.MALFORMED_OFFLINE_URI,
+        offlineUri));
+  }
+
+  return this.initIfNeeded_().then(function() {
+    goog.asserts.assert(manifestId != null, 'Manifest Ids cannot be null.');
+    this.checkDestroyed_();
+    return this.storageEngine_.getManifest(manifestId);
+  }.bind(this)).then((
+      /**
+       * @param {?shakaExtern.ManifestDB} manifestDb
+       * @return {!Promise}
+       */
+      function(manifestDb) {
+        manifestDb.downloadStatus = 'resumed';
+        this.checkDestroyed_();
+        if (!manifestDb) {
+          throw new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.STORAGE,
+              shaka.util.Error.Code.REQUESTED_ITEM_NOT_FOUND,
+              offlineUri);
+        }
+        this.manifest_ = shaka.offline.OfflineManifestParser
+            .reconstructManifest(manifestDb);
+        /** @type {!Array.<shakaExtern.PeriodDB>} */
+        let periods = this.manifest_.periods
+            .map(this.createPeriod_.bind(this));
+
+        OfflineUtils.addDownloadedSegmentsToPeriods(
+            periods,
+            this.manifest_.storedPeriods);
+        manifestDb.periods = periods;
+        this.downloadManager_.offlineManifestStorageId = manifestId;
+        return this.downloadManager_.downloadAndStore(manifestDb)
+            .then(function() {
+              if (manifestDb) {
+                return OfflineUtils.createStoredContentFromManifestDB(
+                    offlineUri,
+                    manifestDb);
+              } else {
+                throw new shaka.util.Error(
+                    shaka.util.Error.Severity.CRITICAL,
+                    shaka.util.Error.Category.STORAGE,
+                    shaka.util.Error.Code.REQUESTED_ITEM_NOT_FOUND,
+                    offlineUri);
+              }
+            }.bind(this));
+      })
+      .bind(this));
+};
+
 
 /**
  * @param {string} manifestUri
@@ -980,7 +1066,8 @@ shaka.offline.Storage.prototype.createStream_ = function(
   let startTime =
       this.manifest_.presentationTimeline.getSegmentAvailabilityStart();
 
-  shaka.offline.Storage.forEachSegment_(stream, startTime, function(segment) {
+  shaka.offline.Storage.forEachSegment_.bind(this)(stream, startTime,
+      function(segment) {
     /** @type {number} */
     let startTime = segment.startTime;
     /** @type {number} */
@@ -989,6 +1076,14 @@ shaka.offline.Storage.prototype.createStream_ = function(
     let duration = endTime - startTime;
     /** @type {number} */
     let bandwidthSize = duration * estimatedStreamBandwidth / 8;
+    /** @type {string} */
+    let uris = segment.uri || segment.getUris();
+    /** @type {number} */
+    let startByte = segment.startByte;
+    /** @type {number} */
+    let endByte = segment.endByte;
+    /** @type {number} */
+    let position = segment.position;
 
     this.downloadManager_.addSegment(
         stream.type,
@@ -999,12 +1094,16 @@ shaka.offline.Storage.prototype.createStream_ = function(
           let segmentDb = {
             startTime: startTime,
             endTime: endTime,
-            dataKey: id
+            dataKey: id,
+            startByte: startByte,
+            endByte: endByte,
+            position: position,
+            uri: uris
           };
 
           streamDb.segments.push(segmentDb);
         });
-  }.bind(this));
+  }.bind(this), this.manifest_.storedPeriods);
 
   let initSegment = stream.initSegmentReference;
   if (initSegment) {
@@ -1026,18 +1125,37 @@ shaka.offline.Storage.prototype.createStream_ = function(
 /**
  * @param {shakaExtern.Stream} stream
  * @param {number} startTime
- * @param {!function(shaka.media.SegmentReference)} callback
+ * @param {!function(shaka.media.SegmentReference)|
+ * !function(shakaExtern.SegmentDB)} callback
+ * @param {!Array.<shakaExtern.PeriodDB>} storedPeriods
  * @private
  */
-shaka.offline.Storage.forEachSegment_ = function(stream, startTime, callback) {
+shaka.offline.Storage.forEachSegment_ =
+    function(stream, startTime, callback, storedPeriods) {
   /** @type {?number} */
   let i = stream.findSegmentPosition(startTime);
   /** @type {?shaka.media.SegmentReference} */
   let ref = i == null ? null : stream.getSegmentReference(i);
+  /** @type {?number} */
+  const streamId = stream.id;
 
-  while (ref) {
-    callback(ref);
-    ref = stream.getSegmentReference(++i);
+  if (storedPeriods) { // "resume download" flow
+    // adding only the segments that should be downloaded
+    let storedPeriod = storedPeriods[0].streams
+        .filter((stream) => {
+          return stream.id === streamId;
+        });
+    storedPeriod[0].segments.filter((segment) => {
+      // filter the segments that are not stored yet
+      return segment.dataKey === null;
+    }).forEach((segment) => {
+      callback(segment);
+    });
+  } else { // "store" flow
+    while (ref) {
+      callback(ref);
+      ref = stream.getSegmentReference(++i);
+    }
   }
 };
 

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -462,7 +462,8 @@ shaka.offline.Storage.prototype.getPendingContent_ = function(manifest) {
     offlineUri: null,
     originalManifestUri: manifest.originalManifestUri,
     size: manifest.size,
-    tracks: null
+    tracks: null,
+    downloadStatus: null
   };
   return content;
 };
@@ -934,7 +935,8 @@ shaka.offline.Storage.prototype.createOfflineManifest_ = function(
     periods: periods,
     sessionIds: this.config_.usePersistentLicense ? sessions : [],
     drmInfo: drmInfo,
-    appMetadata: metadata
+    appMetadata: metadata,
+    downloadStatus: null
   };
 };
 

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -261,10 +261,11 @@ shaka.offline.Storage.prototype.downloadAndStoreManifest_ = function(
       .then(function(id) {
         const OfflineUri = shaka.offline.OfflineUri;
         const OfflineUtils = shaka.offline.OfflineUtils;
-
         /** @type {string} */
         let uri = OfflineUri.manifestIdToUri(id);
-        return OfflineUtils.createStoredContentFromManifestDB(uri, manifestDb);
+        return Object.assign(
+            OfflineUtils.createStoredContentFromManifestDB(uri, manifestDb),
+            {downloadStatus: manifestDb.downloadStatus});
       });
 };
 
@@ -379,9 +380,9 @@ shaka.offline.Storage.prototype.pause = function() {
  * @export
  */
 shaka.offline.Storage.prototype.resume = function(offlineUri) {
-  return this.resume_(offlineUri).then(function() {
+  return this.resume_(offlineUri).then(function(manifestDb) {
     shaka.log.info('finished resume flow');
-    return Promise.resolve('resumed');
+    return Promise.resolve(manifestDb);
   });
 };
 
@@ -438,17 +439,10 @@ shaka.offline.Storage.prototype.resume_ = function(offlineUri) {
         this.pendingContent_ = this.getPendingContent_(manifestDb);
         return this.downloadManager_.downloadAndStore(manifestDb)
             .then(function() {
-              if (manifestDb) {
-                return OfflineUtils.createStoredContentFromManifestDB(
-                    offlineUri,
-                    manifestDb);
-              } else {
-                throw new shaka.util.Error(
-                    shaka.util.Error.Severity.CRITICAL,
-                    shaka.util.Error.Category.STORAGE,
-                    shaka.util.Error.Code.REQUESTED_ITEM_NOT_FOUND,
-                    offlineUri);
+              if (manifestDb.downloadStatus == 'resumed') {
+                manifestDb.downloadStatus = 'ended';
               }
+              return manifestDb;
             }.bind(this));
       })
       .bind(this));
@@ -1126,6 +1120,7 @@ shaka.offline.Storage.prototype.createStream_ = function(
               startTime: startTime,
               endTime: endTime,
               dataKey: id,
+              bandwidthSize: bandwidthSize,
               startByte: startByte,
               endByte: endByte,
               position: position,

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -365,7 +365,6 @@ shaka.offline.Storage.prototype.removeByUrl_ = function(offlineUri) {
 };
 
 /**
- * @return {void}
  * @export
  */
 shaka.offline.Storage.prototype.pause = function() {
@@ -374,7 +373,6 @@ shaka.offline.Storage.prototype.pause = function() {
 
 /**
  * @param {string} offlineUri
- * @return {void}
  * @export
  */
 shaka.offline.Storage.prototype.resume = function(offlineUri) {
@@ -1077,7 +1075,9 @@ shaka.offline.Storage.prototype.createStream_ = function(
     /** @type {number} */
     let bandwidthSize = duration * estimatedStreamBandwidth / 8;
     /** @type {string} */
-    let uris = segment.uri || segment.getUris();
+    let uri = segment.uris && segment.uris.length > 0
+        ? segment.uris
+        : segment.getUris();
     /** @type {number} */
     let startByte = segment.startByte;
     /** @type {number} */
@@ -1091,16 +1091,24 @@ shaka.offline.Storage.prototype.createStream_ = function(
         bandwidthSize,
         function(id) {
           /** @type {shakaExtern.SegmentDB} */
-          let segmentDb = {
-            startTime: startTime,
-            endTime: endTime,
-            dataKey: id,
-            startByte: startByte,
-            endByte: endByte,
-            position: position,
-            uri: uris
-          };
-
+          let segmentDb = {};
+          if (id != null) {
+            segmentDb = {
+              startTime: startTime,
+              endTime: endTime,
+              dataKey: id
+              };
+            } else {
+              segmentDb = {
+                startTime: startTime,
+                endTime: endTime,
+                dataKey: id,
+                startByte: startByte,
+                endByte: endByte,
+                position: position,
+                uris: uri
+              };
+            }
           streamDb.segments.push(segmentDb);
         });
   }.bind(this), this.manifest_.storedPeriods);
@@ -1143,11 +1151,11 @@ shaka.offline.Storage.forEachSegment_ =
     // adding only the segments that should be downloaded
     let storedPeriod = storedPeriods[0].streams
         .filter((stream) => {
-          return stream.id === streamId;
+          return stream.id == streamId;
         });
     storedPeriod[0].segments.filter((segment) => {
       // filter the segments that are not stored yet
-      return segment.dataKey === null;
+      return segment.dataKey == null;
     }).forEach((segment) => {
       callback(segment);
     });

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -306,17 +306,11 @@ shaka.offline.Storage.prototype.removeByUrl_ = function(offlineUri) {
         offlineUri));
   }
 
-  let error = null;
-  let onError = function(e) {
-    // Ignore errors if the session was already removed.
-    if (e.code != shaka.util.Error.Code.OFFLINE_SESSION_REMOVED)
-      error = e;
-  };
 
   /** @type {shakaExtern.ManifestDB} */
   let manifestDb;
-  /** @type {!shaka.media.DrmEngine} */
-  let drmEngine;
+  // /** @type {!shaka.media.DrmEngine} */
+  // let drmEngine;
 
   return this.initIfNeeded_().then(function() {
     goog.asserts.assert(manifestId != null, 'Manifest Ids cannot be null.');
@@ -337,32 +331,32 @@ shaka.offline.Storage.prototype.removeByUrl_ = function(offlineUri) {
               offlineUri);
         }
         manifestDb = data;
-        let manifest =
-            shaka.offline.OfflineManifestParser.reconstructManifest(manifestDb);
         let netEngine = this.player_.getNetworkingEngine();
         goog.asserts.assert(netEngine, 'Player must not be destroyed');
-        drmEngine = new shaka.media.DrmEngine({
-          netEngine: netEngine,
-          onError: onError,
-          onKeyStatus: function() {},
-          onExpirationUpdated: function() {},
-          onEvent: function() {}
-        });
-        drmEngine.configure(this.player_.getConfiguration().drm);
-        let isOffline = this.config_.usePersistentLicense || false;
-        return drmEngine.init(manifest, isOffline);
-      })
-  .bind(this)).then(function() {
-    return drmEngine.removeSessions(manifestDb.sessionIds);
-  }.bind(this)).then(function() {
-    return drmEngine.destroy();
-  }.bind(this)).then(function() {
-    this.checkDestroyed_();
-    if (error) throw error;
-
-    goog.asserts.assert(manifestId != null, 'Manifest id cannot be null');
-    return this.removeManifest_(offlineUri, manifestId, manifestDb);
-  }.bind(this));
+        // if (error) throw error;
+        if (manifestId == null) {
+          return Promise.reject(new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.STORAGE,
+              shaka.util.Error.Code.MALFORMED_OFFLINE_URI,
+              offlineUri));
+        }
+        return this.removeManifest_(offlineUri, manifestId, manifestDb);
+        // drmEngine.configure(this.player_.getConfiguration().drm);
+        // let isOffline = this.config_.usePersistentLicense || false;
+        // return drmEngine.init(manifest, isOffline);
+      }).bind(this));
+  // .then(function() {
+  //   return drmEngine.removeSessions(manifestDb.sessionIds);
+  // }.bind(this)).then(function() {
+  //   return drmEngine.destroy();
+  // }.bind(this)).then(function() {
+  //   this.checkDestroyed_();
+  //   if (error) throw error;
+  //
+  //   goog.asserts.assert(manifestId != null, 'Manifest id cannot be null');
+  //   return this.removeManifest_(offlineUri, manifestId, manifestDb);
+  // }.bind(this));
 };
 
 /**

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -1094,7 +1094,9 @@ shaka.offline.Storage.prototype.createStream_ = function(
     /** @type {number} */
     let duration = endTime - startTime;
     /** @type {number} */
-    let bandwidthSize = duration * estimatedStreamBandwidth / 8;
+    let bandwidthSize = segment.bandwidthSize
+        || duration * estimatedStreamBandwidth / 8
+        || 0;
     /** @type {string} */
     let uri = segment.uris && segment.uris.length > 0
         ? segment.uris

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -366,18 +366,22 @@ shaka.offline.Storage.prototype.removeByUrl_ = function(offlineUri) {
 
 /**
  * @export
+ * @return {!Promise}
  */
 shaka.offline.Storage.prototype.pause = function() {
   this.downloadManager_.pause();
+  return Promise.resolve('paused');
 };
 
 /**
  * @param {string} offlineUri
+ * @return {!Promise}
  * @export
  */
 shaka.offline.Storage.prototype.resume = function(offlineUri) {
-  this.resume_(offlineUri).then(function() {
+  return this.resume_(offlineUri).then(function() {
     shaka.log.info('finished resume flow');
+    return Promise.resolve('resumed');
   });
 };
 
@@ -411,6 +415,7 @@ shaka.offline.Storage.prototype.resume_ = function(offlineUri) {
        */
       function(manifestDb) {
         manifestDb.downloadStatus = 'resumed';
+
         this.checkDestroyed_();
         if (!manifestDb) {
           throw new shaka.util.Error(
@@ -430,6 +435,7 @@ shaka.offline.Storage.prototype.resume_ = function(offlineUri) {
             this.manifest_.storedPeriods);
         manifestDb.periods = periods;
         this.downloadManager_.offlineManifestStorageId = manifestId;
+        this.pendingContent_ = this.getPendingContent_(manifestDb);
         return this.downloadManager_.downloadAndStore(manifestDb)
             .then(function() {
               if (manifestDb) {
@@ -446,6 +452,25 @@ shaka.offline.Storage.prototype.resume_ = function(offlineUri) {
             }.bind(this));
       })
       .bind(this));
+};
+
+/**
+ * @param {shakaExtern.ManifestDB} manifest
+ * @return {shakaExtern.StoredContent}
+ * @private
+ */
+shaka.offline.Storage.prototype.getPendingContent_ = function(manifest) {
+  /** @type {shakaExtern.StoredContent} */
+  let content = {
+    appMetadata: manifest.appMetadata,
+    duration: manifest.duration,
+    expiration: manifest.expiration,
+    offlineUri: null,
+    originalManifestUri: manifest.originalManifestUri,
+    size: manifest.size,
+    tracks: null
+  };
+  return content;
 };
 
 
@@ -1091,24 +1116,22 @@ shaka.offline.Storage.prototype.createStream_ = function(
         bandwidthSize,
         function(id) {
           /** @type {shakaExtern.SegmentDB} */
-          let segmentDb = {};
-          if (id != null) {
+          let segmentDb = {
+            startTime: startTime,
+            endTime: endTime,
+            dataKey: id
+          };
+          if (id == null) {
             segmentDb = {
               startTime: startTime,
               endTime: endTime,
-              dataKey: id
-              };
-            } else {
-              segmentDb = {
-                startTime: startTime,
-                endTime: endTime,
-                dataKey: id,
-                startByte: startByte,
-                endByte: endByte,
-                position: position,
-                uris: uri
-              };
-            }
+              dataKey: id,
+              startByte: startByte,
+              endByte: endByte,
+              position: position,
+              uris: uri
+            };
+          }
           streamDb.segments.push(segmentDb);
         });
   }.bind(this), this.manifest_.storedPeriods);

--- a/test/offline/offline_scheme_unit.js
+++ b/test/offline/offline_scheme_unit.js
@@ -58,7 +58,8 @@ describe('OfflineScheme', function() {
               periods: [],
               sessionIds: [],
               drmInfo: null,
-              appMetadata: {}
+              appMetadata: {},
+              downloadStatus: null
             });
           })
           .then(function(id) {

--- a/test/test/util/manifest_db_builder.js
+++ b/test/test/util/manifest_db_builder.js
@@ -250,7 +250,8 @@ shaka.test.ManifestDBBuilder.emptyManifest_ = function() {
     periods: [],
     sessionIds: [],
     drmInfo: null,
-    appMetadata: {}
+    appMetadata: {},
+    downloadStatus: null
   };
 
   return manifest;

--- a/test/test/util/offline_utils.js
+++ b/test/test/util/offline_utils.js
@@ -31,7 +31,8 @@ shaka.test.OfflineUtils.createManifest = function(originalUri) {
     originalManifestUri: originalUri,
     periods: [],
     sessionIds: [],
-    size: 1024
+    size: 1024,
+    downloadStatus: null
   };
 };
 


### PR DESCRIPTION
I added resume and pause methods to the Storage object.

We wanted to add the ability for the user / application to pause a download and resume it (e.g. upon closing the window).
Pausing a download is done on the local storage object. Resuming a download is done with the offline manifest URI (i assumed it will be saved by the application and not by Shaka).

The pause method signals the download manager and adds `downloadStatus = paused` to the manifest object. The `downloadSegment_` function was changed to support this flag. After pause is triggered, it will populate the manifest with the segment with the `dataKey` set to ` null` (and ` startByte, endByte, position`).

The resume method retrieves the manifest from the indexdb. 
It adds all the downloaded segments (those with `dataKey != null`) to the new manifestDB object.
All the pending segments are added to the `segments_` object in the `download_manager`.

I also changed the demo offline section to demonstrate the feature ability.

I still haven't changed and added tests - i will add them if you think i'm on the right track in implementing this methods.