### PR TITLE
docs: Add Dockerfile and docker build instructions

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,0 +1,26 @@
+# Alpine was chosen by providing a node container less than 100mb
+FROM node:17.7.1-alpine3.15
+
+WORKDIR /usr/src/app
+
+# install dependencies
+RUN apk add --update --no-cache openssh git python3 openjdk11-jre-headless
+RUN ln -sf python3 /usr/bin/python
+
+# Change to non-root user
+USER node
+
+# Python user's setup
+RUN mkdir -p /home/node/.local/bin
+ENV PATH="$PATH:/home/node/.local/bin"
+RUN python3 -m ensurepip
+RUN pip3 install --no-cache --upgrade pip setuptools
+
+# Prevent proxy timeout error (very slow connections)
+RUN npm config set fetch-retry-mintimeout 20000
+RUN npm config set fetch-retry-maxtimeout 120000
+RUN npm config rm proxy
+RUN npm config rm https-proxy
+
+# Run compilation
+CMD [ "python", "build/all.py" ]

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  shaka-compiler:
+    build: ./
+    container_name: shaka-compiler
+    volumes:
+      - ../../:/usr/src/app
+
+# Others services can be added here

--- a/docs/tutorials/welcome.md
+++ b/docs/tutorials/welcome.md
@@ -35,6 +35,8 @@ To get the sources and compile the library, you will need:
     * _NOTE: A local web server is required because browsers place restrictions
       on applications from file:/// URLs._
 
+If you just want to compile for export to other projects, you might consider compiling through a docker container. (see compile instructions)
+
 To quickly install these prerequisites on Ubuntu or Debian, you can run this
 script:
 
@@ -60,6 +62,12 @@ cd shaka-player
 
 ```sh
 python build/all.py
+```
+
+Alternatively you can use a docker container:
+```sh
+cd build/docker
+docker-compose run --rm shaka-compiler
 ```
 
 The output is:


### PR DESCRIPTION
add docker-compose.yml and Dockerfile to compile shaka inside container; reference it on docs;

## Description

Many devs using Shaka and wishing to compile the library are required to install all prerequisites on their machine. For docker devs, this is extremely bad as it requires installing Java and Python on OS.
This commit adds a basic configuration for quick compilation via Docker, without requiring any other prerequisites. Improvements can be made in order to allow all Shaka workflow inside Docker.
Suggested in #181

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works [not applicable/not auto-testable]
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
