### PR TITLE
fix(demo): Fix default demo index versions

### DIFF
--- a/app-engine/demo-version-index/main.py
+++ b/app-engine/demo-version-index/main.py
@@ -112,7 +112,7 @@ def version_key(version):
   return version_tuple + [suffix]
 
 def get_appengine_versions():
-  if os.getenv('SERVER_SOFTWARE', '').startswith('Google App Engine/'):
+  if os.getenv('GAE_ENV', '').startswith('standard'):
     # NOTE: this doesn't return anything useful in a local dev server.
     return google.appengine.api.modules.modules.get_versions()
 


### PR DESCRIPTION
The script for deploying the demo version index page has a function
that chooses which versions to display. This script has a special
mode meant for testing that shows a default list of demo versions.
This mode was only supposed to trigger when run locally, but the
check did not work properly, so the demo version index was deploying
with a very out-of-date list of versions.
This fixes that check.

Closes #4074

<!--
Please remember to:

1. Use Conventional Commits syntax (fix: ..., feat: ..., etc.) in commits and
   PR title (https://www.conventionalcommits.org/)
2. Tag any related or fixed issues ("Issue #123", "Closes #420")
3. Sign the Google CLA if you haven't (https://cla.developers.google.com)

You may delete this comment from the PR description.
-->
