### PR TITLE
test: Fix Jasmine 4 deprecation warnings

### DIFF
--- a/test/test/util/util.js
+++ b/test/test/util/util.js
@@ -464,13 +464,13 @@ shaka.test.Util = class {
  */
 shaka.test.Util.customMatchers_ = {
   // Custom matcher for Element objects.
-  toEqualElement: (util, customEqualityTesters) => {
+  toEqualElement: (util) => {
     return {
       compare: shaka.test.Util.expectToEqualElementCompare_,
     };
   },
   // Custom matcher for working with spies.
-  toHaveBeenCalledOnceMore: (util, customEqualityTesters) => {
+  toHaveBeenCalledOnceMore: (util) => {
     return {
       compare: (actual, expected) => {
         const callCount = actual.calls.count();
@@ -490,7 +490,7 @@ shaka.test.Util.customMatchers_ = {
       },
     };
   },
-  toHaveBeenCalledOnceMoreWith: (util, customEqualityTesters) => {
+  toHaveBeenCalledOnceMoreWith: (util) => {
     return {
       compare: (actual, expected) => {
         const callCount = actual.calls.count();
@@ -503,7 +503,7 @@ shaka.test.Util.customMatchers_ = {
         if (callCount != 1) {
           result.pass = false;
           result.message = 'Expected to be called once, not ' + callCount;
-        } else if (!util.equals(callArgs, expected, customEqualityTesters)) {
+        } else if (!util.equals(callArgs, expected)) {
           result.pass = false;
           result.message =
               'Expected to be called with ' + expected + ' not ' + callArgs;


### PR DESCRIPTION
Jasmine 4 deprecated some part of its custom matcher API.

This puts us in compliance with the new API (by omitting a parameter
we didn't really need), and silences the deprecation warnings (which
only showed up when enabling logging in the tests).
