### PR TITLE
fix: Removing offline content should always resolve its promise

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -99,6 +99,7 @@ Sander Saares <sander@saares.eu>
 Sandra Lokshina <ismena@google.com>
 Sanil Raut <sr1990003@gmail.com>
 Satheesh Velmurugan <satheesh@philo.com>
+Scott Petrovic <spetrovic@swankmp.com>
 Semih Gokceoglu <semih.gkcoglu@gmail.com>
 Seth Madison <seth@philo.com>
 Tatsiana Gelahova <tatsiana.gelahova@gmail.com>

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -610,7 +610,7 @@ shaka.media.DrmEngine = class {
     try {
       await Promise.all(tasks);
     } catch (error) {
-      shaka.log.debug('There was an error removing a session', error);
+      Promise.reject('There was a problem removing a session: ' + error);
     }
 
     this.activeSessions_.delete(session);

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -607,11 +607,7 @@ shaka.media.DrmEngine = class {
     shaka.log.v2('Attempting to remove session', sessionId);
     tasks.push(session.remove());
 
-    try {
-      await Promise.all(tasks);
-    } catch (error) {
-      Promise.reject('There was a problem removing a session: ' + error);
-    }
+    await Promise.all(tasks);
 
     this.activeSessions_.delete(session);
   }

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -608,7 +608,6 @@ shaka.media.DrmEngine = class {
     tasks.push(session.remove());
 
     await Promise.all(tasks);
-
     this.activeSessions_.delete(session);
   }
 

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -607,7 +607,12 @@ shaka.media.DrmEngine = class {
     shaka.log.v2('Attempting to remove session', sessionId);
     tasks.push(session.remove());
 
-    await Promise.all(tasks);
+    try {
+      await Promise.all(tasks);
+    } catch (error) {
+      shaka.log.debug('There was an error removing a session', error);
+    }
+
     this.activeSessions_.delete(session);
   }
 

--- a/lib/offline/session_deleter.js
+++ b/lib/offline/session_deleter.js
@@ -91,7 +91,13 @@ shaka.offline.SessionDeleter = class {
         shaka.log.warning('Error deleting offline session', e);
       }
     }));
-    await drmEngine.destroy();
+
+    // Destroying the engine with no sessions makes the promise not return.
+    // This will happen if there is a problem removing a session.
+    if (sessionIds.length > 0) {
+      await drmEngine.destroy();
+    }
+
     return sessionIds;
   }
 


### PR DESCRIPTION
This fix should address the issue I filed a bit ago: https://github.com/shaka-project/shaka-player/issues/4199

Let me summarize what is going on here more concisely.

When you delete offline content with the remove() function, the promise isn't resolving if there are network issues. It turns into a silent failure which is kind of confusing to work with.

In my case, the license server request is giving an error. That is ok though, so the application still needs to remove the content and return the promise. Adding this try block around the session removal attempt seems to fix it.