### PR TITLE
ci: Use simplified expression syntax

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -30,9 +30,9 @@ jobs:
 
       # If we didn't create a release, we may have created or updated a PR.
       - uses: actions/checkout@v2
-        if: ${{ ! steps.release.outputs.release_created }}
+        if: steps.release.outputs.release_created == false
       - name: Custom update Player version
-        if: ${{ ! steps.release.outputs.release_created }}
+        if: steps.release.outputs.release_created == false
         run: |
           # Check out the branch that release-please created, if it exists.
           git fetch
@@ -56,7 +56,7 @@ jobs:
   tag-main:
     runs-on: ubuntu-latest
     needs: release
-    if: ${{ needs.release.outputs.release_created }}
+    if: needs.release.outputs.release_created
     steps:
       - uses: actions/checkout@v2
       - name: Tag the main branch
@@ -71,7 +71,7 @@ jobs:
   npm:
     runs-on: ubuntu-latest
     needs: release
-    if: ${{ needs.release.outputs.release_created }}
+    if: needs.release.outputs.release_created
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -96,7 +96,7 @@ jobs:
   appspot:
     runs-on: ubuntu-latest
     needs: release
-    if: ${{ needs.release.outputs.release_created }}
+    if: needs.release.outputs.release_created
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The "if" fields do not need to use expression syntax (`${{ }}`), and
some conditionals will be easier to read if we omit that.

<!--
Please remember to:

1. Use Conventional Commits syntax (fix: ..., feat: ..., etc.) in commits and
   PR title (https://www.conventionalcommits.org/)
2. Tag any related or fixed issues ("Issue #123", "Closes #420")
3. Sign the Google CLA if you haven't (https://cla.developers.google.com)

You may delete this comment from the PR description.
-->
