### PR TITLE
build(demo): Minimize goog.require in demo_uncompiled.js

### DIFF
--- a/demo/demo_uncompiled.js
+++ b/demo/demo_uncompiled.js
@@ -4,20 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shakaDemo.AssetCard');
-goog.require('shakaDemo.CloseButton');
 goog.require('shakaDemo.Config');
 goog.require('shakaDemo.Custom');
-goog.require('shakaDemo.Utils');
 goog.require('shakaDemo.Front');
-goog.require('shakaDemo.BoolInput');
-goog.require('shakaDemo.DatalistInput');
-goog.require('shakaDemo.Input');
-goog.require('shakaDemo.MessageIds');
-goog.require('shakaDemo.NumberInput');
-goog.require('shakaDemo.SelectInput');
-goog.require('shakaDemo.TextInput');
-goog.require('shakaDemo.InputContainer');
-goog.require('shakaDemo.Main');
 goog.require('shakaDemo.Search');
-goog.require('shakaDemo.Tooltips');
+goog.require('shakaDemo.Main');


### PR DESCRIPTION
Rather than require everything, require only the top-level classes for
the demo, and let them require their dependencies.  This is consistent
with how this works in the library itself.

Related to issue #4094