### PR TITLE
build: Don't ignore failures to generate deps

### DIFF
--- a/build/gendeps.py
+++ b/build/gendeps.py
@@ -53,6 +53,13 @@ def main(_):
       '--closure-path', 'node_modules/google-closure-library/closure/goog',
     ]
     deps = shakaBuildHelpers.execute_get_output(cmd_line)
+
+    # This command doesn't use exit codes for some stupid reason.
+    # TODO: Remove when https://github.com/google/closure-library/issues/1162
+    # is resolved and we have upgraded.
+    if len(deps) == 0:
+      return 1
+
     with open(os.path.join(base, 'dist', 'deps.js'), 'wb') as f:
       f.write(deps)
     return 0


### PR DESCRIPTION
Since transitioning from the deprecated depswriter.py to the new
closure-make-deps tool in 6f274cbc, the build system has been ignoring
any failures in the generation of deps.js.  This is because the new
tool doesn't return a proper non-zero exit code when it fails.  (See
https://github.com/google/closure-library/issues/1162)

This changes the build scripts to check for empty output instead,
which seems to be reliable for the moment.
