### PR TITLE
test: Disable offline for Xbox One

### DIFF
--- a/lib/offline/indexeddb/storage_mechanism.js
+++ b/lib/offline/indexeddb/storage_mechanism.js
@@ -368,8 +368,10 @@ shaka.offline.indexeddb.StorageMechanism.SESSION_ID_STORE = 'session-ids';
 shaka.offline.StorageMuxer.register(
     'idb',
     () => {
-      // Offline storage is not supported on the Chromecast platform.
-      if (shaka.util.Platform.isChromecast()) {
+      // Offline storage is not supported on the Chromecast or Xbox One
+      // platforms.
+      if (shaka.util.Platform.isChromecast() ||
+          shaka.util.Platform.isXboxOne()) {
         return null;
       }
       // Offline storage requires the IndexedDB API.

--- a/test/offline/indexeddb_storage_unit.js
+++ b/test/offline/indexeddb_storage_unit.js
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const offlineSupported = () => shaka.offline.StorageMuxer.support();
 filterDescribe('IndexeddbStorageCell', offlineSupported, () => {
   const IndexedDBUtils = shaka.test.IndexedDBUtils;
   const OfflineUtils = shaka.test.OfflineUtils;

--- a/test/offline/indexeddb_storage_unit.js
+++ b/test/offline/indexeddb_storage_unit.js
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-filterDescribe('IndexeddbStorageCell', () => window.indexedDB, () => {
+const offlineSupported = () => shaka.offline.StorageMuxer.support();
+filterDescribe('IndexeddbStorageCell', offlineSupported, () => {
   const IndexedDBUtils = shaka.test.IndexedDBUtils;
   const OfflineUtils = shaka.test.OfflineUtils;
   const Util = shaka.test.Util;

--- a/test/offline/storage_compatibility_unit.js
+++ b/test/offline/storage_compatibility_unit.js
@@ -91,7 +91,6 @@ const compatibilityTestsMetadata = [
   },
 ];
 
-const offlineSupported = () => shaka.offline.StorageMuxer.support();
 filterDescribe('Storage Compatibility', offlineSupported, () => {
   for (const metadata of compatibilityTestsMetadata) {
     describe(metadata.name, () => {

--- a/test/offline/storage_compatibility_unit.js
+++ b/test/offline/storage_compatibility_unit.js
@@ -91,7 +91,8 @@ const compatibilityTestsMetadata = [
   },
 ];
 
-filterDescribe('Storage Compatibility', () => window.indexedDB, () => {
+const offlineSupported = () => shaka.offline.StorageMuxer.support();
+filterDescribe('Storage Compatibility', offlineSupported, () => {
   for (const metadata of compatibilityTestsMetadata) {
     describe(metadata.name, () => {
       makeTests(metadata);

--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -243,6 +243,15 @@ window.xfilterDescribe = (describeName, cond, describeBody) => {
 };
 
 /**
+ * A very short alias for filtering offline integration tests.
+ *
+ * @return {boolean}
+ */
+window.offlineSupported = () => {
+  return shaka.offline.StorageMuxer.support();
+};
+
+/**
  * Load node modules used in testing and install them into window.
  * @return {!Promise}
  */

--- a/test/test/externs/filters.js
+++ b/test/test/externs/filters.js
@@ -38,3 +38,7 @@ var filterDescribe = function(name, cond, callback) {};
  * @param {function()} callback
  */
 var xfilterDescribe = function(name, cond, callback) {};
+
+
+/** @return {boolean} */
+var offlineSupported = function() {};


### PR DESCRIPTION
Xbox One tests have been failing often for some time now, so it went
unnoticed that offline was not working.  It seems that IndexedDB is
not working properly on Xbox, and the platform throws `UnknownError`.

This restricts offline so that it is not triggered on Xbox One, and
this also fixes the filtering of our offline tests to respect the
offline storage muxer's support method.