### PR TITLE
ci: Fix Docker build

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -79,5 +79,10 @@ jobs:
     name: Docker
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
       - name: Docker
-        run: docker build build/docker/
+        run: docker-compose -f build/docker/docker-compose.yml up


### PR DESCRIPTION
This fixes the workflow job failing because of missing sources, and it
also fixes the job to run the compiler, not just build the image that
_could_ run the compiler.

Closes #4076

<!--
Please remember to:

1. Use Conventional Commits syntax (fix: ..., feat: ..., etc.) in commits and
   PR title (https://www.conventionalcommits.org/)
2. Tag any related or fixed issues ("Issue #123", "Closes #420")
3. Sign the Google CLA if you haven't (https://cla.developers.google.com)

You may delete this comment from the PR description.
-->
