### PR TITLE
fix: Fix encryption detection to work around broken platforms

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -63,6 +63,11 @@ shaka.media.MediaSourceEngine = class {
                            string>} */
     this.sourceBufferTypes_ = {};
 
+
+    /** @private {!Object.<shaka.util.ManifestParserUtils.ContentType,
+                           boolean>} */
+    this.expectedEncryption_ = {};
+
     /** @private {shaka.text.TextEngine} */
     this.textEngine_ = null;
 
@@ -357,6 +362,7 @@ shaka.media.MediaSourceEngine = class {
         this.sourceBuffers_[contentType] = sourceBuffer;
         this.sourceBufferTypes_[contentType] = mimeType;
         this.queues_[contentType] = [];
+        this.expectedEncryption_[contentType] = !!stream.drmInfos.length;
       }
     }
   }
@@ -1134,7 +1140,7 @@ shaka.media.MediaSourceEngine = class {
    */
   workAroundBrokenPlatforms_(segment, startTime, contentType) {
     const isInitSegment = startTime == null;
-    const encryptionExpected = this.video_.mediaKeys;
+    const encryptionExpected = this.expectedEncryption_[contentType];
 
     // If:
     //   1. this is an init segment,

--- a/test/cast/cast_utils_unit.js
+++ b/test/cast/cast_utils_unit.js
@@ -189,6 +189,7 @@ describe('CastUtils', () => {
         const fakeVideoStream = {
           mimeType: 'video/mp4',
           codecs: 'avc1.42c01e',
+          drmInfos: [],
         };
         const initSegmentUrl = '/base/test/test/assets/sintel-video-init.mp4';
         const videoSegmentUrl =

--- a/test/media/media_source_engine_integration.js
+++ b/test/media/media_source_engine_integration.js
@@ -103,6 +103,7 @@ describe('MediaSourceEngine', () => {
     return {
       mimeType: streamMetadata.mimeType,
       codecs: streamMetadata.codecs,
+      drmInfos: [],
     };
   }
 

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -49,10 +49,10 @@ describe('MediaSourceEngine', () => {
   const buffer2 = /** @type {!ArrayBuffer} */ (/** @type {?} */ (2));
   const buffer3 = /** @type {!ArrayBuffer} */ (/** @type {?} */ (3));
 
-  const fakeVideoStream = {mimeType: 'video/foo'};
-  const fakeAudioStream = {mimeType: 'audio/foo'};
-  const fakeTextStream = {mimeType: 'text/foo'};
-  const fakeTransportStream = {mimeType: 'tsMimetype'};
+  const fakeVideoStream = {mimeType: 'video/foo', drmInfos: []};
+  const fakeAudioStream = {mimeType: 'audio/foo', drmInfos: []};
+  const fakeTextStream = {mimeType: 'text/foo', drmInfos: []};
+  const fakeTransportStream = {mimeType: 'tsMimetype', drmInfos: []};
 
   let audioSourceBuffer;
   let videoSourceBuffer;

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -585,6 +585,7 @@ describe('StreamingEngine', () => {
             width: 600,
             height: 400,
             type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+            drmInfos: [],
           },
           audio: {
             id: 3,
@@ -594,6 +595,7 @@ describe('StreamingEngine', () => {
             codecs: 'mp4a.40.2',
             bandwidth: 192000,
             type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+            drmInfos: [],
           },
         }],
       };


### PR DESCRIPTION
Fixes an issue where non-encrypted content were unable to playback due to encryption detection done with `this.video.mediaKeys`. It seems we could set MediaKeys even though the content is not encrypted, therefore trying & failing to add information in the init segment and resulting into a `CONTENT_TRANSFORMATION_FAILED`.

I am still unsure why this is happening exactly but I think it could be a side-effect of #3776 . I'll keep looking for the real cause of the issue, but I think this is a reasonable fix to rely on stream info

I'll test different versions of Tizens we have because I think this workaround isn't needed on all of the versions