### PR TITLE
Issue 1030: Fix broken Typescript type declarations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,5 +67,4 @@ uStudio Inc. <*@ustudio.com>
 Verizon Digital Media Services <*@verizondigitalmedia.com>
 Vincent Valot <valot.vince@gmail.com>
 Prakash <duggaraju@gmail.com>
-
-
+Raymond Cheng <raycheng100@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -103,3 +103,4 @@ Vincent Valot <valot.vince@gmail.com>
 Yohann Connell <robinconnell@google.com>
 Adrián Gómez Llorente <adgllorente@gmail.com>
 Prakash Duggaraju <duggaraju@gmail.com>
+Raymond Cheng <raycheng100@gmail.com>

--- a/build/generateTsDefs.py
+++ b/build/generateTsDefs.py
@@ -48,8 +48,11 @@ def GenerateTsDefs(inputs, output):
   # and usable directly in TypeScript projects.
   contents = shakaBuildHelpers.execute_get_output(command)
 
-  # Remove the prefix clutz puts on all namespaces.
-  contents = contents.replace(b'\xe0\xb2\xa0_\xe0\xb2\xa0.clutz.', b'')
+  # Remove the prefix clutz puts on all namespaces
+  contents = contents.replace(b'\xe0\xb2\xa0_\xe0\xb2\xa0.clutz.', b'') # Linux
+  contents = contents.replace(b'\xe0\xb2\xa0_\xe0\xb2\xa0.clutz ', b'shakaExterns ') # Linux
+  contents = contents.replace(b'?_?.clutz.', b'') # Windows
+  contents = contents.replace(b'?_?.clutz ', b'shakaExterns ') # Windows
   # Replace "GlobalObject" (from Clutz) with TypeScript-native "object".
   contents = re.sub(br'\bGlobalObject\b', b'object', contents)
   # Remove "Global" from Clutz's Global{Date,Element,Event,EventTarget} and use
@@ -92,6 +95,12 @@ def GenerateTsDefs(inputs, output):
       sections)
   contents = b'\n'.join(sections) + b'\n'
 
+  moduleDeclaration = b"""
+declare module \'shaka-player\' {
+  export = shaka;
+}
+"""
+
   license_header_path = os.path.join(
       shakaBuildHelpers.get_source_base(), 'build/license-header')
 
@@ -100,6 +109,7 @@ def GenerateTsDefs(inputs, output):
 
   with open(output, 'wb') as f:
     f.write(license_header)
+    f.write(moduleDeclaration)
     f.write(b'\n')
     f.write(contents)
 

--- a/build/shakaBuildHelpers.py
+++ b/build/shakaBuildHelpers.py
@@ -357,6 +357,16 @@ def update_node_modules():
   open(_node_modules_last_update_path(), 'wb').close()
   return True
 
+def test_typescript():
+  """Tests the inclusion of shaka-player into a Typescript project."""
+  base = cygwin_safe_path(get_source_base())
+  cmd = 'npm.cmd' if is_windows() else 'npm'
+  try:
+    with InDir(base):
+      execute_get_output([cmd, 'run', 'testTypescript']).decode('utf8')
+      return True
+  except subprocess.CalledProcessError:
+    return False
 
 def run_main(main):
   """Executes the given function with the current command-line arguments.

--- a/build/test.py
+++ b/build/test.py
@@ -413,6 +413,11 @@ class Launcher:
       logging.error('Failed to update node modules')
       return 1
 
+    if not shakaBuildHelpers.test_typescript():
+      logging.error('Failed to include shaka-player from Typescript!')
+      logging.error('npm run testTypescript to get error details.')
+      return 1
+
     karma = shakaBuildHelpers.get_node_binary('karma')
     cmd = ['xvfb-run', '--auto-servernum'] if self.parsed_args.use_xvfb else []
     cmd += karma + ['start']

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "stylelint": "^13.8.0",
     "stylelint-config-standard": "^20.0.0",
     "tippy.js": "^4.3.1",
+    "typescript": "^4.2.4",
     "ua-parser-js": "^0.7.24",
     "which": "^1.3.1"
   },
@@ -71,7 +72,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "python build/checkversion.py && python build/all.py --force"
+    "prepublishOnly": "python build/checkversion.py && python build/all.py --force",
+    "testTypescript": "tsc -p tsconfig.json"
   },
   "dependencies": {
     "eme-encryption-scheme-polyfill": "^2.0.2"

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -1,0 +1,9 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as shaka from 'shaka-player'
+
+const videoSegmentIndex = new shaka.media.SegmentIndex([]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es2015",
+    "module": "es2015",
+    "skipLibCheck": true,
+    "noEmit": true,
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "shaka-player": ["dist/shaka-player.compiled"] // this mapping is relative to "baseUrl"
+    }
+  },
+  "include": ["test/typescript.ts"]
+}


### PR DESCRIPTION
## Description
Issue 1030: Fix broken Typescript type declarations

Partially fixes #1030. The issue was created to track a problem using
Shaka from a Typescript project. Inside the issue, a fix was contributed
by @alexandercerutti, although it was acknowledged that the fix was not
a complete fix. Event types are still missing, for instance. Having said
that, it seems the main reason that @alexandercerutti's partial fix
wasn't applied is that @joeyparrish expressed a desire for a small
Typescript sample to be added as an automated test to verify that this
works.

Changes
1) Modified generateTsDefs.py to apply the partial fix by
@alexandercerutti.
2) While testing, I discovered that the Windows build produces a broken
.d.ts, because the bytes on Windows (b'?_?.clutz.') are different
than Linux (b'\xe0\xb2\xa0_\xe0\xb2\xa0.clutz.'). Fixed by adding a
second replace pattern for Windows. Since the two are mutually
exclusive, I just run them serially without condition.
3) While verifying, I noticed some unreplaced clutz namespaces. These
occur because instead of ".clutz." the pattern is ".clutz ". I looked
into a couple, they seem to have been supplied because the Closure
compiler lacks declarations. Added Linux and Windows replacement lines
to assign these to the "shakaExterns" namespace.
4) Added a simple Typescript compilation test. I structured the
tsconfig.json to look like a typical usage case where shaka-player is
imported as a node module. Note that if we set skipLibCheck to false,
this leads to the errors described in Issue #3185, eg. error TS2694:
Namespace 'google.ima.dai.api' has no exported member 'StreamRequest'
(also mentioned in Issue #1030). NOTE that when this test fails, I
couldn’t figure out how to get the compiler output on-screen, so instead
I provide instructions for re-running the test interactively, which will
produce the error on-screen.

Testing Procedure
1) python build/test.py. Confirm pass.
2) Verify that some of the previously unreplaced clutz namespaces, such
as ಠ_ಠ.clutz.AirPlayEvent, are no longer under the ಠ_ಠ.clutz prefix
and instead are under the shakaExterns namespace, and
that you can compile successfully.
3) Repeat both of the above steps under both Linux and Windows. Confirm
that the produced .d.ts files differ only in the comments, where the
source file path is stated.

## Screenshots (optional)

<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
-->


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
