### PR TITLE
fix: Fix event listener leaks in Player

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -423,8 +423,23 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
      */
     this.isTextVisible_ = false;
 
-    /** @private {shaka.util.EventManager} */
-    this.eventManager_ = new shaka.util.EventManager();
+    /**
+     * For listeners scoped to the lifetime of the Player instance.
+     * @private {shaka.util.EventManager}
+     */
+    this.globalEventManager_ = new shaka.util.EventManager();
+
+    /**
+     * For listeners scoped to the lifetime of the media element attachment.
+     * @private {shaka.util.EventManager}
+     */
+    this.attachEventManager_ = new shaka.util.EventManager();
+
+    /**
+     * For listeners scoped to the lifetime of the loaded content.
+     * @private {shaka.util.EventManager}
+     */
+    this.loadEventManager_ = new shaka.util.EventManager();
 
     /** @private {shaka.net.NetworkingEngine} */
     this.networkingEngine_ = null;
@@ -564,7 +579,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // If the browser comes back online after being offline, then try to play
     // again.
-    this.eventManager_.listen(window, 'online', () => {
+    this.globalEventManager_.listen(window, 'online', () => {
       this.retryStreaming();
     });
 
@@ -756,10 +771,18 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     });
     await this.walker_.destroy();
 
-    // Tear-down the event manager to ensure messages stop moving around.
-    if (this.eventManager_) {
-      this.eventManager_.release();
-      this.eventManager_ = null;
+    // Tear-down the event managers to ensure handlers stop firing.
+    if (this.globalEventManager_) {
+      this.globalEventManager_.release();
+      this.globalEventManager_ = null;
+    }
+    if (this.attachEventManager_) {
+      this.attachEventManager_.release();
+      this.attachEventManager_ = null;
+    }
+    if (this.loadEventManager_) {
+      this.loadEventManager_.release();
+      this.loadEventManager_ = null;
     }
 
     this.abrManagerFactory_ = null;
@@ -1302,7 +1325,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       has.mediaElement = wants.mediaElement;
 
       const onError = (error) => this.onVideoError_(error);
-      this.eventManager_.listen(has.mediaElement, 'error', onError);
+      this.attachEventManager_.listen(has.mediaElement, 'error', onError);
     }
 
     this.video_ = has.mediaElement;
@@ -1329,10 +1352,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   onDetach_(has, wants) {
-    // If we are going from "detached" to "detached" we wouldn't have
+    // If we were going from "detached" to "detached" we wouldn't have
     // a media element to detach from.
     if (has.mediaElement) {
-      this.eventManager_.unlisten(has.mediaElement, 'error');
+      this.attachEventManager_.removeAll();
       has.mediaElement = null;
     }
 
@@ -1390,11 +1413,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // In most cases we should have a media element. The one exception would
     // be if there was an error and we, by chance, did not have a media element.
     if (has.mediaElement) {
-      this.eventManager_.unlisten(has.mediaElement, 'loadedmetadata');
-      this.eventManager_.unlisten(has.mediaElement, 'playing');
-      this.eventManager_.unlisten(has.mediaElement, 'pause');
-      this.eventManager_.unlisten(has.mediaElement, 'ended');
-      this.eventManager_.unlisten(has.mediaElement, 'ratechange');
+      this.loadEventManager_.removeAll();
     }
 
     // Stop the variant checker timer
@@ -1892,18 +1911,18 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.assetUri_ = assetUri;
 
     this.playRateController_ = new shaka.media.PlayRateController({
-      getRate: () => has.mediaElement.playbackRate,
-      getDefaultRate: () => has.mediaElement.defaultPlaybackRate,
-      setRate: (rate) => { has.mediaElement.playbackRate = rate; },
-      movePlayhead: (delta) => { has.mediaElement.currentTime += delta; },
+      getRate: () => mediaElement.playbackRate,
+      getDefaultRate: () => mediaElement.defaultPlaybackRate,
+      setRate: (rate) => { mediaElement.playbackRate = rate; },
+      movePlayhead: (delta) => { mediaElement.currentTime += delta; },
     });
 
     const updateStateHistory = () => this.updateStateHistory_();
     const onRateChange = () => this.onRateChange_();
-    this.eventManager_.listen(mediaElement, 'playing', updateStateHistory);
-    this.eventManager_.listen(mediaElement, 'pause', updateStateHistory);
-    this.eventManager_.listen(mediaElement, 'ended', updateStateHistory);
-    this.eventManager_.listen(mediaElement, 'ratechange', onRateChange);
+    this.loadEventManager_.listen(mediaElement, 'playing', updateStateHistory);
+    this.loadEventManager_.listen(mediaElement, 'pause', updateStateHistory);
+    this.loadEventManager_.listen(mediaElement, 'ended', updateStateHistory);
+    this.loadEventManager_.listen(mediaElement, 'ratechange', onRateChange);
 
     const abrFactory = this.config_.abrFactory;
     if (!this.abrManager_ || this.abrManagerFactory_ != abrFactory) {
@@ -1960,33 +1979,22 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // "streaming" so that they can access internal information.
     this.loadMode_ = shaka.Player.LoadMode.MEDIA_SOURCE;
 
-    // This flag is used below in track management to check if this load was
-    // canceled before the necessary events fired.
-    let unloaded = false;
-    this.cleanupOnUnload_.push(() => {
-      unloaded = true;
-    });
+    if (mediaElement.textTracks) {
+      this.loadEventManager_.listen(
+          mediaElement.textTracks, 'addtrack', (e) => {
+            const trackEvent = /** @type {!TrackEvent} */(e);
+            if (trackEvent.track) {
+              const track = trackEvent.track;
+              goog.asserts.assert(
+                  track instanceof TextTrack, 'Wrong track type!');
 
-    if (this.video_.textTracks) {
-      this.eventManager_.listen(this.video_.textTracks, 'addtrack', (e) => {
-        // If we have moved on to another piece of content while waiting for
-        // the above event, we should not process tracks here.
-        if (unloaded) {
-          return;
-        }
-
-        const trackEvent = /** @type {!TrackEvent} */(e);
-        if (trackEvent.track) {
-          const track = trackEvent.track;
-          goog.asserts.assert(track instanceof TextTrack, 'Wrong track type!');
-
-          switch (track.kind) {
-            case 'chapters':
-              this.activateChaptersTrack_(track);
-              break;
-          }
-        }
-      });
+              switch (track.kind) {
+                case 'chapters':
+                  this.activateChaptersTrack_(track);
+                  break;
+              }
+            }
+          });
     }
 
     // The event must be fired after we filter by restrictions but before the
@@ -2075,7 +2083,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     // Wait for the 'loadedmetadata' event to measure load() latency.
-    this.eventManager_.listenOnce(mediaElement, 'loadedmetadata', () => {
+    this.loadEventManager_.listenOnce(mediaElement, 'loadedmetadata', () => {
       const now = Date.now() / 1000;
       const delta = now - wants.startTimeOfLoad;
       this.stats_.setLoadLatency(delta);
@@ -2229,11 +2237,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // Save the uri so that it can be used outside of the load-graph.
     this.assetUri_ = has.uri;
 
-    this.playhead_ = new shaka.media.SrcEqualsPlayhead(has.mediaElement);
+    const mediaElement = has.mediaElement;
 
-    // This flag is used below in the language preference setup and
-    // track-management to check if this load was canceled before the necessary
-    // events fired.
+    this.playhead_ = new shaka.media.SrcEqualsPlayhead(mediaElement);
+
+    // This flag is used below in the language preference setup to check if
+    // this load was canceled before the necessary awaits completed.
     let unloaded = false;
     this.cleanupOnUnload_.push(() => {
       unloaded = true;
@@ -2244,10 +2253,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     this.playRateController_ = new shaka.media.PlayRateController({
-      getRate: () => has.mediaElement.playbackRate,
-      getDefaultRate: () => has.mediaElement.defaultPlaybackRate,
-      setRate: (rate) => { has.mediaElement.playbackRate = rate; },
-      movePlayhead: (delta) => { has.mediaElement.currentTime += delta; },
+      getRate: () => mediaElement.playbackRate,
+      getDefaultRate: () => mediaElement.defaultPlaybackRate,
+      setRate: (rate) => { mediaElement.playbackRate = rate; },
+      movePlayhead: (delta) => { mediaElement.currentTime += delta; },
     });
 
     // We need to start the buffer management code near the end because it will
@@ -2259,17 +2268,17 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // Add all media element listeners.
     const updateStateHistory = () => this.updateStateHistory_();
     const onRateChange = () => this.onRateChange_();
-    this.eventManager_.listen(has.mediaElement, 'playing', updateStateHistory);
-    this.eventManager_.listen(has.mediaElement, 'pause', updateStateHistory);
-    this.eventManager_.listen(has.mediaElement, 'ended', updateStateHistory);
-    this.eventManager_.listen(has.mediaElement, 'ratechange', onRateChange);
+    this.loadEventManager_.listen(mediaElement, 'playing', updateStateHistory);
+    this.loadEventManager_.listen(mediaElement, 'pause', updateStateHistory);
+    this.loadEventManager_.listen(mediaElement, 'ended', updateStateHistory);
+    this.loadEventManager_.listen(mediaElement, 'ratechange', onRateChange);
 
     // Wait for the 'loadedmetadata' event to measure load() latency, but only
     // if preload is set in a way that would result in this event firing
     // automatically.
     // See https://github.com/shaka-project/shaka-player/issues/2483
-    if (this.video_.preload != 'none') {
-      this.eventManager_.listenOnce(this.video_, 'loadedmetadata', () => {
+    if (mediaElement.preload != 'none') {
+      this.loadEventManager_.listenOnce(mediaElement, 'loadedmetadata', () => {
         const now = Date.now() / 1000;
         const delta = now - wants.startTimeOfLoad;
         this.stats_.setLoadLatency(delta);
@@ -2279,49 +2288,47 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // The audio tracks are only available on Safari at the moment, but this
     // drives the tracks API for Safari's native HLS. So when they change,
     // fire the corresponding Shaka Player event.
-    if (this.video_.audioTracks) {
-      this.eventManager_.listen(
-          this.video_.audioTracks, 'addtrack', () => this.onTracksChanged_());
-      this.eventManager_.listen(
-          this.video_.audioTracks, 'removetrack',
+    if (mediaElement.audioTracks) {
+      this.loadEventManager_.listen(
+          mediaElement.audioTracks, 'addtrack', () => this.onTracksChanged_());
+      this.loadEventManager_.listen(
+          mediaElement.audioTracks, 'removetrack',
           () => this.onTracksChanged_());
-      this.eventManager_.listen(
-          this.video_.audioTracks, 'change', () => this.onTracksChanged_());
+      this.loadEventManager_.listen(
+          mediaElement.audioTracks, 'change', () => this.onTracksChanged_());
     }
 
-    if (this.video_.textTracks) {
-      this.eventManager_.listen(this.video_.textTracks, 'addtrack', (e) => {
-        // If we have moved on to another piece of content while waiting for
-        // the above event, we should not process tracks here.
-        if (unloaded) {
-          return;
-        }
+    if (mediaElement.textTracks) {
+      this.loadEventManager_.listen(
+          mediaElement.textTracks, 'addtrack', (e) => {
+            const trackEvent = /** @type {!TrackEvent} */(e);
+            if (trackEvent.track) {
+              const track = trackEvent.track;
+              goog.asserts.assert(
+                  track instanceof TextTrack, 'Wrong track type!');
 
-        const trackEvent = /** @type {!TrackEvent} */(e);
-        if (trackEvent.track) {
-          const track = trackEvent.track;
-          goog.asserts.assert(track instanceof TextTrack, 'Wrong track type!');
+              switch (track.kind) {
+                case 'metadata':
+                  this.processTimedMetadataSrcEqls_(track);
+                  break;
 
-          switch (track.kind) {
-            case 'metadata':
-              this.processTimedMetadataSrcEqls_(track);
-              break;
+                case 'chapters':
+                  this.activateChaptersTrack_(track);
+                  break;
 
-            case 'chapters':
-              this.activateChaptersTrack_(track);
-              break;
+                default:
+                  this.onTracksChanged_();
+                  break;
+              }
+            }
+          });
 
-            default:
-              this.onTracksChanged_();
-              break;
-          }
-        }
-      });
-
-      this.eventManager_.listen(
-          this.video_.textTracks, 'removetrack', () => this.onTracksChanged_());
-      this.eventManager_.listen(
-          this.video_.textTracks, 'change', () => this.onTracksChanged_());
+      this.loadEventManager_.listen(
+          mediaElement.textTracks, 'removetrack',
+          () => this.onTracksChanged_());
+      this.loadEventManager_.listen(
+          mediaElement.textTracks, 'change',
+          () => this.onTracksChanged_());
     }
 
     const extension = shaka.media.ManifestParser.getExtension(has.uri);
@@ -2330,14 +2337,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // By setting |src| we are done "loading" with src=. We don't need to set
     // the current time because |playhead| will do that for us.
-    has.mediaElement.src = this.cmcdManager_.appendSrcData(has.uri, mimeType);
+    mediaElement.src = this.cmcdManager_.appendSrcData(has.uri, mimeType);
 
     // Tizen 3 / WebOS won't load anything unless you call load() explicitly,
     // no matter the value of the preload attribute.  This is harmful on some
     // other platforms by triggering unbounded loading of media data, but is
     // necessary here.
     if (shaka.util.Platform.isTizen() || shaka.util.Platform.isWebOS()) {
-      has.mediaElement.load();
+      mediaElement.load();
     }
 
     // Set the load mode last so that we know that all our components are
@@ -2353,24 +2360,18 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // wait for the full data, that won't happen on Safari until the play button
     // is hit.
     const fullyLoaded = new shaka.util.PublicPromise();
-    shaka.util.MediaReadyState.waitForReadyState(this.video_,
+    shaka.util.MediaReadyState.waitForReadyState(mediaElement,
         HTMLMediaElement.HAVE_METADATA,
-        this.eventManager_,
+        this.loadEventManager_,
         () => {
           fullyLoaded.resolve();
         });
 
     // We can't switch to preferred languages, though, until the data is loaded.
-    shaka.util.MediaReadyState.waitForReadyState(this.video_,
+    shaka.util.MediaReadyState.waitForReadyState(mediaElement,
         HTMLMediaElement.HAVE_CURRENT_DATA,
-        this.eventManager_,
+        this.loadEventManager_,
         async () => {
-          // If we have moved on to another piece of content while waiting for
-          // the above event, we should not change tracks here.
-          if (unloaded) {
-            return;
-          }
-
           this.setupPreferredAudioOnSrc_();
 
           // Applying the text preference too soon can result in it being
@@ -2378,8 +2379,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           const textTracks = this.getFilteredTextTracks_();
           if (!textTracks.find((t) => t.mode != 'disabled')) {
             await new Promise((resolve) => {
-              this.eventManager_.listenOnce(
-                  this.video_.textTracks, 'change', resolve);
+              this.loadEventManager_.listenOnce(
+                  mediaElement.textTracks, 'change', resolve);
+
               // We expect the event to fire because it does on Safari.
               // But in case it doesn't on some other platform or future
               // version, move on in 1 second no matter what.  This keeps the
@@ -2398,10 +2400,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           this.setupPreferredTextOnSrc_();
         });
 
-    if (this.video_.error) {
+    if (mediaElement.error) {
       // Already failed!
       fullyLoaded.reject(this.videoErrorToShakaError_());
-    } else if (this.video_.preload == 'none') {
+    } else if (mediaElement.preload == 'none') {
       shaka.log.alwaysWarn(
           'With <video preload="none">, the browser will not load anything ' +
           'until play() is called. We are unable to measure load latency in ' +
@@ -2412,7 +2414,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       fullyLoaded.resolve();
     }
 
-    this.eventManager_.listenOnce(this.video_, 'error', () => {
+    this.loadEventManager_.listenOnce(mediaElement, 'error', () => {
       fullyLoaded.reject(this.videoErrorToShakaError_());
     });
 
@@ -2496,7 +2498,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // Hidden mode is required for the cuechange event to launch correctly
     track.mode = 'hidden';
-    this.eventManager_.listen(track, 'cuechange', () => {
+    this.loadEventManager_.listen(track, 'cuechange', () => {
       if (!track.activeCues) {
         return;
       }
@@ -4603,9 +4605,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       await new Promise((resolve, reject) => {
         // The chapter data isn't available until the 'load' event fires, and
         // that won't happen until the chapters track is activated by the
-        // process method.
-        this.eventManager_.listenOnce(trackElement, 'load', resolve);
-        this.eventManager_.listenOnce(trackElement, 'error', (event) => {
+        // activateChaptersTrack_ method.
+        this.loadEventManager_.listenOnce(trackElement, 'load', resolve);
+        this.loadEventManager_.listenOnce(trackElement, 'error', (event) => {
           reject(new shaka.util.Error(
               shaka.util.Error.Severity.RECOVERABLE,
               shaka.util.Error.Category.TEXT,


### PR DESCRIPTION
Event listeners were being leaked in Player across load() / unload()
cycles.  This was fundamentally caused by the difficulty in keeping
track of which event listeners to clean up at which stages of the load
graph.  Everything is cleaned up by Player.destroy() and
EventManager.release(), but for a Player with heavy re-use, there was
still a small leak.

This fixes the leak by splitting the EventManager instance into three
instances, each of which is cleaned up in a different part of the load
graph life cycle.  Listeners which should only live as long as a piece
of content is loaded go into loadEventManager_.  Listeners which
should only live as long as we are attached to the video element go
into attachEventManager_.  Listeners which should live as long as the
Player instance itself go into globalEventManager_.  It is now
impossible to miss unlistening to a particular event, since we no
longer have to unlisten to any individual events at all.  The
removeAll() method of each event manager will clean up all listeners
at the appropriate time.
