### PR TITLE
fix(dash): Account for bandwidth before filtering text stream

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Edgeware AB <*@edgeware.tv>
 Esteban Dosztal <edosztal@gmail.com>
 Fadomire <fadomire@gmail.com>
 Gil Gonen <gil.gonen@gmail.com>
+Giorgio Gamberoni <giorgio.gamberoni@gmail.com>
 Giuseppe Samela <giuseppe.samela@gmail.com>
 Google Inc. <*@google.com>
 Itay Kinnrot <Itay.Kinnrot@Kaltura.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -48,6 +48,7 @@ Esteban Dosztal <edosztal@gmail.com>
 Fadomire <fadomire@gmail.com>
 François Beaufort <fbeaufort@google.com>
 Gil Gonen <gil.gonen@gmail.com>
+Giorgio Gamberoni <giorgio.gamberoni@gmail.com>
 Giuseppe Samela <giuseppe.samela@gmail.com>
 Hichem Taoufik <hichem@code-it.fr>
 Itay Kinnrot <itay.kinnrot@kaltura.com>

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -298,6 +298,7 @@ shaka.util.PeriodCombiner = class {
             t1.label == t2.label &&
             t1.codecs == t2.codecs &&
             t1.mimeType == t2.mimeType &&
+            t1.bandwidth == t2.bandwidth &&
             ArrayUtils.hasSameElements(t1.roles, t2.roles)) {
             duplicate = true;
           }

--- a/test/util/periods_unit.js
+++ b/test/util/periods_unit.js
@@ -477,7 +477,7 @@ describe('PeriodCombiner', () => {
     a3.originalId = 'a3';
     a3.bandwidth = 97065;
     a3.roles = ['role1', 'role2'];
-    a2.codecs = 'mp4a.40.2';
+    a3.codecs = 'mp4a.40.2';
 
     // a4 has a different label from a3, and should not
     // be filtered out.
@@ -500,14 +500,24 @@ describe('PeriodCombiner', () => {
     const t1 = makeTextStream('en');
     t1.originalId = 't1';
     t1.roles = ['role1'];
+    t1.bandwidth = 1158;
 
     const t2 = makeTextStream('en');
     t2.originalId = 't2';
     t2.roles = ['role1', 'role2'];
+    t2.bandwidth = 1172;
 
     const t3 = makeTextStream('en');
     t3.originalId = 't3';
     t3.roles = ['role1'];
+    t3.bandwidth = 1158;
+
+    // t4 has a different bandwidth from t3, and should not
+    // be filtered out.
+    const t4 = makeTextStream('en');
+    t4.originalId = 't4';
+    t4.roles = ['role1'];
+    t4.bandwidth = 1186;
 
     // i1 and i3 are duplicates.
     const i1 = makeImageStream(240);
@@ -539,6 +549,7 @@ describe('PeriodCombiner', () => {
           t1,
           t2,
           t3,
+          t4,
         ],
         imageStreams: [
           i1,
@@ -565,7 +576,7 @@ describe('PeriodCombiner', () => {
     }
 
     const textStreams = combiner.getTextStreams();
-    expect(textStreams.length).toBe(2);
+    expect(textStreams.length).toBe(3);
 
     // t3 should've been filtered out
     const textIds = textStreams.map((t) => t.originalId);


### PR DESCRIPTION
## Description

Fixes #3724

Fix dedup stream logic adding `bandwidth` in the `filterOutTextStreamDuplicates` condition.

Another possible solution could be add the `originalId` in the all the filter conditions: #3725  


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
