### PR TITLE
feat(hls): parse EXT-X-GAP

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1865,6 +1865,11 @@ shaka.hls.HlsParser = class {
       }
     }
 
+    let status = shaka.media.SegmentReference.Status.AVAILABLE;
+    if (shaka.hls.Utils.getFirstTagWithName(tags, 'EXT-X-GAP')) {
+      status = shaka.media.SegmentReference.Status.MISSING;
+    }
+
     // Create SegmentReferences for the partial segments.
     const partialSegmentRefs = [];
     if (this.lowLatencyMode_ && hlsSegment.partialSegments.length) {
@@ -1978,6 +1983,7 @@ shaka.hls.HlsParser = class {
         tilesLayout,
         tileDuration,
         syncTime,
+        status,
     );
   }
 

--- a/lib/media/segment_reference.js
+++ b/lib/media/segment_reference.js
@@ -162,12 +162,15 @@ shaka.media.SegmentReference = class {
    * @param {?number=} syncTime
    *  A time value, expressed in the same scale as the start and end time, which
    *  is used to synchronize between streams.
+   * @param {shaka.media.SegmentReference.Status=} status
+   *  The segment status is used to indicate that a segment does not exist or is
+   *  not available.
    */
   constructor(
       startTime, endTime, uris, startByte, endByte, initSegmentReference,
       timestampOffset, appendWindowStart, appendWindowEnd,
       partialReferences = [], tilesLayout = '', tileDuration = null,
-      syncTime = null) {
+      syncTime = null, status = shaka.media.SegmentReference.Status.AVAILABLE) {
     // A preload hinted Partial Segment has the same startTime and endTime.
     goog.asserts.assert(startTime <= endTime,
         'startTime must be less than or equal to endTime');
@@ -220,6 +223,9 @@ shaka.media.SegmentReference = class {
 
     /** @type {?number} */
     this.syncTime = syncTime;
+
+    /** @type {shaka.media.SegmentReference.Status} */
+    this.status = status;
   }
 
   /**
@@ -315,6 +321,39 @@ shaka.media.SegmentReference = class {
   getTileDuration() {
     return this.tileDuration;
   }
+
+  /**
+   * Returns the segment's status.
+   *
+   * @return {shaka.media.SegmentReference.Status}
+   * @export
+   */
+  getStatus() {
+    return this.status;
+  }
+
+  /**
+   * Mark the reference as unavailable.
+   *
+   * @export
+   */
+  markAsUnavailable() {
+    this.status = shaka.media.SegmentReference.Status.UNAVAILABLE;
+  }
+};
+
+
+/**
+ * Rather than using booleans to communicate what the state of the reference,
+ * we have this enum.
+ *
+ * @enum {number}
+ * @export
+ */
+shaka.media.SegmentReference.Status = {
+  AVAILABLE: 0,
+  UNAVAILABLE: 1,
+  MISSING: 2,
 };
 
 


### PR DESCRIPTION
Parse EXT-X-GAP HLS tag and add a status enum to shaka.media.SegmentReference.

shaka.media.SegmentReference.Status.AVAILABLE --> Normal behaviour
shaka.media.SegmentReference.Status. UNAVAILABLE --> Related to https://github.com/shaka-project/shaka-player/issues/2541
shaka.media.SegmentReference.Status. MISSING --> EXT-X-GAP in HLS

Note: only the parsing is added, but the functionality is not yet implemented.

Issue https://github.com/shaka-project/shaka-player/issues/1308