### PR TITLE
refactor: update node_modules using npm

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -65,6 +65,10 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
       - name: Build Player
         run: python build/all.py
 

--- a/build/all.py
+++ b/build/all.py
@@ -110,7 +110,7 @@ def main(args):
     return 1
 
   if not compile_less('ui', 'controls', parsed_args):
-    return 1;
+    return 1
   if not compile_less('demo', 'demo', parsed_args):
     return 1
 

--- a/build/apps.py
+++ b/build/apps.py
@@ -172,8 +172,7 @@ def main(args):
   force = parsed_args.force
 
   # Update node modules if needed.
-  if not shakaBuildHelpers.update_node_modules():
-    return 1
+  shakaBuildHelpers.update_node_modules()
 
   for is_debug in [True, False]:
     if not build_all(force, is_debug):

--- a/build/build.py
+++ b/build/build.py
@@ -362,8 +362,7 @@ def main(args):
     pass
 
   # Update node modules if needed.
-  if not shakaBuildHelpers.update_node_modules():
-    return 1
+  shakaBuildHelpers.update_node_modules()
 
   # If no commands are given then use complete  by default.
   if len(commands) == 0:

--- a/build/check.py
+++ b/build/check.py
@@ -340,8 +340,7 @@ def main(args):
     pass
 
   # Update node modules if needed.
-  if not shakaBuildHelpers.update_node_modules():
-    return 1
+  shakaBuildHelpers.update_node_modules()
 
   for name, step in _CHECKS:
     if not parsed_args.filter or name in parsed_args.filter:

--- a/build/gendeps.py
+++ b/build/gendeps.py
@@ -38,8 +38,7 @@ deps_args = [
 def main(_):
   """Generates the uncompiled dependencies files."""
   # Update node modules if needed.
-  if not shakaBuildHelpers.update_node_modules():
-    return 1
+  shakaBuildHelpers.update_node_modules()
 
   logging.info('Generating Closure dependencies...')
 

--- a/build/test.py
+++ b/build/test.py
@@ -430,9 +430,7 @@ class Launcher:
       logging.error('xvfb can only be used on Linux')
       return 1
 
-    if not shakaBuildHelpers.update_node_modules():
-      logging.error('Failed to update node modules')
-      return 1
+    shakaBuildHelpers.update_node_modules()
 
     karma = shakaBuildHelpers.get_node_binary('karma')
     cmd = ['xvfb-run', '--auto-servernum'] if self.parsed_args.use_xvfb else []


### PR DESCRIPTION
Now Shaka use package-lock.json, and it's so fast to run npm install, so there is no need to have custom way to check if node_modules is up to date.