### PR TITLE
ci: Do not create a -main tag if the release is from main

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -56,7 +56,7 @@ jobs:
   tag-main:
     runs-on: ubuntu-latest
     needs: release
-    if: needs.release.outputs.release_created
+    if: needs.release.outputs.release_created && endsWith(needs.release.outputs.tag_name, '.0') == false
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Having both v4.0.0 and v4.0.0-main tags refer to the same commit
confuses some of our build scripts because git describe can produce
either tag.  So we should only create -main tags when the release is
from a branch.