### PR TITLE
chore: Update mux.js to 6.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ HLS features supported:
  - Low-latency streaming with partial segments, preload hints, and delta updates
  - Discontinuity
  - ISO-BMFF / MP4 / CMAF support
- - MPEG-2 TS support (transmuxing provided by [mux.js][] v6.1.0+, must be
+ - MPEG-2 TS support (transmuxing provided by [mux.js][] v6.2.0+, must be
    separately included)
  - WebVTT and TTML
  - CEA-608/708 captions
@@ -197,7 +197,7 @@ Shaka Player supports:
       SegmentTemplate@index
     - Not supported in HLS
   - MPEG-2 TS
-    - With help from [mux.js][] v6.1.0+, can be played on any browser which
+    - With help from [mux.js][] v6.2.0+, can be played on any browser which
       supports MP4
     - Can find and parse timestamps to find segment start time in HLS
   - WebVTT
@@ -206,10 +206,10 @@ Shaka Player supports:
     - Supported in both XML form and embedded in MP4
   - CEA-608
     - Supported embedded in MP4
-    - With help from [mux.js][] v6.1.0+, supported embedded in TS
+    - With help from [mux.js][] v6.2.0+, supported embedded in TS
   - CEA-708
     - Supported embedded in MP4
-    - With help from [mux.js][] v6.1.0+, supported embedded in TS
+    - With help from [mux.js][] v6.2.0+, supported embedded in TS
   - SubRip (SRT)
     - UTF-8 encoding only
   - LyRiCs (LRC)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6155,9 +6155,9 @@
       "dev": true
     },
     "node_modules/mux.js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.1.0.tgz",
-      "integrity": "sha512-9Ay5vGzAnJnrA+xGpj93YuVIJSqOGOXxvLn/sc0bD4Li1N4s8ED9jn00WyQfPlLRbqNJ0jN4ZZPvJzbIdgYk5Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.2.0.tgz",
+      "integrity": "sha512-SKuxIcbmK/aJoz78aQNuoXY8R/uEPm1gQMqWTXL6DNl7oF8UPjdt/AunXGkPQpBouGWKDgL/TzSl2VV5NuboRg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.11.2"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "less": "https://gitpkg.now.sh/joeyparrish/less.js/packages/less?28c63a43",
     "less-plugin-clean-css": "github:austingardner/less-plugin-clean-css#4e9e77bf",
     "material-design-lite": "^1.3.0",
-    "mux.js": "^6.1.0",
+    "mux.js": "^6.2.0",
     "open-sans-fonts": "^1.6.2",
     "postcss-less": "^6.0.0",
     "pwacompat": "^2.0.17",


### PR DESCRIPTION
[mux.js 6.2.0 ](https://github.com/videojs/mux.js/releases/tag/v6.2.0)introduce changes that are useful while parsing ID3 HLS in-band metadata.