### PR TITLE
fix: Remove IE 11 from default browsers for Windows (#4271)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,3 +79,4 @@ Verizon Digital Media Services <*@verizondigitalmedia.com>
 ViacomCBS <*@viacomcbs.com>
 Vincent Valot <valot.vince@gmail.com>
 Wayne Morgan <wayne.morgan.dev@gmail.com>
+Raymond Cheng <raycheng100@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -117,3 +117,4 @@ Vignesh Venkatasubramanian <vigneshv@google.com>
 Vincent Valot <valot.vince@gmail.com>
 Wayne Morgan <wayne.morgan.dev@gmail.com>
 Yohann Connell <robinconnell@google.com>
+Raymond Cheng <raycheng100@gmail.com>

--- a/build/test.py
+++ b/build/test.py
@@ -104,7 +104,7 @@ def _GetDefaultBrowsers():
     return ['Chrome','Edge','Firefox','Safari']
 
   if shakaBuildHelpers.is_windows() or shakaBuildHelpers.is_cygwin():
-    return ['Chrome','Edge','Firefox','IE']
+    return ['Chrome','Edge','Firefox']
 
   raise Error('Unrecognized system: %s' % platform.uname()[0])
 


### PR DESCRIPTION
IE 11 has not been supported since v3.1, so developers following
CONTRIBUTING.md should not see tests fail due to the continued inclusion
of IE. Removed IE from the default list of browsers for Windows. Anybody
who still needs to test against IE can explicitly test via python
build/test.py --browsers IE.