### PR TITLE
fix: Fix segment index assertions with DAI

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -513,6 +513,11 @@ shaka.dash.DashParser = class {
         }
         presentationTimeline.setClockOffset(offset);
       }
+
+      // This is the first point where we have a meaningful presentation start
+      // time, and we need to tell PresentationTimeline that so that it can
+      // maintain consistency from here on.
+      presentationTimeline.lockStartTime();
     } else {
       // Just update the variants and text streams, which may change as periods
       // are added or removed.

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -740,7 +740,13 @@ shaka.hls.HlsParser = class {
     for (const stream of streamsToNotify) {
       this.segmentsToNotifyByStream_.push(stream.segmentIndex.references);
     }
+
     this.notifySegments_();
+
+    // This is the first point where we have a meaningful presentation start
+    // time, and we need to tell PresentationTimeline that so that it can
+    // maintain consistency from here on.
+    this.presentationTimeline_.lockStartTime();
 
     // This asserts that the live edge is being calculated from segment times.
     // For VOD and event streams, this check should still pass.
@@ -1859,8 +1865,6 @@ shaka.hls.HlsParser = class {
       /* presentationStartTime= */ null, /* delay= */ 0);
       this.presentationTimeline_.setStatic(true);
     }
-
-    this.notifySegments_();
   }
 
   /**

--- a/lib/media/presentation_timeline.js
+++ b/lib/media/presentation_timeline.js
@@ -93,6 +93,9 @@ shaka.media.PresentationTimeline = class {
      * @private {number}
      */
     this.availabilityTimeOffset_ = 0;
+
+    /** @private {boolean} */
+    this.startTimeLocked_ = false;
   }
 
 
@@ -229,7 +232,8 @@ shaka.media.PresentationTimeline = class {
     this.maxSegmentEndTime_ =
         Math.max(this.maxSegmentEndTime_, lastReferenceEndTime);
 
-    if (this.presentationStartTime_ != null && this.autoCorrectDrift_) {
+    if (this.presentationStartTime_ != null && this.autoCorrectDrift_ &&
+        !this.startTimeLocked_) {
       // Since we have explicit segment end times, calculate a presentation
       // start based on them.  This start time accounts for drift.
       // Date.now() is in milliseconds, from which we compute "now" in seconds.
@@ -240,6 +244,25 @@ shaka.media.PresentationTimeline = class {
 
     shaka.log.v1('notifySegments:',
         'maxSegmentDuration=' + this.maxSegmentDuration_);
+  }
+
+
+  /**
+   * Lock the presentation timeline's start time.  After this is called, no
+   * further adjustments to presentationStartTime_ will be permitted.
+   *
+   * This should be called after all Periods have been parsed, and all calls to
+   * notifySegments() from the initial manifest parse have been made.
+   *
+   * Without this, we can get assertion failures in SegmentIndex for certain
+   * DAI content.  If DAI adds ad segments to the manifest faster than
+   * real-time, adjustments to presentationStartTime_ can cause availability
+   * windows to jump around on updates.
+   *
+   * @export
+   */
+  lockStartTime() {
+    this.startTimeLocked_ = true;
   }
 
 


### PR DESCRIPTION
When DAI adds ad segments faster than real-time, the availability
windows gets messed up, and some assertions in SegmentIndex break.
This locks down the presentation start time after the initial manifest
is parsed, so that the availability window is stable throughout
playback.

b/233075535