### PR TITLE
fix: Re-add initDataTransform config

### DIFF
--- a/docs/tutorials/upgrade.md
+++ b/docs/tutorials/upgrade.md
@@ -42,8 +42,7 @@ application:
       `manifest.defaultPresentationDelay` (deprecated in v3.0.0)
     - Configuration of factories should be plain factory functions, not
       constructors; these will not be invoked with `new` (deprecated in v3.1.0)
-    - `drm.initDataTransform` has been removed (no longer needed since the
-      minimum supported version of iOS is now 13)
+    - `drm.initDataTransform` now defaults to a no-op
     - `streaming.smallGapLimit` and `streaming.jumpLargeGaps` have been removed;
       all gaps will now be jumped
     - `manifest.hls.useFullSegmentsForStartTime` has been removed; this setting

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -618,6 +618,9 @@ shaka.extern.AdvancedDrmConfiguration;
  *   clearKeys: !Object.<string, string>,
  *   delayLicenseRequestUntilPlayed: boolean,
  *   advanced: Object.<string, shaka.extern.AdvancedDrmConfiguration>,
+ *   initDataTransform:
+ *       ((function(!Uint8Array, string, ?shaka.extern.DrmInfo):!Uint8Array)|
+ *         undefined),
  *   logLicenseExchange: boolean,
  *   updateExpirationTime: number,
  *   preferredKeySystems: !Array.<string>
@@ -641,6 +644,14 @@ shaka.extern.AdvancedDrmConfiguration;
  *   <i>Optional.</i> <br>
  *   A dictionary which maps key system IDs to advanced DRM configuration for
  *   those key systems.
+ * @property
+ *     {((function(!Uint8Array, string, ?shaka.extern.DrmInfo):!Uint8Array)|
+ *        undefined)}
+ *   initDataTransform
+ *   <i>Optional.</i><br>
+ *   If given, this function is called with the init data from the
+ *   manifest/media and should return the (possibly transformed) init data to
+ *   pass to the browser.
  * @property {boolean} logLicenseExchange
  *   <i>Optional.</i><br>
  *   If set to <code>true</code>, prints logs containing the license exchange.

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -1253,6 +1253,22 @@ shaka.media.DrmEngine = class {
     };
     this.activeSessions_.set(session, metadata);
 
+    try {
+      initData = this.config_.initDataTransform(
+          initData, initDataType, this.currentDrmInfo_);
+    } catch (error) {
+      let shakaError = error;
+      if (!(error instanceof shaka.util.Error)) {
+        shakaError = new shaka.util.Error(
+            shaka.util.Error.Severity.CRITICAL,
+            shaka.util.Error.Category.DRM,
+            shaka.util.Error.Code.INIT_DATA_TRANSFORM_ERROR,
+            error);
+      }
+      this.onError_(shakaError);
+      return;
+    }
+
     if (this.config_.logLicenseExchange) {
       const str = shaka.util.Uint8ArrayUtils.toBase64(initData);
       shaka.log.info('EME init data: type=', initDataType, 'data=', str);

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -66,6 +66,9 @@ shaka.util.PlayerConfiguration = class {
       clearKeys: {},  // key is arbitrary key system ID, value must be string
       advanced: {},    // key is arbitrary key system ID, value is a record type
       delayLicenseRequestUntilPlayed: false,
+      initDataTransform: (initData, initDataType, drmInfo) => {
+        return initData;
+      },
       logLicenseExchange: false,
       updateExpirationTime: 1,
       preferredKeySystems: [],

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -67,7 +67,9 @@ shaka.util.PlayerConfiguration = class {
       advanced: {},    // key is arbitrary key system ID, value is a record type
       delayLicenseRequestUntilPlayed: false,
       initDataTransform: (initData, initDataType, drmInfo) => {
-        return initData;
+        return shaka.util.ConfigUtils.referenceParametersAndReturn(
+            [initData, initDataType, drmInfo],
+            initData);
       },
       logLicenseExchange: false,
       updateExpirationTime: 1,


### PR DESCRIPTION
Some FairPlay providers still need this part, so we should never have removed it.

The default is to do no transformation.