### PR TITLE
refactor: migrate to goog.module

### DIFF
--- a/build/generateExterns.js
+++ b/build/generateExterns.js
@@ -39,6 +39,7 @@ if (assert.strict) {
 const esprima = require('esprima');
 const fs = require('fs');
 
+const googModule = ['goog.module', 'goog.provide'];
 // The annotations we will consider "exporting" a symbol.
 const EXPORT_REGEX = /@(?:export|exportInterface|expose)\b/;
 
@@ -127,7 +128,7 @@ function dumpNode(node) {
  */
 function isProvideNode(node) {
   return isCallNode(node) &&
-         getIdentifierString(node.expression.callee) == 'goog.provide';
+          googModule.includes(getIdentifierString(node.expression.callee));
 }
 
 

--- a/lib/abr/ewma.js
+++ b/lib/abr/ewma.js
@@ -4,23 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.abr.Ewma');
+goog.module('shaka.abr.Ewma');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
+const {assert} = goog.require('goog.asserts');
 
 
 /**
  * @summary
  * This class computes an exponentionally-weighted moving average.
  */
-shaka.abr.Ewma = class {
+exports = class Ewma {
   /**
    * @param {number} halfLife The quantity of prior samples (by weight) used
    *   when creating a new estimate.  Those prior samples make up half of the
    *   new estimate.
    */
   constructor(halfLife) {
-    goog.asserts.assert(halfLife > 0, 'expected halfLife to be positive');
+    assert(halfLife > 0, 'expected halfLife to be positive');
 
     /**
      * Larger values of alpha expire historical data more slowly.
@@ -44,7 +45,7 @@ shaka.abr.Ewma = class {
    *   new estimate.
    */
   updateAlpha(halfLife) {
-    goog.asserts.assert(halfLife > 0, 'expected halfLife to be positive');
+    assert(halfLife > 0, 'expected halfLife to be positive');
     this.alpha_ = Math.exp(Math.log(0.5) / halfLife);
   }
 

--- a/lib/abr/ewma_bandwidth_estimator.js
+++ b/lib/abr/ewma_bandwidth_estimator.js
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.abr.EwmaBandwidthEstimator');
+goog.module('shaka.abr.EwmaBandwidthEstimator');
+goog.module.declareLegacyNamespace();
 
-goog.require('shaka.abr.Ewma');
+const Ewma = goog.require('shaka.abr.Ewma');
 
 
 /**
@@ -16,22 +17,22 @@ goog.require('shaka.abr.Ewma');
  * different half-lives.
  *
  */
-shaka.abr.EwmaBandwidthEstimator = class {
+exports = class EwmaBandwidthEstimator {
   /** */
   constructor() {
     /**
      * A fast-moving average.
      * Half of the estimate is based on the last 2 seconds of sample history.
-     * @private {!shaka.abr.Ewma}
+     * @private {!Ewma}
      */
-    this.fast_ = new shaka.abr.Ewma(2);
+    this.fast_ = new Ewma(2);
 
     /**
      * A slow-moving average.
      * Half of the estimate is based on the last 5 seconds of sample history.
-     * @private {!shaka.abr.Ewma}
+     * @private {!Ewma}
      */
-    this.slow_ = new shaka.abr.Ewma(5);
+    this.slow_ = new Ewma(5);
 
     /**
      * Number of bytes sampled.

--- a/lib/util/array_utils.js
+++ b/lib/util/array_utils.js
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.ArrayUtils');
+goog.module('shaka.util.ArrayUtils');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -13,7 +14,7 @@ goog.provide('shaka.util.ArrayUtils');
  */
 
 
-shaka.util.ArrayUtils = class {
+exports = class ArrayUtils {
   /**
    * Returns whether the two values contain the same value.  This correctly
    * handles comparisons involving NaN.
@@ -75,7 +76,7 @@ shaka.util.ArrayUtils = class {
    */
   static hasSameElements(a, b, compareFn) {
     if (!compareFn) {
-      compareFn = shaka.util.ArrayUtils.defaultEquals;
+      compareFn = ArrayUtils.defaultEquals;
     }
     if (a.length != b.length) {
       return false;
@@ -108,7 +109,7 @@ shaka.util.ArrayUtils = class {
    */
   static equal(a, b, compareFn) {
     if (!compareFn) {
-      compareFn = shaka.util.ArrayUtils.defaultEquals;
+      compareFn = ArrayUtils.defaultEquals;
     }
     if (a.length != b.length) {
       return false;

--- a/lib/util/delayed_tick.js
+++ b/lib/util/delayed_tick.js
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.DelayedTick');
+goog.module('shaka.util.DelayedTick');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -14,7 +15,7 @@ goog.provide('shaka.util.DelayedTick');
  *
  * @final
  */
-shaka.util.DelayedTick = class {
+exports = class DelayedTick {
   /**
    * @param {function()} onTick
    */

--- a/lib/util/iterables.js
+++ b/lib/util/iterables.js
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.Iterables');
+goog.module('shaka.util.Iterables');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -12,7 +13,7 @@ goog.provide('shaka.util.Iterables');
  * type.
  * @final
  */
-shaka.util.Iterables = class {
+exports = class Iterables {
   /**
    * @param {!Iterable.<FROM>} iterable
    * @param {function(FROM):TO} mapping

--- a/lib/util/lazy.js
+++ b/lib/util/lazy.js
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.Lazy');
+goog.module('shaka.util.Lazy');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
+const {assert} = goog.require('goog.asserts');
 
 
 /**
@@ -16,7 +17,7 @@ goog.require('goog.asserts');
  *
  * @template T
  */
-shaka.util.Lazy = class {
+exports = class Lazy {
   /** @param {function():T} gen */
   constructor(gen) {
     /** @private {function():T} */
@@ -31,7 +32,7 @@ shaka.util.Lazy = class {
     if (this.value_ == undefined) {
       // Compiler complains about unknown fields without this cast.
       this.value_ = /** @type {*} */ (this.gen_());
-      goog.asserts.assert(
+      assert(
           this.value_ != undefined, 'Unable to create lazy value');
     }
     return this.value_;

--- a/lib/util/map_utils.js
+++ b/lib/util/map_utils.js
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.MapUtils');
+goog.module('shaka.util.MapUtils');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * @summary A set of map/object utility functions.
  */
-shaka.util.MapUtils = class {
+exports = class MapUtils {
   /**
    * @param {!Object.<KEY, VALUE>} object
    * @return {!Map.<KEY, VALUE>}

--- a/lib/util/multi_map.js
+++ b/lib/util/multi_map.js
@@ -4,14 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.MultiMap');
+goog.module('shaka.util.MultiMap');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * @summary A simple multimap template.
  * @template T
  */
-shaka.util.MultiMap = class {
+exports = class MultiMap {
   /** */
   constructor() {
     /** @private {!Object.<string, !Array.<T>>} */

--- a/lib/util/mutex.js
+++ b/lib/util/mutex.js
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.Mutex');
+goog.module('shaka.util.Mutex');
+goog.module.declareLegacyNamespace();
 
 
 /**
  * @summary A simple mutex.
  */
-shaka.util.Mutex = class {
+exports = class Mutex {
   /** Creates the mutex. */
   constructor() {
     /** @private {!Array.<function()>} */

--- a/lib/util/object_utils.js
+++ b/lib/util/object_utils.js
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.ObjectUtils');
+goog.module('shaka.util.ObjectUtils');
+goog.module.declareLegacyNamespace();
 
 
-shaka.util.ObjectUtils = class {
+exports = class ObjectUtils {
   /**
    * Performs a deep clone of the given simple object.  This does not copy
    * prototypes, custom properties (e.g. read-only), or multiple references to

--- a/lib/util/public_promise.js
+++ b/lib/util/public_promise.js
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.PublicPromise');
+goog.module('shaka.util.PublicPromise');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -15,7 +16,7 @@ goog.provide('shaka.util.PublicPromise');
  * @extends {Promise.<T>}
  * @template T
  */
-shaka.util.PublicPromise = class {
+exports = class PublicPromise {
   /**
    * @return {!Promise.<T>}
    */
@@ -39,7 +40,7 @@ shaka.util.PublicPromise = class {
 
     // Now cast the Promise object to our subclass PublicPromise so that the
     // compiler will permit us to attach resolve() and reject() to it.
-    const publicPromise = /** @type {shaka.util.PublicPromise} */(promise);
+    const publicPromise = /** @type {PublicPromise} */(promise);
     publicPromise.resolve = resolvePromise;
     publicPromise.reject = rejectPromise;
 

--- a/lib/util/state_history.js
+++ b/lib/util/state_history.js
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.StateHistory');
+goog.module('shaka.util.StateHistory');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
-goog.require('shaka.log');
+
+const {assert} = goog.require('goog.asserts');
+const log = goog.require('shaka.log');
 
 
 /**
@@ -18,7 +20,7 @@ goog.require('shaka.log');
  *
  * @final
  */
-shaka.util.StateHistory = class {
+exports = class StateHistory {
   /** */
   constructor() {
     /**
@@ -102,10 +104,10 @@ shaka.util.StateHistory = class {
    * @private
    */
   start_(state) {
-    goog.asserts.assert(
+    assert(
         this.open_ == null,
         'There must be no open entry in order when we start');
-    shaka.log.v1('Changing Player state to', state);
+    log.v1('Changing Player state to', state);
 
     this.open_ = {
       timestamp: this.getNowInSeconds_(),
@@ -119,7 +121,7 @@ shaka.util.StateHistory = class {
    * @private
    */
   update_(state) {
-    goog.asserts.assert(
+    assert(
         this.open_,
         'There must be an open entry in order to update it');
 
@@ -135,7 +137,7 @@ shaka.util.StateHistory = class {
     }
 
     // We have changed states, so "close" the open state.
-    shaka.log.v1('Changing Player state to', state);
+    log.v1('Changing Player state to', state);
     this.closed_.push(this.open_);
     this.open_ = {
       timestamp: currentTimeSeconds,

--- a/lib/util/stats.js
+++ b/lib/util/stats.js
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.Stats');
+goog.module('shaka.util.Stats');
+goog.module.declareLegacyNamespace();
 
-goog.require('shaka.util.StateHistory');
-goog.require('shaka.util.SwitchHistory');
+const StateHistory = goog.require('shaka.util.StateHistory');
+const SwitchHistory = goog.require('shaka.util.SwitchHistory');
 
 
 /**
@@ -16,7 +17,7 @@ goog.require('shaka.util.SwitchHistory');
  *
  * @final
  */
-shaka.util.Stats = class {
+exports = class Stats {
   /** */
   constructor() {
     /** @private {number} */
@@ -57,11 +58,11 @@ shaka.util.Stats = class {
     /** @private {number} */
     this.bandwidthEstimate_ = NaN;
 
-    /** @private {!shaka.util.StateHistory} */
-    this.stateHistory_ = new shaka.util.StateHistory();
+    /** @private {!StateHistory} */
+    this.stateHistory_ = new StateHistory();
 
-    /** @private {!shaka.util.SwitchHistory} */
-    this.switchHistory_ = new shaka.util.SwitchHistory();
+    /** @private {!SwitchHistory} */
+    this.switchHistory_ = new SwitchHistory();
   }
 
   /**
@@ -181,14 +182,14 @@ shaka.util.Stats = class {
   }
 
   /**
-   * @return {!shaka.util.StateHistory}
+   * @return {!StateHistory}
    */
   getStateHistory() {
     return this.stateHistory_;
   }
 
   /**
-   * @return {!shaka.util.SwitchHistory}
+   * @return {!SwitchHistory}
    */
   getSwitchHistory() {
     return this.switchHistory_;

--- a/lib/util/switch_history.js
+++ b/lib/util/switch_history.js
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.SwitchHistory');
+goog.module('shaka.util.SwitchHistory');
+goog.module.declareLegacyNamespace();
 
 
 /**
@@ -13,7 +14,7 @@ goog.provide('shaka.util.SwitchHistory');
  *
  * @final
  */
-shaka.util.SwitchHistory = class {
+exports = class SwitchHistory {
   /** */
   constructor() {
     /** @private {?shaka.extern.Variant} */

--- a/lib/util/text_parser.js
+++ b/lib/util/text_parser.js
@@ -4,15 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.TextParser');
+goog.module('shaka.util.TextParser');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
+const {assert} = goog.require('goog.asserts');
 
 
 /**
  * Reads elements from strings.
  */
-shaka.util.TextParser = class {
+exports = class TextParser {
   /**
    * @param {string} data
    */
@@ -117,7 +118,7 @@ shaka.util.TextParser = class {
    */
   indexOf_(regex) {
     // The global flag is required to use lastIndex.
-    goog.asserts.assert(regex.global, 'global flag should be set');
+    assert(regex.global, 'global flag should be set');
 
     regex.lastIndex = this.position_;
     const results = regex.exec(this.data_);

--- a/lib/util/xml_utils.js
+++ b/lib/util/xml_utils.js
@@ -4,17 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.util.XmlUtils');
+goog.module('shaka.util.XmlUtils');
+goog.module.declareLegacyNamespace();
 
-goog.require('goog.asserts');
-goog.require('shaka.log');
-goog.require('shaka.util.StringUtils');
+const {assert} = goog.require('goog.asserts');
+const log = goog.require('shaka.log');
+const StringUtils = goog.require('shaka.util.StringUtils');
 
 
 /**
  * @summary A set of XML utility functions.
  */
-shaka.util.XmlUtils = class {
+exports = class XmlUtils {
   /**
    * Finds a child XML element.
    * @param {!Node} elem The parent XML element.
@@ -24,7 +25,7 @@ shaka.util.XmlUtils = class {
    *   child XML element with the given tag name.
    */
   static findChild(elem, name) {
-    const children = shaka.util.XmlUtils.findChildren(elem, name);
+    const children = XmlUtils.findChildren(elem, name);
     if (children.length != 1) {
       return null;
     }
@@ -42,7 +43,7 @@ shaka.util.XmlUtils = class {
    *   child XML element with the given tag name.
    */
   static findChildNS(elem, ns, name) {
-    const children = shaka.util.XmlUtils.findChildrenNS(elem, ns, name);
+    const children = XmlUtils.findChildrenNS(elem, ns, name);
     if (children.length != 1) {
       return null;
     }
@@ -128,7 +129,6 @@ shaka.util.XmlUtils = class {
    * @return {?string} The text contents, or null if there are none.
    */
   static getContents(elem) {
-    const XmlUtils = shaka.util.XmlUtils;
     if (!Array.from(elem.childNodes).every(XmlUtils.isText)) {
       return null;
     }
@@ -215,7 +215,7 @@ shaka.util.XmlUtils = class {
     const matches = new RegExp(re).exec(durationString);
 
     if (!matches) {
-      shaka.log.warning('Invalid duration string:', durationString);
+      log.warning('Invalid duration string:', durationString);
       return null;
     }
 
@@ -344,30 +344,30 @@ shaka.util.XmlUtils = class {
     try {
       xml = parser.parseFromString(xmlString, 'text/xml');
     } catch (exception) {
-      shaka.log.error('XML parsing exception:', exception);
+      log.error('XML parsing exception:', exception);
       return null;
     }
 
     // According to MDN, parseFromString never returns null.
-    goog.asserts.assert(xml, 'Parsed XML document cannot be null!');
+    assert(xml, 'Parsed XML document cannot be null!');
 
     // Check for empty documents.
     const rootElem = xml.documentElement;
     if (!rootElem) {
-      shaka.log.error('XML document was empty!');
+      log.error('XML document was empty!');
       return null;
     }
 
     // Check for parser errors.
     const parserErrorElements = rootElem.getElementsByTagName('parsererror');
     if (parserErrorElements.length) {
-      shaka.log.error('XML parser error found:', parserErrorElements[0]);
+      log.error('XML parser error found:', parserErrorElements[0]);
       return null;
     }
 
     // The top-level element in the loaded XML should have the name we expect.
     if (xml.documentElement.tagName != expectedRootElemName) {
-      shaka.log.error(
+      log.error(
           `XML tag name does not match expected "${expectedRootElemName}":`,
           xml.documentElement.tagName);
       return null;
@@ -386,10 +386,10 @@ shaka.util.XmlUtils = class {
    */
   static parseXml(data, expectedRootElemName) {
     try {
-      const string = shaka.util.StringUtils.fromUTF8(data);
-      return shaka.util.XmlUtils.parseXmlString(string, expectedRootElemName);
+      const string = StringUtils.fromUTF8(data);
+      return XmlUtils.parseXmlString(string, expectedRootElemName);
     } catch (exception) {
-      shaka.log.error('parseXmlString threw!', exception);
+      log.error('parseXmlString threw!', exception);
       return null;
     }
   }


### PR DESCRIPTION
I was thinking about migrating Shaka player to JS only tooling, and re-ignited when @joeyparrish [said](https://github.com/shaka-project/shaka-player/issues/3188) that he is open to TypeScript idea. Then I found that **googl.module** might ease the migration. Below is an excerpt from goog.module documentation.

> Presently goog.module is recommended over goog.provide for new Closure files

Short plan:
1. Migrate everything to goog.module, more like ES6 module export/import. See https://github.com/google/closure-library/wiki/goog.module:-an-ES6-module-like-alternative-to-goog.provide.
4. remove goog.module.declareLegacyNamespace(), and make sure everything works as expected.

Then it's easier to migrate to ES6 (using TypeScript in JSDoc) with https://github.com/google/closure-compiler/wiki/Migrating-from-goog.modules-to-ES6-modules.

@joeyparrish could you please review the code and plan