### PR TITLE
fix: Do not report MANIFEST RESTRICTIONS_CANNOT_BE_MET error twice

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5679,7 +5679,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }  // if (keyIds.size)
 
     if (tracksChanged) {
-      this.updateAbrManagerVariants_();
+      const variantsUpdated = this.updateAbrManagerVariants_();
+      if (!variantsUpdated) {
+        return;
+      }
     }
 
     const currentVariant = this.streamingEngine_.getCurrentVariant();


### PR DESCRIPTION
## Description

We want to avoid reporting MANIFEST RESTRICTIONS_CANNOT_BE_MET error twice.
This is because when error detected from `onKeyStatus_` calls `updateAbrManagerVariants_` which calls `checkRestrictedVariants_` and error is catched and propagated from `onError_` **but source code execution continues** 
and `chooseVariantAndSwitch_` triggers same error again:

```javascript
onKeyStatus_() {
  ....
  if (tracksChanged) {
    this.updateAbrManagerVariants_(); 
    //   -> checkRestrictedVariants_ 
    //     -> RESTRICTIONS_CANNOT_BE_MET
  }
  ...
  if (currentVariant && !currentVariant.allowedByKeySystem) {
    ...
    this.chooseVariantAndSwitch_(); 
    //  -> chooseVariant_
    //    -> updateAbrManagerVariants_ 
    //      -> checkRestrictedVariants_ 
    //        -> RESTRICTIONS_CANNOT_BE_MET
  }
```

## Resolves

https://github.com/shaka-project/shaka-player/issues/4190