### PR TITLE
fix(ui): Widen touchable button area

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Adrián Gómez Llorente <adgllorente@gmail.com>
 Alex Jones <alexedwardjones@gmail.com>
 Alugha GmbH <*@alugha.com>
 Alvaro Velad Galvan <alvaro.velad@mirada.tv>
+Amila Sampath <lucksy@gmail.com>
 Anthony Stansbridge <github@anthonystansbridge.co.uk>
 Benjamin Wallberg <me@bwallberg.com>
 Bonnier Broadcasting <*@bonnierbroadcasting.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@
 Aaron Vaage <vaage@google.com>
 Alex Jones <alexedwardjones@gmail.com>
 Alvaro Velad Galvan <alvaro.velad@mirada.tv>
+Amila Sampath <lucksy@gmail.com>
 Andy Hochhaus <ahochhaus@samegoal.com>
 Anthony Stansbridge <github@anthonystansbridge.co.uk>
 Ashutosh Kumar Mukhiya <ashukm4@gmail.com>

--- a/demo/demo.less
+++ b/demo/demo.less
@@ -71,7 +71,6 @@ main.mdl-layout__content {
 
   /* Give the button a round background, meant to look like the play button. */
   border-radius: 50%;
-  width: 32px;
   color: #000;
   background: rgba(255, 255, 255, 0.85);
 }

--- a/ui/less/containers.less
+++ b/ui/less/containers.less
@@ -160,7 +160,7 @@
     /* Consistent margins (external) and padding (internal) between controls. */
     .bottom-panels-elements-margin();
 
-    padding: 0;
+    padding: 0 5px;
 
     /* Transparent backgrounds, no borders, and a pointer when you mouse over
      * them. */

--- a/ui/less/general.less
+++ b/ui/less/general.less
@@ -37,7 +37,7 @@
 }
 
 .bottom-panels-elements-margin() {
-  margin: 1px 6px;
+  margin: 1px;
 }
 
 /* For containers which host elements overlaying other things. */

--- a/ui/less/range_elements.less
+++ b/ui/less/range_elements.less
@@ -158,6 +158,7 @@
 
 .shaka-volume-bar-container {
   width: 100px;
+  padding: 0;
 }
 
 .shaka-range-element {


### PR DESCRIPTION
## Description

Currently, player buttons clickable area are 24px by 32px which is not close to WCAG guidelines(44px by 44px)

Fixes # (issue)
Solution would be moving margins around buttons to paddings since padding rendered as touchable area. This makes player buttons 34*32px. (and makes focus indicators look nicer too :)

## Screenshots (optional)
![buttons-touchable-area](https://user-images.githubusercontent.com/29239/111704336-42cd4c80-883f-11eb-98b3-e56c07b7a592.png)

## Type of change

Two CSS changes in the 'containers.less' file and 'general.less' file.


- [*] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [*] My changes generate no new warnings
