### PR TITLE
fix: Fix broken deps file generation on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "fastestsmallesttextencoderdecoder": "^1.0.22",
         "fontfaceonload": "^1.0.2",
         "google-closure-compiler-java": "^20220301.0.0",
-        "google-closure-deps": "^20220301.0.0",
+        "google-closure-deps": "https://gitpkg.now.sh/google/closure-library/closure-deps?d7736da6",
         "google-closure-library": "^20220301.0.0",
         "htmlhint": "^1.1.3",
         "jasmine-ajax": "^4.0.0",
@@ -4575,9 +4575,10 @@
     },
     "node_modules/google-closure-deps": {
       "version": "20220301.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-deps/-/google-closure-deps-20220301.0.0.tgz",
-      "integrity": "sha512-ZlJCUwpc9IpsuaeCwt15Y+PfdHhUaQYB4F+wahWVPnQeD5xcSXFd3URrXyYkLbZS+6hUH0ZwWtWZFj+W2eqq0Q==",
+      "resolved": "https://gitpkg.now.sh/google/closure-library/closure-deps?d7736da6",
+      "integrity": "sha512-OUmhEm8aXW+eUb+4QonusAl4wrXU+sUQ4joJ3zz4UjTNfJRyLF1ac5egw2vr6irg/tW8BsiZ3KL4FrNTsGCz0Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^3.0.4",
         "yargs": "^16.2.0"
@@ -5305,7 +5306,7 @@
     },
     "node_modules/jsdoc": {
       "version": "3.6.10",
-      "resolved": "git+ssh://git@github.com/joeyparrish/jsdoc.git#2ca85bb6e7686dac8790325d2b029df83547a1b4",
+      "resolved": "https://github.com/joeyparrish/jsdoc.git#2ca85bb6e7686dac8790325d2b029df83547a1b4",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5672,7 +5673,7 @@
     },
     "node_modules/less-plugin-clean-css": {
       "version": "1.5.1",
-      "resolved": "git+ssh://git@github.com/austingardner/less-plugin-clean-css.git#4e9e77bf746adcd6e51beeaf8f226bf6e8932822",
+      "resolved": "https://github.com/austingardner/less-plugin-clean-css.git#4e9e77bf746adcd6e51beeaf8f226bf6e8932822",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6178,7 +6179,7 @@
     },
     "node_modules/needle": {
       "version": "3.0.1",
-      "resolved": "git+ssh://git@github.com/joeyparrish/needle.git#86b2c2fffc35b4a6433482ea5ebcc1837702d26f",
+      "resolved": "https://github.com/joeyparrish/needle.git#86b2c2fffc35b4a6433482ea5ebcc1837702d26f",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -11959,9 +11960,8 @@
       "dev": true
     },
     "google-closure-deps": {
-      "version": "20220301.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-deps/-/google-closure-deps-20220301.0.0.tgz",
-      "integrity": "sha512-ZlJCUwpc9IpsuaeCwt15Y+PfdHhUaQYB4F+wahWVPnQeD5xcSXFd3URrXyYkLbZS+6hUH0ZwWtWZFj+W2eqq0Q==",
+      "version": "https://gitpkg.now.sh/google/closure-library/closure-deps?d7736da6",
+      "integrity": "sha512-OUmhEm8aXW+eUb+4QonusAl4wrXU+sUQ4joJ3zz4UjTNfJRyLF1ac5egw2vr6irg/tW8BsiZ3KL4FrNTsGCz0Q==",
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4",
@@ -12512,7 +12512,7 @@
       "dev": true
     },
     "jsdoc": {
-      "version": "git+ssh://git@github.com/joeyparrish/jsdoc.git#2ca85bb6e7686dac8790325d2b029df83547a1b4",
+      "version": "https://github.com/joeyparrish/jsdoc.git#2ca85bb6e7686dac8790325d2b029df83547a1b4",
       "dev": true,
       "from": "jsdoc@github:joeyparrish/jsdoc#2ca85bb6",
       "requires": {
@@ -12841,7 +12841,7 @@
       }
     },
     "less-plugin-clean-css": {
-      "version": "git+ssh://git@github.com/austingardner/less-plugin-clean-css.git#4e9e77bf746adcd6e51beeaf8f226bf6e8932822",
+      "version": "https://github.com/austingardner/less-plugin-clean-css.git#4e9e77bf746adcd6e51beeaf8f226bf6e8932822",
       "dev": true,
       "from": "less-plugin-clean-css@github:austingardner/less-plugin-clean-css#4e9e77bf",
       "requires": {
@@ -13193,7 +13193,7 @@
       "dev": true
     },
     "needle": {
-      "version": "git+ssh://git@github.com/joeyparrish/needle.git#86b2c2fffc35b4a6433482ea5ebcc1837702d26f",
+      "version": "https://github.com/joeyparrish/needle.git#86b2c2fffc35b4a6433482ea5ebcc1837702d26f",
       "dev": true,
       "from": "needle@github:joeyparrish/needle#86b2c2ff",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "fastestsmallesttextencoderdecoder": "^1.0.22",
     "fontfaceonload": "^1.0.2",
     "google-closure-compiler-java": "^20220301.0.0",
-    "google-closure-deps": "^20220301.0.0",
+    "google-closure-deps": "https://gitpkg.now.sh/google/closure-library/closure-deps?d7736da6",
     "google-closure-library": "^20220301.0.0",
     "htmlhint": "^1.1.3",
     "jasmine-ajax": "^4.0.0",


### PR DESCRIPTION
This fixes broken deps file generation on Window by upgrading to a
pre-release version of the deps tool.  The upstream issue was filed in
https://github.com/google/closure-library/issues/1159 and fixed in
https://github.com/google/closure-library/pull/1160.

This issue has never affected a release version of Shaka Player, and
was introduced when we switched deps tools in 6f274cbc.

Closes #4085

<!--
Please remember to:

1. Use Conventional Commits syntax (fix: ..., feat: ..., etc.) in commits and
   PR title (https://www.conventionalcommits.org/)
2. Tag any related or fixed issues ("Issue #123", "Closes #420")
3. Sign the Google CLA if you haven't (https://cla.developers.google.com)

You may delete this comment from the PR description.
-->
