### PR TITLE
test: Add debug info to failure messages in test waiter

### DIFF
--- a/test/media/drm_engine_integration.js
+++ b/test/media/drm_engine_integration.js
@@ -256,6 +256,7 @@ describe('DrmEngine', () => {
       video.play();
 
       const waiter = new shaka.test.Waiter(eventManager).timeoutAfter(15);
+      waiter.setMediaSourceEngine(mediaSourceEngine);
       await waiter.waitForMovement(video);
 
       // Something should have played by now.
@@ -336,6 +337,7 @@ describe('DrmEngine', () => {
       video.play();
 
       const waiter = new shaka.test.Waiter(eventManager).timeoutAfter(15);
+      waiter.setMediaSourceEngine(mediaSourceEngine);
       await waiter.waitForMovement(video);
 
       // Something should have played by now.

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -68,6 +68,7 @@ describe('StreamingEngine', () => {
         video,
         new shaka.test.FakeClosedCaptionParser(),
         new shaka.test.FakeTextDisplayer());
+    waiter.setMediaSourceEngine(mediaSourceEngine);
   });
 
   afterEach(async () => {
@@ -295,10 +296,6 @@ describe('StreamingEngine', () => {
           // Actually a success!
         } else {
           // This error has debugging info to help explain the state.
-          // Get buffering info from MediaSourceEngine to add to that.
-          const bufferedInfo = mediaSourceEngine.getBufferedInfo();
-          error.message += `bufferedInfo: ${JSON.stringify(bufferedInfo)}\n`;
-
           throw error;
         }
       }

--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -35,6 +35,7 @@ filterDescribe('Offline', supportsStorage, () => {
 
     eventManager = new shaka.util.EventManager();
     waiter = new shaka.test.Waiter(eventManager);
+    waiter.setPlayer(player);
 
     // Make sure we are starting with a blank slate.
     await shaka.offline.Storage.deleteAll();

--- a/test/player_external.js
+++ b/test/player_external.js
@@ -39,6 +39,7 @@ describe('Player', () => {
     // Grab event manager from the uncompiled library:
     eventManager = new shaka.util.EventManager();
     waiter = new shaka.test.Waiter(eventManager);
+    waiter.setPlayer(player);
 
     onErrorSpy = jasmine.createSpy('onError');
     onErrorSpy.and.callFake((event) => fail(event.detail));

--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -649,7 +649,7 @@ describe('Player', () => {
 
       const waiter = new shaka.test.Waiter(eventManager)
           .setPlayer(player)
-          .setTimeoutAfter(10);
+          .timeoutAfter(10);
       const canPlayThrough = waiter.waitForEvent(video, 'canplaythrough');
 
       await player.load('test:sintel_compiled', 5);

--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -37,6 +37,7 @@ describe('Player', () => {
     // Grab event manager from the uncompiled library:
     eventManager = new shaka.util.EventManager();
     waiter = new shaka.test.Waiter(eventManager);
+    waiter.setPlayer(player);
 
     onErrorSpy = jasmine.createSpy('onError');
     onErrorSpy.and.callFake((event) => {
@@ -646,7 +647,9 @@ describe('Player', () => {
       eventManager.listen(video, 'waiting', checkOnEvent);
       eventManager.listen(player, 'trackschanged', checkOnEvent);
 
-      const waiter = (new shaka.test.Waiter(eventManager)).timeoutAfter(10);
+      const waiter = new shaka.test.Waiter(eventManager)
+          .setPlayer(player)
+          .setTimeoutAfter(10);
       const canPlayThrough = waiter.waitForEvent(video, 'canplaythrough');
 
       await player.load('test:sintel_compiled', 5);
@@ -720,6 +723,7 @@ describe('Player', () => {
       player.addEventListener('mediaqualitychanged',
           Util.spyFunc(onQualityChange));
       waiter = new shaka.test.Waiter(eventManager)
+          .setPlayer(player)
           .timeoutAfter(10)
           .failOnTimeout(true);
     });
@@ -777,7 +781,9 @@ describe('Player', () => {
       eventManager.listen(player, 'error', Util.spyFunc(onErrorSpy));
       /** @type {shaka.test.Waiter} */
       const waiter = new shaka.test.Waiter(eventManager)
-          .timeoutAfter(20).failOnTimeout(true);
+          .setPlayer(player)
+          .timeoutAfter(20)
+          .failOnTimeout(true);
       await waiter.waitForEnd(video);
 
       // The stream should have transitioned to VOD by now.
@@ -802,6 +808,7 @@ describe('Player', () => {
       player.addEventListener('buffering', Util.spyFunc(onBuffering));
 
       waiter = new shaka.test.Waiter(eventManager)
+          .setPlayer(player)
           .timeoutAfter(10)
           .failOnTimeout(true);
     });
@@ -992,7 +999,9 @@ describe('Player', () => {
 
       /** @type {shaka.test.Waiter} */
       const waiter = new shaka.test.Waiter(eventManager)
-          .timeoutAfter(1).failOnTimeout(true);
+          .setPlayer(player)
+          .timeoutAfter(1)
+          .failOnTimeout(true);
 
       await waiter.waitForPromise(abrEnabled, 'AbrManager enabled');
 
@@ -1012,7 +1021,9 @@ describe('Player', () => {
 
       /** @type {shaka.test.Waiter} */
       const waiter = new shaka.test.Waiter(eventManager)
-          .timeoutAfter(1).failOnTimeout(true);
+          .setPlayer(player)
+          .timeoutAfter(1)
+          .failOnTimeout(true);
 
       await waiter.waitForPromise(abrEnabled, 'AbrManager enabled');
 

--- a/test/test/util/waiter.js
+++ b/test/test/util/waiter.js
@@ -305,7 +305,7 @@ shaka.test.Waiter = class {
     let buffered;
     if (this.player_) {
       buffered = player.getBufferedInfo();
-    else if (this.mediaSourceEngine_) {
+    } else if (this.mediaSourceEngine_) {
       buffered = mediaSourceEngine.getBufferedInfo();
     } else {
       buffered = shaka.media.TimeRangesUtils.getBufferedInfo(

--- a/test/test/util/waiter.js
+++ b/test/test/util/waiter.js
@@ -255,7 +255,7 @@ shaka.test.Waiter = class {
 
       // Improve the error message with media-specific debug info.
       if (target instanceof HTMLMediaElement) {
-        this.logDebugInfoForMedia_(error.message, target);
+        this.logDebugInfoForMedia_(error, target);
       }
 
       // Reject or resolve based on our settings.
@@ -268,20 +268,21 @@ shaka.test.Waiter = class {
   }
 
   /**
-   * @param {string} message
+   * @param {!Error} error
    * @param {!HTMLMediaElement} mediaElement
    * @private
    */
-  logDebugInfoForMedia_(message, mediaElement) {
+  logDebugInfoForMedia_(error, mediaElement) {
     const buffered =
         shaka.media.TimeRangesUtils.getBufferedInfo(mediaElement.buffered);
-    shaka.log.error(message,
-        'current time', mediaElement.currentTime,
-        'duration', mediaElement.duration,
-        'ready state', mediaElement.readyState,
-        'playback rate', mediaElement.playbackRate,
-        'paused', mediaElement.paused,
-        'ended', mediaElement.ended,
-        'buffered', buffered);
+    error.message += '\n' +
+        `current time: ${mediaElement.currentTime}\n` +
+        `duration: ${mediaElement.duration}\n` +
+        `ready state: ${mediaElement.readyState}\n` +
+        `playback rate: ${mediaElement.playbackRate}\n` +
+        `paused: ${mediaElement.paused}\n` +
+        `ended: ${mediaElement.ended}\n` +
+        `buffered: ${JSON.stringify(buffered)}\n`;
+    shaka.log.error(error.message);
   }
 };

--- a/test/test/util/waiter.js
+++ b/test/test/util/waiter.js
@@ -304,9 +304,9 @@ shaka.test.Waiter = class {
   logDebugInfoForMedia_(error, mediaElement) {
     let buffered;
     if (this.player_) {
-      buffered = player.getBufferedInfo();
+      buffered = this.player_.getBufferedInfo();
     } else if (this.mediaSourceEngine_) {
-      buffered = mediaSourceEngine.getBufferedInfo();
+      buffered = this.mediaSourceEngine_.getBufferedInfo();
     } else {
       buffered = shaka.media.TimeRangesUtils.getBufferedInfo(
           mediaElement.buffered);


### PR DESCRIPTION
This should help debug flakiness and failures in StreamingEngine tests
on Safari and Firefox.
