### PR TITLE
Anchor cues based on Regions

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -401,7 +401,6 @@ shaka.text.UITextDisplayer = class {
 
       // Handle anchoring. Convert everything to percentages of the video
       // container to avoid comparing percentages to pixels.
-
       let width = cue.region.width;
       if (cue.region.widthUnits != percentageUnit) {
         width = width / videoBoundingBox.width * 100;

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -48,6 +48,15 @@ shaka.text.UITextDisplayer = class {
     this.textContainer_.classList.add('shaka-text-container');
     this.videoContainer_.appendChild(this.textContainer_);
 
+    const videoContainerBoundingBox =
+        this.videoContainer_.getBoundingClientRect();
+
+    /** @private {!number} */
+    this.videoContainerWidth_ = videoContainerBoundingBox.width;
+
+    /** @private {!number} */
+    this.videoContainerHeight_ = videoContainerBoundingBox.height;
+
     /**
      * The captions' update period in seconds.
      * @private {number}
@@ -388,20 +397,18 @@ shaka.text.UITextDisplayer = class {
       let height = cue.region.height;
       let viewportAnchorX = cue.region.viewportAnchorX;
       let viewportAnchorY = cue.region.viewportAnchorY;
-      const videoContainerWidth = this.videoContainer_.clientWidth;
-      const videoContainerHeight = this.videoContainer_.clientHeight;
 
       if (cue.region.widthUnits != percentageUnit) {
-        width = width / videoContainerWidth * 100;
+        width = width / this.videoContainerWidth_ * 100;
       }
 
       if (cue.region.heightUnits != percentageUnit) {
-        height = height / videoContainerHeight * 100;
+        height = height / this.videoContainerHeight_ * 100;
       }
 
       if (cue.region.viewportAnchorUnits != percentageUnit) {
-        viewportAnchorX = viewportAnchorX / videoContainerWidth * 100;
-        viewportAnchorY = viewportAnchorY / videoContainerHeight * 100;
+        viewportAnchorX = viewportAnchorX / this.videoContainerWidth_ * 100;
+        viewportAnchorY = viewportAnchorY / this.videoContainerHeight_ * 100;
       }
 
       style.height = height + '%';

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -382,15 +382,42 @@ shaka.text.UITextDisplayer = class {
       // TODO: Revisit this as we update the TTML parser.  See special case for
       // backgroundImage + region above.
       const percentageUnit = shaka.text.CueRegion.units.PERCENTAGE;
-      const heightUnit = cue.region.heightUnits == percentageUnit ? '%' : 'px';
-      const widthUnit = cue.region.widthUnits == percentageUnit ? '%' : 'px';
-      const viewportAnchorUnit =
-          cue.region.viewportAnchorUnits == percentageUnit ? '%' : 'px';
-      style.height = cue.region.height + heightUnit;
-      style.width = cue.region.width + widthUnit;
+
+      // Convert everything to percentages of the video container.
+      let width = cue.region.width;
+      let height = cue.region.height;
+      let viewportAnchorX = cue.region.viewportAnchorX;
+      let viewportAnchorY = cue.region.viewportAnchorY;
+      const videoContainerWidth = this.videoContainer_.clientWidth;
+      const videoContainerHeight = this.videoContainer_.clientHeight;
+
+      if (cue.region.widthUnits != percentageUnit) {
+        width = width / videoContainerWidth * 100;
+      }
+
+      if (cue.region.heightUnits != percentageUnit) {
+        height = height / videoContainerHeight * 100;
+      }
+
+      if (cue.region.viewportAnchorUnits != percentageUnit) {
+        viewportAnchorX = viewportAnchorX / videoContainerWidth * 100;
+        viewportAnchorY = viewportAnchorY / videoContainerHeight * 100;
+      }
+
+      style.height = height + '%';
+      style.width = width + '%';
       style.position = 'absolute';
-      style.top = cue.region.viewportAnchorY + viewportAnchorUnit;
-      style.left = cue.region.viewportAnchorX + viewportAnchorUnit;
+
+      // Region and viewport anchors are similar to pinning a paper on a board.
+      // Region anchor is analogous to where the pin goes on the paper, where
+      // the paper is the region. Viewport anchor is analogous to where the
+      // paper goes on the board, where the board is the video.
+
+      // regionAnchorX and regionAnchorY are guaranteed percentages.
+      const pinLocationX = cue.region.regionAnchorX / 100 * width;
+      const pinLocationY = cue.region.regionAnchorY / 100 * height;
+      style.top = cue.region.viewportAnchorY - pinLocationY + '%';
+      style.left = cue.region.viewportAnchorX - pinLocationX + '%';
     }
 
     style.lineHeight = cue.lineHeight;

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -421,7 +421,7 @@ shaka.text.UITextDisplayer = class {
       // Region and viewport anchors are similar to pinning a paper on a board.
       // Region anchor is analogous to where the pin goes on the paper, where
       // the paper is the region. Viewport anchor is analogous to where the
-      // paper goes on the board, where the board is the video.
+      // pin goes on the board, where the board is the video.
 
       // regionAnchorX and regionAnchorY are guaranteed percentages.
       const pinLocationX = cue.region.regionAnchorX / 100 * width;

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -401,19 +401,19 @@ shaka.text.UITextDisplayer = class {
 
       // Handle anchoring. Convert everything to percentages of the video
       // container to avoid comparing percentages to pixels.
-      let width = cue.region.width;
-      let height = cue.region.height;
-      let viewportAnchorX = cue.region.viewportAnchorX;
-      let viewportAnchorY = cue.region.viewportAnchorY;
 
+      let width = cue.region.width;
       if (cue.region.widthUnits != percentageUnit) {
         width = width / videoBoundingBox.width * 100;
       }
 
+      let height = cue.region.height;
       if (cue.region.heightUnits != percentageUnit) {
         height = height / videoBoundingBox.height * 100;
       }
 
+      let viewportAnchorX = cue.region.viewportAnchorX;
+      let viewportAnchorY = cue.region.viewportAnchorY;
       if (cue.region.viewportAnchorUnits != percentageUnit) {
         viewportAnchorX = viewportAnchorX / videoBoundingBox.width * 100;
         viewportAnchorY = viewportAnchorY / videoBoundingBox.height * 100;
@@ -428,8 +428,8 @@ shaka.text.UITextDisplayer = class {
       // regionAnchorX and regionAnchorY are guaranteed percentages.
       const pinLocationX = cue.region.regionAnchorX / 100 * width;
       const pinLocationY = cue.region.regionAnchorY / 100 * height;
-      style.top = cue.region.viewportAnchorY - pinLocationY + '%';
-      style.left = cue.region.viewportAnchorX - pinLocationX + '%';
+      style.top = viewportAnchorY - pinLocationY + '%';
+      style.left = viewportAnchorX - pinLocationX + '%';
     }
 
     style.lineHeight = cue.lineHeight;

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -393,7 +393,14 @@ shaka.text.UITextDisplayer = class {
       // backgroundImage + region above.
       const percentageUnit = shaka.text.CueRegion.units.PERCENTAGE;
 
-      // Convert everything to percentages of the video container.
+      const heightUnit = cue.region.heightUnits == percentageUnit ? '%' : 'px';
+      const widthUnit = cue.region.widthUnits == percentageUnit ? '%' : 'px';
+      style.height = cue.region.height + heightUnit;
+      style.width = cue.region.width + widthUnit;
+      style.position = 'absolute';
+
+      // Handle anchoring. Convert everything to percentages of the video
+      // container to avoid comparing percentages to pixels.
       let width = cue.region.width;
       let height = cue.region.height;
       let viewportAnchorX = cue.region.viewportAnchorX;
@@ -412,9 +419,6 @@ shaka.text.UITextDisplayer = class {
         viewportAnchorY = viewportAnchorY / videoBoundingBox.height * 100;
       }
 
-      style.height = height + '%';
-      style.width = width + '%';
-      style.position = 'absolute';
 
       // Region and viewport anchors are similar to pinning a paper on a board.
       // Region anchor is analogous to where the pin goes on the paper, where

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -419,7 +419,6 @@ shaka.text.UITextDisplayer = class {
         viewportAnchorY = viewportAnchorY / videoBoundingBox.height * 100;
       }
 
-
       // Region and viewport anchors are similar to pinning a paper on a board.
       // Region anchor is analogous to where the pin goes on the paper, where
       // the paper is the region. Viewport anchor is analogous to where the

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -190,6 +190,10 @@ shaka.text.UITextDisplayer = class {
       }
     });
 
+    if (!currentCues.length) {
+      return;
+    }
+
     // Calculate the video bounding box once before processing all the
     // current cues, since this is an expensive operation.
     const videoBoundingBox = this.videoContainer_.getBoundingClientRect();

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -48,15 +48,6 @@ shaka.text.UITextDisplayer = class {
     this.textContainer_.classList.add('shaka-text-container');
     this.videoContainer_.appendChild(this.textContainer_);
 
-    const videoContainerBoundingBox =
-        this.videoContainer_.getBoundingClientRect();
-
-    /** @private {!number} */
-    this.videoContainerWidth_ = videoContainerBoundingBox.width;
-
-    /** @private {!number} */
-    this.videoContainerHeight_ = videoContainerBoundingBox.height;
-
     /**
      * The captions' update period in seconds.
      * @private {number}
@@ -199,9 +190,12 @@ shaka.text.UITextDisplayer = class {
       }
     });
 
+    // Calculate the video bounding box once before processing all the
+    // current cues, since this is an expensive operation.
+    const videoBoundingBox = this.videoContainer_.getBoundingClientRect();
     for (const cue of currentCues) {
       const cueElement = this.displayCue_(
-          this.textContainer_, cue, /* isNested= */ false);
+          this.textContainer_, cue, videoBoundingBox, /* isNested= */ false);
       this.currentCuesMap_.set(cue, cueElement);
     }
   }
@@ -211,19 +205,21 @@ shaka.text.UITextDisplayer = class {
    *
    * @param {Element} container
    * @param {!shaka.extern.Cue} cue
+   * @param {!DOMRect} videoBoundingBox
    * @param {boolean} isNested
    * @return {!Element} the created captions element
    * @private
    */
-  displayCue_(container, cue, isNested) {
+  displayCue_(container, cue, videoBoundingBox, isNested) {
     // Nested cues are inline elements.  Top-level cues are block elements.
     const cueElement = shaka.util.Dom.createHTMLElement(
         isNested ? 'span' : 'div');
 
-    this.setCaptionStyles_(cueElement, cue, isNested);
+    this.setCaptionStyles_(cueElement, cue, videoBoundingBox, isNested);
 
     for (const nestedCue of cue.nestedCues) {
-      this.displayCue_(cueElement, nestedCue, /* isNested= */ true);
+      this.displayCue_(cueElement, nestedCue,
+          videoBoundingBox, /* isNested= */ true);
     }
 
     container.appendChild(cueElement);
@@ -233,10 +229,11 @@ shaka.text.UITextDisplayer = class {
   /**
    * @param {!HTMLElement} cueElement
    * @param {!shaka.extern.Cue} cue
+   * @param {!DOMRect} videoBoundingBox
    * @param {boolean} isNested
    * @private
    */
-  setCaptionStyles_(cueElement, cue, isNested) {
+  setCaptionStyles_(cueElement, cue, videoBoundingBox, isNested) {
     const Cue = shaka.text.Cue;
     const style = cueElement.style;
     const isLeaf = cue.nestedCues.length == 0;
@@ -399,16 +396,16 @@ shaka.text.UITextDisplayer = class {
       let viewportAnchorY = cue.region.viewportAnchorY;
 
       if (cue.region.widthUnits != percentageUnit) {
-        width = width / this.videoContainerWidth_ * 100;
+        width = width / videoBoundingBox.width * 100;
       }
 
       if (cue.region.heightUnits != percentageUnit) {
-        height = height / this.videoContainerHeight_ * 100;
+        height = height / videoBoundingBox.height * 100;
       }
 
       if (cue.region.viewportAnchorUnits != percentageUnit) {
-        viewportAnchorX = viewportAnchorX / this.videoContainerWidth_ * 100;
-        viewportAnchorY = viewportAnchorY / this.videoContainerHeight_ * 100;
+        viewportAnchorX = viewportAnchorX / videoBoundingBox.width * 100;
+        viewportAnchorY = viewportAnchorY / videoBoundingBox.height * 100;
       }
 
       style.height = height + '%';

--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -144,6 +144,43 @@ describe('UITextDisplayer', () => {
         }));
   });
 
+  it('correctly anchors CueRegion objects', async () => {
+    const cue = new shaka.text.Cue(0, 100, '');
+    const nestedCue = new shaka.text.Cue(0, 100, 'test');
+    const region = new shaka.text.CueRegion();
+
+    region.id = 'test';
+
+    // Region occupies 50% of both the height and width.
+    region.height = 50;
+    region.width = 50;
+
+    // Pin the bottom center of the region...
+    region.regionAnchorX = 50;
+    region.regionAnchorY = 100;
+
+    // To the center of the video.
+    region.viewportAnchorX = 50;
+    region.viewportAnchorY = 50;
+
+    cue.region = region;
+    cue.nestedCues.push(nestedCue);
+
+    textDisplayer.setTextVisibility(true);
+    textDisplayer.append([cue]);
+    // Wait until updateCaptions_() gets called.
+    await shaka.test.Util.delay(0.5);
+
+    // Verify the top-level cue corresponds to a div that is correctly
+    // anchored and positioned based off its region.
+    const textContainer =
+        videoContainer.querySelector('.shaka-text-container');
+    const captionContainer = textContainer.querySelector('div');
+
+    expect(captionContainer.style.top).toEqual('0%');
+    expect(captionContainer.style.left).toEqual('25%');
+  });
+
   it('correctly displays styles for cellResolution units', async () => {
     /** @type {!shaka.text.Cue} */
     const cue = new shaka.text.Cue(0, 100, 'Captain\'s log.');

--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -177,8 +177,8 @@ describe('UITextDisplayer', () => {
         videoContainer.querySelector('.shaka-text-container');
     const captionContainer = textContainer.querySelector('div');
 
-    expect(captionContainer.style.top).toEqual('0%');
-    expect(captionContainer.style.left).toEqual('25%');
+    expect(captionContainer.style.top).toBe('0%');
+    expect(captionContainer.style.left).toBe('25%');
   });
 
   it('correctly displays styles for cellResolution units', async () => {

--- a/ui/less/containers.less
+++ b/ui/less/containers.less
@@ -227,11 +227,8 @@
   div {
     font-size: 20px;
     line-height: 1.4;  // relative to font size.
-    color: rgb(255, 255, 255);
-  }
-
-  span {
     background-color: rgba(0, 0, 0, 0.8);
+    color: rgb(255, 255, 255);
   }
 }
 

--- a/ui/less/containers.less
+++ b/ui/less/containers.less
@@ -227,8 +227,11 @@
   div {
     font-size: 20px;
     line-height: 1.4;  // relative to font size.
-    background-color: rgba(0, 0, 0, 0.8);
     color: rgb(255, 255, 255);
+  }
+
+  span {
+    background-color: rgba(0, 0, 0, 0.8);
   }
 }
 


### PR DESCRIPTION
Currently we anchor a region's top-left position to a provided viewport. However, there may be a better way to do this.

As described in the code below, and inspired by: https://www.speechpad.com/captions/webvtt.
Region and viewport anchors are similar to pinning a paper on a board. A region anchor is analogous to where the pin goes on the paper, where the paper is the region. A viewport anchor is analogous to where the paper goes on the board, where the board is the video.

This pull request implements the logic described by the paragraph above.