### PR TITLE
docs: Deprecate the mailing list for releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,10 @@ attributes.
  * [Hosted builds on jsDelivr](https://www.jsdelivr.com/package/npm/shaka-player)
  * [Development roadmap](roadmap.md)
  * [Announcement list](https://groups.google.com/forum/#!forum/shaka-player-users)
-     ([join](docs/announcement-list-join-group.png) for release and survey
-      announcements)
+     ([join](docs/announcement-list-join-group.png) for infrequent
+      announcements and surveys)
+ * Subscribe to releases by following
+     [instructions from this blog](https://www.jessesquires.com/blog/2020/07/30/github-tip-watching-releases/)
 
 
 ## FAQ ##

--- a/docs/tutorials/welcome.md
+++ b/docs/tutorials/welcome.md
@@ -98,11 +98,14 @@ You can find a full list of available browsers with `--browsers help`, and you
 can find a complete list of testing options with `--help`.
 
 
-#### Join the announcement list
+#### Announcements
 
-If you want to receive release or survey announcements, you should join our
+To subscribe to new releases on GitHub, you can follow
+[instructions from this blog](https://www.jessesquires.com/blog/2020/07/30/github-tip-watching-releases/).
+
+To receive infrequent announcements and surveys from us, you can join our
 [mailing list](https://groups.google.com/forum/#!forum/shaka-player-users).
-The list is very low volume.
+The list is very low volume, and can only be written to by us.
 
 
 #### Continue the Tutorials


### PR DESCRIPTION
Releases will no longer be announced on the mailing list.  Instead,
users can subscribe directly through GitHub.