### PR TITLE
Adding fast-forward and rewind buttons to seek video on taps.

### DIFF
--- a/build/types/ui
+++ b/build/types/ui
@@ -35,3 +35,5 @@
 +../../ui/ui.js
 +../../ui/ui_utils.js
 +../../ui/volume_bar.js
++../../ui/hidden_rewind_button.js
++../../ui/hidden_fast_forward_button.js

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -160,9 +160,10 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
      *
      * @private {shaka.util.Timer}
      */
-    this.hideFastForwardButtonOnVideoContainerTimer_ = new shaka.util.Timer(() => {
-      this.HideFastForwardButtonOnVideoContainer();
-    });
+    this.hideFastForwardButtonOnVideoContainerTimer_ = new shaka.util.Timer(
+        () => {
+          this.hideFastForwardButtonOnVideoContainer();
+        });
 
     /**
      * This timer will be used to hide rewind button on video Container.
@@ -170,15 +171,15 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
      *
      * @private {shaka.util.Timer}
      */
-     this.hideRewindButtonOnVideoContainerTimer_ = new shaka.util.Timer(() => {
-      this.HideRewindButtonOnVideoContainer();
+    this.hideRewindButtonOnVideoContainerTimer_ = new shaka.util.Timer(() => {
+      this.hideRewindButtonOnVideoContainer();
     });
 
     /** @private {?number} */
     this.lastTouchEventTime_ = null;
 
     /** @private {?number} */
-    this.lastTouchEventTimeSet_ = 0;
+    this.lastTouchEventTimeSet_ = null;
 
     /** @private {?boolean} */
     this.triggeredTouchValid_ = false;
@@ -683,7 +684,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
 
     if (this.config_.rewindOnTaps) {
       this.addRewindButtonOnVideoContainer_();
-    }   
+    }
 
     this.addDaiAdContainer_();
 
@@ -801,7 +802,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
 
   /**
    * Add fast-forward button on video container
-   * for moving video 5s ahead when the video is 
+   * for moving video 5s ahead when the video is
    * tapped more than once, video seeks ahead 5s
    * for every extra tap.
    * @private
@@ -813,17 +814,18 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
         'shaka-fast-foward-onVideoContainer');
     this.controlsContainer_.appendChild(this.fastforwardContainer_);
 
-    this.eventManager_.listen(this.fastforwardContainer_, 'touchstart',(event) => {
-      //prevent the default changes that browser triggers
-      event.preventDefault();
-      // incase any settings menu are open this assigns the first touch
-      // to close the menu.
-      if (this.anySettingsMenusAreOpen()) {
-        this.hideSettingsMenusTimer_.tickNow();
-      } else{
-        this.onFastForwardButtonClick_();
-      }
-    });
+    this.eventManager_.listen(
+        this.fastforwardContainer_, 'touchstart', (event) => {
+          // prevent the default changes that browser triggers
+          event.preventDefault();
+          // incase any settings menu are open this assigns the first touch
+          // to close the menu.
+          if (this.anySettingsMenusAreOpen()) {
+            this.hideSettingsMenusTimer_.tickNow();
+          } else {
+            this.onFastForwardButtonClick_();
+          }
+        });
 
     /** @private {!HTMLElement} */
     this.fastForwardValue_ = shaka.util.Dom.createHTMLElement('span');
@@ -840,26 +842,26 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
 
   /**
    * Add Rewind button on video container
-   * for moving video 5s behind when the video is 
+   * for moving video 5s behind when the video is
    * tapped more than once, video seeks behind 5s
    * for every extra tap.
    * @private
    */
-   addRewindButtonOnVideoContainer_() {
+  addRewindButtonOnVideoContainer_() {
     /** @private {!HTMLElement} */
     this.rewindContainer_ = shaka.util.Dom.createHTMLElement('div');
     this.rewindContainer_.classList.add(
         'shaka-rewind-onVideoContainer');
     this.controlsContainer_.appendChild(this.rewindContainer_);
 
-    this.eventManager_.listen(this.rewindContainer_, 'touchstart',(event) => {
-      //prevent the default changes that browser triggers
+    this.eventManager_.listen(this.rewindContainer_, 'touchstart', (event) => {
+      // prevent the default changes that browser triggers
       event.preventDefault();
       // incase any settings menu are open this assigns the first touch
       // to close the menu.
       if (this.anySettingsMenusAreOpen()) {
         this.hideSettingsMenusTimer_.tickNow();
-      } else{
+      } else {
         this.onRewindButtonClick_();
       }
     });
@@ -1181,86 +1183,80 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
 
   /**
    * This callback is for detecting a double tap or more continuos
-   * taps and seeking the video forward as per the number of taps 
+   * taps and seeking the video forward as per the number of taps
    * @private
    */
-  onFastForwardButtonClick_(){
+  onFastForwardButtonClick_() {
     // this stores the time for first touch and makes touch valid for
-    // next 1s so incase the touch event is triggered again within 1s 
-    // this if condition fails and the video seeking happens. 
+    // next 1s so incase the touch event is triggered again within 1s
+    // this if condition fails and the video seeking happens.
     if (!this.triggeredTouchValid_) {
       this.triggeredTouchValid_ = true;
       this.lastTouchEventTimeSet_ = Date.now();
       this.hideFastForwardButtonOnVideoContainerTimer_.tickAfter(1);
-    }
-    else if (this.lastTouchEventTimeSet_+1000 > Date.now()) {
+    } else if (this.lastTouchEventTimeSet_+1000 > Date.now()) {
       // stops hidding of fast-forward button incase the timmer is active
       // bbecause of previous touch event.
       this.hideFastForwardButtonOnVideoContainerTimer_.stop();
       this.lastTouchEventTimeSet_ = Date.now();
-      this.fastForwardValue_.textContent = 
-        (parseInt(this.fastForwardValue_.textContent) + 5).toString() + 's';
-      this.fastforwardContainer_.style.opacity = '1'; 
+      this.fastForwardValue_.textContent =
+        (parseInt(this.fastForwardValue_.textContent, 10) + 5).toString() + 's';
+      this.fastforwardContainer_.style.opacity = '1';
       this.hideFastForwardButtonOnVideoContainerTimer_.tickAfter(1);
     }
-   }
+  }
+
   /**
-   * called when the fast forward button needs to be hidden 
-   *@private
+   * called when the fast forward button needs to be hidden
    */
-  HideFastForwardButtonOnVideoContainer(){
+  hideFastForwardButtonOnVideoContainer() {
     // prevent adding seek value if its a single tap.
-    if (parseInt(this.fastForwardValue_.textContent) != 0) {
+    if (parseInt(this.fastForwardValue_.textContent, 10) != 0) {
       this.seek_(this.seekBar_.getValue() + parseInt(
-          this.fastForwardValue_.textContent));
+          this.fastForwardValue_.textContent, 10));
     }
     this.fastforwardContainer_.style.opacity = '0';
     this.triggeredTouchValid_ = false;
     this.fastForwardValue_.textContent = '0s';
-
   }
 
   /**
    * This callback is for detecting a double tap or more continuos
-   * taps and seeking the video forward as per the number of taps 
+   * taps and seeking the video forward as per the number of taps
    * @private
    */
-   onRewindButtonClick_(){
-     // this stores the time for first touch and makes touch valid for
-    // next 1s so incase the touch event is triggered again within 1s 
-    // this if condition fails and the video seeking happens. 
+  onRewindButtonClick_() {
+    // this stores the time for first touch and makes touch valid for
+    // next 1s so incase the touch event is triggered again within 1s
+    // this if condition fails and the video seeking happens.
     if (!this.triggeredTouchValid_) {
       this.triggeredTouchValid_ = true;
       this.lastTouchEventTimeSet_ = Date.now();
       this.hideRewindButtonOnVideoContainerTimer_.tickAfter(1);
-    }
-    else if (this.lastTouchEventTimeSet_+1000 > Date.now()) {
+    } else if (this.lastTouchEventTimeSet_+1000 > Date.now()) {
       // stops hidding of fast-forward button incase the timmer is active
       // bbecause of previous touch event.
       this.hideRewindButtonOnVideoContainerTimer_.stop();
       this.lastTouchEventTimeSet_ = Date.now();
-      this.rewindValue_.textContent = 
-        (parseInt(this.rewindValue_.textContent) - 5).toString() + 's';
-      this.rewindContainer_.style.opacity = '1'; 
+      this.rewindValue_.textContent =
+        (parseInt(this.rewindValue_.textContent, 10) - 5).toString() + 's';
+      this.rewindContainer_.style.opacity = '1';
       this.hideRewindButtonOnVideoContainerTimer_.tickAfter(1);
     }
-    
-   }
+  }
 
   /**
-   * called when the rewind button needs to be hidden 
-   *@private
+   * called when the rewind button needs to be hidden
    */
-  HideRewindButtonOnVideoContainer(){
+  hideRewindButtonOnVideoContainer() {
     // prevent adding seek value if its a single tap.
-    if (parseInt(this.rewindValue_.textContent) != 0) {
+    if (parseInt(this.rewindValue_.textContent, 10) != 0) {
       this.seek_(this.seekBar_.getValue() + parseInt(
-          this.rewindValue_.textContent));
+          this.rewindValue_.textContent, 10));
     }
     this.rewindContainer_.style.opacity = '0';
     this.triggeredTouchValid_ = false;
     this.rewindValue_.textContent = '0s';
-
   }
 
   /**

--- a/ui/externs/ui.js
+++ b/ui/externs/ui.js
@@ -65,6 +65,8 @@ shaka.extern.UIVolumeBarColors;
  *   overflowMenuButtons: !Array.<string>,
  *   addSeekBar: boolean,
  *   addBigPlayButton: boolean,
+ *   fastForwardOnTaps: boolean,
+ *   rewindOnTaps: boolean,
  *   castReceiverAppId: string,
  *   clearBufferOnQualityChange: boolean,
  *   showUnbufferedStart: boolean,

--- a/ui/externs/ui.js
+++ b/ui/externs/ui.js
@@ -89,6 +89,14 @@ shaka.extern.UIVolumeBarColors;
  * @property {boolean} addBigPlayButton
  *   Whether or not a big play button in the center of the video
  *   should be part of the UI.
+ * @property {boolean} fastForwardOnTaps
+ *   Whether or not a fast-forward button that seeks video 5s
+ *   ahead on tap present to the right of the video
+ *   should be a part of the UI.
+ * @property {boolean} rewindOnTaps
+ *   Whether or not a Rewind button that seeks video 5s
+ *   behind on tap present to the left of the video
+ *   should be a part of the UI.
  * @property {string} castReceiverAppId
  *   Receiver app id to use for the Chromecast support.
  * @property {boolean} clearBufferOnQualityChange

--- a/ui/hidden_fast_forward_button.js
+++ b/ui/hidden_fast_forward_button.js
@@ -1,0 +1,118 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.provide('shaka.ui.HiddenFastForwardButton');
+
+goog.require('shaka.ui.Element');
+goog.require('shaka.util.Timer');
+goog.require('shaka.ui.Enums');
+goog.require('shaka.util.Dom');
+
+goog.requireType('shaka.ui.Controls');
+
+/**
+ * @extends {shaka.ui.Element}
+ * @final
+ * @export
+ */
+shaka.ui.HiddenFastForwardButton = class extends shaka.ui.Element {
+  /**
+   * @param {!HTMLElement} parent
+   * @param {!shaka.ui.Controls} controls
+   */
+  constructor(parent, controls) {
+    super(parent, controls);
+
+    /** @private {?number} */
+    this.lastTouchEventTimeSet_ = null;
+
+    /** @private {?boolean} */
+    this.triggeredTouchValid_ = false;
+
+    /**
+     * This timer will be used to hide fast forward button on video Container.
+     * When the timer ticks it will force button to be invisible.
+     *
+     * @private {shaka.util.Timer}
+     */
+    this.hideFastForwardButtonOnControlsContainerTimer_ = new shaka.util.Timer(
+        () => {
+          this.hideFastForwardButtonOnControlsContainer();
+        });
+
+
+    /** @private {!HTMLElement} */
+    this.fastforwardContainer_ = shaka.util.Dom.createHTMLElement('div');
+    this.fastforwardContainer_.classList.add(
+        'shaka-fast-foward-onControlsContainer');
+    this.parent.appendChild(this.fastforwardContainer_);
+
+    this.eventManager.listen(
+        this.fastforwardContainer_, 'touchstart', (event) => {
+          // prevent the default changes that browser triggers
+          event.preventDefault();
+          // incase any settings menu are open this assigns the first touch
+          // to close the menu.
+          if (this.controls.anySettingsMenusAreOpen()) {
+            this.controls.hideSettingsMenus();
+          } else {
+            this.onFastForwardButtonClick_();
+          }
+        });
+
+    /** @private {!HTMLElement} */
+    this.fastForwardValue_ = shaka.util.Dom.createHTMLElement('span');
+    this.fastForwardValue_.textContent = '0s';
+    this.fastforwardContainer_.appendChild(this.fastForwardValue_);
+
+    /** @private {!HTMLElement} */
+    this.fastforwardIcon_ = shaka.util.Dom.createHTMLElement('span');
+    this.fastforwardIcon_.classList.add(
+        'shaka-forward-rewind-onControlsContainer-icon');
+    this.fastforwardIcon_.textContent =
+        shaka.ui.Enums.MaterialDesignIcons.FAST_FORWARD;
+    this.fastforwardContainer_.appendChild(this.fastforwardIcon_);
+  }
+
+  /**
+   * This callback is for detecting a double tap or more continuos
+   * taps and seeking the video forward as per the number of taps
+   * @private
+   */
+  onFastForwardButtonClick_() {
+    // this stores the time for first touch and makes touch valid for
+    // next 1s so incase the touch event is triggered again within 1s
+    // this if condition fails and the video seeking happens.
+    if (!this.triggeredTouchValid_) {
+      this.triggeredTouchValid_ = true;
+      this.lastTouchEventTimeSet_ = Date.now();
+      this.hideFastForwardButtonOnControlsContainerTimer_.tickAfter(1);
+    } else if (this.lastTouchEventTimeSet_+1000 > Date.now()) {
+      // stops hidding of fast-forward button incase the timmer is active
+      // because of previous touch event.
+      this.hideFastForwardButtonOnControlsContainerTimer_.stop();
+      this.lastTouchEventTimeSet_ = Date.now();
+      this.fastForwardValue_.textContent =
+        (parseInt(this.fastForwardValue_.textContent, 10) + 5).toString() + 's';
+      this.fastforwardContainer_.style.opacity = '1';
+      this.hideFastForwardButtonOnControlsContainerTimer_.tickAfter(1);
+    }
+  }
+
+  /**
+   * called when the fast forward button needs to be hidden
+   */
+  hideFastForwardButtonOnControlsContainer() {
+    // prevent adding seek value if its a single tap.
+    if (parseInt(this.fastForwardValue_.textContent, 10) != 0) {
+      this.video.currentTime = this.controls.getDisplayTime() + parseInt(
+          this.fastForwardValue_.textContent, 10);
+    }
+    this.fastforwardContainer_.style.opacity = '0';
+    this.triggeredTouchValid_ = false;
+    this.fastForwardValue_.textContent = '0s';
+  }
+};

--- a/ui/hidden_rewind_button.js
+++ b/ui/hidden_rewind_button.js
@@ -1,0 +1,116 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.provide('shaka.ui.HiddenRewindButton');
+
+goog.require('shaka.ui.Element');
+goog.require('shaka.util.Timer');
+goog.require('shaka.ui.Enums');
+goog.require('shaka.util.Dom');
+
+goog.requireType('shaka.ui.Controls');
+
+/**
+ * @extends {shaka.ui.Element}
+ * @final
+ * @export
+ */
+shaka.ui.HiddenRewindButton = class extends shaka.ui.Element {
+  /**
+   * @param {!HTMLElement} parent
+   * @param {!shaka.ui.Controls} controls
+   */
+  constructor(parent, controls) {
+    super(parent, controls);
+
+    /** @private {?number} */
+    this.lastTouchEventTimeSet_ = null;
+
+    /** @private {?boolean} */
+    this.triggeredTouchValid_ = false;
+
+    /**
+     * This timer will be used to hide rewind button on video Container.
+     * When the timer ticks it will force button to be invisible.
+     *
+     * @private {shaka.util.Timer}
+     */
+    this.hideRewindButtonOnControlsContainerTimer_ = new shaka.util.Timer(
+        () => {
+          this.hideRewindButtonOnControlsContainer();
+        });
+
+    /** @private {!HTMLElement} */
+    this.rewindContainer_ = shaka.util.Dom.createHTMLElement('div');
+    this.rewindContainer_.classList.add(
+        'shaka-rewind-onControlsContainer');
+    this.parent.appendChild(this.rewindContainer_);
+
+    this.eventManager.listen(this.rewindContainer_, 'touchstart', (event) => {
+      // prevent the default changes that browser triggers
+      event.preventDefault();
+      // incase any settings menu are open this assigns the first touch
+      // to close the menu.
+      if (this.controls.anySettingsMenusAreOpen()) {
+        this.controls.hideSettingsMenus();
+      } else {
+        this.onRewindButtonClick_();
+      }
+    });
+
+    /** @private {!HTMLElement} */
+    this.rewindValue_ = shaka.util.Dom.createHTMLElement('span');
+    this.rewindValue_.textContent = '0s';
+    this.rewindContainer_.appendChild(this.rewindValue_);
+
+    /** @private {!HTMLElement} */
+    this.rewindIcon_ = shaka.util.Dom.createHTMLElement('span');
+    this.rewindIcon_.classList.add(
+        'shaka-forward-rewind-onControlsContainer-icon');
+    this.rewindIcon_.textContent =
+        shaka.ui.Enums.MaterialDesignIcons.REWIND;
+    this.rewindContainer_.appendChild(this.rewindIcon_);
+  }
+
+  /**
+   * This callback is for detecting a double tap or more continuos
+   * taps and seeking the video forward as per the number of taps
+   * @private
+   */
+  onRewindButtonClick_() {
+    // this stores the time for first touch and makes touch valid for
+    // next 1s so incase the touch event is triggered again within 1s
+    // this if condition fails and the video seeking happens.
+    if (!this.triggeredTouchValid_) {
+      this.triggeredTouchValid_ = true;
+      this.lastTouchEventTimeSet_ = Date.now();
+      this.hideRewindButtonOnControlsContainerTimer_.tickAfter(1);
+    } else if (this.lastTouchEventTimeSet_+1000 > Date.now()) {
+      // stops hidding of fast-forward button incase the timmer is active
+      // because of previous touch event.
+      this.hideRewindButtonOnControlsContainerTimer_.stop();
+      this.lastTouchEventTimeSet_ = Date.now();
+      this.rewindValue_.textContent =
+        (parseInt(this.rewindValue_.textContent, 10) - 5).toString() + 's';
+      this.rewindContainer_.style.opacity = '1';
+      this.hideRewindButtonOnControlsContainerTimer_.tickAfter(1);
+    }
+  }
+
+  /**
+   * called when the rewind button needs to be hidden
+   */
+  hideRewindButtonOnControlsContainer() {
+    // prevent adding seek value if its a single tap.
+    if (parseInt(this.rewindValue_.textContent, 10) != 0) {
+      this.video.currentTime = this.controls.getDisplayTime() + parseInt(
+          this.rewindValue_.textContent, 10);
+    }
+    this.rewindContainer_.style.opacity = '0';
+    this.triggeredTouchValid_ = false;
+    this.rewindValue_.textContent = '0s';
+  }
+};

--- a/ui/less/buttons.less
+++ b/ui/less/buttons.less
@@ -110,3 +110,94 @@
     outline: none;
   }
 }
+
+/* this button is placed on the video container and forwards the 
+ * video on more than one tap. It covers almost 40% of right 
+ * side of video container and stays hidden until clicked. */
+.shaka-fast-foward-onVideoContainer{
+  height: 100%;
+  width:40%;
+  .shrinkable();
+
+  /* Keep the fast forward button to the right of this container. */
+  position: absolute;
+  top:0;
+  right: 0;
+  left:60%;
+  bottom:0;
+
+  /* keep all the elements inside fast forward div in center and in row*/
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items:center;
+  border-radius: 40% 0  0 40%;
+
+  /* To be properly positioned, this should have no margin.*/
+  margin: 0;
+
+  /* No border. */
+  border: none;
+
+  /* setting text color to white */
+  color: rgb(255, 255, 255);
+
+  /* setting background color to black so white text can be
+   * seen clearly */
+  background-color: rgba(0, 0, 0, 0.3);
+
+
+  cursor: default;
+  font-size: 20px;
+
+  /* hidding the container by setting opacity*/
+  opacity: 0;
+
+
+  z-index: 1;
+}
+
+/* this button is placed on the video container and rewinds the 
+ * video on more than one tap. It covers almost 40% of left 
+ * side of video container and stays hidden until clicked. */
+ .shaka-rewind-onVideoContainer{
+  height: 100%;
+  width:40%;
+  .shrinkable();
+  .absolute-position();
+
+  /* keep all the elements inside rewind div in center and in row*/
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items:center;
+  border-radius: 0 40% 40% 0;
+
+  /* To be properly positioned, this should have no margin.*/
+  margin: 0;
+
+  /* No border. */
+  border: none;
+
+  /* setting text color to white */
+  color: rgb(255, 255, 255);
+
+  /* setting background color to black so white text can be
+   * seen clearly */
+  background-color: rgba(0, 0, 0, 0.3);
+
+
+  cursor: default;
+  font-size: 20px;
+
+  /* hidding the container by setting opacity*/
+  opacity: 0;
+
+
+  z-index: 1;
+}
+
+.shaka-forward-rewind-onVideoContainer-icon{
+  font-family: 'Material Icons Round';
+  font-size: 34px;
+}

--- a/ui/less/buttons.less
+++ b/ui/less/buttons.less
@@ -124,9 +124,8 @@
   top:0;
   right: 0;
   left:60%;
-  bottom:0;
 
-  /* keep all the elements inside fast forward div in center and in row*/
+  /* keep all the elements inside fast forward div in center and in a row*/
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -144,7 +143,7 @@
 
   /* setting background color to black so white text can be
    * seen clearly */
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: rgba(0, 0, 0, 0.5);
 
 
   cursor: default;
@@ -153,8 +152,13 @@
   /* hidding the container by setting opacity*/
   opacity: 0;
 
-
-  z-index: 1;
+  /* make the text inside this button unselectable */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 /* this button is placed on the video container and rewinds the 
@@ -164,6 +168,7 @@
   height: 100%;
   width:40%;
   .shrinkable();
+  /* keep the rewind button to the left */
   .absolute-position();
 
   /* keep all the elements inside rewind div in center and in row*/
@@ -184,8 +189,7 @@
 
   /* setting background color to black so white text can be
    * seen clearly */
-  background-color: rgba(0, 0, 0, 0.3);
-
+  background-color: rgba(0, 0, 0, 0.5);
 
   cursor: default;
   font-size: 20px;
@@ -193,10 +197,17 @@
   /* hidding the container by setting opacity*/
   opacity: 0;
 
-
-  z-index: 1;
+  /* make the text inside this button unselectable */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
+/* This class is instead of material-icon-round
+ * because the font-size of 24 doesn't look good*/
 .shaka-forward-rewind-onVideoContainer-icon{
   font-family: 'Material Icons Round';
   font-size: 34px;

--- a/ui/less/buttons.less
+++ b/ui/less/buttons.less
@@ -111,28 +111,28 @@
   }
 }
 
-/* this button is placed on the video container and forwards the 
- * video on more than one tap. It covers almost 40% of right 
+/* this button is placed on the video container and forwards the
+ * video on more than one tap. It covers almost 40% of right
  * side of video container and stays hidden until clicked. */
-.shaka-fast-foward-onVideoContainer{
+.shaka-fast-foward-onVideoContainer {
   height: 100%;
-  width:40%;
+  width: 40%;
   .shrinkable();
 
   /* Keep the fast forward button to the right of this container. */
   position: absolute;
-  top:0;
+  top: 0;
   right: 0;
-  left:60%;
+  left: 60%;
 
-  /* keep all the elements inside fast forward div in center and in a row*/
+  /* keep all the elements inside fast forward div in center and in a row */
   display: flex;
   flex-direction: row;
   justify-content: center;
-  align-items:center;
+  align-items: center;
   border-radius: 40% 0  0 40%;
 
-  /* To be properly positioned, this should have no margin.*/
+  /* To be properly positioned, this should have no margin. */
   margin: 0;
 
   /* No border. */
@@ -145,11 +145,10 @@
    * seen clearly */
   background-color: rgba(0, 0, 0, 0.5);
 
-
   cursor: default;
   font-size: 20px;
 
-  /* hidding the container by setting opacity*/
+  /* hidding the container by setting opacity */
   opacity: 0;
 
   /* make the text inside this button unselectable */
@@ -161,24 +160,25 @@
   user-select: none;
 }
 
-/* this button is placed on the video container and rewinds the 
- * video on more than one tap. It covers almost 40% of left 
+/* this button is placed on the video container and rewinds the
+ * video on more than one tap. It covers almost 40% of left
  * side of video container and stays hidden until clicked. */
- .shaka-rewind-onVideoContainer{
+.shaka-rewind-onVideoContainer {
   height: 100%;
-  width:40%;
+  width: 40%;
   .shrinkable();
+
   /* keep the rewind button to the left */
   .absolute-position();
 
-  /* keep all the elements inside rewind div in center and in row*/
+  /* keep all the elements inside rewind div in center and in row */
   display: flex;
   flex-direction: row;
   justify-content: center;
-  align-items:center;
+  align-items: center;
   border-radius: 0 40% 40% 0;
 
-  /* To be properly positioned, this should have no margin.*/
+  /* To be properly positioned, this should have no margin. */
   margin: 0;
 
   /* No border. */
@@ -194,7 +194,7 @@
   cursor: default;
   font-size: 20px;
 
-  /* hidding the container by setting opacity*/
+  /* hidding the container by setting opacity */
   opacity: 0;
 
   /* make the text inside this button unselectable */
@@ -207,8 +207,8 @@
 }
 
 /* This class is instead of material-icon-round
- * because the font-size of 24 doesn't look good*/
-.shaka-forward-rewind-onVideoContainer-icon{
+ * because the font-size of 24 doesn't look good */
+.shaka-forward-rewind-onVideoContainer-icon {
   font-family: 'Material Icons Round';
   font-size: 34px;
 }

--- a/ui/less/buttons.less
+++ b/ui/less/buttons.less
@@ -111,19 +111,14 @@
   }
 }
 
-/* this button is placed on the video container and forwards the
+/* this button is placed on the Controls container and forwards the
  * video on more than one tap. It covers almost 40% of right
  * side of video container and stays hidden until clicked. */
-.shaka-fast-foward-onVideoContainer {
+.shaka-fast-foward-onControlsContainer {
   height: 100%;
-  width: 40%;
+  width: 100%;
   .shrinkable();
-
-  /* Keep the fast forward button to the right of this container. */
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 60%;
+  .absolute-position();
 
   /* keep all the elements inside fast forward div in center and in a row */
   display: flex;
@@ -163,12 +158,10 @@
 /* this button is placed on the video container and rewinds the
  * video on more than one tap. It covers almost 40% of left
  * side of video container and stays hidden until clicked. */
-.shaka-rewind-onVideoContainer {
+.shaka-rewind-onControlsContainer {
   height: 100%;
-  width: 40%;
+  width: 100%;
   .shrinkable();
-
-  /* keep the rewind button to the left */
   .absolute-position();
 
   /* keep all the elements inside rewind div in center and in row */
@@ -208,7 +201,7 @@
 
 /* This class is instead of material-icon-round
  * because the font-size of 24 doesn't look good */
-.shaka-forward-rewind-onVideoContainer-icon {
+.shaka-forward-rewind-onControlsContainer-icon {
   font-family: 'Material Icons Round';
   font-size: 34px;
 }

--- a/ui/less/containers.less
+++ b/ui/less/containers.less
@@ -277,3 +277,24 @@
   on a black background. */
   filter: drop-shadow(0 0 2px rgba(255, 255, 255, 0.5));
 }
+
+.shaka-hidden-fast-forward-container {
+  height: 100%;
+  width: 40%;
+  .shrinkable();
+
+  /* Keep the fast forward button to the right of this container. */
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 60%;
+}
+
+.shaka-hidden-rewind-container {
+  height: 100%;
+  width: 40%;
+  .shrinkable();
+
+  /* keep the rewind button to the left */
+  .absolute-position();
+}

--- a/ui/ui.js
+++ b/ui/ui.js
@@ -189,6 +189,8 @@ shaka.ui.Overlay = class {
       ],
       addSeekBar: true,
       addBigPlayButton: false,
+      fastForwardOnTaps: true,
+      rewindOnTaps: true,
       castReceiverAppId: '',
       clearBufferOnQualityChange: true,
       showUnbufferedStart: false,


### PR DESCRIPTION
## Description

<!--
  Give the PR a helpful title that summaries what this PR changes. Here, include
  a summary of the change and which issue is fixed. Also include relevant
  motivation and context. List any dependencies that are required for this
  change.

  If this fixes any issues, include lines like this:
  Fixes #123
-->
#3357 

This PR adds fast-forward button to the right side of the video and a rewind button to the left side of the video both having a width of 40%. they are hidden and are only shown when the user double taps on the video(left or right side), which seeks the video by 5s forward or backward. it keeps seeking +5 or -5 if the user keeps tapping

The changes have been tested in chrome and firefox on windows 8.1. 

The only glitch I can see is if the browser triggers both `dblclick` and `touchstart` events at once which seeks the video and also makes it go fullscreen. I don't know if any browser does that.

Both the buttons are configurable. By default, it is set to true, but can be prevented from getting added.

The video can be controlled this way only on touch screen devices because I don't think anyone uses the mouse to double click on a video to forward or rewind. But these buttons could also be added to run on mouse click by few minor changes.

The below video shows the working of buttons.


## Screenshots (optional)

<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
-->


https://user-images.githubusercontent.com/71056993/116399181-7ce62280-a7dd-11eb-8f21-e8a527617bb2.mp4


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
