### PR TITLE
ci: Test on Safari 14

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -32,14 +32,18 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        browser: ["Chrome", "Firefox", "Edge", "Safari"]
+        browser: ["Chrome", "Firefox", "Edge", "Safari", "Safari-14"]
         exclude:
           - os: ubuntu-latest
             browser: Edge
           - os: windows-latest
             browser: Safari
+          - os: windows-latest
+            browser: Safari-14
           - os: ubuntu-latest
             browser: Safari
+          - os: ubuntu-latest
+            browser: Safari-14
         include:
           # Run Linux browsers with xvfb, so they're in a headless X session.
           - os: ubuntu-latest
@@ -65,12 +69,43 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
+      # Safari 14 can be installed, but not to the root, and it can't replace
+      # the standard version, at least not on GitHub's VMs.  If you try to
+      # install directly to the root with sudo, it will appear to succeed, but
+      # will have no effect.  If you try to script it explicitly with rm -rf
+      # and cp, this will fail.  Safari may be on a read-only filesystem.
+      - name: Install Safari 14 to home directory
+        if: matrix.os == 'macos-latest' && matrix.browser == 'Safari-14'
+        run: |
+          # Download Safari 14
+          # See also https://www.macupdate.com/app/mac/15675/apple-safari/old-versions
+          curl -Lv https://www.macupdate.com/action/download/63550 > safari-14.1.2.pkg
+
+          # Install Safari 14 to homedir specifically.
+          installer -pkg safari-14.1.2.pkg -target CurrentUserHomeDirectory
+
+          # Install a launcher that can execute a shell script to launch this
+          npm install karma-script-launcher --save-dev
+
       - name: Build Player
         run: python build/all.py
 
       - name: Test Player
+        shell: bash
         run: |
-          python build/test.py --browsers ${{ matrix.browser }} --reporters spec --spec-hide-passed --drm ${{ matrix.extra_flags }}
+          browser=${{ matrix.browser }}
+
+          if [[ "$browser" == "Safari-14" ]]; then
+            # Replace the browser name with a script that can launch this
+            # browser from the command line.
+            browser="$PWD/.github/workflows/safari-homedir-launcher.sh"
+          fi
+
+          python build/test.py \
+            --browsers "$browser" \
+            --reporters spec --spec-hide-passed \
+            --drm \
+            ${{ matrix.extra_flags }}
 
   build_in_docker:
     # Don't waste time doing a full matrix of test runs when there was an

--- a/.github/workflows/safari-homedir-launcher.sh
+++ b/.github/workflows/safari-homedir-launcher.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# A script to launch a homedir-installed copy of Safari in Karma.  Used with
+# karma-script-launcher and --browsers path/to/script.
+
+# There is an issue where opening a URL in a browser that is not already open
+# will also open it in the default browser.  See
+# https://apple.stackexchange.com/a/122000/454832 and the comments below it for
+# details.
+
+# The workaround is to open the browser explicitly first, without a URL.
+open -a ~/Applications/Safari.app --fresh
+sleep 5
+
+# Then open the browser with the URL, and wait for it to quite.  In fact, the
+# browser won't be closed automatically at all, and Karma will kill this script
+# when the tests complete.  But if we don't wait, Karma will error instead.
+open -a ~/Applications/Safari.app --wait-apps "$1"


### PR DESCRIPTION
In the GitHub Actions environment, it is now possible to install and
run tests on Safari 14.  Though not completely straightforward, it
doesn't add much code to the workflow and shouldn't be too difficult
to maintain.

Closes #3899