### PR TITLE
docs: update git.io link to original destination

### DIFF
--- a/ui/seek_bar.js
+++ b/ui/seek_bar.js
@@ -74,7 +74,8 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
     });
 
     /**
-     * When user is scrubbing the seek bar - we should pause the video - see https://git.io/JUhHG
+     * When user is scrubbing the seek bar - we should pause the video - see
+     * https://github.com/google/shaka-player/pull/2898#issuecomment-705229215
      * but will conditionally pause or play the video after scrubbing
      * depending on its previous state
      *


### PR DESCRIPTION
On 29th of April, git.io will stop redirecting

Ref: https://github.blog/changelog/2022-04-25-git-io-deprecation/

So let's update this comment to keep the original reference there
