### PR TITLE
chore(deps): Upgrade less to v4 (prerelease)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "karma-sourcemap-loader": "^0.3.8",
         "karma-spec-reporter": "^0.0.33",
         "karma-webdriver-launcher": "^1.0.8",
-        "less": "^3.13.1",
+        "less": "https://gitpkg.now.sh/joeyparrish/less.js/packages/less?28c63a43",
         "less-plugin-clean-css": "github:austingardner/less-plugin-clean-css#4e9e77bf",
         "material-design-lite": "^1.3.0",
         "mux.js": "^5.14.1",
@@ -5644,13 +5644,15 @@
       }
     },
     "node_modules/less": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/less/-/less-3.13.1.tgz",
-      "integrity": "sha512-SwA1aQXGUvp+P5XdZslUOhhLnClSLIjWvJhmd+Vgib5BFIr9lMNlQwmwUNOjXThF/A0x+MCYYPeWEfeWiLRnTw==",
+      "version": "4.1.2",
+      "resolved": "https://gitpkg.now.sh/joeyparrish/less.js/packages/less?28c63a43",
+      "integrity": "sha512-i5qb64PowTQ7eCLt7rlRcsNwFK9M5htl1ioP3Y/7WdU5NNpjpE8JgbUInlA97w4Vqqcd7PdCTgSBPLrs+Yvxag==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "copy-anything": "^2.0.1",
-        "tslib": "^1.10.0"
+        "parse-node-version": "^1.0.1",
+        "tslib": "^2.3.0"
       },
       "bin": {
         "lessc": "bin/lessc"
@@ -5664,7 +5666,7 @@
         "image-size": "~0.5.0",
         "make-dir": "^2.1.0",
         "mime": "^1.4.1",
-        "native-request": "^1.0.5",
+        "needle": "github:joeyparrish/needle#86b2c2ff",
         "source-map": "~0.6.0"
       }
     },
@@ -6174,18 +6176,52 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/native-request": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/native-request/-/native-request-1.1.0.tgz",
-      "integrity": "sha512-uZ5rQaeRn15XmpgE0xoPL8YWqcX90VtCFglYwAgkvKM5e8fog+vePLAhHxuuv/gRkrQxIeh5U3q9sMNUrENqWw==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/needle": {
+      "version": "3.0.1",
+      "resolved": "git+ssh://git@github.com/joeyparrish/needle.git#86b2c2fffc35b4a6433482ea5ebcc1837702d26f",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.6.3",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/needle/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -6488,6 +6524,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-node-version": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/parseurl": {
@@ -7953,9 +7998,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
     },
     "node_modules/tunnel-agent": {
@@ -12749,9 +12794,8 @@
       }
     },
     "less": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/less/-/less-3.13.1.tgz",
-      "integrity": "sha512-SwA1aQXGUvp+P5XdZslUOhhLnClSLIjWvJhmd+Vgib5BFIr9lMNlQwmwUNOjXThF/A0x+MCYYPeWEfeWiLRnTw==",
+      "version": "https://gitpkg.now.sh/joeyparrish/less.js/packages/less?28c63a43",
+      "integrity": "sha512-i5qb64PowTQ7eCLt7rlRcsNwFK9M5htl1ioP3Y/7WdU5NNpjpE8JgbUInlA97w4Vqqcd7PdCTgSBPLrs+Yvxag==",
       "dev": true,
       "requires": {
         "copy-anything": "^2.0.1",
@@ -12760,9 +12804,10 @@
         "image-size": "~0.5.0",
         "make-dir": "^2.1.0",
         "mime": "^1.4.1",
-        "native-request": "^1.0.5",
+        "needle": "github:joeyparrish/needle#86b2c2ff",
+        "parse-node-version": "^1.0.1",
         "source-map": "~0.6.0",
-        "tslib": "^1.10.0"
+        "tslib": "^2.3.0"
       },
       "dependencies": {
         "make-dir": {
@@ -13154,18 +13199,44 @@
       "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
     },
-    "native-request": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/native-request/-/native-request-1.1.0.tgz",
-      "integrity": "sha512-uZ5rQaeRn15XmpgE0xoPL8YWqcX90VtCFglYwAgkvKM5e8fog+vePLAhHxuuv/gRkrQxIeh5U3q9sMNUrENqWw==",
-      "dev": true,
-      "optional": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "needle": {
+      "version": "git+ssh://git@github.com/joeyparrish/needle.git#86b2c2fffc35b4a6433482ea5ebcc1837702d26f",
+      "dev": true,
+      "from": "needle@github:joeyparrish/needle#86b2c2ff",
+      "optional": true,
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.6.3",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
     },
     "negotiator": {
       "version": "0.6.3",
@@ -13393,6 +13464,12 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-node-version": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.3",
@@ -14529,9 +14606,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "karma-sourcemap-loader": "^0.3.8",
     "karma-spec-reporter": "^0.0.33",
     "karma-webdriver-launcher": "^1.0.8",
-    "less": "^3.13.1",
+    "less": "https://gitpkg.now.sh/joeyparrish/less.js/packages/less?28c63a43",
     "less-plugin-clean-css": "github:austingardner/less-plugin-clean-css#4e9e77bf",
     "material-design-lite": "^1.3.0",
     "mux.js": "^5.14.1",


### PR DESCRIPTION
In #3991, I changed the syntax of our colors to a modern rgba syntax.
For example, rgba(255, 255, 255, 0.85) would become rgba(255 255 255 /
85%). However, less v3 seems not to understand that properly, and
performs division on the last two parts, resulting in output of
rgba(255 255 3%), which is indeed invalid.

This fixes the issue by upgrading to less v4, which understands the
new rgba syntax and leaves it alone. The output for that will now
match the input.

To work around an issue with less v4, this uses a prerelease version
with a fix for https://github.com/less/less.js/issues/3693 . See also
https://github.com/tomas/needle/issues/391

This doesn't affect any release branches, since #3991 hasn't been
cherry-picked.

Closes #4027
