### PR TITLE
ci: Fix demo index deployment

### DIFF
--- a/app-engine/demo-version-index/app.yaml
+++ b/app-engine/demo-version-index/app.yaml
@@ -15,7 +15,13 @@
 runtime: python39
 default_expiration: 1h
 
-# Serve the static/ folder directly.
+handlers:
+# Server static/index.html as the root.
+- url: /
+  secure: always
+  static_files: static/index.html
+  upload: static/index.html
+# Any other requests are served from the static/ folder.
 - url: /(.+)
   secure: always
   static_files: static/\1

--- a/app-engine/demo-version-index/main.py
+++ b/app-engine/demo-version-index/main.py
@@ -1,0 +1,11 @@
+# Shaka Player Version Index - Appspot Entrypoint
+# Copyright 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# In the App Engine Python 3 runtime, you must have an entrypoint, even if all
+# content is static and no routes are defined.  This seems pretty weird, and
+# wasn't required in the Python 2 runtime.
+
+from flask import Flask
+
+app = Flask(__name__)


### PR DESCRIPTION
Fixes these issues with the demo index deployment (tested by manual deployment):

 - Missing `handlers:` field in app.yaml
 - Missing handler for the URL `/`
 - Missing Flask entrypoint (even though no dynamic content is generated by it)

Closes #4074