### PR TITLE
fix: Don't send drmsessionupdate after unload

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -1424,6 +1424,9 @@ shaka.media.DrmEngine = class {
       }
       return;
     }
+    if (this.destroyer_.destroyed()) {
+      return;
+    }
 
     const updateEvent = new shaka.util.FakeEvent('drmsessionupdate');
     this.playerInterface_.onEvent(updateEvent);


### PR DESCRIPTION
There is an async call, waiting for sessions to update, right before
the StreamingEngine fires off an drmsessionupdate event.
This could potentially cause an error, as the StreamingEngine's
player interface could potentially be set to null during destruction.
This adds a check to see if the StreamingEngine has been destroyed,
to catch that case.

Based on a test failure of #4241

<!--
Please remember to:

1. Use Conventional Commits syntax (fix: ..., feat: ..., etc.) in commits and
   PR title (https://www.conventionalcommits.org/)
2. Tag any related or fixed issues ("Issue #123", "Closes #420")
3. Sign the Google CLA if you haven't (https://cla.developers.google.com)

You may delete this comment from the PR description.
-->
