### PR TITLE
renew license api (issue #1347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,49 @@
+## 2.3.3 (2018-03-01)
+
+New features:
+  - Warn if parsing the date from UTCTiming fails
+    - https://github.com/google/shaka-player/issues/1317
+    - https://github.com/google/shaka-player/pull/1318
+  - Backpropagate language selections on track change
+    - https://github.com/google/shaka-player/issues/1299
+
+Bugfixes:
+  - Fix MP4+VTT in HLS
+    - https://github.com/google/shaka-player/issues/1270
+  - Fix track selection during "streaming" event
+    - https://github.com/google/shaka-player/issues/1119
+  - Work around MSE rounding errors in Edge
+    - https://github.com/google/shaka-player/issues/1281
+    - Edge bug: https://goo.gl/3ZTzse
+  - Fix IE stuck buffering at the end after replay
+    - https://github.com/google/shaka-player/issues/979
+  - Fix catastrophic backtracking in TTML text parser
+    - https://github.com/google/shaka-player/issues/1312
+  - Fix infinite loop when jumping very small gaps
+    - https://github.com/google/shaka-player/issues/1309
+  - Fix seek range for live content with less than a full availability window
+    - https://github.com/google/shaka-player/issues/1224
+  - Remove misleading logging in DrmEngine#fillInDrmInfoDefaults
+    - https://github.com/google/shaka-player/pull/1288
+    - https://github.com/google/shaka-player/issues/1284
+  - Fix old text cues displayed after loading new text stream
+    - https://github.com/google/shaka-player/issues/1293
+  - Fix truncated HLS duration with short text streams
+    - https://github.com/google/shaka-player/issues/1271
+  - Fix DASH SegmentTemplate w/ duration
+    - https://github.com/google/shaka-player/issues/1232
+
+Docs:
+  - Fix out-of-date docs for error 6014 EXPIRED
+    - https://github.com/google/shaka-player/issues/1319
+  - Simplify prerequisite installation on Linux
+    - https://github.com/google/shaka-player/issues/1175
+  - Simplify the debugging tutorial
+  - Fix various typos
+    - https://github.com/google/shaka-player/pull/1272
+    - https://github.com/google/shaka-player/pull/1274
+
+
 ## 2.3.2 (2018-02-01)
 
 New features:

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -407,6 +407,26 @@ shaka.media.DrmEngine.prototype.keySystem = function() {
 
 
 /**
+ * Returns the mediaKeys object
+ *
+ * @return {MediaKeys}
+ */
+shaka.media.DrmEngine.prototype.getMediaKeys = function() {
+  return this.mediaKeys_;
+};
+
+/**
+ * Returns returns the active sessions array
+ *
+ * @return {!Array.<shaka.media.DrmEngine.ActiveSession>}
+ */
+shaka.media.DrmEngine.prototype.getActiveSessions = function() {
+  return this.activeSessions_;
+};
+
+
+
+/**
  * Returns an array of the media types supported by the current key system.
  * These will be full mime types (e.g. 'video/webm; codecs="vp8"').
  *

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -101,6 +101,90 @@ shaka.offline.Storage = function(player) {
 
 
 /**
+ * @param {string} offlineUri
+ * @export
+ * @return {!Promise}
+ */
+shaka.offline.Storage.prototype.renewLicense = function(offlineUri) {
+  const OfflineUtils = shaka.offline.OfflineUtils;
+  const manifestId = shaka.offline.OfflineUri.uriToManifestId(offlineUri);
+  if (manifestId == null) {
+    return Promise.reject(new shaka.util.Error(
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.STORAGE,
+        shaka.util.Error.Code.MALFORMED_OFFLINE_URI,
+        offlineUri));
+  }
+  let error = null;
+  let onError = function(e) {
+    error = e;
+  };
+
+  let oldManifestDB_;
+  /** @private {MediaKeySession} */
+  let session_;
+  let newManifestDB_;
+
+  return this.initIfNeeded_().then(() => {
+    goog.asserts.assert(manifestId != null, 'Manifest Ids cannot be null.');
+    this.checkDestroyed_();
+    return this.storageEngine_.getManifest(manifestId);
+  }).then((manifestDB) => {
+    oldManifestDB_ = manifestDB;
+    let manifest = shaka.offline.OfflineManifestParser
+        .reconstructManifest(manifestDB);
+    let netEngine = this.player_.getNetworkingEngine();
+    goog.asserts.assert(netEngine, 'Player must not be destroyed');
+    this.drmEngine_ = new shaka.media.DrmEngine({
+      netEngine: netEngine,
+      onError: onError,
+      onKeyStatus: function() {},
+      onExpirationUpdated: function() {},
+      onEvent: function() {}
+    });
+    this.drmEngine_.configure(this.player_.getConfiguration().drm);
+    return this.drmEngine_.init(manifest, true);
+  }).then(() => {
+    session_ = this.drmEngine_.getMediaKeys()
+        .createSession('persistent-license');
+    return session_.load(oldManifestDB_.sessionIds[0]);
+  }).then(()=>{
+    return session_.remove();
+  }).then(()=>{
+    return this.loadInternal(oldManifestDB_.originalManifestUri, onError);
+  }).then((data) => {
+    // Save these references so that they can be accessed elsewhere.
+    this.manifest_ = data.manifest;
+    this.drmEngine_ = data.drmEngine;
+    const storedPeriods = oldManifestDB_.periods;
+    // Re-filter now that DrmEngine is initialized.
+    this.filterAllPeriods_(data.manifest.periods);
+    this.pendingContent_ = OfflineUtils.createStoredContentFromManifest(
+        oldManifestDB_.originalManifestUri,
+        data.manifest,
+        0,  // start with a size of 0
+        oldManifestDB_.appMetadata);
+    newManifestDB_ = this.createOfflineManifest_(
+        oldManifestDB_.originalManifestUri, oldManifestDB_.appMetadata);
+    newManifestDB_.periods = storedPeriods;
+    this.drmEngine_.getActiveSessions()[0].session.close();
+    if (manifestId != null) {
+      return this.storageEngine_.updateManifest(manifestId, newManifestDB_);
+    }
+  }).then(()=>{
+    return Promise.resolve(newManifestDB_);
+  }).catch((err)=> {
+    // If we already had an error, ignore this error to avoid hiding
+    // the original error.
+    error = error || err;
+    return this.cleanup_().then(function() {
+      throw error;
+    });
+  });
+};
+
+
+/**
  * Gets whether offline storage is supported.  Returns true if offline storage
  * is supported for clear content.  Support for offline storage of encrypted
  * content will not be determined until storage is attempted.


### PR DESCRIPTION
Hi,
The purpose of this pull request is to provide renewal license api for stored content.
It gets an offline uri (e.g "`offline:manifest/9`") and returns the offline manifest object (with the new expiration timestamp).

The flow is pretty much as I described [here](https://github.com/google/shaka-player/issues/1347)

My two main concerns are:
1. I exposed two properties in drm_engine (maybe there is a better way to do it - active_sessions + mediaKeys).
2. is there a simpler way to create the new manifest? what i am running the whole '`loadInternals`' flow, cause i guess i need the initData etc.

would be happy to hear what you think.

Thanks,
Oded