### PR TITLE
ci: Next release from main will be v4.0.0

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,7 +3,7 @@
   "packages": {
     ".": {
       "include-component-in-tag": false,
-      "release-as": "3.4.0"
+      "release-as": "4.0.0"
     }
   }
 }


### PR DESCRIPTION
This release-please config file is a temporary measure until our first
automated feature release from main.  So we have to explicitly state
the version number for this first release, and keep it up-to-date.

After the release, we should be able to remove this file and let the
workflow decide on version numbers automatically based on commit
messages.

<!--
Please remember to:

1. Use Conventional Commits syntax (fix: ..., feat: ..., etc.) in commits and
   PR title (https://www.conventionalcommits.org/)
2. Tag any related or fixed issues ("Issue #123", "Closes #420")
3. Sign the Google CLA if you haven't (https://cla.developers.google.com)

You may delete this comment from the PR description.
-->
