### PR TITLE
test: Minimize file globs served by test runner

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -136,17 +136,18 @@ module.exports = (config) => {
       {pattern: 'ui/**/*.js', included: false},
       {pattern: 'ui/**/*.less', included: false},
       {pattern: 'third_party/**/*.js', included: false},
-      {
-        pattern: 'node_modules/google-closure-library/closure/goog/**/*.js',
-        included: false,
-      },
       {pattern: 'test/test/assets/*', included: false},
       {pattern: 'test/test/assets/3675/*', included: false},
       {pattern: 'dist/shaka-player.ui.js', included: false},
       {pattern: 'dist/locales.js', included: false},
       {pattern: 'demo/locales/en.json', included: false},
       {pattern: 'demo/locales/source.json', included: false},
-      {pattern: 'node_modules/**/*.js', included: false},
+      {pattern: 'node_modules/sprintf-js/src/sprintf.js', included: false},
+      {pattern: 'node_modules/less/dist/less.js', included: false},
+      {
+        pattern: 'node_modules/fontfaceonload/dist/fontfaceonload.js',
+        included: false,
+      },
     ],
 
     // NOTE: Do not use proxies at all!  They cannot be used with the --hostname


### PR DESCRIPTION
This was originally supposed to help resolve "too many open file"
errors in the test runner, but we could not prove that this made any
difference.  Still, it doesn't seem to hurt.  Tests start up ~6%
faster (several seconds difference on my workstation).
