### PR TITLE
ci: Fix generation of demo index by fetching all history

### DIFF
--- a/.github/workflows/demo-version-index.yaml
+++ b/.github/workflows/demo-version-index.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        # We need a list of all tags for this, so fetch the entire history.
+        fetch-depth: 0
 
       - name: Generate static content
         run: python3 app-engine/demo-version-index/generate.py


### PR DESCRIPTION
The demo index generation is now based on the git tags.  So when
checking out the repo to generate the index, the entire history is
needed.

Closes #4074 