### PR TITLE
fix(HLS): Fix duplicate hinted segments

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1893,9 +1893,20 @@ shaka.hls.HlsParser = class {
         const pPreviousReference = i == 0 ?
           previousReference : partialSegmentRefs[partialSegmentRefs.length - 1];
         const pStartTime = (i == 0) ? startTime : pPreviousReference.endTime;
-        const pDuration = Number(item.getAttributeValue('DURATION'));
-        // A preload hinted partial segment doesn't have duration information,
-        // so its startTime and endTime are the same.
+
+        // If DURATION is missing from this partial segment, use the target
+        // partial duration from the top of the playlist, which is a required
+        // attribute for content with partial segments.
+        const pDuration = Number(item.getAttributeValue('DURATION')) ||
+            this.partialTargetDuration_;
+
+        // If for some reason we have neither an explicit duration, nor a target
+        // partial duration, we should SKIP this partial segment to avoid
+        // duplicating content in the presentation timeline.
+        if (!pDuration) {
+          continue;
+        }
+
         const pEndTime = pStartTime + pDuration;
 
         let pStartByte = 0;


### PR DESCRIPTION
Because zero-duration references cause such chaos, ensure that the HLS
parser never produces these.  Preload-hinted segments should use the
target duration for partial segments, and if that required attribute
is missing from the playlist, then preload-hinted segments should be
skipped.

Closes #4223