### PR TITLE
fix: Fix CMCD output consistency on Xbox One

### DIFF
--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -480,6 +480,12 @@ shaka.util.CmcdManager = class {
         result = key;
       } else if (type === 'symbol') {
         result = `${key}=${value.description}`;
+      } else if (value == null) {
+        // On some platforms (Xbox), `key=${undefined}` returns
+        // 'key=undefined', whereas on others, it returns 'key='.  For
+        // consistency in output and in tests, check for null & undefined
+        // explicitly.
+        result = `${key}=`;
       } else {
         result = `${key}=${value}`;
       }


### PR DESCRIPTION
CMCD tests were failing on Xbox One due to an inconsistency in the
treatment of `key=${undefined}`.  This fixes the test and any possible
related issues by checking for undefined/null explicitly in the CMCD
manager when it serializes values.