### PR TITLE
chore: Upgrade HTMLHint to new version with vulnerability fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "google-closure-compiler-java": "^20220301.0.0",
         "google-closure-deps": "^20220301.0.0",
         "google-closure-library": "^20220301.0.0",
-        "htmlhint": "github:joeyparrish/HTMLHint#1c3a7e8b",
+        "htmlhint": "^1.1.3",
         "jasmine-ajax": "^4.0.0",
         "jimp": "^0.16.1",
         "jsdoc": "github:joeyparrish/jsdoc#2ca85bb6",
@@ -3141,12 +3141,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.1.0.tgz",
+      "integrity": "sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==",
       "dev": true,
       "engines": {
-        "node": ">= 12"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/component-emitter": {
@@ -4692,14 +4692,14 @@
       }
     },
     "node_modules/htmlhint": {
-      "version": "1.1.2",
-      "resolved": "git+ssh://git@github.com/joeyparrish/HTMLHint.git#1c3a7e8bc338a6206baad228dd6bbb6b347f8b02",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/htmlhint/-/htmlhint-1.1.3.tgz",
+      "integrity": "sha512-Z2GtamhFnhCAXKP5lsfqShIDlk6eHEI5U6B9A/JXstdgakoOC2y9nF1b38DcVNBJ8eHn/wfSdh4GVrW4NmmFEQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "async": "3.2.3",
         "chalk": "^4.1.2",
-        "commander": "^8.3.0",
+        "commander": "^9.1.0",
         "glob": "^7.2.0",
         "is-glob": "^4.0.3",
         "node-fetch": "^2.6.2",
@@ -10836,9 +10836,9 @@
       }
     },
     "commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.1.0.tgz",
+      "integrity": "sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==",
       "dev": true
     },
     "component-emitter": {
@@ -12045,13 +12045,14 @@
       "dev": true
     },
     "htmlhint": {
-      "version": "git+ssh://git@github.com/joeyparrish/HTMLHint.git#1c3a7e8bc338a6206baad228dd6bbb6b347f8b02",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/htmlhint/-/htmlhint-1.1.3.tgz",
+      "integrity": "sha512-Z2GtamhFnhCAXKP5lsfqShIDlk6eHEI5U6B9A/JXstdgakoOC2y9nF1b38DcVNBJ8eHn/wfSdh4GVrW4NmmFEQ==",
       "dev": true,
-      "from": "htmlhint@github:joeyparrish/HTMLHint#1c3a7e8b",
       "requires": {
         "async": "3.2.3",
         "chalk": "^4.1.2",
-        "commander": "^8.3.0",
+        "commander": "^9.1.0",
         "glob": "^7.2.0",
         "is-glob": "^4.0.3",
         "node-fetch": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "google-closure-compiler-java": "^20220301.0.0",
     "google-closure-deps": "^20220301.0.0",
     "google-closure-library": "^20220301.0.0",
-    "htmlhint": "github:joeyparrish/HTMLHint#1c3a7e8b",
+    "htmlhint": "^1.1.3",
     "jasmine-ajax": "^4.0.0",
     "jimp": "^0.16.1",
     "jsdoc": "github:joeyparrish/jsdoc#2ca85bb6",


### PR DESCRIPTION
We were using a pre-release version of the same for a while, but this
is the same fix in an official release.
