### PR TITLE
test: Run DRM tests by default

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -111,7 +111,6 @@ jobs:
           python build/test.py \
             --browsers "$browser" \
             --reporters spec --spec-hide-passed \
-            --drm \
             ${{ matrix.extra_flags }}
 
   build_in_docker:

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -76,7 +76,6 @@ jobs:
         run: |
           python3 build/test.py \
               --reporters spec --spec-hide-passed \
-              --drm \
               --lets-encrypt-folder /etc/shakalab.rocks \
               --hostname karma.shakalab.rocks \
               --port 61731 \

--- a/build/README.md
+++ b/build/README.md
@@ -80,8 +80,8 @@ directly:
 * `--external` will run integration tests against external assets.  This will
   take an extremely long time to run, and requires a fast and reliable internet
   connection.
-* `--drm` will run integration tests against DRM license servers.  This will
-  require a connection to the open internet.
+* `--no-drm` will skip integration tests against DRM license servers.  Not
+  specifying this flag requires a connection to the open internet.
 * `--uncompiled` will run integration tests using the uncompiled library instead
   of the compiled version.
 * `--random` will run the tests in a random order to isolate test dependencies.

--- a/build/test.py
+++ b/build/test.py
@@ -209,8 +209,14 @@ class Launcher:
         action='store_true')
     running_commands.add_argument(
         '--drm',
-        help='Run tests that require DRM.',
+        help='Run tests that require DRM (on by default).',
+        default=True,
         action='store_true')
+    running_commands.add_argument(
+        '--no-drm', '--nodrm',
+        help='Skip tests that require DRM (opposite of --drm).',
+        dest='drm',
+        action='store_false')
     running_commands.add_argument(
         '--quarantined',
         help='Run tests that have been quarantined.',


### PR DESCRIPTION
This changes the default behavior of the test runner.  Now tests that
require access to license servers will run by default.  To disable DRM
tests (for example, if there is no connection to the outside
internet), use --no-drm.
