### PR TITLE
test: Improve TextDisplayer test reliability and timing

### DIFF
--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -61,7 +61,18 @@ describe('UITextDisplayer', () => {
     document.body.removeChild(videoContainer);
   });
 
-  it('correctly displays styles for cues', async () => {
+  /**
+   * @suppress {visibility}
+   * "suppress visibility" has function scope, so this is a mini-function that
+   * exists solely to suppress visibility rules for these actions.
+   */
+  function updateCaptions() {
+    // Rather than wait for a timer, which can be unreliable on Safari when the
+    // device is heavily loaded, trigger the update explicitly.
+    textDisplayer.updateCaptions_();
+  }
+
+  it('correctly displays styles for cues', () => {
     /** @type {!shaka.text.Cue} */
     const cue = new shaka.text.Cue(0, 100, 'Captain\'s log.');
     cue.color = 'green';
@@ -77,8 +88,7 @@ describe('UITextDisplayer', () => {
 
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([cue]);
-    // Wait until updateCaptions_() gets called.
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
 
     const textContainer = videoContainer.querySelector('.shaka-text-container');
     const captions = textContainer.querySelector('div');
@@ -110,7 +120,7 @@ describe('UITextDisplayer', () => {
         .toEqual(jasmine.objectContaining({'background-color': 'black'}));
   });
 
-  it('correctly displays styles for nested cues', async () => {
+  it('correctly displays styles for nested cues', () => {
     /** @type {!shaka.text.Cue} */
     const cue = new shaka.text.Cue(0, 100, '');
     const nestedCue = new shaka.text.Cue(0, 100, 'Captain\'s log.');
@@ -127,8 +137,7 @@ describe('UITextDisplayer', () => {
 
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([cue]);
-    // Wait until updateCaptions_() gets called.
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
 
     // Verify styles applied to the nested cues.
     const textContainer = videoContainer.querySelector('.shaka-text-container');
@@ -161,7 +170,7 @@ describe('UITextDisplayer', () => {
         .toEqual(jasmine.objectContaining({'background-color': 'black'}));
   });
 
-  it('correctly displays styles for cellResolution units', async () => {
+  it('correctly displays styles for cellResolution units', () => {
     /** @type {!shaka.text.Cue} */
     const cue = new shaka.text.Cue(0, 100, 'Captain\'s log.');
     cue.fontSize = '0.80c';
@@ -173,8 +182,7 @@ describe('UITextDisplayer', () => {
 
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([cue]);
-    // Wait until updateCaptions_() gets called.
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
 
     // Expected value is calculated based on  ttp:cellResolution="60 20"
     // videoContainerHeight=450px and tts:fontSize="0.80c" on the default style.
@@ -196,7 +204,7 @@ describe('UITextDisplayer', () => {
         }));
   });
 
-  it('correctly displays styles for percentages units', async () => {
+  it('correctly displays styles for percentages units', () => {
     /** @type {!shaka.text.Cue} */
     const cue = new shaka.text.Cue(0, 100, 'Captain\'s log.');
     cue.fontSize = '90%';
@@ -207,8 +215,7 @@ describe('UITextDisplayer', () => {
 
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([cue]);
-    // Wait until updateCaptions_() gets called.
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
 
     // Expected value is calculated based on  ttp:cellResolution="32 15"
     // videoContainerHeight=450px and tts:fontSize="90%" on the default style.
@@ -221,15 +228,15 @@ describe('UITextDisplayer', () => {
         jasmine.objectContaining({'font-size': expectedFontSize}));
   });
 
-  it('does not display duplicate cues', async () => {
+  it('does not display duplicate cues', () => {
     // These are identical.
     const cue1 = new shaka.text.Cue(0, 100, 'Captain\'s log.');
     const cue2 = new shaka.text.Cue(0, 100, 'Captain\'s log.');
 
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([cue1]);
-    // Wait until updateCaptions_() gets called.
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
+
     /** @type {Element} */
     const textContainer = videoContainer.querySelector('.shaka-text-container');
     let captions = textContainer.querySelectorAll('div');
@@ -237,14 +244,14 @@ describe('UITextDisplayer', () => {
     expect(captions.length).toBe(1);
 
     textDisplayer.append([cue2]);
-    // Wait until updateCaptions_() gets called.
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
+
     captions = textContainer.querySelectorAll('div');
     // Expect textContainer to display one cue without duplication.
     expect(captions.length).toBe(1);
   });
 
-  it('does not mistake cues with nested cues as duplicates', async () => {
+  it('does not mistake cues with nested cues as duplicates', () => {
     // These are not identical, but might look like it at the top level.
     const cue1 = new shaka.text.Cue(0, 100, '');
     cue1.nestedCues = [
@@ -261,8 +268,8 @@ describe('UITextDisplayer', () => {
 
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([cue1]);
-    // Wait until updateCaptions_() gets called.
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
+
     /** @type {Element} */
     const textContainer = videoContainer.querySelector('.shaka-text-container');
     let captions = textContainer.querySelectorAll('div');
@@ -270,15 +277,15 @@ describe('UITextDisplayer', () => {
     expect(captions.length).toBe(1);
 
     textDisplayer.append([cue2, cue3]);
-    // Wait until updateCaptions_() gets called.
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
+
     captions = textContainer.querySelectorAll('div');
     // Expect textContainer to display all three cues, since they are not truly
     // duplicates.
     expect(captions.length).toBe(3);
   });
 
-  it('does not mistake cues with different styles duplicates', async () => {
+  it('does not mistake cues with different styles duplicates', () => {
     // These all have the same text and timing, but different styles.
     const cue1 = new shaka.text.Cue(0, 100, 'Hello!');
     cue1.color = 'green';
@@ -292,8 +299,8 @@ describe('UITextDisplayer', () => {
 
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([cue1]);
-    // Wait until updateCaptions_() gets called.
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
+
     /** @type {Element} */
     const textContainer = videoContainer.querySelector('.shaka-text-container');
     let captions = textContainer.querySelectorAll('div');
@@ -301,20 +308,20 @@ describe('UITextDisplayer', () => {
     expect(captions.length).toBe(1);
 
     textDisplayer.append([cue2, cue3]);
-    // Wait until updateCaptions_() gets called.
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
+
     captions = textContainer.querySelectorAll('div');
     // Expect textContainer to display all three cues, since they are not truly
     // duplicates.
     expect(captions.length).toBe(3);
   });
 
-  it('hides currently displayed cue when removed', async () => {
+  it('hides currently displayed cue when removed', () => {
     const cue = new shaka.text.Cue(0, 50, 'One');
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([cue]);
     video.currentTime = 10;
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
     const textContainer = videoContainer.querySelector('.shaka-text-container');
 
     let cueElements = textContainer.querySelectorAll('div');
@@ -327,7 +334,7 @@ describe('UITextDisplayer', () => {
     expect(cueElements.length).toBe(0);
   });
 
-  it('hides and shows nested cues at appropriate times', async () => {
+  it('hides and shows nested cues at appropriate times', () => {
     const parentCue1 = new shaka.text.Cue(0, 100, '');
     const cue1 = new shaka.text.Cue(0, 50, 'One');
     parentCue1.nestedCues.push(cue1);
@@ -344,7 +351,7 @@ describe('UITextDisplayer', () => {
     textDisplayer.append([parentCue1, parentCue2]);
 
     video.currentTime = 10;
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
     /** @type {Element} */
     const textContainer = videoContainer.querySelector('.shaka-text-container');
     let parentCueElements = textContainer.querySelectorAll('div');
@@ -353,38 +360,38 @@ describe('UITextDisplayer', () => {
     expect(parentCueElements[0].textContent).toBe('One');
 
     video.currentTime = 35;
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
     parentCueElements = textContainer.querySelectorAll('div');
     expect(parentCueElements.length).toBe(1);
     expect(parentCueElements[0].textContent).toBe('OneTwo');
 
     video.currentTime = 60;
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
     parentCueElements = textContainer.querySelectorAll('div');
     expect(parentCueElements.length).toBe(1);
     expect(parentCueElements[0].textContent).toBe('TwoThree');
 
     video.currentTime = 85;
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
     parentCueElements = textContainer.querySelectorAll('div');
     expect(parentCueElements.length).toBe(1);
     expect(parentCueElements[0].textContent).toBe('Three');
 
     video.currentTime = 95;
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
     parentCueElements = textContainer.querySelectorAll('div');
     expect(parentCueElements.length).toBe(2);
     expect(parentCueElements[0].textContent).toBe('Three');
     expect(parentCueElements[1].textContent).toBe('Four');
 
     video.currentTime = 105;
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
     parentCueElements = textContainer.querySelectorAll('div');
     expect(parentCueElements.length).toBe(1);
     expect(parentCueElements[0].textContent).toBe('Four');
 
     video.currentTime = 150;
-    await shaka.test.Util.delay(0.5);
+    updateCaptions();
     parentCueElements = textContainer.querySelectorAll('div');
     expect(parentCueElements.length).toBe(1);
     expect(parentCueElements[0].textContent).toBe('');


### PR DESCRIPTION
This seems to reduce flakiness in the TextDisplayer tests.  The
theory is that Safari throttles timers when the system is very busy,
which it often is during full test runs across multiple browsers.  By
not relying on timers and triggering an explicit update in the
TextDisplayer, the tests seem to become more reliable.
