### PR TITLE
fix(UI): Add cursor pointer to range elements

### DIFF
--- a/ui/less/range_elements.less
+++ b/ui/less/range_elements.less
@@ -57,6 +57,11 @@
   /* The track should fill the range element. */
   width: 100%;
 
+  /* Since range elements are special input elements, they must reflect user
+   * interaction, so when the user hovers over the range element, the cursor
+   * must be a pointer. */
+  cursor: pointer;
+
   /* The track should be tall enough to contain the thumb without clipping it.
    * It is very tricky to make the thumb show outside the track on IE 11, and
    * it is incompatible with our background gradients. */


### PR DESCRIPTION
Since range elements are special input elements, they must reflect user interaction, so when the user hovers over the range element, the cursor must be a pointer.

Related https://github.com/shaka-project/shaka-player/pull/3220