### PR TITLE
build: Add missing provide/require in demo

### DIFF
--- a/demo/asset_card.js
+++ b/demo/asset_card.js
@@ -4,11 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 goog.provide('shakaDemo.AssetCard');
 
-
 goog.require('goog.asserts');
+goog.require('shakaAssets');
 goog.require('shakaDemo.MessageIds');
 goog.require('shakaDemo.Tooltips');
 goog.requireType('ShakaDemoAssetInfo');

--- a/demo/common/assets.js
+++ b/demo/common/assets.js
@@ -13,6 +13,8 @@
 goog.require('ShakaDemoAssetInfo');
 goog.require('shakaDemo.MessageIds');
 
+goog.provide('shakaAssets');
+
 
 // Types and enums {{{
 /**


### PR DESCRIPTION
The demo sources didn't properly provide/require the shakaAssets
namespace.  This caused issues when I tried to change the way demo
sources were loaded in tests.

Related to issue #4094
