### PR TITLE
test: Late load tests, fix Chromecast test flake

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -11,7 +11,6 @@ goog.require('goog.asserts');
 goog.require('shakaDemo.BoolInput');
 goog.require('shakaDemo.DatalistInput');
 goog.require('shakaDemo.InputContainer');
-goog.require('shakaDemo.Main');
 goog.require('shakaDemo.MessageIds');
 goog.require('shakaDemo.NumberInput');
 goog.require('shakaDemo.SelectInput');

--- a/demo/custom.js
+++ b/demo/custom.js
@@ -12,7 +12,6 @@ goog.require('ShakaDemoAssetInfo');
 goog.require('shakaDemo.AssetCard');
 goog.require('shakaDemo.Input');
 goog.require('shakaDemo.InputContainer');
-goog.require('shakaDemo.Main');
 goog.require('shakaDemo.MessageIds');
 goog.require('shakaDemo.TextInput');
 

--- a/test/abr/simple_abr_manager_unit.js
+++ b/test/abr/simple_abr_manager_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.abr.SimpleAbrManager');
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.PlayerConfiguration');
-
 describe('SimpleAbrManager', () => {
   const sufficientBWMultiplier = 1.06;
   const defaultBandwidthEstimate = 500e3; // 500kbps

--- a/test/ads/ad_manager_unit.js
+++ b/test/ads/ad_manager_unit.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.Player');
-goog.require('shaka.ads.AdManager');
-goog.require('shaka.test.FakeVideo');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-
 describe('Ad manager', () => {
   /** @type {!shaka.test.FakeVideo} */
   let mockVideo;

--- a/test/cast/cast_proxy_unit.js
+++ b/test/cast/cast_proxy_unit.js
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.cast.CastProxy');
-goog.require('shaka.cast.CastSender');
-goog.require('shaka.test.FakeVideo');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.FakeEvent');
-goog.require('shaka.util.PublicPromise');
-
 describe('CastProxy', () => {
   const CastProxy = shaka.cast.CastProxy;
   const FakeEvent = shaka.util.FakeEvent;

--- a/test/cast/cast_receiver_integration.js
+++ b/test/cast/cast_receiver_integration.js
@@ -4,20 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.Player');
-goog.require('shaka.cast.CastReceiver');
-goog.require('shaka.cast.CastUtils');
-goog.require('shaka.log');
-goog.require('shaka.media.DrmEngine');
-goog.require('shaka.media.ManifestParser');
-goog.require('shaka.media.StreamingEngine');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.test.TestScheme');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.util.EventManager');
-goog.require('shaka.util.Platform');
-goog.require('shaka.util.PublicPromise');
-
 // The receiver is only meant to run on the Chromecast, so we have the
 // ability to use modern APIs there that may not be available on all of the
 // browsers our library supports.  Because of this, CastReceiver tests will

--- a/test/cast/cast_receiver_unit.js
+++ b/test/cast/cast_receiver_unit.js
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.cast.CastReceiver');
-goog.require('shaka.cast.CastUtils');
-goog.require('shaka.test.FakeVideo');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.Platform');
-goog.require('shaka.util.PublicPromise');
-
 // The receiver is only meant to run on the Chromecast, so we have the
 // ability to use modern APIs there that may not be available on all of the
 // browsers our library supports.  Because of this, CastReceiver tests will

--- a/test/cast/cast_sender_unit.js
+++ b/test/cast/cast_sender_unit.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.cast.CastSender');
-goog.require('shaka.cast.CastUtils');
-goog.require('shaka.test.StatusPromise');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-
 describe('CastSender', () => {
   const CastSender = shaka.cast.CastSender;
   const CastUtils = shaka.cast.CastUtils;

--- a/test/cast/cast_utils_unit.js
+++ b/test/cast/cast_utils_unit.js
@@ -4,19 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.Player');
-goog.require('shaka.cast.CastUtils');
-goog.require('shaka.media.MediaSourceEngine');
-goog.require('shaka.media.TimeRangesUtils');
-goog.require('shaka.test.FakeClosedCaptionParser');
-goog.require('shaka.test.FakeTextDisplayer');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.EventManager');
-goog.require('shaka.util.FakeEvent');
-goog.require('shaka.util.FakeEventTarget');
-goog.require('shaka.util.ManifestParserUtils');
-
 describe('CastUtils', () => {
   const CastUtils = shaka.cast.CastUtils;
   const FakeEvent = shaka.util.FakeEvent;

--- a/test/cea/cea608_memory_unit.js
+++ b/test/cea/cea608_memory_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.cea.Cea608Memory');
-goog.require('shaka.cea.CeaUtils');
-goog.require('shaka.test.CeaUtils');
-goog.require('shaka.text.Cue');
-
 describe('Cea608Memory', () => {
   const CeaUtils = shaka.test.CeaUtils;
 

--- a/test/cea/cea708_service_unit.js
+++ b/test/cea/cea708_service_unit.js
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.cea.Cea708Service');
-goog.require('shaka.cea.CeaUtils');
-goog.require('shaka.cea.DtvccPacket');
-goog.require('shaka.cea.DtvccPacketBuilder');
-goog.require('shaka.test.CeaUtils');
-goog.require('shaka.text.Cue');
-
 describe('Cea708Service', () => {
   const CeaUtils = shaka.test.CeaUtils;
 

--- a/test/cea/cea708_window_unit.js
+++ b/test/cea/cea708_window_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.cea.Cea708Window');
-goog.require('shaka.cea.CeaUtils');
-goog.require('shaka.test.CeaUtils');
-goog.require('shaka.text.Cue');
-
 describe('Cea708Window', () => {
   const CeaUtils = shaka.test.CeaUtils;
 

--- a/test/cea/cea_decoder_unit.js
+++ b/test/cea/cea_decoder_unit.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.cea.CeaDecoder');
-goog.require('shaka.cea.CeaUtils');
-goog.require('shaka.log');
-goog.require('shaka.test.CeaUtils');
-goog.require('shaka.text.Cue');
-
 describe('CeaDecoder', () => {
   const CeaUtils = shaka.test.CeaUtils;
 

--- a/test/cea/dtvcc_packet_builder_unit.js
+++ b/test/cea/dtvcc_packet_builder_unit.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.cea.DtvccPacket');
-goog.require('shaka.cea.DtvccPacketBuilder');
-
 describe('DtvccPacketBuilder', () => {
   /** @type {!shaka.cea.DtvccPacketBuilder} */
   let dtvccPacketBuilder;

--- a/test/cea/dtvcc_packet_unit.js
+++ b/test/cea/dtvcc_packet_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.cea.DtvccPacket');
-goog.require('shaka.cea.DtvccPacketBuilder');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-
 describe('DtvccPacket', () => {
   /** @type {!shaka.cea.DtvccPacket} */
   let dtvccPacket;

--- a/test/cea/mp4_cea_parser_unit.js
+++ b/test/cea/mp4_cea_parser_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.cea.Mp4CeaParser');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-
 describe('Mp4CeaParser', () => {
   const ceaInitSegmentUri = '/base/test/test/assets/cea-init.mp4';
   const ceaSegmentUri = '/base/test/test/assets/cea-segment.mp4';

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.dash.ContentProtection');
-goog.require('shaka.dash.DashParser');
-goog.require('shaka.test.Dash');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.PlayerConfiguration');
-goog.require('shaka.util.Uint8ArrayUtils');
-
 // Test DRM-related parsing.
 describe('DashParser ContentProtection', () => {
   const Dash = shaka.test.Dash;

--- a/test/dash/dash_parser_live_unit.js
+++ b/test/dash/dash_parser_live_unit.js
@@ -4,19 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.dash.DashParser');
-goog.require('shaka.media.SegmentReference');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.ManifestParser');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.AbortableOperation');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.PlayerConfiguration');
-goog.require('shaka.util.StringUtils');
-goog.requireType('shaka.util.PublicPromise');
-
 describe('DashParser Live', () => {
   const Util = shaka.test.Util;
   const ManifestParser = shaka.test.ManifestParser;

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -4,21 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.media.SegmentReference');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.test.Dash');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.AbortableOperation');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.LanguageUtils');
-goog.require('shaka.util.ManifestParserUtils');
-goog.require('shaka.util.PlayerConfiguration');
-goog.require('shaka.util.StringUtils');
-goog.requireType('shaka.dash.DashParser');
-
 // Test basic manifest parsing functionality.
 describe('DashParser Manifest', () => {
   const ContentType = shaka.util.ManifestParserUtils.ContentType;

--- a/test/dash/dash_parser_segment_base_unit.js
+++ b/test/dash/dash_parser_segment_base_unit.js
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.test.Dash');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-goog.requireType('shaka.dash.DashParser');
-
 describe('DashParser SegmentBase', () => {
   const Dash = shaka.test.Dash;
 

--- a/test/dash/dash_parser_segment_list_unit.js
+++ b/test/dash/dash_parser_segment_list_unit.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.test.Dash');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.ManifestParser');
-goog.require('shaka.util.Error');
-
 describe('DashParser SegmentList', () => {
   const Dash = shaka.test.Dash;
   const ManifestParser = shaka.test.ManifestParser;

--- a/test/dash/dash_parser_segment_template_unit.js
+++ b/test/dash/dash_parser_segment_template_unit.js
@@ -4,15 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.test.Dash');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.ManifestParser');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.PlayerConfiguration');
-goog.requireType('shaka.dash.DashParser');
-
 describe('DashParser SegmentTemplate', () => {
   const Dash = shaka.test.Dash;
   const ManifestParser = shaka.test.ManifestParser;

--- a/test/dash/mpd_utils_unit.js
+++ b/test/dash/mpd_utils_unit.js
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.dash.MpdUtils');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-goog.requireType('shaka.util.PublicPromise');
-
 describe('MpdUtils', () => {
   const MpdUtils = shaka.dash.MpdUtils;
 

--- a/test/demo/demo_unit.js
+++ b/test/demo/demo_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.FakeDemoMain');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.StringUtils');
-goog.require('shakaDemo.MessageIds');
-
 describe('Demo', () => {
   beforeEach(() => {
     // Make mock versions of misc third-party libraries.

--- a/test/deprecate/enforcer_unit.js
+++ b/test/deprecate/enforcer_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.deprecate.Enforcer');
-goog.require('shaka.deprecate.Version');
-goog.require('shaka.test.Util');
-
 describe('Enforcer', () => {
   const Enforcer = shaka.deprecate.Enforcer;
   const Version = shaka.deprecate.Version;

--- a/test/deprecate/version_unit.js
+++ b/test/deprecate/version_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.deprecate.Version');
-
 describe('Version', () => {
   const Version = shaka.deprecate.Version;
 

--- a/test/hls/hls_live_unit.js
+++ b/test/hls/hls_live_unit.js
@@ -4,15 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.hls.HlsParser');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.ManifestParser');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.PlayerConfiguration');
-goog.require('shaka.util.Uint8ArrayUtils');
-goog.requireType('shaka.util.PublicPromise');
-
 describe('HlsParser live', () => {
   const ManifestParser = shaka.test.ManifestParser;
 

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -4,17 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.hls.HlsParser');
-goog.require('shaka.log');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
-goog.require('shaka.util.PlayerConfiguration');
-goog.require('shaka.util.Uint8ArrayUtils');
-
 describe('HlsParser', () => {
   const ContentType = shaka.util.ManifestParserUtils.ContentType;
   const TextStreamKind = shaka.util.ManifestParserUtils.TextStreamKind;

--- a/test/hls/manifest_text_parser_unit.js
+++ b/test/hls/manifest_text_parser_unit.js
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
-goog.require('shaka.hls.Attribute');
-goog.require('shaka.hls.ManifestTextParser');
-goog.require('shaka.hls.PlaylistType');
-goog.require('shaka.hls.Segment');
-goog.require('shaka.hls.Tag');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.StringUtils');
-
 describe('ManifestTextParser', () => {
   /** @type {!shaka.hls.ManifestTextParser} */
   let parser;

--- a/test/media/adaptation_set_criteria_unit.js
+++ b/test/media/adaptation_set_criteria_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.PreferenceBasedCriteria');
-goog.require('shaka.test.ManifestGenerator');
-goog.requireType('shaka.media.AdaptationSet');
-
 describe('AdaptationSetCriteria', () => {
   describe('preference based selection', () => {
     it('chooses variants in user\'s preferred language', () => {

--- a/test/media/adaptation_set_unit.js
+++ b/test/media/adaptation_set_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.AdaptationSet');
-
 describe('AdaptationSet', () => {
   describe('roles', () => {
     const mimeType = 'mime-type';

--- a/test/media/buffering_observer_unit.js
+++ b/test/media/buffering_observer_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.BufferingObserver');
-
 describe('BufferingObserver', () => {
   const BufferingObserver = shaka.media.BufferingObserver;
   const State = shaka.media.BufferingObserver.State;

--- a/test/media/closed_caption_parser_unit.js
+++ b/test/media/closed_caption_parser_unit.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.ClosedCaptionParser');
-goog.require('shaka.test.Util');
-
 describe('ClosedCaptionParser', () => {
   it('can handle empty caption packets', async () => {
     const initSegment = await shaka.test.Util.fetch(

--- a/test/media/drm_engine_integration.js
+++ b/test/media/drm_engine_integration.js
@@ -4,21 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.DrmEngine');
-goog.require('shaka.media.MediaSourceEngine');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.test.FakeClosedCaptionParser');
-goog.require('shaka.test.FakeTextDisplayer');
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.test.Waiter');
-goog.require('shaka.util.EventManager');
-goog.require('shaka.util.ManifestParserUtils');
-goog.require('shaka.util.Platform');
-goog.require('shaka.util.PlayerConfiguration');
-goog.require('shaka.util.PublicPromise');
-
 describe('DrmEngine', () => {
   const ContentType = shaka.util.ManifestParserUtils.ContentType;
 

--- a/test/media/drm_engine_unit.js
+++ b/test/media/drm_engine_unit.js
@@ -4,26 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.log');
-goog.require('shaka.media.DrmEngine');
-goog.require('shaka.media.Transmuxer');
-goog.require('shaka.net.DataUriPlugin');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.FakeVideo');
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.AbortableOperation');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.Platform');
-goog.require('shaka.util.PlayerConfiguration');
-goog.require('shaka.util.Platform');
-goog.require('shaka.util.PublicPromise');
-goog.require('shaka.util.StringUtils');
-goog.require('shaka.util.Uint8ArrayUtils');
-
-
 describe('DrmEngine', () => {
   const Util = shaka.test.Util;
 

--- a/test/media/manifest_parser_unit.js
+++ b/test/media/manifest_parser_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.ManifestParser');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.test.FakeNetworkingEngine');
-
 const testGetMimeType = async (expertedMimeType, contentType) => {
   const netEngine = new shaka.test.FakeNetworkingEngine()
       .setHeaders('dummy://foo', {'content-type': contentType});

--- a/test/media/media_source_engine_integration.js
+++ b/test/media/media_source_engine_integration.js
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.ClosedCaptionParser');
-goog.require('shaka.media.MediaSourceEngine');
-goog.require('shaka.test.FakeTextDisplayer');
-goog.require('shaka.test.TestScheme');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.util.ManifestParserUtils');
-
 describe('MediaSourceEngine', () => {
   const ContentType = shaka.util.ManifestParserUtils.ContentType;
   const presentationDuration = 840;

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -4,19 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
-goog.require('goog.asserts');
-goog.require('shaka.media.MediaSourceEngine');
-goog.require('shaka.media.Transmuxer');
-goog.require('shaka.test.FakeClosedCaptionParser');
-goog.require('shaka.test.FakeTextDisplayer');
-goog.require('shaka.test.FakeTransmuxer');
-goog.require('shaka.test.StatusPromise');
-goog.require('shaka.test.Util');
-goog.require('shaka.text.TextEngine');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
-
 /**
  * @typedef {{
  *   length: number,

--- a/test/media/mp4_segment_index_parser_unit.js
+++ b/test/media/mp4_segment_index_parser_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.Mp4SegmentIndexParser');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-
 describe('Mp4SegmentIndexParser', () => {
   const Util = shaka.test.Util;
 

--- a/test/media/play_rate_controller_unit.js
+++ b/test/media/play_rate_controller_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
-goog.require('shaka.media.PlayRateController');
-goog.require('shaka.test.Util');
-
 describe('PlayRateController', () => {
   /** @type {!jasmine.Spy} */
   let getPlayRateSpy;

--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
-goog.require('shaka.media.MediaSourcePlayhead');
-goog.require('shaka.test.FakePresentationTimeline');
-goog.require('shaka.test.FakeVideo');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.PlayerConfiguration');
-goog.requireType('shaka.media.Playhead');
-
 /**
  * @typedef {{start: number, end: number}}
  *

--- a/test/media/presentation_timeline_unit.js
+++ b/test/media/presentation_timeline_unit.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.PresentationTimeline');
-goog.require('shaka.test.ManifestParser');
-
 describe('PresentationTimeline', () => {
   const originalDateNow = Date.now;
   const makeSegmentReference = (startTime, endTime) => {

--- a/test/media/quality_observer_unit.js
+++ b/test/media/quality_observer_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.QualityObserver');
-goog.require('shaka.test.Util');
-
-
 describe('QualityObserver', () => {
   /** @type {!shaka.media.QualityObserver} */
   let observer;

--- a/test/media/region_observer_unit.js
+++ b/test/media/region_observer_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.RegionObserver');
-goog.require('shaka.media.RegionTimeline');
-goog.require('shaka.test.Util');
-goog.requireType('shaka.media.IPlayheadObserver');
-
 describe('RegionObserver', () => {
   /** @type {!shaka.media.RegionTimeline} */
   let timeline;

--- a/test/media/region_timeline_unit.js
+++ b/test/media/region_timeline_unit.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.RegionTimeline');
-goog.require('shaka.test.Util');
-
 describe('RegionTimeline', () => {
   /** @type {!shaka.media.RegionTimeline} */
   let timeline;

--- a/test/media/segment_index_unit.js
+++ b/test/media/segment_index_unit.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.media.MetaSegmentIndex');
-goog.require('shaka.media.SegmentIndex');
-goog.require('shaka.media.SegmentReference');
-goog.require('shaka.test.Util');
-
 describe('SegmentIndex', /** @suppress {accessControls} */ () => {
   const actual1 = makeReference(uri(0), 0, 10);
   const actual2 = makeReference(uri(20), 10, 20);

--- a/test/media/segment_reference_unit.js
+++ b/test/media/segment_reference_unit.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.InitSegmentReference');
-goog.require('shaka.media.SegmentReference');
-
 describe('SegmentReference', () => {
   it('returns in getters values from constructor parameters', () => {
     const initSegmentReference = new shaka.media.InitSegmentReference(

--- a/test/media/stall_detector_unit.js
+++ b/test/media/stall_detector_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
-goog.require('shaka.media.StallDetector');
-goog.require('shaka.media.StallDetector.Implementation');
-goog.require('shaka.test.Util');
-
 describe('StallDetector', () => {
   /**
    * @implements {shaka.media.StallDetector.Implementation}

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -4,31 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.InitSegmentReference');
-goog.require('shaka.media.MediaSourceEngine');
-goog.require('shaka.media.MediaSourcePlayhead');
-goog.require('shaka.media.SegmentIndex');
-goog.require('shaka.media.SegmentReference');
-goog.require('shaka.media.StreamingEngine');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.test.FakeClosedCaptionParser');
-goog.require('shaka.test.FakeTextDisplayer');
-goog.require('shaka.test.Mp4LiveStreamGenerator');
-goog.require('shaka.test.Mp4VodStreamGenerator');
-goog.require('shaka.test.StreamingEngineUtil');
-goog.require('shaka.test.TestScheme');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.test.Waiter');
-goog.require('shaka.util.EventManager');
-goog.require('shaka.util.ManifestParserUtils');
-goog.require('shaka.util.Platform');
-goog.require('shaka.util.PlayerConfiguration');
-goog.requireType('shaka.media.Playhead');
-goog.requireType('shaka.media.PresentationTimeline');
-goog.requireType('shaka.test.FakeNetworkingEngine');
-goog.requireType('shaka.test.FakePresentationTimeline');
-
 describe('StreamingEngine', () => {
   const ContentType = shaka.util.ManifestParserUtils.ContentType;
   const Util = shaka.test.Util;

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -4,29 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.log');
-goog.require('shaka.media.InitSegmentReference');
-goog.require('shaka.media.SegmentReference');
-goog.require('shaka.media.StreamingEngine');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.net.NetworkingEngine.PendingRequest');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.FakeMediaSourceEngine');
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.test.StreamingEngineUtil');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.AbortableOperation');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
-goog.require('shaka.util.MimeUtils');
-goog.require('shaka.util.PlayerConfiguration');
-goog.require('shaka.util.PublicPromise');
-goog.require('shaka.util.Uint8ArrayUtils');
-goog.requireType('shaka.media.PresentationTimeline');
-goog.requireType('shaka.test.FakeNetworkingEngine');
-goog.requireType('shaka.test.FakePresentationTimeline');
-
 describe('StreamingEngine', () => {
   const Util = shaka.test.Util;
   const ContentType = shaka.util.ManifestParserUtils.ContentType;

--- a/test/media/time_ranges_utils_unit.js
+++ b/test/media/time_ranges_utils_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.TimeRangesUtils');
-
 describe('TimeRangesUtils', () => {
   const TimeRangesUtils = shaka.media.TimeRangesUtils;
 

--- a/test/media/transmuxer_integration.js
+++ b/test/media/transmuxer_integration.js
@@ -3,12 +3,6 @@
  * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-goog.require('goog.asserts');
-goog.require('shaka.media.Transmuxer');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.ManifestParserUtils');
-goog.require('shaka.util.Mp4BoxParsers');
-goog.require('shaka.util.Mp4Parser');
 
 describe('Transmuxer', () => {
   const ContentType = shaka.util.ManifestParserUtils.ContentType;

--- a/test/media/webm_segment_index_parser_unit.js
+++ b/test/media/webm_segment_index_parser_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.WebmSegmentIndexParser');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-
 describe('WebmSegmentIndexParser', () => {
   const indexSegmentUri = '/base/test/test/assets/index-segment.webm';
   const initSegmentUri = '/base/test/test/assets/init-segment.webm';

--- a/test/net/data_uri_plugin_unit.js
+++ b/test/net/data_uri_plugin_unit.js
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.net.DataUriPlugin');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.net.NetworkingEngine.RequestType');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.StringUtils');
-
 describe('DataUriPlugin', () => {
   const retryParameters = shaka.net.NetworkingEngine.defaultRetryParameters();
 

--- a/test/net/http_plugin_unit.js
+++ b/test/net/http_plugin_unit.js
@@ -4,15 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
-goog.require('shaka.net.HttpFetchPlugin');
-goog.require('shaka.net.HttpXHRPlugin');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.net.NetworkingEngine.RequestType');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.Error');
-
 /**
  * Add a set of http plugin tests, for the given scheme plugin.
  *

--- a/test/net/networking_engine_unit.js
+++ b/test/net/networking_engine_unit.js
@@ -4,17 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.net.Backoff');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.net.NetworkingEngine.RequestType');
-goog.require('shaka.test.StatusPromise');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.AbortableOperation');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.Networking');
-goog.require('shaka.util.PublicPromise');
-goog.requireType('shaka.net.NetworkingEngine.PendingRequest');
-
 describe('NetworkingEngine', /** @suppress {accessControls} */ () => {
   const StatusPromise = shaka.test.StatusPromise;
   const Util = shaka.test.Util;

--- a/test/offline/download_progress_estimator_unit.js
+++ b/test/offline/download_progress_estimator_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.offline.DownloadProgressEstimator');
-
 describe('DownloadProgressEstimator', () => {
   /** @type {!shaka.offline.DownloadProgressEstimator} */
   let estimator;

--- a/test/offline/indexeddb_storage_unit.js
+++ b/test/offline/indexeddb_storage_unit.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.offline.indexeddb.V5StorageCell');
-goog.require('shaka.test.IndexedDBUtils');
-goog.require('shaka.test.OfflineUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-
 filterDescribe('IndexeddbStorageCell', () => window.indexedDB, () => {
   const IndexedDBUtils = shaka.test.IndexedDBUtils;
   const OfflineUtils = shaka.test.OfflineUtils;

--- a/test/offline/manifest_convert_unit.js
+++ b/test/offline/manifest_convert_unit.js
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.media.InitSegmentReference');
-goog.require('shaka.media.PresentationTimeline');
-goog.require('shaka.media.SegmentIndex');
-goog.require('shaka.offline.ManifestConverter');
-goog.require('shaka.offline.OfflineUri');
-goog.require('shaka.util.ManifestParserUtils');
-goog.requireType('shaka.media.SegmentReference');
-
 describe('ManifestConverter', () => {
   describe('createVariants', () => {
     const audioType = 'audio';

--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.Player');
-goog.require('shaka.offline.Storage');
-goog.require('shaka.test.TestScheme');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.test.Waiter');
-goog.require('shaka.util.EventManager');
-goog.require('shaka.util.Platform');
-
 /** @return {boolean} */
 const supportsStorage = () => shaka.offline.Storage.support();
 

--- a/test/offline/offline_manifest_parser_unit.js
+++ b/test/offline/offline_manifest_parser_unit.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.offline.OfflineManifestParser');
-goog.require('shaka.offline.OfflineUri');
-goog.require('shaka.offline.StorageMuxer');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-
 /** @return {boolean} */
 const offlineManifestParserSupport = () => shaka.offline.StorageMuxer.support();
 filterDescribe('OfflineManifestParser', offlineManifestParserSupport, () => {

--- a/test/offline/offline_scheme_unit.js
+++ b/test/offline/offline_scheme_unit.js
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.net.NetworkingEngine.RequestType');
-goog.require('shaka.offline.OfflineScheme');
-goog.require('shaka.offline.OfflineUri');
-goog.require('shaka.offline.StorageMuxer');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-
 /** @return {boolean} */
 const offlineSchemeSupport = () => shaka.offline.StorageMuxer.support();
 filterDescribe('OfflineScheme', offlineSchemeSupport, () => {

--- a/test/offline/offline_uri_unit.js
+++ b/test/offline/offline_uri_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.offline.OfflineUri');
-
 describe('OfflineUri', () => {
   const OfflineUri = shaka.offline.OfflineUri;
 

--- a/test/offline/storage_compatibility_unit.js
+++ b/test/offline/storage_compatibility_unit.js
@@ -4,19 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.offline.ManifestConverter');
-goog.require('shaka.offline.indexeddb.V1StorageCell');
-goog.require('shaka.offline.indexeddb.V2StorageCell');
-goog.require('shaka.offline.indexeddb.V5StorageCell');
-goog.require('shaka.test.CannedIDB');
-goog.require('shaka.test.IndexedDBUtils');
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
-goog.require('shaka.util.StringUtils');
-
 // All of the database dumps referenced below were originally made from the
 // "Heliocentrism" content in our demo app.
 // https://storage.googleapis.com/shaka-demo-assets/heliocentrism/heliocentrism.mpd

--- a/test/offline/storage_integration.js
+++ b/test/offline/storage_integration.js
@@ -4,32 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.Player');
-goog.require('shaka.media.DrmEngine');
-goog.require('shaka.media.ManifestParser');
-goog.require('shaka.media.SegmentIndex');
-goog.require('shaka.net.NetworkingEngine.RequestType');
-goog.require('shaka.offline.ManifestConverter');
-goog.require('shaka.offline.OfflineUri');
-goog.require('shaka.offline.Storage');
-goog.require('shaka.offline.StorageMuxer');
-goog.require('shaka.test.FakeDrmEngine');
-goog.require('shaka.test.FakeManifestParser');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.Loader');
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.test.TestScheme');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.AbortableOperation');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.EventManager');
-goog.require('shaka.util.PlayerConfiguration');
-goog.require('shaka.util.PublicPromise');
-goog.require('shaka.util.Uint8ArrayUtils');
-goog.requireType('shaka.media.SegmentReference');
-
 /** @return {boolean} */
 function storageSupport() {
   return shaka.offline.Storage.support();

--- a/test/player_external.js
+++ b/test/player_external.js
@@ -4,15 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('ShakaDemoAssetInfo');
-goog.require('shaka.test.Loader');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.test.Waiter');
-goog.require('shaka.util.EventManager');
-goog.requireType('shaka.Player');
-goog.requireType('shaka.net.NetworkingEngine.RequestType');
-
 describe('Player', () => {
   const Util = shaka.test.Util;
   const Feature = shakaAssets.Feature;

--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -4,20 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.Uri');
-goog.require('shaka.Player');
-goog.require('shaka.log');
-goog.require('shaka.media.DrmEngine');
-goog.require('shaka.media.TimeRangesUtils');
-goog.require('shaka.test.FakeAbrManager');
-goog.require('shaka.test.FakeTextDisplayer');
-goog.require('shaka.test.Loader');
-goog.require('shaka.test.TestScheme');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.test.Waiter');
-goog.require('shaka.util.EventManager');
-
 describe('Player', () => {
   /** @type {!jasmine.Spy} */
   let onErrorSpy;

--- a/test/player_load_graph_integration.js
+++ b/test/player_load_graph_integration.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.Player');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-
 describe('Player Load Graph', () => {
   const SMALL_MP4_CONTENT_URI = '/base/test/test/assets/small.mp4';
 

--- a/test/player_src_equals_external.js
+++ b/test/player_src_equals_external.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.Player');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.test.Waiter');
-goog.require('shaka.util.EventManager');
-
 describe('Player Src Equals', () => {
   // This asset needs to be (1) long and (2) high bitrate so that we can
   // invoke unbuffered seeks.

--- a/test/player_src_equals_integration.js
+++ b/test/player_src_equals_integration.js
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.Uri');
-goog.require('shaka.Player');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.test.Waiter');
-goog.require('shaka.util.EventManager');
-
 // These tests are for testing Shaka Player's integration with
 // |HTMLMediaElement.src=|. These tests are to verify that all |shaka.Player|
 // public methods behaviour correctly when playing content video |src=|.

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -4,29 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.Player');
-goog.require('shaka.log');
-goog.require('shaka.media.BufferingObserver');
-goog.require('shaka.media.ManifestParser');
-goog.require('shaka.media.PresentationTimeline');
-goog.require('shaka.media.SegmentReference');
-goog.require('shaka.media.SegmentIndex');
-goog.require('shaka.test.FakeAbrManager');
-goog.require('shaka.test.FakeDrmEngine');
-goog.require('shaka.test.FakeManifestParser');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.FakePlayhead');
-goog.require('shaka.test.FakeStreamingEngine');
-goog.require('shaka.test.FakeTextDisplayer');
-goog.require('shaka.test.FakeVideo');
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.ConfigUtils');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
-goog.requireType('shaka.media.Playhead');
-
 describe('Player', () => {
   const ContentType = shaka.util.ManifestParserUtils.ContentType;
   const Util = shaka.test.Util;

--- a/test/routing/walker_unit.js
+++ b/test/routing/walker_unit.js
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.routing.Walker');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.AbortableOperation');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.PublicPromise');
-goog.requireType('shaka.routing.Node');
-
 describe('Walker', () => {
   const AbortableOperation = shaka.util.AbortableOperation;
 

--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.Player');
-goog.require('shaka.log');
-goog.require('shaka.polyfill');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.Platform');
-
 // If ENABLE_DEBUG_LOADER is not set to false, goog.require() will try to load
 // extra sources on-the-fly using pre-computed pathes in deps.js, which is not
 // applicable for the tests.

--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// If ENABLE_DEBUG_LOADER is not set to false, goog.require() will try to load
-// extra sources on-the-fly using pre-computed pathes in deps.js, which is not
-// applicable for the tests.
-goog['ENABLE_DEBUG_LOADER'] = false;
-
 /**
  * Gets the value of an argument passed from karma.
  * @param {string} name
@@ -377,9 +372,10 @@ function configureJasmineEnvironment() {
   };
 }
 
-// Executed before test utilities and tests are loaded, but after Shaka Player
-// is loaded in uncompiled mode.
-try {
+/**
+ * Set up the Shaka Player test environment.
+ */
+function setupTestEnvironment() {
   failTestsOnFailedAssertions();
   failTestsOnNamespacedElementOrAttributeNames();
   failTestsOnUnhandledRejections();
@@ -392,12 +388,76 @@ try {
   shaka.polyfill.installAll();
 
   configureJasmineEnvironment();
-
-  // eslint-disable-next-line no-restricted-syntax
-} catch (error) {
-  // Throw this boot-sequence error in place of jasmine's execute method, to
-  // fail clearly and right away without running any tests.
-  jasmine.getEnv().execute = () => {
-    throw error;
-  };
 }
+
+/**
+ * Load a script dynamically and await completion.
+ *
+ * @param {string} file
+ * @return {!Promise}
+ */
+function loadScript(file) {
+  return new Promise((resolve, reject) => {
+    const script = /** @type {!HTMLScriptElement} */(
+      document.createElement('script'));
+    script.defer = false;
+    script['async'] = false;
+    script.onload = resolve;
+    script.onerror = reject;
+    script.setAttribute('src', '/base/' + file);
+    document.head.appendChild(script);
+  });
+}
+
+/**
+ * Load all test scripts and await completion.
+ *
+ * @return {!Promise}
+ */
+function loadTests() {
+  const loadPromises = [];
+  for (const file of getClientArg('testFiles')) {
+    loadPromises.push(loadScript(file));
+  }
+  return Promise.all(loadPromises);
+}
+
+// Hijack Karma's start() method and start things our way.
+// eslint-disable-next-line no-restricted-syntax
+const originalStart = window.__karma__.start.bind(window.__karma__);
+window.__karma__.start = async () => {
+  // Executed when Karma has finished loading everything it loads for us.
+  // Those things were all loaded in parallel, and had no interdependencies
+  // other than those in the Shaka Player library, tracked by the Closure
+  // library's goog.require/goog.provide.
+
+  // Now we load the tests from here, rather than letting Karma do it.  This
+  // give us control over the order, so that everything else is loaded and
+  // complete before any tests are requested.  Then we may reference test
+  // utilities and library namespaces in the body of describe() blocks, which
+  // are executed synchronously as the test scripts are loaded.  Without this
+  // ordering, we would have to either:
+  //    1. very carefully avoid references in describe() and defer them to
+  //       beforeAll()
+  // or 2. strictly adopt goog.provide/goog.require throughout our tests
+  // In those scenarios, failure to do so would only manifest some of the time
+  // and on certain platforms.  So this seems to be the more robust solution.
+
+  // See https://github.com/shaka-project/shaka-player/issues/4094
+
+  try {
+    setupTestEnvironment();
+    console.log('Set up test environment.');
+    await loadTests();
+    console.log('Loaded all tests.');
+
+    // eslint-disable-next-line no-restricted-syntax
+  } catch (error) {
+    console.error('Error during setup:', error);
+    window.__karma__.error(error);
+    return;
+  }
+
+  // Finally, start the tests.
+  originalStart();
+};

--- a/test/test/externs/karma.js
+++ b/test/test/externs/karma.js
@@ -20,3 +20,7 @@ __karma__.config = {};
 
 /** @const {!Array.<*>} */
 __karma__.config.args;
+
+
+/** @param {?} error */
+__karma__.error = function(error) {};

--- a/test/test/namespace.js
+++ b/test/test/namespace.js
@@ -1,0 +1,10 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Define the shaka.test namespace before we load the test utilities.
+// Without goog.provide in the test utils, this has to be explicit and come
+// before we load the utils.
+shaka.test = {};

--- a/test/test/util/canned_idb.js
+++ b/test/test/util/canned_idb.js
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.CannedIDB');
-
-goog.require('shaka.log');
-goog.require('shaka.offline.indexeddb.DBOperation');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.Uint8ArrayUtils');
-
-
 /**
  * A testing utility that can be used to dump and restore entire IndexedDB
  * databases.  This can be inserted into a running app to snapshot databases

--- a/test/test/util/cea_utils.js
+++ b/test/test/util/cea_utils.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.CeaUtils');
-
-goog.require('shaka.cea.CeaUtils');
-goog.require('shaka.text.Cue');
-
-
 /**
  * Testing helpers to assist tests for Closed Caption decoders for CEA captions.
  */

--- a/test/test/util/dash_parser_util.js
+++ b/test/test/util/dash_parser_util.js
@@ -4,19 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.Dash');
-
-goog.require('goog.asserts');
-goog.require('shaka.dash.DashParser');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.ManifestParser');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.PlayerConfiguration');
-goog.require('shaka.util.StringUtils');
-goog.requireType('shaka.media.SegmentReference');
-goog.requireType('shaka.util.Error');
-
-
 /** @summary Utilities for working with the DASH parser. */
 shaka.test.Dash = class {
   /**

--- a/test/test/util/fake_ad.js
+++ b/test/test/util/fake_ad.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.FakeAd');
-
-
 /**
  * @implements {shaka.extern.IAd}
  */

--- a/test/test/util/fake_ad_manager.js
+++ b/test/test/util/fake_ad_manager.js
@@ -4,15 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.FakeAdManager');
-
-goog.require('shaka.ads.AdManager');
-goog.require('shaka.ads.AdsStats');
-goog.require('shaka.util.FakeEvent');
-goog.require('shaka.util.FakeEventTarget');
-goog.requireType('shaka.test.FakeAd');
-
-
 /**
  * @implements {shaka.extern.IAdManager}
  * @final

--- a/test/test/util/fake_demo_main.js
+++ b/test/test/util/fake_demo_main.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.FakeDemoMain');
-
-goog.require('shaka.Player');
-
-
 /**
  * @summary
  * This simulates the interface between ShakaDemoMain and the various tabs.

--- a/test/test/util/fake_drm_engine.js
+++ b/test/test/util/fake_drm_engine.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.FakeDrmEngine');
-
-goog.require('shaka.media.DrmEngine');
-goog.require('shaka.test.Util');
-
-
 /**
  * A fake DrmEngine.
  *

--- a/test/test/util/fake_media_source_engine.js
+++ b/test/test/util/fake_media_source_engine.js
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.FakeMediaSourceEngine');
-
-goog.require('shaka.media.MediaSourceEngine');
-goog.require('shaka.test.FakeTextDisplayer');
-goog.require('shaka.util.ManifestParserUtils');
-
-
 /**
  * @summary
  * This simulates multiple SourceBuffers. However, it only

--- a/test/test/util/fake_networking_engine.js
+++ b/test/test/util/fake_networking_engine.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.FakeNetworkingEngine');
-
-/** @fileoverview @suppress {missingRequire} */
-
-
 /**
  * A fake networking engine that returns constant data.  The request member
  * is a jasmine spy and can be used to check the actual calls that occurred.

--- a/test/test/util/fake_text_displayer.js
+++ b/test/test/util/fake_text_displayer.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.FakeTextDisplayer');
-
-goog.require('shaka.test.Util');
-
-
 /**
  * @implements {shaka.extern.TextDisplayer}
  * @final

--- a/test/test/util/indexeddb_utils.js
+++ b/test/test/util/indexeddb_utils.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.IndexedDBUtils');
-
-goog.require('shaka.test.Util');
-goog.require('shaka.util.PublicPromise');
-
-
 shaka.test.IndexedDBUtils = class {
   /**
    * Make a connection to indexeddb. This assumes that it will be a new

--- a/test/test/util/jasmine_fetch.js
+++ b/test/test/util/jasmine_fetch.js
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 // TODO: this only contains the methods that we use; if this is published
 // it should contain the entire breadth of options in jasmine-ajax.
 

--- a/test/test/util/loader.js
+++ b/test/test/util/loader.js
@@ -4,24 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.Loader');
-
-goog.require('shaka.log');
-goog.require('shaka.test.TestScheme');
-goog.require('shaka.util.PublicPromise');
-goog.requireType('shaka.Player');
-goog.requireType('shaka.media.InitSegmentReference');
-goog.requireType('shaka.media.PresentationTimeline');
-goog.requireType('shaka.media.SegmentIndex');
-goog.requireType('shaka.media.SegmentReference');
-goog.requireType('shaka.net.NetworkingEngine');
-goog.requireType('shaka.offline.Storage');
-goog.requireType('shaka.ui.Controls');
-goog.requireType('shaka.ui.Element');
-goog.requireType('shaka.ui.Overlay');
-goog.requireType('shaka.util.StringUtils');
-
-
 /**
  * A stand-in type for the "shaka" namespace.  Used when loading the compiled
  * library or when referencing it in ManifestGenerator or TestScheme.

--- a/test/test/util/manifest_generator.js
+++ b/test/test/util/manifest_generator.js
@@ -4,17 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.ManifestGenerator');
-
-goog.require('goog.asserts');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.ManifestParserUtils');
-goog.require('shaka.util.Uint8ArrayUtils');
-goog.requireType('shaka.media.InitSegmentReference');
-goog.requireType('shaka.media.PresentationTimeline');
-goog.requireType('shaka.media.SegmentIndex');
-
-
 /**
  * @summary
  * A helper class used to generate manifests.  This is done through a series

--- a/test/test/util/manifest_parser_util.js
+++ b/test/test/util/manifest_parser_util.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.ManifestParser');
-
-goog.require('shaka.media.InitSegmentReference');
-goog.require('shaka.media.SegmentReference');
-
-
 shaka.test.ManifestParser = class {
   /**
    * Verifies the segment references of a stream.

--- a/test/test/util/offline_utils.js
+++ b/test/test/util/offline_utils.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.OfflineUtils');
-
-goog.require('shaka.util.BufferUtils');
-
-
 shaka.test.OfflineUtils = class {
   /**
    * @param {string} originalUri

--- a/test/test/util/simple_fakes.js
+++ b/test/test/util/simple_fakes.js
@@ -4,28 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.FakeAbrManager');
-goog.provide('shaka.test.FakeClosedCaptionParser');
-goog.provide('shaka.test.FakeManifestParser');
-goog.provide('shaka.test.FakePlayhead');
-goog.provide('shaka.test.FakePlayheadObserver');
-goog.provide('shaka.test.FakePresentationTimeline');
-goog.provide('shaka.test.FakeSegmentIndex');
-goog.provide('shaka.test.FakeStreamingEngine');
-goog.provide('shaka.test.FakeTextTrack');
-goog.provide('shaka.test.FakeTransmuxer');
-goog.provide('shaka.test.FakeVideo');
-
-goog.require('shaka.test.Util');
-goog.require('shaka.abr.SimpleAbrManager');
-goog.require('shaka.media.IClosedCaptionParser');
-goog.require('shaka.media.Playhead');
-goog.require('shaka.media.PresentationTimeline');
-goog.require('shaka.media.SegmentIndex');
-goog.require('shaka.media.StreamingEngine');
-goog.require('shaka.media.Transmuxer');
-
-
 /**
  * @fileoverview Defines simple mocks for library types.
  * @suppress {checkTypes} Suppress errors about missmatches between the

--- a/test/test/util/stream_generator.js
+++ b/test/test/util/stream_generator.js
@@ -4,20 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.IStreamGenerator');
-goog.provide('shaka.test.Mp4LiveStreamGenerator');
-goog.provide('shaka.test.Mp4VodStreamGenerator');
-goog.provide('shaka.test.StreamGenerator');
-goog.provide('shaka.test.TSVodStreamGenerator');
-
-goog.require('goog.asserts');
-goog.require('shaka.log');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.DataViewReader');
-goog.require('shaka.util.Uint8ArrayUtils');
-
-
 /**
  * @summary
  * Defines an interface to generate streams.

--- a/test/test/util/streaming_engine_util.js
+++ b/test/test/util/streaming_engine_util.js
@@ -4,21 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.StreamingEngineUtil');
-
-goog.require('goog.asserts');
-goog.require('shaka.media.InitSegmentReference');
-goog.require('shaka.media.SegmentReference');
-goog.require('shaka.test.FakeNetworkingEngine');
-goog.require('shaka.test.FakePresentationTimeline');
-goog.require('shaka.test.FakeSegmentIndex');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.AbortableOperation');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
-goog.requireType('shaka.media.PresentationTimeline');
-
-
 shaka.test.StreamingEngineUtil = class {
   /**
    * Creates a FakeNetworkingEngine.

--- a/test/test/util/test_scheme.js
+++ b/test/test/util/test_scheme.js
@@ -4,24 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.TestScheme');
-
-goog.require('goog.asserts');
-goog.require('goog.Uri');
-goog.require('shaka.Player');
-goog.require('shaka.media.ManifestParser');
-goog.require('shaka.net.NetworkingEngine');
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.test.Mp4VodStreamGenerator');
-goog.require('shaka.test.TSVodStreamGenerator');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.AbortableOperation');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
-goog.requireType('shaka.net.NetworkingEngine.RequestType');
-goog.requireType('shaka.test.IStreamGenerator');
-
-
 /**
  * @typedef {{
  *   initSegmentUri: string,

--- a/test/test/util/ttml_utils.js
+++ b/test/test/util/ttml_utils.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.TtmlUtils');
-
 shaka.test.TtmlUtils = class {
   /**
    * @param {!Array} expectedCues

--- a/test/test/util/ui_utils.js
+++ b/test/test/util/ui_utils.js
@@ -4,15 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
-goog.provide('shaka.test.UiUtils');
-
-goog.require('shaka.Player');
-goog.require('shaka.test.Waiter');
-goog.require('shaka.ui.Overlay');
-goog.require('shaka.util.EventManager');
-
-
 shaka.test.UiUtils = class {
   /**
    * @param {!HTMLElement} videoContainer

--- a/test/test/util/util.js
+++ b/test/test/util/util.js
@@ -4,17 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.StatusPromise');
-goog.provide('shaka.test.Util');
-
-goog.require('goog.asserts');
-goog.require('shaka.media.InitSegmentReference');
-goog.require('shaka.media.SegmentReference');
-goog.require('shaka.util.StringUtils');
-goog.require('shaka.util.XmlUtils');
-goog.requireType('shaka.util.Error');
-
-
 /**
  * @extends {Promise}
  */

--- a/test/test/util/waiter.js
+++ b/test/test/util/waiter.js
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.test.Waiter');
-
-goog.require('shaka.log');
-goog.require('shaka.media.TimeRangesUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.EventManager');
-
-
 shaka.test.Waiter = class {
   /** @param {!shaka.util.EventManager} eventManager */
   constructor(eventManager) {

--- a/test/text/cue_integration.js
+++ b/test/text/cue_integration.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.text.VttTextParser');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.StringUtils');
-
 describe('Cue', () => {
   // This integration test checks platform support for various cue scenarios
   // that have caused platform-specific issues.  The unit tests for each parser

--- a/test/text/lrc_text_parser_unit.js
+++ b/test/text/lrc_text_parser_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.text.LrcTextParser');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.StringUtils');
-
 describe('LrcTextParser', () => {
   it('supports no cues', () => {
     verifyHelper([],

--- a/test/text/mp4_ttml_parser_unit.js
+++ b/test/text/mp4_ttml_parser_unit.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.TtmlUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.text.Mp4TtmlParser');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.Error');
-
 describe('Mp4TtmlParser', () => {
   const ttmlInitSegmentUri = '/base/test/test/assets/ttml-init.mp4';
   const ttmlSegmentUri = '/base/test/test/assets/ttml-segment.mp4';

--- a/test/text/mp4_vtt_parser_unit.js
+++ b/test/text/mp4_vtt_parser_unit.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.Util');
-goog.require('shaka.text.Cue');
-goog.require('shaka.text.Mp4VttParser');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.Error');
-
 describe('Mp4VttParser', () => {
   const vttInitSegmentUri = '/base/test/test/assets/vtt-init.mp4';
   const vttSegmentUri = '/base/test/test/assets/vtt-segment.mp4';

--- a/test/text/sbv_text_parser_unit.js
+++ b/test/text/sbv_text_parser_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.text.SbvTextParser');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.StringUtils');
-
 describe('SbvTextParser', () => {
   it('supports no cues', () => {
     verifyHelper([],

--- a/test/text/simple_text_displayer_unit.js
+++ b/test/text/simple_text_displayer_unit.js
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
-goog.require('shaka.test.FakeVideo');
-goog.require('shaka.text.Cue');
-goog.require('shaka.text.SimpleTextDisplayer');
-goog.require('shaka.util.Functional');
-goog.requireType('shaka.test.FakeTextTrack');
-
 describe('SimpleTextDisplayer', () => {
   const originalVTTCue = window.VTTCue;
   const Cue = shaka.text.Cue;

--- a/test/text/srt_text_parser_unit.js
+++ b/test/text/srt_text_parser_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.text.SrtTextParser');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.StringUtils');
-
 describe('SrtTextParser', () => {
   it('supports no cues', () => {
     verifyHelper([],

--- a/test/text/ssa_text_parser_unit.js
+++ b/test/text/ssa_text_parser_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.text.Cue');
-goog.require('shaka.text.SsaTextParser');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.StringUtils');
-
 describe('SsaTextParser', () => {
   const Cue = shaka.text.Cue;
 

--- a/test/text/text_engine_unit.js
+++ b/test/text/text_engine_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.FakeTextDisplayer');
-goog.require('shaka.text.Cue');
-goog.require('shaka.text.TextEngine');
-goog.require('shaka.util.MimeUtils');
-
 describe('TextEngine', () => {
   const TextEngine = shaka.text.TextEngine;
 

--- a/test/text/text_track_integration.js
+++ b/test/text/text_track_integration.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.UiUtils');
-
 // This tests three assumptions we make about text tracks in Shaka Player:
 //   1. If a non-null value for cues is stored, it will always be the
 //      non-null value for cues when cues returns a non-null value.

--- a/test/text/ttml_text_parser_unit.js
+++ b/test/text/ttml_text_parser_unit.js
@@ -4,15 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.TtmlUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.text.Cue');
-goog.require('shaka.text.CueRegion');
-goog.require('shaka.text.TtmlTextParser');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.StringUtils');
-
 describe('TtmlTextParser', () => {
   const Cue = shaka.text.Cue;
   const CueRegion = shaka.text.CueRegion;

--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.Util');
-goog.require('shaka.text.Cue');
-goog.require('shaka.text.UITextDisplayer');
-
 describe('UITextDisplayer', () => {
   /** @type {!HTMLElement} */
   let videoContainer;

--- a/test/text/vtt_text_parser_unit.js
+++ b/test/text/vtt_text_parser_unit.js
@@ -4,15 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.log');
-goog.require('shaka.test.Util');
-goog.require('shaka.text.Cue');
-goog.require('shaka.text.CueRegion');
-goog.require('shaka.text.VttTextParser');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.StringUtils');
-
 describe('VttTextParser', () => {
   const Cue = shaka.text.Cue;
   const CueRegion = shaka.text.CueRegion;

--- a/test/text/web_vtt_generator_unit.js
+++ b/test/text/web_vtt_generator_unit.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.text.Cue');
-goog.require('shaka.text.WebVttGenerator');
-
 describe('WebVttGenerator', () => {
   it('supports no cues', () => {
     verifyHelper([], [], 'WEBVTT\n\n');

--- a/test/ui/ad_ui_unit.js
+++ b/test/ui/ad_ui_unit.js
@@ -4,17 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.Player');
-goog.require('shaka.ads.AdManager');
-goog.require('shaka.test.FakeAd');
-goog.require('shaka.test.FakeAdManager');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.test.Waiter');
-goog.require('shaka.ui.Locales');
-goog.require('shaka.util.EventManager');
-goog.requireType('shaka.ui.Localization');
-
 describe('Ad UI', () => {
   const UiUtils = shaka.test.UiUtils;
   /** @type {!HTMLLinkElement} */

--- a/test/ui/localization_unit.js
+++ b/test/ui/localization_unit.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.ui.Localization');
-goog.requireType('shaka.util.FakeEvent');
-
 describe('Localization', () => {
   const Localization = shaka.ui.Localization;
 

--- a/test/ui/text_displayer_layout_unit.js
+++ b/test/ui/text_displayer_layout_unit.js
@@ -4,17 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.Player');
-goog.require('shaka.test.FakeVideo');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.test.Waiter');
-goog.require('shaka.text.Cue');
-goog.require('shaka.text.SimpleTextDisplayer');
-goog.require('shaka.text.UITextDisplayer');
-goog.require('shaka.ui.Overlay');
-goog.require('shaka.util.EventManager');
-
 // TODO: Move this suite to the text/ folder where it belongs
 const supportsScreenshots = () => shaka.test.Util.supportsScreenshots();
 filterDescribe('TextDisplayer layout', supportsScreenshots, () => {

--- a/test/ui/ui_customization_unit.js
+++ b/test/ui/ui_customization_unit.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Waiter');
-goog.require('shaka.util.EventManager');
-goog.requireType('shaka.ui.Overlay');
-
 describe('UI Customization', () => {
   const UiUtils = shaka.test.UiUtils;
   /** @type {!HTMLLinkElement} */

--- a/test/ui/ui_integration.js
+++ b/test/ui/ui_integration.js
@@ -4,22 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('mozilla.LanguageMapping');
-goog.require('shaka.test.Loader');
-goog.require('shaka.test.TestScheme');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.test.Waiter');
-goog.require('shaka.ui.Element');
-goog.require('shaka.util.Dom');
-goog.require('shaka.util.EventManager');
-goog.require('shaka.util.Iterables');
-goog.requireType('shaka.Player');
-goog.requireType('shaka.ui.Controls');
-goog.requireType('shaka.ui.Overlay');
-
-
 describe('UI', () => {
   const Util = shaka.test.Util;
   const UiUtils = shaka.test.UiUtils;

--- a/test/ui/ui_unit.js
+++ b/test/ui/ui_unit.js
@@ -4,20 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.media.ManifestParser');
-goog.require('shaka.test.FakeManifestParser');
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.test.UiUtils');
-goog.require('shaka.test.Util');
-goog.require('shaka.ui.OverflowMenu');
-goog.require('shaka.ui.ResolutionSelection');
-goog.require('shaka.util.Platform');
-goog.require('shaka.util.Platform');
-goog.requireType('shaka.Player');
-goog.requireType('shaka.ui.Controls');
-goog.requireType('shaka.ui.Overlay');
-
 describe('UI', () => {
   const UiUtils = shaka.test.UiUtils;
   const Util = shaka.test.Util;

--- a/test/util/abortable_operation_unit.js
+++ b/test/util/abortable_operation_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.Util');
-goog.require('shaka.util.AbortableOperation');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.PublicPromise');
-
 describe('AbortableOperation', () => {
   const Util = shaka.test.Util;
 

--- a/test/util/array_utils_unit.js
+++ b/test/util/array_utils_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.util.ArrayUtils');
-
 describe('ArrayUtils', () => {
   const ArrayUtils = shaka.util.ArrayUtils;
 

--- a/test/util/buffer_utils_unit.js
+++ b/test/util/buffer_utils_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.util.BufferUtils');
-
 describe('BufferUtils', () => {
   const BufferUtils = shaka.util.BufferUtils;
 

--- a/test/util/cmcd_manager_unit.js
+++ b/test/util/cmcd_manager_unit.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.util.CmcdManager');
-goog.require('shaka.util.ObjectUtils');
-
 describe('CmcdManager', () => {
   const CmcdManager = shaka.util.CmcdManager;
   const uuidRegex =

--- a/test/util/data_view_reader_unit.js
+++ b/test/util/data_view_reader_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.Util');
-goog.require('shaka.util.DataViewReader');
-goog.require('shaka.util.Error');
-
 describe('DataViewReader', () => {
   const Util = shaka.test.Util;
 

--- a/test/util/ebml_parser_unit.js
+++ b/test/util/ebml_parser_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.Util');
-goog.require('shaka.util.EbmlParser');
-goog.require('shaka.util.Error');
-
 describe('EbmlParser', /** @suppress {accessControls} */ () => {
   const Util = shaka.test.Util;
 

--- a/test/util/event_manager_unit.js
+++ b/test/util/event_manager_unit.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.Util');
-goog.require('shaka.util.EventManager');
-
 describe('EventManager', () => {
   const Util = shaka.test.Util;
 

--- a/test/util/fake_event_target_unit.js
+++ b/test/util/fake_event_target_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.log');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.FakeEvent');
-goog.require('shaka.util.FakeEventTarget');
-
 describe('FakeEventTarget', () => {
   const Util = shaka.test.Util;
   const originalLogError = shaka.log.error;

--- a/test/util/iterables_unit.js
+++ b/test/util/iterables_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.util.Iterables');
-
 describe('Iterables', () => {
   const Iterables = shaka.util.Iterables;
 

--- a/test/util/language_utils_unit.js
+++ b/test/util/language_utils_unit.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.util.LanguageUtils');
-goog.require('shaka.util.ManifestParserUtils');
-
 describe('LanguageUtils', () => {
   const LanguageUtils = shaka.util.LanguageUtils;
 

--- a/test/util/manifest_parser_utils_unit.js
+++ b/test/util/manifest_parser_utils_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.util.ManifestParserUtils');
-
 describe('ManifestParserUtils', () => {
   const ManifestParserUtils = shaka.util.ManifestParserUtils;
 

--- a/test/util/mp4_box_parsers_unit.js
+++ b/test/util/mp4_box_parsers_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Mp4BoxParsers');
-goog.require('shaka.util.Mp4Parser');
-
 describe('Mp4BoxParsers', () => {
   const videoInitSegmentUri = '/base/test/test/assets/sintel-video-init.mp4';
   const videoSegmentUri = '/base/test/test/assets/sintel-video-segment.mp4';

--- a/test/util/mp4_parser_unit.js
+++ b/test/util/mp4_parser_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.Mp4Parser');
-
 describe('Mp4Parser', () => {
   const Util = shaka.test.Util;
 

--- a/test/util/multi_map_unit.js
+++ b/test/util/multi_map_unit.js
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.Util');
-goog.require('shaka.util.MultiMap');
-
 describe('MultiMap', () => {
   /** @type {shaka.util.MultiMap<number>} */
   let map;

--- a/test/util/object_utils_unit.js
+++ b/test/util/object_utils_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.util.ObjectUtils');
-
 describe('ObjectUtils', () => {
   const ObjectUtils = shaka.util.ObjectUtils;
 

--- a/test/util/periods_unit.js
+++ b/test/util/periods_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.util.ManifestParserUtils');
-goog.require('shaka.util.PeriodCombiner');
-
 describe('PeriodCombiner', () => {
   // These test cases don't really read well as "it" statements.  Phrasing them
   // that way would make the names very long, so here we break with that

--- a/test/util/pssh_unit.js
+++ b/test/util/pssh_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.Util');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.Pssh');
-goog.require('shaka.util.Uint8ArrayUtils');
-
 describe('Pssh', () => {
   const Uint8ArrayUtils = shaka.util.Uint8ArrayUtils;
 

--- a/test/util/state_history_unit.js
+++ b/test/util/state_history_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.util.StateHistory');
-
 describe('StateHistory', () => {
   const oldDateNow = Date.now;
 

--- a/test/util/stream_utils_unit.js
+++ b/test/util/stream_utils_unit.js
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.FakeDrmEngine');
-goog.require('shaka.test.ManifestGenerator');
-goog.require('shaka.test.Util');
-goog.require('shaka.util.StreamUtils');
-
 describe('StreamUtils', () => {
   const StreamUtils = shaka.util.StreamUtils;
 

--- a/test/util/string_utils_unit.js
+++ b/test/util/string_utils_unit.js
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.test.Util');
-goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
-goog.require('shaka.util.StringUtils');
-
 describe('StringUtils', () => {
   const StringUtils = shaka.util.StringUtils;
 

--- a/test/util/text_parser_unit.js
+++ b/test/util/text_parser_unit.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('shaka.util.TextParser');
-
 describe('TextParser', () => {
   const TextParser = shaka.util.TextParser;
 

--- a/test/util/xml_utils_unit.js
+++ b/test/util/xml_utils_unit.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.require('goog.asserts');
-goog.require('shaka.util.XmlUtils');
-
-
 describe('XmlUtils', () => {
   // A number that cannot be represented as a Javascript number.
   const HUGE_NUMBER_STRING = new Array(500).join('7');


### PR DESCRIPTION
This change fixes tests on Chromecast by loading tests later in the process.  Test scripts are now dynamically inserted by boot.js, rather than loaded by Karma.  The bootstrapping code then awaits the completion of that before starting the Karma frameworks (Jasmine) to run the tests.

This also removes the use of goog.provide/goog.require in tests and test utils.  We don't need to load test utils or library sources dynamically in each test, and this gives us more explicit control over script loading and ordering.

Closes #4094