### PR TITLE
conformance: lift ban for Element.children

### DIFF
--- a/build/conformance.textproto
+++ b/build/conformance.textproto
@@ -163,14 +163,6 @@ requirement: {
 }
 
 
-# Disallow Element.children.
-requirement: {
-  type: BANNED_PROPERTY
-  value: 'Element.prototype.children'
-  error_message: 'Using "Element.children" is not allowed; '
-                 'use Node.childNodes instead'
-}
-
 requirement: {
   type: BANNED_PROPERTY
   value: 'DataView.prototype.buffer'


### PR DESCRIPTION
## Description
Previously we ban Element.chidren in https://github.com/google/shaka-player/commit/b641a24acf8482cf901d47908283b0d692a66299

Because we have dropped support for IE, we can bring this back ? cc @theodab 

I see that in https://github.com/google/shaka-player/blob/master/lib/text/vtt_text_parser.js#L507-L516
I think what he want is `Element.children` and since we ban that, he have to hack around that limitation (cc @avelad)

## Checklist:
- [x] I have signed the Google CLA <https://cla.developers.google.com>
