### PR TITLE
style: Re-enable the require-jsdoc eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -175,13 +175,6 @@ module.exports = {
       // verbatim through the compiler.
       'markers': ['*', '!'],
     }],
-    'require-jsdoc': ['error', {
-      'require': {
-        'FunctionDeclaration': true,
-        'MethodDefinition': true,
-        'ClassDeclaration': true,
-      },
-    }],
     // }}}
 
     // "ECMAScript 6" rules: {{{


### PR DESCRIPTION
Default values of require-jsdoc in https://eslint.org/docs/rules/require-jsdoc

Closes https://github.com/shaka-project/shaka-player/issues/2639