### PR TITLE
docs: Add note to upgrade guide about manifest.hls.useFullSegmentsForStartTime

### DIFF
--- a/docs/tutorials/upgrade.md
+++ b/docs/tutorials/upgrade.md
@@ -46,6 +46,9 @@ application:
       minimum supported version of iOS is now 13)
     - `streaming.smallGapLimit` and `streaming.jumpLargeGaps` have been removed;
       all gaps will now be jumped
+    - `manifest.hls.useFullSegmentsForStartTime` has been removed; this setting
+      is no longer necessary, as we no longer fetch segments for start times in
+      the HLS parser
 
   - Player API changes:
     - `shaka.Player.prototype.addTextTrack()` has been replaced by


### PR DESCRIPTION
This was removed in the release, but we failed to note this in the
upgrade guide.

Closes #4210
