### PR TITLE
ci: Fix -main tags on release

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -59,6 +59,8 @@ jobs:
     if: needs.release.outputs.release_created
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: main
       - name: Tag the main branch
         run: |
           # Emulate the actions bot.


### PR DESCRIPTION
These tags should be attached to the head of the main branch, so that
is what we should check out during the tagging job.

In v3.1.7, v3.2.5, and v3.3.3, we accidentally tagged the heads of the
release branches.  The `-main` tags for those releases had to be
corrected manually.
