### PR TITLE
fix: Fix audio mime type in multiplexed HLS stream

### DIFF
--- a/lib/util/mime_utils.js
+++ b/lib/util/mime_utils.js
@@ -35,6 +35,8 @@ shaka.util.MimeUtils = class {
   /**
    * Takes a MIME type and a codecs string and produces the full MIME
    * type. If it's a transport stream, convert its codecs to MP4 codecs.
+   * Otherwise for multiplexed content, convert the video MIME types to
+   * their audio equivalents if the content type is audio.
    *
    * @param {string} mimeType
    * @param {string} codecs

--- a/lib/util/mime_utils.js
+++ b/lib/util/mime_utils.js
@@ -8,6 +8,7 @@ goog.provide('shaka.util.MimeUtils');
 
 goog.require('shaka.dependencies');
 goog.require('shaka.media.Transmuxer');
+goog.require('shaka.util.ManifestParserUtils');
 
 /**
  * @summary A set of utility functions for dealing with MIME types.
@@ -42,13 +43,19 @@ shaka.util.MimeUtils = class {
    */
   static getFullOrConvertedType(mimeType, codecs, contentType) {
     const fullMimeType = shaka.util.MimeUtils.getFullType(mimeType, codecs);
+    const ContentType = shaka.util.ManifestParserUtils.ContentType;
 
-    if (!shaka.dependencies.muxjs() ||
-        !shaka.media.Transmuxer.isTsContainer(fullMimeType)) {
-      return fullMimeType;
+    if (shaka.media.Transmuxer.isTsContainer(fullMimeType)) {
+      if (shaka.dependencies.muxjs()) {
+        return shaka.media.Transmuxer.convertTsCodecs(
+            contentType, fullMimeType);
+      }
+    } else if (contentType == ContentType.AUDIO) {
+      // video/mp2t is the correct mime type for TS audio, so only replace the
+      // word "video" with "audio" for non-TS audio content.
+      return fullMimeType.replace('video', 'audio');
     }
-
-    return shaka.media.Transmuxer.convertTsCodecs(contentType, fullMimeType);
+    return fullMimeType;
   }
 
 


### PR DESCRIPTION
This should fix the fMP4 playback issue in https://github.com/shaka-project/shaka-player/issues/3691

In multiplexed HLS stream, the audio mime type is incorrectly set to `video/*` but `MediaCapabilities.decodingInfo()` is expecting `audio/*`.

```
{
   "type":"media-source",
   "audio":{
      "contentType":"video/mp4; codecs=\"mp4a.40.2\"",
      "channels":2,
      "bitrate":8000000,
      "samplerate":1,
      "spatialRendering":false
   },
   "video":{
      "contentType":"video/mp4; codecs=\"avc1.640033\"",
      "width":1920,
      "height":1080,
      "bitrate":8000000,
      "framerate":59.94,
      "transferFunction":"srgb"
   }
}
```

```
...
Guessing multiplexed audio+video.
...
TypeError: Failed to execute 'decodingInfo' on 'MediaCapabilities': The audio configuration dictionary is not valid.
```
HLS manifest:
```
#EXTM3U
#EXT-X-STREAM-INF:BANDWIDTH=8000000,VIDEO-RANGE=SDR,CODECS="avc1.640033,mp4a.40.2",RESOLUTION=1920x1080,FRAME-RATE=59.94
main.m3u8
```