### PR TITLE
fix: Fix MediaCapabilities polyfill on Playstation 4

### DIFF
--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -37,12 +37,16 @@ shaka.polyfill.MediaCapabilities = class {
     // See: https://github.com/shaka-project/shaka-player/issues/3582
     // TODO: re-evaluate MediaCapabilities in the future versions of PS5
     // Browsers.
+    // Since MediaCapabilities implementation does not exist in PS4 browsers, we
+    // should always install polyfill.
     let canUseNativeMCap = true;
     if (shaka.util.Platform.isApple() ||
         shaka.util.Platform.isPS5() ||
+        shaka.util.Platform.isPS4() ||
         shaka.util.Platform.isChromecast()) {
       canUseNativeMCap = false;
     }
+
     if (shaka.util.Platform.isAndroidCastDevice()) {
       canUseNativeMCap = true;
     }
@@ -52,7 +56,6 @@ shaka.polyfill.MediaCapabilities = class {
       return;
     }
 
-    shaka.log.info('MediaCapabilities: install');
 
     if (!navigator.mediaCapabilities) {
       navigator.mediaCapabilities = /** @type {!MediaCapabilities} */ ({});
@@ -180,7 +183,7 @@ shaka.polyfill.MediaCapabilities = class {
         keySystemAccess = await navigator.requestMediaKeySystemAccess(
             mediaCapkeySystemConfig.keySystem, [mediaKeySystemConfig]);
       } catch (e) {
-        shaka.log.info('navigator.requestMediaKeySystemAccess failed.');
+        shaka.log.info('navigator.requestMediaKeySystemAccess failed.', e);
       }
 
       if (keySystemAccess) {

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -46,7 +46,6 @@ shaka.polyfill.MediaCapabilities = class {
         shaka.util.Platform.isChromecast()) {
       canUseNativeMCap = false;
     }
-
     if (shaka.util.Platform.isAndroidCastDevice()) {
       canUseNativeMCap = true;
     }
@@ -56,6 +55,7 @@ shaka.polyfill.MediaCapabilities = class {
       return;
     }
 
+    shaka.log.info('MediaCapabilities: install');
 
     if (!navigator.mediaCapabilities) {
       navigator.mediaCapabilities = /** @type {!MediaCapabilities} */ ({});

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -183,7 +183,7 @@ shaka.polyfill.MediaCapabilities = class {
         keySystemAccess = await navigator.requestMediaKeySystemAccess(
             mediaCapkeySystemConfig.keySystem, [mediaKeySystemConfig]);
       } catch (e) {
-        shaka.log.info('navigator.requestMediaKeySystemAccess failed.', e);
+        shaka.log.info('navigator.requestMediaKeySystemAccess failed.');
       }
 
       if (keySystemAccess) {

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -198,7 +198,8 @@ shaka.util.Platform = class {
   static isApple() {
     return !!navigator.vendor && navigator.vendor.includes('Apple') &&
         !shaka.util.Platform.isTizen() &&
-        !shaka.util.Platform.isEOS() && !shaka.util.Platform.isPS4();
+        !shaka.util.Platform.isEOS() &&
+        !shaka.util.Platform.isPS4();
   }
 
   /**

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -198,7 +198,7 @@ shaka.util.Platform = class {
   static isApple() {
     return !!navigator.vendor && navigator.vendor.includes('Apple') &&
         !shaka.util.Platform.isTizen() &&
-        !shaka.util.Platform.isEOS();
+        !shaka.util.Platform.isEOS() && !shaka.util.Platform.isPS4();
   }
 
   /**
@@ -212,6 +212,13 @@ shaka.util.Platform = class {
    */
   static isPS5() {
     return shaka.util.Platform.userAgentContains_('PlayStation 5');
+  }
+
+  /**
+   * Check if the current platform is Playstation 4.
+   */
+  static isPS4() {
+    return shaka.util.Platform.userAgentContains_('PlayStation 4');
   }
 
   /**


### PR DESCRIPTION
This PR adds PS4 to the platform list, fixes an issue where ps4 was identified as an apple device/browser and explicitly sets the condition for installation of the mediaCapabilities polyfill for ps4, as its native implementation does not exist.

Closes #4315