### PR TITLE
fix: Fix getVideoPlaybackQuality in WebOS 3

### DIFF
--- a/lib/polyfill/videoplaybackquality.js
+++ b/lib/polyfill/videoplaybackquality.js
@@ -7,6 +7,7 @@
 goog.provide('shaka.polyfill.VideoPlaybackQuality');
 
 goog.require('shaka.polyfill');
+goog.require('shaka.util.Platform');
 
 
 /**
@@ -33,7 +34,8 @@ shaka.polyfill.VideoPlaybackQuality = class {
       return;
     }
 
-    if ('webkitDroppedFrameCount' in proto) {
+    if ('webkitDroppedFrameCount' in proto ||
+        shaka.util.Platform.isWebOS3()) {
       proto.getVideoPlaybackQuality =
           shaka.polyfill.VideoPlaybackQuality.webkit_;
     }


### PR DESCRIPTION
It seems that webkitDroppedFrameCount is not included in the prototype but it is included in the video element itself, that's why it fails in WebOS 3.

Closes https://github.com/shaka-project/shaka-player/issues/4313