### PR TITLE
fix: Revert "Add missing module export in generated typescript defs"

### DIFF
--- a/build/generateTsDefs.py
+++ b/build/generateTsDefs.py
@@ -102,8 +102,6 @@ def GenerateTsDefs(inputs, output):
     f.write(license_header)
     f.write(b'\n')
     f.write(contents)
-    f.write(b'\n')
-    f.write(b'export default shaka;\n')
 
 
 def CreateParser():


### PR DESCRIPTION
Reverts shaka-project/shaka-player#4163

Closes #4167