### PR TITLE
test: Fix custom asset and external tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -363,6 +363,8 @@ module.exports = (config) => {
     // If testing custom assets, we don't serve other unit or integration tests.
     // External asset tests are the basis for custom asset testing, so this file
     // is automatically included.
+    clientArgs.testFiles.push('demo/common/asset.js');
+    clientArgs.testFiles.push('demo/common/assets.js');
     clientArgs.testFiles.push('test/player_external.js');
   } else {
     // In a normal test run, we serve unit tests.
@@ -374,6 +376,8 @@ module.exports = (config) => {
     }
     if (settings.external) {
       // If --external is present, we serve external asset tests.
+      clientArgs.testFiles.push('demo/common/asset.js');
+      clientArgs.testFiles.push('demo/common/assets.js');
       clientArgs.testFiles.push('test/**/*_external.js');
     }
   }

--- a/test/player_external.js
+++ b/test/player_external.js
@@ -114,7 +114,13 @@ describe('Player', () => {
         const networkingEngine = player.getNetworkingEngine();
         asset.applyFilters(networkingEngine);
 
-        await player.load(asset.manifestUri);
+        // Rather than awaiting the load() method, catch any load() errors and
+        // wait on the 'canplay' event.  This has the advantage that we will
+        // get better logging of the media state on a timeout, since that
+        // capabilitiy is built into the waiter for media element events.
+        player.load(asset.manifestUri).catch(fail);
+        await waiter.timeoutAfter(60).waitForEvent(video, 'canplay');
+
         if (asset.features) {
           const isLive = asset.features.includes(Feature.LIVE);
           expect(player.isLive()).toBe(isLive);


### PR DESCRIPTION
Custom asset and external tests (not run by default) were failing to run due to
missing dependencies.  This fixes that issue.

This also improves logging of debug info when a custom asset test times out.

Related to investigation of #4161
