### PR TITLE
feat(lang): add `vi` to Tier 1 languages as of June 2022

### DIFF
--- a/build/generateLocalizations.py
+++ b/build/generateLocalizations.py
@@ -38,7 +38,7 @@ import shakaBuildHelpers
 
 _INDENTATION = '  '
 
-# These are Google's "Tier 1" languages as of April 2019.
+# These are Google's "Tier 1" languages as of June 2022.
 DEFAULT_LOCALES = [
     'ar',
     'de',
@@ -56,6 +56,7 @@ DEFAULT_LOCALES = [
     'ru',
     'th',
     'tr',
+    'vi',
     'zh',
     'zh-TW',
 ]


### PR DESCRIPTION
Hi shaka team,

I try google the term `Google Tier 1 Languages` and it does not have searching result.

However as a member of shaka community, may I have `vi` language add in (so it can be display during development).

Is this reasonable?