### PR TITLE
fix: Add Support to Firefox in MediaCapabilities polyfill

### DIFF
--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -37,10 +37,15 @@ shaka.polyfill.MediaCapabilities = class {
     // See: https://github.com/shaka-project/shaka-player/issues/3582
     // TODO: re-evaluate MediaCapabilities in the future versions of PS5
     // Browsers.
+    // Since MediaCapabilities is not fully supported on some Firefox yet,
+    // we should always install polyfill for all firefox.
+    // TODO: re-evaluate MediaCapabilities in the future versions of Firefox
+    // Browsers.
     let canUseNativeMCap = true;
     if (shaka.util.Platform.isApple() ||
         shaka.util.Platform.isPS5() ||
-        shaka.util.Platform.isChromecast()) {
+        shaka.util.Platform.isChromecast()||
+        shaka.util.Platform.isFirefox()) {
       canUseNativeMCap = false;
     }
     if (shaka.util.Platform.isAndroidCastDevice()) {

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -186,6 +186,15 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is Firefox.
+   *
+   * @return {boolean}
+   */
+  static isFirefox() {
+    return shaka.util.Platform.userAgentContains_('Firefox');
+  }
+
+  /**
    * Check if the current platform is from Apple.
    *
    * Returns true on all iOS browsers and on desktop Safari.


### PR DESCRIPTION
Since MediaCapabilities is not fully supported on some Firefox yet,
we should always install polyfill for all firefox