### PR TITLE
chore: Remove SSH URLs from package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4678,7 +4678,7 @@
     },
     "node_modules/htmlhint": {
       "version": "1.1.2",
-      "resolved": "git+ssh://git@github.com/joeyparrish/HTMLHint.git#1c3a7e8bc338a6206baad228dd6bbb6b347f8b02",
+      "resolved": "git+https://github.com/joeyparrish/HTMLHint.git#1c3a7e8bc338a6206baad228dd6bbb6b347f8b02",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5290,7 +5290,7 @@
     },
     "node_modules/jsdoc": {
       "version": "3.6.10",
-      "resolved": "git+ssh://git@github.com/joeyparrish/jsdoc.git#2ca85bb6e7686dac8790325d2b029df83547a1b4",
+      "resolved": "git+https://github.com/joeyparrish/jsdoc.git#2ca85bb6e7686dac8790325d2b029df83547a1b4",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5672,7 +5672,7 @@
     },
     "node_modules/less-plugin-clean-css": {
       "version": "1.5.1",
-      "resolved": "git+ssh://git@github.com/austingardner/less-plugin-clean-css.git#4e9e77bf746adcd6e51beeaf8f226bf6e8932822",
+      "resolved": "git+https://github.com/austingardner/less-plugin-clean-css.git#4e9e77bf746adcd6e51beeaf8f226bf6e8932822",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6184,7 +6184,7 @@
     },
     "node_modules/needle": {
       "version": "3.0.1",
-      "resolved": "git+ssh://git@github.com/joeyparrish/needle.git#86b2c2fffc35b4a6433482ea5ebcc1837702d26f",
+      "resolved": "git+https://github.com/joeyparrish/needle.git#86b2c2fffc35b4a6433482ea5ebcc1837702d26f",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -12041,7 +12041,7 @@
       "dev": true
     },
     "htmlhint": {
-      "version": "git+ssh://git@github.com/joeyparrish/HTMLHint.git#1c3a7e8bc338a6206baad228dd6bbb6b347f8b02",
+      "version": "git+https://github.com/joeyparrish/HTMLHint.git#1c3a7e8bc338a6206baad228dd6bbb6b347f8b02",
       "dev": true,
       "from": "htmlhint@github:joeyparrish/HTMLHint#1c3a7e8b",
       "requires": {
@@ -12507,7 +12507,7 @@
       "dev": true
     },
     "jsdoc": {
-      "version": "git+ssh://git@github.com/joeyparrish/jsdoc.git#2ca85bb6e7686dac8790325d2b029df83547a1b4",
+      "version": "git+https://github.com/joeyparrish/jsdoc.git#2ca85bb6e7686dac8790325d2b029df83547a1b4",
       "dev": true,
       "from": "jsdoc@github:joeyparrish/jsdoc#2ca85bb6",
       "requires": {
@@ -12845,7 +12845,7 @@
       }
     },
     "less-plugin-clean-css": {
-      "version": "git+ssh://git@github.com/austingardner/less-plugin-clean-css.git#4e9e77bf746adcd6e51beeaf8f226bf6e8932822",
+      "version": "git+https://github.com/austingardner/less-plugin-clean-css.git#4e9e77bf746adcd6e51beeaf8f226bf6e8932822",
       "dev": true,
       "from": "less-plugin-clean-css@github:austingardner/less-plugin-clean-css#4e9e77bf",
       "requires": {
@@ -13206,7 +13206,7 @@
       "dev": true
     },
     "needle": {
-      "version": "git+ssh://git@github.com/joeyparrish/needle.git#86b2c2fffc35b4a6433482ea5ebcc1837702d26f",
+      "version": "git+https://github.com/joeyparrish/needle.git#86b2c2fffc35b4a6433482ea5ebcc1837702d26f",
       "dev": true,
       "from": "needle@github:joeyparrish/needle#86b2c2ff",
       "optional": true,


### PR DESCRIPTION
This was causing issues with older versions of npm.
