### PR TITLE
feat(hls): Support AES-128 in HLS TS segments.

### DIFF
--- a/demo/common/assets.js
+++ b/demo/common/assets.js
@@ -905,6 +905,15 @@ shakaAssets.testAssets = [
       .addFeature(shakaAssets.Feature.MP2TS)
       .addFeature(shakaAssets.Feature.OFFLINE),
   new ShakaDemoAssetInfo(
+      /* name= */ 'Art of Motion (HLS, TS, AES-128)',
+      /* iconUri= */ 'https://storage.googleapis.com/shaka-asset-icons/art_of_motion.png',
+      /* manifestUri= */ 'https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8',
+      /* source= */ shakaAssets.Source.BITCODIN)
+      .addFeature(shakaAssets.Feature.HIGH_DEFINITION)
+      .addFeature(shakaAssets.Feature.HLS)
+      .addFeature(shakaAssets.Feature.MP2TS)
+      .addFeature(shakaAssets.Feature.OFFLINE),
+  new ShakaDemoAssetInfo(
       /* name= */ 'Sintel (HLS, TS, 4k)',
       /* iconUri= */ 'https://storage.googleapis.com/shaka-asset-icons/sintel.png',
       /* manifestUri= */ 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',

--- a/externs/shaka/manifest.js
+++ b/externs/shaka/manifest.js
@@ -239,6 +239,33 @@ shaka.extern.CreateSegmentIndexFunction;
 
 /**
  * @typedef {{
+ *   method: string,
+ *   cryptoKey: !webCrypto.CryptoKey,
+ *   iv: (!Uint8Array|undefined),
+ *   firstMediaSequenceNumber: number
+ * }}
+ *
+ * @description
+ * AES-128 key and iv info from the HLS manifest.
+ *
+ * @property {string} method
+ *   The key method defined in the HLS manifest.
+ * @property {!webCrypto.CryptoKey} cryptoKey
+ *   Web crypto key object of the AES-128 CBC key.
+ * @property {(!Uint8Array|undefined)} iv
+ *   The IV in the HLS manifest if defined. See HLS RFC 8216 Section 5.2 for
+ *   handling undefined IV.
+ * @property {number} firstMediaSequenceNumber
+ *   The starting Media Sequence Number of the playlist, used when IV is
+ *   undefined.
+ *
+ * @exportDoc
+ */
+shaka.extern.HlsAes128Key;
+
+
+/**
+ * @typedef {{
  *   id: number,
  *   originalId: ?string,
  *   createSegmentIndex: shaka.extern.CreateSegmentIndexFunction,
@@ -256,6 +283,7 @@ shaka.extern.CreateSegmentIndexFunction;
  *   encrypted: boolean,
  *   drmInfos: !Array.<shaka.extern.DrmInfo>,
  *   keyIds: !Set.<string>,
+ *   hlsAes128Key: (shaka.extern.HlsAes128Key|undefined),
  *   language: string,
  *   label: ?string,
  *   type: string,
@@ -336,6 +364,9 @@ shaka.extern.CreateSegmentIndexFunction;
  *   The stream's key IDs as lowercase hex strings. These key IDs identify the
  *   encryption keys that the browser (key system) can use to decrypt the
  *   stream.
+ * @property {(shaka.extern.HlsAes128Key|undefined)} hlsAes128Key
+ *   <i>Defaults to undefined (i.e., no HLS AES-128 encryption).</i> <br>
+ *   The HLS stream's AES-128-CBC full segment encryption key and iv.
  * @property {string} language
  *   The Stream's language, specified as a language code. <br>
  *   Audio stream's language must be identical to the language of the containing

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -37,6 +37,7 @@ goog.require('shaka.util.OperationManager');
 goog.require('shaka.util.Pssh');
 goog.require('shaka.util.Timer');
 goog.require('shaka.util.Platform');
+goog.require('shaka.util.Uint8ArrayUtils');
 goog.require('shaka.util.XmlUtils');
 goog.requireType('shaka.hls.Segment');
 
@@ -1516,24 +1517,86 @@ shaka.hls.HlsParser = class {
     }
 
     let encrypted = false;
+    let hlsAes128Key;
     /** @type {!Array.<shaka.extern.DrmInfo>}*/
     const drmInfos = [];
     const keyIds = new Set();
 
-    // TODO: May still need changes to support key rotation.
+    // TODO: May still need changes to support key rotation and discontinuity.
     for (const drmTag of drmTags) {
       const method = drmTag.getRequiredAttrValue('METHOD');
-      if (method != 'NONE') {
+      if (method == 'AES-128') {
         encrypted = true;
+        this.aesEncrypted_ = true;
 
-        // We do not support AES-128 encryption with HLS yet. So, do not create
-        // StreamInfo for the playlist encrypted with AES-128.
-        // TODO: Remove the error message once we add support for AES-128.
-        if (method == 'AES-128') {
-          shaka.log.warning('Unsupported HLS Encryption', method);
-          this.aesEncrypted_ = true;
+        if (mimeType != 'video/mp2t') {
+          shaka.log.alwaysWarn(
+              'AES-128 in MP4 HLS is not yet supported. Skipping ' + mimeType);
           return null;
         }
+
+        // Check if the Web Crypto API is available.
+        if (!window.crypto || !window.crypto.subtle) {
+          shaka.log.alwaysWarn('Web Crypto API is not available to decrypt ' +
+              'AES-128. (Web Crypto only exists in secure origins like https)');
+          throw new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.MANIFEST,
+              shaka.util.Error.Code.NO_WEB_CRYPTO_API);
+        }
+
+        // HLS RFC 8216 Section 5.2:
+        // An EXT-X-KEY tag with a KEYFORMAT of "identity" that does not have an
+        // IV attribute indicates that the Media Sequence Number is to be used
+        // as the IV when decrypting a Media Segment, by putting its big-endian
+        // binary representation into a 16-octet (128-bit) buffer and padding
+        // (on the left) with zeros.
+        let firstMediaSequenceNumber = 0;
+        let iv;
+        const ivHex = drmTag.getAttributeValue('IV', '');
+        if (!ivHex) {
+          // Media Sequence Number will be used as IV.
+          firstMediaSequenceNumber =
+              shaka.hls.Utils.getFirstTagWithNameAsNumber(
+                  playlist.tags, 'EXT-X-MEDIA-SEQUENCE', 0);
+        } else {
+          // Exclude 0x at the start of string.
+          iv = shaka.util.Uint8ArrayUtils.fromHex(ivHex.substr(2));
+          if (iv.byteLength != 16) {
+            throw new shaka.util.Error(
+                shaka.util.Error.Severity.CRITICAL,
+                shaka.util.Error.Category.MANIFEST,
+                shaka.util.Error.Code.HLS_AES_128_INVALID_KEY_OR_IV_LENGTH,
+                'IV');
+          }
+        }
+
+        const keyUri = shaka.hls.Utils.constructAbsoluteUri(
+            this.masterPlaylistUri_, drmTag.getRequiredAttrValue('URI'));
+
+        const requestType = shaka.net.NetworkingEngine.RequestType.KEY;
+        const request = shaka.net.NetworkingEngine.makeRequest(
+            [keyUri], this.config_.retryParameters);
+
+        // eslint-disable-next-line no-await-in-loop
+        const keyResponse = await this.makeNetworkRequest_(
+            request, requestType);
+
+        // keyResponse.status is undefined when URI is "data:text/plain;base64,"
+        if (!keyResponse.data || keyResponse.data.byteLength != 16) {
+          throw new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.MANIFEST,
+              shaka.util.Error.Code.HLS_AES_128_INVALID_KEY_OR_IV_LENGTH,
+              'KEY');
+        }
+        // eslint-disable-next-line no-await-in-loop
+        const cryptoKey = await window.crypto.subtle.importKey(
+            'raw', keyResponse.data, 'AES-CBC', true, ['decrypt']);
+
+        hlsAes128Key = {method, cryptoKey, iv, firstMediaSequenceNumber};
+      } else if (method != 'NONE') {
+        encrypted = true;
 
         const keyFormat = drmTag.getRequiredAttrValue('KEYFORMAT');
         const drmParser =
@@ -1553,7 +1616,7 @@ shaka.hls.HlsParser = class {
       }
     }
 
-    if (encrypted && !drmInfos.length) {
+    if (encrypted && !drmInfos.length && !hlsAes128Key) {
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MANIFEST,
@@ -1615,6 +1678,7 @@ shaka.hls.HlsParser = class {
       encrypted,
       drmInfos,
       keyIds,
+      hlsAes128Key,
       language,
       label: name,  // For historical reasons, since before "originalId".
       type,

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -505,6 +505,14 @@ shaka.media.SegmentIterator = class {
   }
 
   /**
+   * @return {number}
+   * @export
+   */
+  currentPosition() {
+    return this.currentPosition_;
+  }
+
+  /**
    * @return {shaka.media.SegmentReference}
    * @export
    */

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1266,7 +1266,21 @@ shaka.media.StreamingEngine = class {
             'ReadableStream is not supported by the browser.');
         }
         const fetchSegment = this.fetch_(mediaState, reference);
-        const result = await fetchSegment;
+        let result = await fetchSegment;
+        if (stream.hlsAes128Key) {
+          let iv = stream.hlsAes128Key.iv;
+          if (!iv) {
+            iv = shaka.util.BufferUtils.toUint8(new ArrayBuffer(16));
+            let sequence = stream.hlsAes128Key.firstMediaSequenceNumber +
+                iter.currentPosition();
+            for (let i = iv.byteLength - 1; i >= 0; i--) {
+              iv[i] = sequence & 0xff;
+              sequence >>= 8;
+            }
+          }
+          result = await window.crypto.subtle.decrypt(
+              {name: 'AES-CBC', iv}, stream.hlsAes128Key.cryptoKey, result);
+        }
         this.destroyer_.ensureNotDestroyed();
         if (this.fatalError_) {
           return;

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -749,6 +749,7 @@ shaka.net.NetworkingEngine.RequestType = {
   'APP': 3,
   'TIMING': 4,
   'SERVER_CERTIFICATE': 5,
+  'KEY': 6,
 };
 
 

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -682,6 +682,17 @@ shaka.util.Error.Code = {
 
   // RETIRED: 'HLS_MSE_ENCRYPTED_LEGACY_APPLE_MEDIA_KEYS_NOT_SUPPORTED': 4041,
 
+  /**
+   * Web Crypto API is not available (to decrypt AES-128 streams). Web Crypto
+   * only exists in secure origins like https.
+   */
+  'NO_WEB_CRYPTO_API': 4042,
+
+  /**
+   * AES-128 encryption key or iv length should be 16 bytes.
+   */
+  'HLS_AES_128_INVALID_KEY_OR_IV_LENGTH': 4043,
+
 
   // RETIRED: 'INCONSISTENT_BUFFER_STATE': 5000,
   // RETIRED: 'INVALID_SEGMENT_INDEX': 5001,


### PR DESCRIPTION
## Description

Part of #850. Use with mux.js:

```
<script src="https://cdn.jsdelivr.net/npm/mux.js@6.0.1/dist/mux.min.js"></script>
```

These demo videos can play:
https://playertest.longtailvideo.com/adaptive/oceans_aes/oceans_aes.m3u8 (No IV)
https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8 (Const IV)

Key rotation (and maybe discontinuity) is not supported. (Existing TODO: May still need changes to support key rotation)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
