### PR TITLE
chore: remove goog.require('shaka.polyfill.MathRound') in uncompiled

### DIFF
--- a/shaka-player.uncompiled.js
+++ b/shaka-player.uncompiled.js
@@ -35,7 +35,6 @@ goog.require('shaka.offline.indexeddb.StorageMechanism');
 goog.require('shaka.polyfill.Aria');
 goog.require('shaka.polyfill.EncryptionScheme');
 goog.require('shaka.polyfill.Fullscreen');
-goog.require('shaka.polyfill.MathRound');
 goog.require('shaka.polyfill.MediaSource');
 goog.require('shaka.polyfill.MediaCapabilities');
 goog.require('shaka.polyfill.Orientation');


### PR DESCRIPTION
Related https://github.com/shaka-project/shaka-player/pull/4114