### PR TITLE
User hooks for hls parser

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ Google Inc. <*@google.com>
 Edgeware AB <*@edgeware.tv>
 Gil Gonen <gil.gonen@gmail.com>
 Giuseppe Samela <giuseppe.samela@gmail.com>
+Hotstar <*@hotstar.com>
 Itay Kinnrot <Itay.Kinnrot@Kaltura.com>
 Jason Palmer <jason@jason-palmer.com>
 Jesper Haug Karsrud <jesper.karsrud@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@
 Aaron Vaage <vaage@google.com>
 Alvaro Velad Galvan <alvaro.velad@mirada.tv>
 Andy Hochhaus <ahochhaus@samegoal.com>
+Anurag Kalia <anurag.kalia@hotstar.com>
 Benjamin Wallberg <benjamin.wallberg@bonnierbroadcasting.com>
 Boris Cupac <borisrt2309@gmail.com>
 Bryan Huh <bhh1988@gmail.com>

--- a/externs/shaka/manifest_parser.js
+++ b/externs/shaka/manifest_parser.js
@@ -59,6 +59,7 @@ shaka.extern.ManifestParser = function() {};
  *   filterNewPeriod: function(shaka.extern.Period),
  *   filterAllPeriods: function(!Array.<!shaka.extern.Period>),
  *   onTimelineRegionAdded: function(shaka.extern.TimelineRegionInfo),
+ *   onSegmentParsed: function(string, number, *),
  *   onEvent: function(!Event),
  *   onError: function(!shaka.util.Error)
  * }}
@@ -77,6 +78,8 @@ shaka.extern.ManifestParser = function() {};
  *   Should be called on all Periods so that they can be filtered.
  * @property {function(shaka.extern.TimelineRegionInfo)} onTimelineRegionAdded
  *   Should be called when a new timeline region is added.
+ * @property {function(string, number, *)} onSegmentParsed
+ *   Should be called with segment metadata when a new segment is parsed.
  * @property {function(!Event)} onEvent
  *   Should be called to raise events.
  * @property {function(!shaka.util.Error)} onError

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -287,7 +287,9 @@ shaka.hls.HlsParser = class {
         playlist,
         startPosition,
         stream.mimeType,
-        stream.codecs);
+        stream.codecs,
+        stream.id,
+        streamInfo.segmentIndex.getAll());
 
     streamInfo.segmentIndex.replace(segments);
 
@@ -1167,8 +1169,11 @@ shaka.hls.HlsParser = class {
 
     const startPosition = mediaSequenceTag ? Number(mediaSequenceTag.value) : 0;
 
+    const nextStreamId = this.globalId_++;
+
     const segments = await this.createSegments_(
-        verbatimMediaPlaylistUri, playlist, startPosition, mimeType, codecs);
+        verbatimMediaPlaylistUri, playlist, startPosition, mimeType, codecs,
+        nextStreamId, []);
 
     const minTimestamp = segments[0].startTime;
     const lastEndTime = segments[segments.length - 1].endTime;
@@ -1186,7 +1191,7 @@ shaka.hls.HlsParser = class {
 
     /** @type {shaka.extern.Stream} */
     const stream = {
-      id: this.globalId_++,
+      id: nextStreamId,
       originalId: name,
       createSegmentIndex: () => Promise.resolve(),
       findSegmentPosition: (i) => segmentIndex.find(i),
@@ -1435,16 +1440,25 @@ shaka.hls.HlsParser = class {
    * @param {number} startPosition
    * @param {string} mimeType
    * @param {string} codecs
+   * @param {number} streamId
+   * @param {Array.<!shaka.media.SegmentReference>} existingSegmentRefs
    * @return {!Promise<!Array.<!shaka.media.SegmentReference>>}
    * @private
    */
   async createSegments_(
-      verbatimMediaPlaylistUri, playlist, startPosition, mimeType, codecs) {
+      verbatimMediaPlaylistUri, playlist, startPosition, mimeType, codecs,
+      streamId, existingSegmentRefs) {
     /** @type {Array.<!shaka.hls.Segment>} */
     const hlsSegments = playlist.segments;
-    /** @type {!Array.<!shaka.media.SegmentReference>} */
+    /** @type {Array.<!shaka.media.SegmentReference>} */
     const references = [];
+    let exisitingRefCount = 0;
 
+    if (existingSegmentRefs.length > 0) {
+      const earlierStartPosition = existingSegmentRefs[0].getPosition();
+      exisitingRefCount = existingSegmentRefs.length -
+          (startPosition - earlierStartPosition);
+    }
     goog.asserts.assert(hlsSegments.length, 'Playlist should have segments!');
     // We may need to look at the media itself to determine a segment start
     // time.
@@ -1463,11 +1477,21 @@ shaka.hls.HlsParser = class {
         initSegmentRef, firstSegmentRef, mimeType, codecs);
     shaka.log.debug('First segment', firstSegmentUri.split('/').pop(),
         'starts at', firstStartTime);
-    for (let i = 0; i < hlsSegments.length; ++i) {
+
+    // Append brand-new segments
+    for (let i = references.length; i < hlsSegments.length; ++i) {
       const hlsSegment = hlsSegments[i];
       const previousReference = references[references.length - 1];
       const startTime = (i == 0) ? firstStartTime : previousReference.endTime;
       const position = startPosition + i;
+
+      if (i >= exisitingRefCount) {
+        // Only fire this event for brand new segments
+        this.playerInterface_.onSegmentParsed(
+            'application/vnd.apple.mpegurl',
+            streamId,
+            hlsSegment);
+      }
 
       const reference = this.createSegmentReference_(
           playlist,

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1452,12 +1452,15 @@ shaka.hls.HlsParser = class {
     const hlsSegments = playlist.segments;
     /** @type {Array.<!shaka.media.SegmentReference>} */
     const references = [];
-    let exisitingRefCount = 0;
+    // number of segment references in both the last and the current playlist
+    let reappearingRefsCount = 0;
 
     if (existingSegmentRefs.length > 0) {
       const earlierStartPosition = existingSegmentRefs[0].getPosition();
-      exisitingRefCount = existingSegmentRefs.length -
-          (startPosition - earlierStartPosition);
+      // number of segment references in the last but not the current playlist
+      // (in HLS, segments are dropped only from the beginning of the playlist)
+      const droppedRefsCount = startPosition - earlierStartPosition;
+      reappearingRefsCount = existingSegmentRefs.length - droppedRefsCount;
     }
     goog.asserts.assert(hlsSegments.length, 'Playlist should have segments!');
     // We may need to look at the media itself to determine a segment start
@@ -1479,14 +1482,15 @@ shaka.hls.HlsParser = class {
         'starts at', firstStartTime);
 
     // Append brand-new segments
-    for (let i = references.length; i < hlsSegments.length; ++i) {
+    for (let i = 0; i < hlsSegments.length; ++i) {
       const hlsSegment = hlsSegments[i];
       const previousReference = references[references.length - 1];
       const startTime = (i == 0) ? firstStartTime : previousReference.endTime;
       const position = startPosition + i;
 
-      if (i >= exisitingRefCount) {
-        // Only fire this event for brand new segments
+      if (i >= reappearingRefsCount) {
+        // Segment references which appeared only in the current playlist:
+        // Fire 'segmentparsed' event for them.
         this.playerInterface_.onSegmentParsed(
             'application/vnd.apple.mpegurl',
             streamId,

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1452,13 +1452,19 @@ shaka.hls.HlsParser = class {
     const hlsSegments = playlist.segments;
     /** @type {Array.<!shaka.media.SegmentReference>} */
     const references = [];
-    // number of segment references in both the last and the current playlist
+    /**
+     * Number of segment references in both the last and the current playlist.
+     * @type {number}
+     */
     let reappearingRefsCount = 0;
 
     if (existingSegmentRefs.length > 0) {
       const earlierStartPosition = existingSegmentRefs[0].getPosition();
-      // number of segment references in the last but not the current playlist
-      // (in HLS, segments are dropped only from the beginning of the playlist)
+      /**
+       * Number of segment references in the last but not the current playlist
+       * (in HLS, segments are dropped only from the beginning of the playlist).
+       * @type {number}
+       */
       const droppedRefsCount = startPosition - earlierStartPosition;
       reappearingRefsCount = existingSegmentRefs.length - droppedRefsCount;
     }

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1450,7 +1450,7 @@ shaka.hls.HlsParser = class {
       streamId, existingSegmentRefs) {
     /** @type {Array.<!shaka.hls.Segment>} */
     const hlsSegments = playlist.segments;
-    /** @type {Array.<!shaka.media.SegmentReference>} */
+    /** @type {!Array.<!shaka.media.SegmentReference>} */
     const references = [];
     /**
      * Number of segment references in both the last and the current playlist.

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -107,6 +107,16 @@ shaka.media.SegmentIndex = class {
     return this.references_[index];
   }
 
+  /**
+   * Get all the SegmentReferences
+   *
+   * @return {Array.<!shaka.media.SegmentReference>} existing segment references
+   * @export
+   */
+  getAll() {
+    return this.references_;
+  }
+
 
   /**
    * Offset all segment references by a fixed amount.

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -797,6 +797,7 @@ shaka.offline.Storage = class {
       filterNewPeriod: () => {},
 
       onTimelineRegionAdded: () => {},
+      onSegmentParsed: () => {},
       onEvent: () => {},
 
       // Used to capture an error from the manifest parser. We will check the

--- a/lib/player.js
+++ b/lib/player.js
@@ -1451,6 +1451,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // manifest).
       onTimelineRegionAdded: (region) => this.regionTimeline_.addRegion(region),
 
+      // Called to signal new segment metadata upon parsing in the manifest
+      // segment metadata can vary depending on mimeType and streamId
+      onSegmentParsed: (mimeType, streamId, segment) => this.onSegmentParsed_(
+          mimeType, streamId, segment),
+
       onEvent: (event) => this.dispatchEvent(event),
       onError: (error) => this.onError_(error),
     };
@@ -4247,6 +4252,27 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (this.playhead_) {
       this.playhead_.notifyOfBufferingChange();
     }
+  }
+
+  /**
+   * Callback from player
+   *
+   * @param {string} mimeType of the manifest-parser
+   * @param {number} streamId to which the segment belongs
+   * @param {*} segment segment metadata (format depends on mimeType+segment)
+   * @private
+   */
+
+  onSegmentParsed_(mimeType, streamId, segment) {
+    const eventData = {
+      mimeType,
+      streamId,
+      segment,
+    };
+
+    this.dispatchEvent(
+        new shaka.util.FakeEvent('segmentparsed', eventData)
+    );
   }
 
   /**

--- a/lib/player.js
+++ b/lib/player.js
@@ -266,6 +266,17 @@ goog.require('shaka.util.StreamUtils');
  * @exportDoc
  */
 
+/**
+ * @event shaka.Player.SegmentParsedEvent
+ * @description Optionally fired from inside a manifest parser plugin if a newly
+ *   parsed segment has some extra metadata. It emits mime type of the parser,
+ *   id of the stream that segment belonged to, and segment data (format may
+ *   differ according to manifest parser).
+ * @property {string} type
+ *   'segmentparsed'
+ * @exportDoc
+ */
+
 
 /**
  * @event shaka.Player.StreamingEvent
@@ -4265,9 +4276,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
   onSegmentParsed_(mimeType, streamId, segment) {
     const eventData = {
-      mimeType,
-      streamId,
-      segment,
+      detail: {
+        mimeType,
+        streamId,
+        segment,
+      },
     };
 
     this.dispatchEvent(

--- a/lib/player.js
+++ b/lib/player.js
@@ -269,11 +269,15 @@ goog.require('shaka.util.StreamUtils');
 /**
  * @event shaka.Player.SegmentParsedEvent
  * @description Optionally fired from inside a manifest parser plugin if a newly
- *   parsed segment has some extra metadata. It emits mime type of the parser,
- *   id of the stream that segment belonged to, and segment data (format may
- *   differ according to manifest parser).
+ *   parsed segment has some extra metadata.
  * @property {string} type
  *   'segmentparsed'
+ * @property {string} mimeType
+ *   Mime type of the manifest parser.
+ * @property {number} streamId
+ *   Id of the stream that segment belonged to.
+ * @property {*} segmentData
+ *   Its format depends on the manifest parser.
  * @exportDoc
  */
 
@@ -4268,19 +4272,17 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   /**
    * Callback from player
    *
-   * @param {string} mimeType of the manifest-parser
-   * @param {number} streamId to which the segment belongs
-   * @param {*} segment segment metadata (format depends on mimeType+segment)
+   * @param {string} mimeType Mime type of the manifest parser.
+   * @property {number} streamId Id of the stream that segment belonged to.
+   * @property {*} segmentData Its format depends on the manifest parser.
    * @private
    */
 
-  onSegmentParsed_(mimeType, streamId, segment) {
+  onSegmentParsed_(mimeType, streamId, segmentData) {
     const eventData = {
-      detail: {
-        mimeType,
-        streamId,
-        segment,
-      },
+      mimeType,
+      streamId,
+      segmentData,
     };
 
     this.dispatchEvent(

--- a/lib/player.js
+++ b/lib/player.js
@@ -4273,11 +4273,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Callback from player
    *
    * @param {string} mimeType Mime type of the manifest parser.
-   * @property {number} streamId Id of the stream that segment belonged to.
-   * @property {*} segmentData Its format depends on the manifest parser.
+   * @param {number} streamId Id of the stream that segment belonged to.
+   * @param {*} segmentData Its format depends on the manifest parser.
    * @private
    */
-
   onSegmentParsed_(mimeType, streamId, segmentData) {
     const eventData = {
       mimeType,

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -47,6 +47,7 @@ describe('DashParser ContentProtection', () => {
       filterNewPeriod: () => {},
       filterAllPeriods: () => {},
       onTimelineRegionAdded: fail,  // Should not have any EventStream elements.
+      onSegmentParsed: fail,
       onEvent: fail,
       onError: fail,
     };

--- a/test/dash/dash_parser_live_unit.js
+++ b/test/dash/dash_parser_live_unit.js
@@ -47,6 +47,7 @@ describe('DashParser Live', () => {
       filterNewPeriod: () => {},
       filterAllPeriods: () => {},
       onTimelineRegionAdded: fail,  // Should not have any EventStream elements.
+      onSegmentParsed: fail,
       onEvent: fail,
       onError: fail,
     };

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -38,6 +38,7 @@ describe('DashParser Manifest', () => {
       filterNewPeriod: () => {},
       filterAllPeriods: () => {},
       onTimelineRegionAdded: fail,  // Should not have any EventStream elements.
+      onSegmentParsed: fail,
       onEvent: shaka.test.Util.spyFunc(onEventSpy),
       onError: fail,
     };

--- a/test/dash/dash_parser_segment_base_unit.js
+++ b/test/dash/dash_parser_segment_base_unit.js
@@ -42,6 +42,7 @@ describe('DashParser SegmentBase', () => {
       filterNewPeriod: () => {},
       filterAllPeriods: () => {},
       onTimelineRegionAdded: fail,  // Should not have any EventStream elements.
+      onSegmentParsed: fail,
       onEvent: fail,
       onError: fail,
     };

--- a/test/dash/dash_parser_segment_template_unit.js
+++ b/test/dash/dash_parser_segment_template_unit.js
@@ -36,6 +36,7 @@ describe('DashParser SegmentTemplate', () => {
       filterNewPeriod: () => {},
       filterAllPeriods: () => {},
       onTimelineRegionAdded: fail,  // Should not have any EventStream elements.
+      onSegmentParsed: fail,
       onEvent: fail,
       onError: fail,
     };

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -91,11 +91,22 @@ describe('HlsParser', () => {
       onError: fail,
       onEvent: fail,
       onTimelineRegionAdded: fail,
+      onSegmentParsed: fail,
     };
 
     parser = new shaka.hls.HlsParser();
     parser.configure(config);
   });
+
+  /** @type {!jasmine.Spy} */
+  let onSegmentParsedSpy;
+
+  beforeEach(() => {
+    onSegmentParsedSpy = jasmine.createSpy('onSegmentParsed');
+    playerInterface.onSegmentParsed =
+        shaka.test.Util.spyFunc(onSegmentParsedSpy);
+  });
+
 
   /**
    * @param {string} master

--- a/test/test/util/dash_parser_util.js
+++ b/test/test/util/dash_parser_util.js
@@ -50,6 +50,7 @@ shaka.test.Dash = class {
       filterNewPeriod: () => {},
       filterAllPeriods: () => {},
       onTimelineRegionAdded: fail,  // Should not have any EventStream elements.
+      onSegmentParsed: fail,
       onEvent: fail,
       onError: fail,
     };
@@ -77,6 +78,7 @@ shaka.test.Dash = class {
       filterNewPeriod: () => {},
       filterAllPeriods: () => {},
       onTimelineRegionAdded: fail,  // Should not have any EventStream elements.
+      onSegmentParsed: fail,
       onEvent: fail,
       onError: fail,
     };

--- a/test/test/util/util.js
+++ b/test/test/util/util.js
@@ -227,6 +227,40 @@ shaka.test.Util = class {
   }
 
   /**
+   * Custom comparer for HLS segments.
+   * @param {*} first
+   * @param {*} second
+   * @return {boolean|undefined}
+   */
+
+  static compareHlsSegments(first, second) {
+    const isHlsSegment = first instanceof shaka.hls.Segment &&
+        second instanceof shaka.hls.Segment;
+
+    if (isHlsSegment) {
+      return first.absoluteUri === second.absoluteUri &&
+          compareTagsArray(first.tags, second.tags);
+    }
+
+    return undefined;
+
+
+    function compareTagsArray(tags1, tags2) {
+      if (tags1 instanceof Array && tags2 instanceof Array) {
+        try {
+          const tagsAsString = (tagsArray) => tagsArray.map((tags) =>
+            tags.toString()).sort().join(',');
+
+          return tagsAsString(tags1) === tagsAsString(tags2);
+        } catch (e) {
+          return false;
+        }
+      }
+      return false;
+    }
+  }
+
+  /**
    * Fetches the resource at the given URI.
    *
    * @param {string} uri
@@ -475,5 +509,6 @@ shaka.test.Util.customMatchers_ = {
 
 beforeEach(() => {
   jasmine.addCustomEqualityTester(shaka.test.Util.compareReferences);
+  jasmine.addCustomEqualityTester(shaka.test.Util.compareHlsSegments);
   jasmine.addMatchers(shaka.test.Util.customMatchers_);
 });


### PR DESCRIPTION
This is regarding the issue https://github.com/google/shaka-player/issues/1983.

I have added an extra function onSegmentParsed on the playerInterface passed to each manifest parser. If the manifest parser wants, it can call the function with mime type, stream id, and data (whose format may differ according to the manifest parser) whenever it encounters a new fragment in its stream.

This function right now simply emits an event 'segmentparsed' from the player when this function is called.

Also find the unit tests to go along with it. And let me know if there is any improvement to be made. :)
