### PR TITLE
ci: Test Docker build

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -48,7 +48,7 @@ jobs:
       # ones end early.
       fail-fast: false
 
-    name: Build and test ${{ matrix.os }} ${{ matrix.browser }}
+    name: ${{ matrix.os }} ${{ matrix.browser }}
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -71,3 +71,13 @@ jobs:
       - name: Test Player
         run: |
           python build/test.py --browsers ${{ matrix.browser }} --reporters spec --spec-hide-passed --drm ${{ matrix.extra_flags }}
+
+  build_in_docker:
+    # Don't waste time doing a full matrix of test runs when there was an
+    # obvious linter error.
+    needs: lint
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docker
+      - run: docker build build/docker/

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -3,18 +3,12 @@ FROM node:17.7.1-alpine3.15
 
 WORKDIR /usr/src/app
 
-# install dependencies
+# Install dependencies
 RUN apk add --update --no-cache openssh git python3 openjdk11-jre-headless
 RUN ln -sf python3 /usr/bin/python
 
 # Change to non-root user
 USER node
-
-# Python user's setup
-RUN mkdir -p /home/node/.local/bin
-ENV PATH="$PATH:/home/node/.local/bin"
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade pip setuptools
 
 # Prevent proxy timeout error (very slow connections)
 RUN npm config set fetch-retry-mintimeout 20000


### PR DESCRIPTION
This adds CI tests for Docker builds, to make sure they keep working.

This also simplifies the Docker build by removing things related to "pip", which we do not use.