### PR TITLE
feat: add listenable events for playback stall detection and gap jumping

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -66,6 +66,7 @@ John Bowers <john.bowers@verizondigitalmedia.com>
 Jonas Birmé <jonas.birme@eyevinn.se>
 Jono Ward <jonoward@gmail.com>
 Jozef Chúťka <jozefchutka@gmail.com>
+Julian Domingo <juliandomingo@google.com>
 Jun Hong Chong <chongjunhong@gmail.com>
 Leandro Ribeiro Moreira <leandro.ribeiro.moreira@gmail.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -82,6 +82,9 @@ shaka.extern.StateChange;
  *
  *   maxSegmentDuration: number,
  *
+ *   gapsJumped: number,
+ *   stallsDetected: number,
+ *
  *   switchHistory: !Array.<shaka.extern.TrackChoice>,
  *   stateHistory: !Array.<shaka.extern.StateChange>
  * }}
@@ -111,6 +114,11 @@ shaka.extern.StateChange;
  *   <code>NaN</code> if this is not supported by the browser.
  * @property {number} estimatedBandwidth
  *   The current estimated network bandwidth (in bit/sec).
+ *
+ * @property {number} gapsJumped
+ *   The total number of playback gaps jumped by the GapJumpingController.
+ * @property {number} stallsDetected
+ *   The total number of playback stalls detected by the StallDetector.
  *
  * @property {number} completionPercent
  *   This is the greatest completion percent that the user has experienced in

--- a/lib/cast/cast_proxy.js
+++ b/lib/cast/cast_proxy.js
@@ -278,8 +278,8 @@ shaka.cast.CastProxy = class extends shaka.util.FakeEventTarget {
           (event) => this.videoProxyLocalEvent_(event));
     }
 
-    for (const key in shaka.Player.EventName) {
-      const name = shaka.Player.EventName[key];
+    for (const key in shaka.util.FakeEvent.EventName) {
+      const name = shaka.util.FakeEvent.EventName[key];
       this.eventManager_.listen(this.localPlayer_, name,
           (event) => this.playerProxyLocalEvent_(event));
     }
@@ -537,7 +537,7 @@ shaka.cast.CastProxy = class extends shaka.util.FakeEventTarget {
       // Pass any errors through to the app.
       goog.asserts.assert(error instanceof shaka.util.Error,
           'Wrong error type!');
-      const eventType = shaka.Player.EventName.Error;
+      const eventType = shaka.util.FakeEvent.EventName.Error;
       const data = (new Map()).set('detail', error);
       const event = new shaka.util.FakeEvent(eventType, data);
       this.localPlayer_.dispatchEvent(event);

--- a/lib/cast/cast_receiver.js
+++ b/lib/cast/cast_receiver.js
@@ -281,8 +281,8 @@ shaka.cast.CastReceiver = class extends shaka.util.FakeEventTarget {
           this.video_, name, (event) => this.proxyEvent_('video', event));
     }
 
-    for (const key in shaka.Player.EventName) {
-      const name = shaka.Player.EventName[key];
+    for (const key in shaka.util.FakeEvent.EventName) {
+      const name = shaka.util.FakeEvent.EventName[key];
       this.eventManager_.listen(
           this.player_, name, (event) => this.proxyEvent_('player', event));
     }
@@ -409,7 +409,7 @@ shaka.cast.CastReceiver = class extends shaka.util.FakeEventTarget {
         // Pass any errors through to the app.
         goog.asserts.assert(error instanceof shaka.util.Error,
             'Wrong error type!');
-        const eventType = shaka.Player.EventName.Error;
+        const eventType = shaka.util.FakeEvent.EventName.Error;
         const data = (new Map()).set('detail', error);
         const event = new shaka.util.FakeEvent(eventType, data);
         // Only dispatch the event if the player still exists.

--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -11,6 +11,7 @@ goog.require('shaka.media.PresentationTimeline');
 goog.require('shaka.media.StallDetector');
 goog.require('shaka.media.TimeRangesUtils');
 goog.require('shaka.util.EventManager');
+goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.IReleasable');
 goog.require('shaka.util.Timer');
 
@@ -32,8 +33,13 @@ shaka.media.GapJumpingController = class {
    *   playable region. The gap jumping controller takes ownership over the
    *   stall detector.
    *   If no stall detection logic is desired, |null| may be provided.
+   * @param {function(!Event)} onEvent
+   *     Called when an event is raised to be sent to the application.
    */
-  constructor(video, timeline, config, stallDetector) {
+  constructor(video, timeline, config, stallDetector, onEvent) {
+    /** @private {?function(!Event)} */
+    this.onEvent_ = onEvent;
+
     /** @private {HTMLMediaElement} */
     this.video_ = video;
 
@@ -51,6 +57,9 @@ shaka.media.GapJumpingController = class {
 
     /** @private {number} */
     this.prevReadyState_ = video.readyState;
+
+    /** @private {number} */
+    this.gapsJumped_ = 0;
 
     /**
      * The stall detector tries to keep the playhead moving forward. It is
@@ -98,6 +107,7 @@ shaka.media.GapJumpingController = class {
       this.stallDetector_ = null;
     }
 
+    this.onEvent_ = null;
     this.timeline_ = null;
     this.video_ = null;
   }
@@ -118,6 +128,15 @@ shaka.media.GapJumpingController = class {
   onSeeking() {
     this.seekingEventReceived_ = true;
     this.hadSegmentAppended_ = false;
+  }
+
+
+  /**
+   * Returns the total number of playback gaps jumped.
+   * @return {number}
+   */
+  getGapsJumped() {
+    return this.gapsJumped_;
   }
 
 
@@ -209,6 +228,9 @@ shaka.media.GapJumpingController = class {
     }
 
     this.video_.currentTime = jumpTo;
+    this.gapsJumped_++;
+    this.onEvent_(
+        new shaka.util.FakeEvent(shaka.util.FakeEvent.EventName.GapJumped));
   }
 };
 

--- a/lib/media/playhead.js
+++ b/lib/media/playhead.js
@@ -42,6 +42,20 @@ shaka.media.Playhead = class {
   setStartTime(startTime) {}
 
   /**
+   * Get the number of playback stalls detected by the StallDetector.
+   *
+   * @return {number}
+   */
+  getStallsDetected() {}
+
+  /**
+   * Get the number of playback gaps jumped by the GapJumpingController.
+   *
+   * @return {number}
+   */
+  getGapsJumped() {}
+
+  /**
    * Get the current playhead position. The position will be restricted to valid
    * time ranges.
    *
@@ -134,6 +148,16 @@ shaka.media.SrcEqualsPlayhead = class {
   }
 
   /** @override */
+  getStallsDetected() {
+    return 0;
+  }
+
+  /** @override */
+  getGapsJumped() {
+    return 0;
+  }
+
+  /** @override */
   notifyOfBufferingChange() {}
 };
 
@@ -160,8 +184,10 @@ shaka.media.MediaSourcePlayhead = class {
    * @param {function()} onSeek
    *     Called when the user agent seeks to a time within the presentation
    *     timeline.
+   * @param {function(!Event)} onEvent
+   *     Called when an event is raised to be sent to the application.
    */
-  constructor(mediaElement, manifest, config, startTime, onSeek) {
+  constructor(mediaElement, manifest, config, startTime, onSeek, onEvent) {
     /**
      * The seek range must be at least this number of seconds long. If it is
      * smaller than this, change it to be this big so we don't repeatedly seek
@@ -192,12 +218,17 @@ shaka.media.MediaSourcePlayhead = class {
     /** @private {?number} */
     this.lastCorrectiveSeek_ = null;
 
+    /** @private {shaka.media.StallDetector} */
+    this.stallDetector_ =
+        this.createStallDetector_(mediaElement, config, onEvent);
+
     /** @private {shaka.media.GapJumpingController} */
     this.gapController_ = new shaka.media.GapJumpingController(
         mediaElement,
         manifest.presentationTimeline,
         config,
-        this.createStallDetector_(mediaElement, config));
+        this.stallDetector_,
+        onEvent);
 
     /** @private {shaka.media.VideoWrapper} */
     this.videoWrapper_ = new shaka.media.VideoWrapper(
@@ -259,6 +290,16 @@ shaka.media.MediaSourcePlayhead = class {
     }
 
     return time;
+  }
+
+  /** @override */
+  getStallsDetected() {
+    return this.stallDetector_.getStallsDetected();
+  }
+
+  /** @override */
+  getGapsJumped() {
+    return this.gapController_.getGapsJumped();
   }
 
   /**
@@ -475,10 +516,12 @@ shaka.media.MediaSourcePlayhead = class {
    *
    * @param {!HTMLMediaElement} mediaElement
    * @param {shaka.extern.StreamingConfiguration} config
+   * @param {function(!Event)} onEvent
+   *     Called when an event is raised to be sent to the application.
    * @return {shaka.media.StallDetector}
    * @private
    */
-  createStallDetector_(mediaElement, config) {
+  createStallDetector_(mediaElement, config, onEvent) {
     if (!config.stallEnabled) {
       return null;
     }
@@ -492,7 +535,7 @@ shaka.media.MediaSourcePlayhead = class {
     // playhead forward.
     const detector = new shaka.media.StallDetector(
         new shaka.media.StallDetector.MediaElementImplementation(mediaElement),
-        threshold);
+        threshold, onEvent);
 
     detector.onStall((at, duration) => {
       shaka.log.debug(`Stall detected at ${at} for ${duration} seconds.`);

--- a/lib/media/stall_detector.js
+++ b/lib/media/stall_detector.js
@@ -9,6 +9,7 @@ goog.provide('shaka.media.StallDetector.Implementation');
 goog.provide('shaka.media.StallDetector.MediaElementImplementation');
 
 goog.require('shaka.media.TimeRangesUtils');
+goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.IReleasable');
 
 /**
@@ -23,11 +24,14 @@ shaka.media.StallDetector = class {
   /**
    * @param {shaka.media.StallDetector.Implementation} implementation
    * @param {number} stallThresholdSeconds
+   * @param {function(!Event)} onEvent
+   *     Called when an event is raised to be sent to the application.
    */
-  constructor(implementation, stallThresholdSeconds) {
+  constructor(implementation, stallThresholdSeconds, onEvent) {
+    /** @private {?function(!Event)} */
+    this.onEvent_ = onEvent;
     /** @private {shaka.media.StallDetector.Implementation} */
     this.implementation_ = implementation;
-
     /** @private {boolean} */
     this.wasMakingProgress_ = implementation.shouldBeMakingProgress();
     /** @private {number} */
@@ -36,6 +40,8 @@ shaka.media.StallDetector = class {
     this.lastUpdateSeconds_ = implementation.getWallSeconds();
     /** @private {boolean} */
     this.didJump_ = false;
+    /** @private {number} */
+    this.stallsDetected_ = 0;
 
     /**
      * The amount of time in seconds that we must have the same value of
@@ -53,6 +59,7 @@ shaka.media.StallDetector = class {
   release() {
     // Drop external references to make things easier on the GC.
     this.implementation_ = null;
+    this.onEvent_ = null;
     this.onStall_ = () => {};
   }
 
@@ -64,6 +71,13 @@ shaka.media.StallDetector = class {
    */
   onStall(doThis) {
     this.onStall_ = doThis;
+  }
+
+  /**
+   * Returns the number of playback stalls detected.
+   */
+  getStallsDetected() {
+    return this.stallsDetected_;
   }
 
   /**
@@ -100,6 +114,9 @@ shaka.media.StallDetector = class {
       // If the onStall_ method updated the current time, update our stored
       // value so we don't think that was an update.
       this.value_ = impl.getPresentationSeconds();
+      this.stallsDetected_++;
+      this.onEvent_(new shaka.util.FakeEvent(
+          shaka.util.FakeEvent.EventName.StallDetected));
     }
 
     return triggerCallback;

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1701,7 +1701,7 @@ shaka.media.StreamingEngine = class {
         };
 
         // Dispatch an event to notify the application about the emsg box.
-        const eventName = shaka.Player.EventName.Emsg;
+        const eventName = shaka.util.FakeEvent.EventName.Emsg;
         const data = (new Map()).set('detail', emsg);
         const event = new shaka.util.FakeEvent(eventName, data);
         this.playerInterface_.onEvent(event);

--- a/lib/player.js
+++ b/lib/player.js
@@ -386,6 +386,26 @@ goog.requireType('shaka.routing.Payload');
 
 
 /**
+ * @event shaka.Player.StallDetectedEvent
+ * @description Fired when a stall in playback is detected by the StallDetector.
+ *     Not all stalls are caused by gaps in the buffered ranges.
+ * @property {string} type
+ *   'stalldetected'
+ * @exportDoc
+ */
+
+
+/**
+ * @event shaka.Player.GapJumpedEvent
+ * @description Fired when the GapJumpingController jumps over a gap in the
+ *     buffered ranges.
+ * @property {string} type
+ *   'gapjumped'
+ * @exportDoc
+ */
+
+
+/**
  * @summary The main player object for Shaka Player.
  *
  * @implements {shaka.util.IDestroyable}
@@ -652,7 +672,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       },
       enterNode: (node, has, wants) => {
         this.dispatchEvent(this.makeEvent_(
-            /* name= */ shaka.Player.EventName.OnStateChange,
+            /* name= */ shaka.util.FakeEvent.EventName.OnStateChange,
             /* data= */ (new Map()).set('state', node.name)));
 
         const action = actions.get(node);
@@ -683,7 +703,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       },
       onIdle: (node) => {
         this.dispatchEvent(this.makeEvent_(
-            /* name= */ shaka.Player.EventName.OnStateIdle,
+            /* name= */ shaka.util.FakeEvent.EventName.OnStateIdle,
             /* data= */ (new Map()).set('state', node.name)));
       },
     };
@@ -707,7 +727,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   }
 
   /**
-   * @param {!shaka.Player.EventName} name
+   * @param {!shaka.util.FakeEvent.EventName} name
    * @param {Map.<string, Object>=} data
    * @return {!shaka.util.FakeEvent}
    * @private
@@ -1133,7 +1153,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // We dispatch the loading event when someone calls |load| because we want
     // to surface the user intent.
-    this.dispatchEvent(this.makeEvent_(shaka.Player.EventName.Loading));
+    this.dispatchEvent(this.makeEvent_(shaka.util.FakeEvent.EventName.Loading));
 
     // Right away we know what the asset uri and start-of-load time are. We will
     // fill-in the rest of the information later.
@@ -1197,7 +1217,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       events.onEnd = () => {
         resolve();
         // We dispatch the loaded event when the load promise is resolved
-        this.dispatchEvent(this.makeEvent_(shaka.Player.EventName.Loaded));
+        this.dispatchEvent(
+            this.makeEvent_(shaka.util.FakeEvent.EventName.Loaded));
       };
       events.onCancel = () => reject(this.createAbortLoadError_());
       events.onError = (e) => reject(e);
@@ -1402,7 +1423,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     await Promise.all(cleanupTasks);
 
     // Dispatch the unloading event.
-    this.dispatchEvent(this.makeEvent_(shaka.Player.EventName.Unloading));
+    this.dispatchEvent(
+        this.makeEvent_(shaka.util.FakeEvent.EventName.Unloading));
 
     // Remove everything that has to do with loading content from our payload
     // since we are releasing everything that depended on it.
@@ -1706,7 +1728,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.regionTimeline_.addEventListener('regionadd', (event) => {
       /** @type {shaka.extern.TimelineRegionInfo} */
       const region = event['region'];
-      this.onRegionEvent_(shaka.Player.EventName.TimelineRegionAdded, region);
+      this.onRegionEvent_(
+          shaka.util.FakeEvent.EventName.TimelineRegionAdded, region);
 
       if (this.adManager_) {
         this.adManager_.onDashTimedMetadata(region);
@@ -1761,7 +1784,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
       // This event is fired after the manifest is parsed, but before any
       // filtering takes place.
-      const event = this.makeEvent_(shaka.Player.EventName.ManifestParsed);
+      const event =
+          this.makeEvent_(shaka.util.FakeEvent.EventName.ManifestParsed);
       this.dispatchEvent(event);
 
       // We require all manifests to have at least one variant.
@@ -1835,7 +1859,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       },
       onEvent: (e) => {
         this.dispatchEvent(e);
-        if (e.type == shaka.Player.EventName.DrmSessionUpdate && firstEvent) {
+        if (e.type == shaka.util.FakeEvent.EventName.DrmSessionUpdate &&
+            firstEvent) {
           firstEvent = false;
           const now = Date.now() / 1000;
           const delta = now - startTime;
@@ -2000,7 +2025,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // The event must be fired after we filter by restrictions but before the
     // active stream is picked to allow those listening for the "streaming"
     // event to make changes before streaming starts.
-    this.dispatchEvent(this.makeEvent_(shaka.Player.EventName.Streaming));
+    this.dispatchEvent(
+        this.makeEvent_(shaka.util.FakeEvent.EventName.Streaming));
 
     // Pick the initial streams to play.
     // however, we would skip switch to initial variant
@@ -2128,7 +2154,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       },
       onEvent: (e) => {
         this.dispatchEvent(e);
-        if (e.type == shaka.Player.EventName.DrmSessionUpdate && firstEvent) {
+        if (e.type == shaka.util.FakeEvent.EventName.DrmSessionUpdate &&
+            firstEvent) {
           firstEvent = false;
           const now = Date.now() / 1000;
           const delta = now - startTime;
@@ -2354,7 +2381,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // The event doesn't mean as much for src= playback, since we don't control
     // streaming.  But we should fire it in this path anyway since some
     // applications may be expecting it as a life-cycle event.
-    this.dispatchEvent(this.makeEvent_(shaka.Player.EventName.Streaming));
+    this.dispatchEvent(
+        this.makeEvent_(shaka.util.FakeEvent.EventName.Streaming));
 
     // The "load" Promise is resolved when we have loaded the metadata.  If we
     // wait for the full data, that won't happen on Safari until the play button
@@ -2566,7 +2594,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   dispatchMetadataEvent_(startTime, endTime, metadataType, payload) {
     goog.asserts.assert(!endTime || startTime <= endTime,
         'Metadata start time should be less or equal to the end time!');
-    const eventName = shaka.Player.EventName.Metadata;
+    const eventName = shaka.util.FakeEvent.EventName.Metadata;
     const data = new Map()
         .set('startTime', startTime)
         .set('endTime', endTime)
@@ -2663,7 +2691,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @type {shaka.net.NetworkingEngine.OnHeadersReceived} */
     const onHeadersReceived_ = (headers, request, requestType) => {
       // Release a 'downloadheadersreceived' event.
-      const name = shaka.Player.EventName.DownloadHeadersReceived;
+      const name = shaka.util.FakeEvent.EventName.DownloadHeadersReceived;
       const data = new Map()
           .set('headers', headers)
           .set('request', request)
@@ -2673,7 +2701,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @type {shaka.net.NetworkingEngine.OnDownloadFailed} */
     const onDownloadFailed_ = (request, error, httpResponseCode, aborted) => {
       // Release a 'downloadfailed' event.
-      const name = shaka.Player.EventName.DownloadFailed;
+      const name = shaka.util.FakeEvent.EventName.DownloadFailed;
       const data = new Map()
           .set('request', request)
           .set('error', error)
@@ -2701,7 +2729,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.manifest_,
         this.config_.streaming,
         startTime,
-        () => this.onSeek_());
+        () => this.onSeek_(),
+        (event) => this.dispatchEvent(event));
   }
 
   /**
@@ -2723,13 +2752,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     regionObserver.addEventListener('enter', (event) => {
       /** @type {shaka.extern.TimelineRegionInfo} */
       const region = event['region'];
-      this.onRegionEvent_(shaka.Player.EventName.TimelineRegionEnter, region);
+      this.onRegionEvent_(
+          shaka.util.FakeEvent.EventName.TimelineRegionEnter, region);
     });
 
     regionObserver.addEventListener('exit', (event) => {
       /** @type {shaka.extern.TimelineRegionInfo} */
       const region = event['region'];
-      this.onRegionEvent_(shaka.Player.EventName.TimelineRegionExit, region);
+      this.onRegionEvent_(
+          shaka.util.FakeEvent.EventName.TimelineRegionExit, region);
     });
 
     regionObserver.addEventListener('skip', (event) => {
@@ -2740,8 +2771,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // If we are seeking, we don't want to surface the enter/exit events since
       // they didn't play through them.
       if (!seeking) {
-        this.onRegionEvent_(shaka.Player.EventName.TimelineRegionEnter, region);
-        this.onRegionEvent_(shaka.Player.EventName.TimelineRegionExit, region);
+        this.onRegionEvent_(
+            shaka.util.FakeEvent.EventName.TimelineRegionEnter, region);
+        this.onRegionEvent_(
+            shaka.util.FakeEvent.EventName.TimelineRegionExit, region);
       }
     });
 
@@ -4368,6 +4401,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.stats_.setCompletionPercent(Math.round(100 * completionRatio));
     }
 
+    if (this.playhead_) {
+      this.stats_.setGapsJumped(this.playhead_.getGapsJumped());
+      this.stats_.setStallsDetected(this.playhead_.getStallsDetected());
+    }
+
     if (element.getVideoPlaybackQuality) {
       const info = element.getVideoPlaybackQuality();
 
@@ -5131,7 +5169,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // Surface the buffering event so that the app knows if/when we are
     // buffering.
-    const eventName = shaka.Player.EventName.Buffering;
+    const eventName = shaka.util.FakeEvent.EventName.Buffering;
     const data = (new Map()).set('buffering', isBuffering);
     this.dispatchEvent(this.makeEvent_(eventName, data));
   }
@@ -5166,7 +5204,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.playRateController_.set(newRate);
     }
 
-    const event = this.makeEvent_(shaka.Player.EventName.RateChange);
+    const event = this.makeEvent_(shaka.util.FakeEvent.EventName.RateChange);
     this.dispatchEvent(event);
   }
 
@@ -5513,7 +5551,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const data = new Map()
         .set('oldTrack', from)
         .set('newTrack', to);
-    const event = this.makeEvent_(shaka.Player.EventName.Adaptation, data);
+    const event =
+        this.makeEvent_(shaka.util.FakeEvent.EventName.Adaptation, data);
     this.delayDispatchEvent_(event);
   }
 
@@ -5524,7 +5563,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   onTracksChanged_() {
     // Delay the 'trackschanged' event so StreamingEngine has time to absorb the
     // changes before the user tries to query it.
-    const event = this.makeEvent_(shaka.Player.EventName.TracksChanged);
+    const event = this.makeEvent_(shaka.util.FakeEvent.EventName.TracksChanged);
     this.delayDispatchEvent_(event);
   }
 
@@ -5540,7 +5579,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const data = new Map()
         .set('oldTrack', from)
         .set('newTrack', to);
-    const event = this.makeEvent_(shaka.Player.EventName.VariantChanged, data);
+    const event =
+        this.makeEvent_(shaka.util.FakeEvent.EventName.VariantChanged, data);
     this.delayDispatchEvent_(event);
   }
 
@@ -5551,13 +5591,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   onTextChanged_() {
     // Delay the 'textchanged' event so StreamingEngine time to absorb the
     // changes before the user tries to query it.
-    const event = this.makeEvent_(shaka.Player.EventName.TextChanged);
+    const event = this.makeEvent_(shaka.util.FakeEvent.EventName.TextChanged);
     this.delayDispatchEvent_(event);
   }
 
   /** @private */
   onTextTrackVisibility_() {
-    const event = this.makeEvent_(shaka.Player.EventName.TextTrackVisibility);
+    const event =
+        this.makeEvent_(shaka.util.FakeEvent.EventName.TextTrackVisibility);
     this.delayDispatchEvent_(event);
   }
 
@@ -5565,7 +5606,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   onAbrStatusChanged_() {
     const data = (new Map()).set('newStatus', this.config_.abr.enabled);
     this.delayDispatchEvent_(this.makeEvent_(
-        shaka.Player.EventName.AbrStatusChanged, data));
+        shaka.util.FakeEvent.EventName.AbrStatusChanged, data));
   }
 
   /**
@@ -5653,7 +5694,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return;
     }
 
-    const eventName = shaka.Player.EventName.Error;
+    const eventName = shaka.util.FakeEvent.EventName.Error;
     const event = this.makeEvent_(eventName, (new Map()).set('detail', error));
     this.dispatchEvent(event);
     if (event.defaultPrevented) {
@@ -5667,7 +5708,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * copy here because this is the transition point between the player and the
    * app.
    *
-   * @param {!shaka.Player.EventName} eventName
+   * @param {!shaka.util.FakeEvent.EventName} eventName
    * @param {shaka.extern.TimelineRegionInfo} region
    *
    * @private
@@ -5716,7 +5757,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         .set('position', position);
 
     this.dispatchEvent(this.makeEvent_(
-        shaka.Player.EventName.MediaQualityChanged, data));
+        shaka.util.FakeEvent.EventName.MediaQualityChanged, data));
   }
 
   /**
@@ -5862,7 +5903,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.parser_.onExpirationUpdated(keyId, expiration);
     }
 
-    const event = this.makeEvent_(shaka.Player.EventName.ExpirationUpdated);
+    const event =
+        this.makeEvent_(shaka.util.FakeEvent.EventName.ExpirationUpdated);
     this.dispatchEvent(event);
   }
 
@@ -6473,42 +6515,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       listeners.onSkip = () => reject(this.createAbortLoadError_());
     });
   }
-};
-
-/**
- * An internal enum that contains the string values of all of the player events.
- * This exists primarily to act as an implicit list of events, for tests.
- *
- * @enum {string}
- */
-shaka.Player.EventName = {
-  AbrStatusChanged: 'abrstatuschanged',
-  Adaptation: 'adaptation',
-  Buffering: 'buffering',
-  DownloadFailed: 'downloadfailed',
-  DownloadHeadersReceived: 'downloadheadersreceived',
-  DrmSessionUpdate: 'drmsessionupdate',
-  Emsg: 'emsg',
-  Error: 'error',
-  ExpirationUpdated: 'expirationupdated',
-  Loaded: 'loaded',
-  Loading: 'loading',
-  ManifestParsed: 'manifestparsed',
-  MediaQualityChanged: 'mediaqualitychanged',
-  Metadata: 'metadata',
-  OnStateChange: 'onstatechange',
-  OnStateIdle: 'onstateidle',
-  RateChange: 'ratechange',
-  SessionDataEvent: 'sessiondata',
-  Streaming: 'streaming',
-  TextChanged: 'textchanged',
-  TextTrackVisibility: 'texttrackvisibility',
-  TimelineRegionAdded: 'timelineregionadded',
-  TimelineRegionEnter: 'timelineregionenter',
-  TimelineRegionExit: 'timelineregionexit',
-  TracksChanged: 'trackschanged',
-  Unloading: 'unloading',
-  VariantChanged: 'variantchanged',
 };
 
 

--- a/lib/util/fake_event.js
+++ b/lib/util/fake_event.js
@@ -144,3 +144,42 @@ shaka.util.FakeEvent = class {
    */
   stopPropagation() {}
 };
+
+
+/**
+ * An internal enum that contains the string values of all of the player events.
+ * This exists primarily to act as an implicit list of events, for tests.
+ *
+ * @enum {string}
+ */
+shaka.util.FakeEvent.EventName = {
+  AbrStatusChanged: 'abrstatuschanged',
+  Adaptation: 'adaptation',
+  Buffering: 'buffering',
+  DownloadFailed: 'downloadfailed',
+  DownloadHeadersReceived: 'downloadheadersreceived',
+  DrmSessionUpdate: 'drmsessionupdate',
+  Emsg: 'emsg',
+  Error: 'error',
+  ExpirationUpdated: 'expirationupdated',
+  GapJumped: 'gapjumped',
+  Loaded: 'loaded',
+  Loading: 'loading',
+  ManifestParsed: 'manifestparsed',
+  MediaQualityChanged: 'mediaqualitychanged',
+  Metadata: 'metadata',
+  OnStateChange: 'onstatechange',
+  OnStateIdle: 'onstateidle',
+  RateChange: 'ratechange',
+  SessionDataEvent: 'sessiondata',
+  StallDetected: 'stalldetected',
+  Streaming: 'streaming',
+  TextChanged: 'textchanged',
+  TextTrackVisibility: 'texttrackvisibility',
+  TimelineRegionAdded: 'timelineregionadded',
+  TimelineRegionEnter: 'timelineregionenter',
+  TimelineRegionExit: 'timelineregionexit',
+  TracksChanged: 'trackschanged',
+  Unloading: 'unloading',
+  VariantChanged: 'variantchanged',
+};

--- a/lib/util/stats.js
+++ b/lib/util/stats.js
@@ -32,6 +32,11 @@ shaka.util.Stats = class {
     this.totalCorruptedFrames_ = NaN;
 
     /** @private {number} */
+    this.totalStallsDetected_ = NaN;
+    /** @private {number} */
+    this.totalGapsJumped_ = NaN;
+
+    /** @private {number} */
     this.completionPercent_ = NaN;
 
     /** @private {number} */
@@ -76,7 +81,6 @@ shaka.util.Stats = class {
     this.totalDecodedFrames_ = decoded;
   }
 
-
   /**
    * Update corrupted frames. This will replace the previous values.
    *
@@ -84,6 +88,25 @@ shaka.util.Stats = class {
    */
   setCorruptedFrames(corrupted) {
     this.totalCorruptedFrames_ = corrupted;
+  }
+
+  /**
+   * Update number of stalls detected. This will replace the previous value.
+   *
+   * @param {number} stallsDetected
+   */
+  setStallsDetected(stallsDetected) {
+    this.totalStallsDetected_ = stallsDetected;
+  }
+
+  /**
+   * Update number of playback gaps jumped over. This will replace the previous
+   * value.
+   *
+   * @param {number} gapsJumped
+   */
+  setGapsJumped(gapsJumped) {
+    this.totalGapsJumped_ = gapsJumped;
   }
 
   /**
@@ -208,6 +231,8 @@ shaka.util.Stats = class {
       decodedFrames: this.totalDecodedFrames_,
       droppedFrames: this.totalDroppedFrames_,
       corruptedFrames: this.totalCorruptedFrames_,
+      stallsDetected: this.totalStallsDetected_,
+      gapsJumped: this.totalGapsJumped_,
       estimatedBandwidth: this.bandwidthEstimate_,
       completionPercent: this.completionPercent_,
       loadLatency: this.loadLatencySeconds_,
@@ -238,6 +263,8 @@ shaka.util.Stats = class {
       decodedFrames: NaN,
       droppedFrames: NaN,
       corruptedFrames: NaN,
+      stallsDetected: NaN,
+      gapsJumped: NaN,
       estimatedBandwidth: NaN,
       completionPercent: NaN,
       loadLatency: NaN,

--- a/test/media/stall_detector_unit.js
+++ b/test/media/stall_detector_unit.js
@@ -5,6 +5,8 @@
  */
 
 describe('StallDetector', () => {
+  const Util = shaka.test.Util;
+
   /**
    * @implements {shaka.media.StallDetector.Implementation}
    * @final
@@ -38,16 +40,21 @@ describe('StallDetector', () => {
   /** @type {!jasmine.Spy} */
   let onStall;
 
+  /** @type {!jasmine.Spy} */
+  let onEvent;
+
   beforeEach(() => {
     onStall = jasmine.createSpy('onStall');
+    onEvent = jasmine.createSpy('onEvent');
 
     implementation = new TestImplementation();
 
     detector = new shaka.media.StallDetector(
         implementation,
-        /* stallThresholdSeconds= */ 1);
+        /* stallThresholdSeconds= */ 1,
+        Util.spyFunc(onEvent));
 
-    detector.onStall(shaka.test.Util.spyFunc(onStall));
+    detector.onStall(Util.spyFunc(onStall));
   });
 
   it('does not call onStall when values changes', () => {
@@ -63,6 +70,7 @@ describe('StallDetector', () => {
 
     detector.poll();
 
+    expect(onEvent).not.toHaveBeenCalled();
     expect(onStall).not.toHaveBeenCalled();
   });
 
@@ -74,6 +82,7 @@ describe('StallDetector', () => {
       implementation.wallSeconds = time;
 
       detector.poll();
+      expect(onEvent).not.toHaveBeenCalled();
       expect(onStall).not.toHaveBeenCalled();
     }
 
@@ -81,6 +90,7 @@ describe('StallDetector', () => {
     implementation.wallSeconds = 1;
 
     detector.poll();
+    expect(onEvent).toHaveBeenCalled();
     expect(onStall).toHaveBeenCalledOnceMoreWith([
       /* stalledWith= */ 5,
       /* stallDurationSeconds= */ 1,
@@ -96,6 +106,7 @@ describe('StallDetector', () => {
     implementation.wallSeconds = 10;
     detector.poll();
 
+    expect(onEvent).toHaveBeenCalled();
     expect(onStall).toHaveBeenCalledOnceMoreWith([
       /* stalledWith= */ 5,
       /* stallDurationms= */ 10,
@@ -117,6 +128,7 @@ describe('StallDetector', () => {
 
     detector.poll();
 
+    expect(onEvent).not.toHaveBeenCalled();
     expect(onStall).not.toHaveBeenCalled();
   });
 
@@ -135,6 +147,7 @@ describe('StallDetector', () => {
     implementation.wallSeconds = 10;
     detector.poll();
 
+    expect(onEvent).not.toHaveBeenCalled();
     expect(onStall).not.toHaveBeenCalled();
   });
 
@@ -143,16 +156,20 @@ describe('StallDetector', () => {
     implementation.presentationSeconds = 0;
     implementation.wallSeconds = 0;
     detector.poll();
+    expect(onEvent).not.toHaveBeenCalled();
     expect(onStall).not.toHaveBeenCalled();
 
     implementation.wallSeconds = 10;
     detector.poll();
+    expect(onEvent).toHaveBeenCalled();
     expect(onStall).toHaveBeenCalled();
+    onEvent.calls.reset();
     onStall.calls.reset();
 
     // This is the same stall, should not be called again.
     implementation.wallSeconds = 20;
     detector.poll();
+    expect(onEvent).not.toHaveBeenCalled();
     expect(onStall).not.toHaveBeenCalled();
 
     // Now that we changed time, we should get another call.
@@ -161,6 +178,7 @@ describe('StallDetector', () => {
     detector.poll();
     implementation.wallSeconds = 40;
     detector.poll();
+    expect(onEvent).toHaveBeenCalled();
     expect(onStall).toHaveBeenCalled();
   });
 });

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -214,7 +214,8 @@ describe('StreamingEngine', () => {
         manifest,
         config,
         /* startTime= */ null,
-        onSeek);
+        onSeek,
+        shaka.test.Util.spyFunc(onEvent));
   }
 
   function setupManifest(

--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -126,6 +126,9 @@ describe('Player', () => {
         corruptedFrames: jasmine.any(Number),
         estimatedBandwidth: jasmine.any(Number),
 
+        gapsJumped: jasmine.any(Number),
+        stallsDetected: jasmine.any(Number),
+
         completionPercent: jasmine.any(Number),
         loadLatency: jasmine.any(Number),
         manifestTimeSeconds: jasmine.any(Number),

--- a/test/test/util/simple_fakes.js
+++ b/test/test/util/simple_fakes.js
@@ -333,6 +333,12 @@ shaka.test.FakePlayhead = class {
     /** @private {number} */
     this.startTime_ = 0;
 
+    /** @private {number} */
+    this.gapsJumped_ = 0;
+
+    /** @private {number} */
+    this.stallsDetected_ = 0;
+
     /** @type {!jasmine.Spy} */
     this.setStartTime = jasmine.createSpy('setStartTime')
         .and.callFake((value) => {
@@ -342,6 +348,14 @@ shaka.test.FakePlayhead = class {
     /** @type {!jasmine.Spy} */
     this.getTime = jasmine.createSpy('getTime')
         .and.callFake(() => this.startTime_);
+
+    /** @type {!jasmine.Spy} */
+    this.getGapsJumped = jasmine.createSpy('getGapsJumped')
+        .and.callFake(() => this.gapsJumped_);
+
+    /** @type {!jasmine.Spy} */
+    this.getStallsDetected = jasmine.createSpy('getTime')
+        .and.callFake(() => this.stallsDetected_);
 
     /** @type {!jasmine.Spy} */
     this.setBuffering = jasmine.createSpy('setBuffering');

--- a/test/ui/ui_unit.js
+++ b/test/ui/ui_unit.js
@@ -809,12 +809,25 @@ describe('UI', () => {
         }
       });
       it('is updated periodically', async () => {
-        function getStatsFromContainer() {
+        // There is no guaranteed ordering, so fetch by the stat name.
+        function getStatsElementByName(name) {
           const nodes = statisticsContainer.childNodes;
-          width = nodes[0].childNodes[1].textContent.replace(' (px)', '');
-          height = nodes[1].childNodes[1].textContent.replace(' (px)', '');
-          bufferingTime =
-              nodes[13].childNodes[1].textContent.replace(' (s)', '');
+          for (const node of nodes) {
+            if (node.hasChildNodes() &&
+                node.childNodes[0].textContent.includes(name)) {
+              return node;
+            }
+          }
+          return null;
+        }
+
+        function getStatsFromContainer() {
+          width = getStatsElementByName(
+              'width').childNodes[1].textContent.replace(' (px)', '');
+          height = getStatsElementByName(
+              'height').childNodes[1].textContent.replace(' (px)', '');
+          bufferingTime = getStatsElementByName(
+              'bufferingTime').childNodes[1].textContent.replace(' (s)', '');
         }
 
         /** @type {!string} */

--- a/ui/statistics_button.js
+++ b/ui/statistics_button.js
@@ -109,6 +109,14 @@ shaka.ui.StatisticsButton = class extends shaka.ui.Element {
           this.currentStats_[name], false) + ' (m)';
     };
 
+    const parseGaps = (name) => {
+      return this.currentStats_[name] + ' (gaps)';
+    };
+
+    const parseStalls = (name) => {
+      return this.currentStats_[name] + ' (stalls)';
+    };
+
     /** @private {!Object.<string, function(string):string>} */
     this.parseFrom_ = {
       'width': parsePx,
@@ -128,6 +136,8 @@ shaka.ui.StatisticsButton = class extends shaka.ui.Element {
       'corruptedFrames': parseFrames,
       'decodedFrames': parseFrames,
       'droppedFrames': parseFrames,
+      'stallsDetected': parseStalls,
+      'gapsJumped': parseGaps,
     };
 
     /** @private {shaka.util.Timer} */


### PR DESCRIPTION
An event `stalldetected` can be dispatched when Shaka Player detects a stall based on the value of stallThreshold through [StreamingConfiguration](https://shaka-player-demo.appspot.com/docs/api/externs_shaka_player.js.html#line920).

A second event `gapjumped` could also be dispatched when Shaka performs a jump in a media gap.

Related to issue https://github.com/shaka-project/shaka-player/issues/4227.