### PR TITLE
ci: Fix player version update on release

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -28,9 +28,10 @@ jobs:
       - name: Custom update Player version
         if: steps.release.outputs.release_created == false
         run: |
-          # Check out the branch that release-please created, if it exists.
+          # Check out the branch that release-please created.
+          # If it does not exist, FAIL!
           git fetch
-          git checkout release-please--branches--${{ github.ref_name }} || exit 0
+          git checkout release-please--branches--${{ github.ref_name }}--components--shaka-player || exit 1
           # If it does exist, update lib/player.js in the PR branch, so that the
           # -uncompiled tag remains in the player version in that context.
           VERSION="v$(jq -r .version package.json)-uncompiled"


### PR DESCRIPTION
The v3.2.7 and v3.3.5 releases went out without updating the version
number in lib/player.js.  This fixes the workflow to match the
release-please branch name, and changes the workflow to fail if the
branch name changes again in the future.
