### PR TITLE
feat(HLS): Re-add TS support to Safari

### DIFF
--- a/lib/polyfill/mediasource.js
+++ b/lib/polyfill/mediasource.js
@@ -38,11 +38,6 @@ shaka.polyfill.MediaSource = class {
       // Chromecast cannot make accurate determinations via isTypeSupported.
       shaka.polyfill.MediaSource.patchCastIsTypeSupported_();
     } else if (safariVersion) {
-      // TS content is broken on Safari in general.
-      // See https://github.com/shaka-project/shaka-player/issues/743
-      // and https://bugs.webkit.org/show_bug.cgi?id=165342
-      shaka.polyfill.MediaSource.rejectTsContent_();
-
       // NOTE:  shaka.Player.isBrowserSupported() has its own restrictions on
       // Safari version.
       if (safariVersion <= 12) {
@@ -124,29 +119,6 @@ shaka.polyfill.MediaSource = class {
     SourceBuffer.prototype.remove = function(startTime, endTime) {
       // eslint-disable-next-line no-restricted-syntax
       return originalRemove.call(this, startTime, endTime - 0.001);
-    };
-  }
-
-  /**
-   * Patch isTypeSupported() to reject TS content.  Used to avoid TS-related MSE
-   * bugs on Safari.
-   *
-   * @private
-   */
-  static rejectTsContent_() {
-    const originalIsTypeSupported = MediaSource.isTypeSupported;
-
-    MediaSource.isTypeSupported = (mimeType) => {
-      // Parse the basic MIME type from its parameters.
-      const pieces = mimeType.split(/ *; */);
-      const basicMimeType = pieces[0];
-      const container = basicMimeType.split('/')[1];
-
-      if (container.toLowerCase() == 'mp2t') {
-        return false;
-      }
-
-      return originalIsTypeSupported(mimeType);
     };
   }
 


### PR DESCRIPTION
It appears that the problems we previously had with TS content
on Safari have been fixed. We no longer need the workaround where
we transmuxed TS on that platform.