### PR TITLE
Fixed_#3571_seekRange().start is going back and forth while start-over

### DIFF
--- a/lib/media/presentation_timeline.js
+++ b/lib/media/presentation_timeline.js
@@ -424,6 +424,15 @@ shaka.media.PresentationTimeline = class {
     return this.getSafeSeekRangeStart(/* offset= */ 0);
   }
 
+  /**
+   * Gets the seek range Start time.
+   *
+   * @return {number}
+   * @export
+   */
+  getSeekRangeStartTime() {
+    return Math.max(this.minSegmentStartTime_, this.userSeekStart_);
+  }
 
   /**
    * Gets the seek range end.

--- a/lib/player.js
+++ b/lib/player.js
@@ -3195,7 +3195,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const timeline = this.manifest_.presentationTimeline;
 
       return {
-        'start': timeline.getSeekRangeStart(),
+        'start': timeline.getSeekRangeStartTime(),
         'end': timeline.getSeekRangeEnd(),
       };
     }


### PR DESCRIPTION
  Fixes #3571 
## Description

Added a new get function ` getSeekRangeStartTime() `  in `lib/media/presentation_timeline.js` .
And changed the function to call  `getSeekRangeStartTime()` instead of `getSeekRangeStart()` in `lib/player.js`. 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass

### Please provide me appropriate feedback/review so that I can continue working on this.


