### PR TITLE
feat: EOS set-top box wrongly identifies as an Apple device.

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -197,7 +197,8 @@ shaka.util.Platform = class {
    */
   static isApple() {
     return !!navigator.vendor && navigator.vendor.includes('Apple') &&
-        !shaka.util.Platform.isTizen();
+        !shaka.util.Platform.isTizen() &&
+        !shaka.util.Platform.isEOS();
   }
 
   /**
@@ -258,6 +259,15 @@ shaka.util.Platform = class {
    */
   static isSafari() {
     return !!shaka.util.Platform.safariVersion();
+  }
+
+  /**
+   * Check if the current platform is EOS set-top box.
+   *
+   * @return {boolean}
+   */
+  static isEOS() {
+    return shaka.util.Platform.userAgentContains_('PC=EOS');
   }
 
   /**

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -262,12 +262,12 @@ shaka.util.Platform = class {
   }
 
   /**
-   * Check if the current platform is EOS set-top box.
+   * Check if the current platform is an EOS set-top box.
    *
    * @return {boolean}
    */
   static isEOS() {
-    return shaka.util.Platform.userAgentContains_('PC=EOS');
+    return shaka.util.Platform.userAgentContains_('PC=EOSSTB');
   }
 
   /**

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -267,7 +267,7 @@ shaka.util.Platform = class {
    * @return {boolean}
    */
   static isEOS() {
-    return shaka.util.Platform.userAgentContains_('PC=EOSSTB');
+    return shaka.util.Platform.userAgentContains_('PC=EOS');
   }
 
   /**


### PR DESCRIPTION
The EOS set-top box, built by Liberty Global, has WebKit embedded and should play MSE (+ EME) compatible streams. With the latest version (`4`), streams didn't play. When attaching a debugger to the box, I noticed that the srcEquals node is selected.

The EOS box identifies itself as an Apple device, which is wrong. `Platform.isApple()` returns true, therefore `shouldUseSrcEquals_` (in combination with `config_.streaming.useNativeHlsOnSafari`) returns true as-well. The native playback check is not holding it from selecting srcEquals (https://github.com/shaka-project/shaka-player/blob/main/lib/player.js#L1273) as EOS supports MPEG-DASH natively (but not in combination with DRM, as far as I know). Nonetheless, MSE is preferred.