### PR TITLE
fix(dash): Fix playback of Dolby Atmos

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -1229,7 +1229,6 @@ shaka.dash.DashParser = class {
     });
     let spatialAudio = false;
     if (hasJoc) {
-      context.representation.mimeType = 'audio/eac3-joc';
       spatialAudio = true;
     }
 

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -447,30 +447,6 @@ describe('DashParser Manifest', () => {
         expect(stream.closedCaptions).toEqual(expectedClosedCaptions);
       });
 
-  it('Detects E-AC3 JOC content by SupplementalProperty', async () => {
-    const idUri = 'tag:dolby.com,2018:dash:EC3_ExtensionType:2018';
-    const source = [
-      '<MPD>',
-      '  <Period duration="PT30M">',
-      '    <AdaptationSet mimeType="audio/mp4" lang="\u2603">',
-      '      <Representation bandwidth="500">',
-      '        <SupplementalProperty schemeIdUri="' + idUri + '" value="JOC"/>',
-      '        <BaseURL>http://example.com</BaseURL>',
-      '        <SegmentTemplate media="2.mp4" duration="1" />',
-      '      </Representation>',
-      '    </AdaptationSet>',
-      '  </Period>',
-      '</MPD>',
-    ].join('\n');
-
-    fakeNetEngine.setResponseText('dummy://foo', source);
-
-    /** @type {shaka.extern.Manifest} */
-    const manifest = await parser.start('dummy://foo', playerInterface);
-    const stream = manifest.variants[0].audio;
-    expect(stream.mimeType).toBe('audio/eac3-joc');
-  });
-
   it('Detects spatial audio', async () => {
     const idUri = 'tag:dolby.com,2018:dash:EC3_ExtensionType:2018';
     const source = [


### PR DESCRIPTION
According to https://developerkb.dolby.com/support/solutions/articles/16000067758-what-is-dolby-digital-plus-joc-joint-object-coding- Dolby Atmos (JOC):

> Joint Object Coding describes the process by which Dolby Digital Plus with Atmos decoders, receiving a legacy 5.1 mix and sideband metadata, are able to reconstruct the original Atmos mix.

So there is no need to deal with a separate mimetype, it can be decoded with Dolby Digital+ (better for retrocompatibility).

Closes https://github.com/shaka-project/shaka-player/issues/4171