### PR TITLE
fix: exception if on early adError

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,6 +43,7 @@ Johan Sundström <oyasumi@gmail.com>
 Jonas Birmé <jonas.birme@eyevinn.se>
 Jozef Chúťka <jozefchutka@gmail.com>
 Jun Hong Chong <chongjunhong@gmail.com>
+Jürgen Kartnaller <kartnaller@lovelysystems.com>
 JW Player <*@jwplayer.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Matthias Van Parijs <matvp91@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -70,6 +70,7 @@ Jono Ward <jonoward@gmail.com>
 Jozef Chúťka <jozefchutka@gmail.com>
 Julian Domingo <juliandomingo@google.com>
 Jun Hong Chong <chongjunhong@gmail.com>
+Jürgen Kartnaller <kartnaller@lovelysystems.com>
 Leandro Ribeiro Moreira <leandro.ribeiro.moreira@gmail.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Matias Russitto <russitto@gmail.com>

--- a/lib/ads/client_side_ad_manager.js
+++ b/lib/ads/client_side_ad_manager.js
@@ -427,7 +427,7 @@ shaka.ads.ClientSideAdManager = class {
   onAdComplete_(e) {
     this.onEvent_(new shaka.util.FakeEvent(shaka.ads.AdManager.AD_STOPPED,
         (new Map()).set('originalEvent', e)));
-    if (this.ad_.isLinear()) {
+    if (this.ad_ && this.ad_.isLinear()) {
       this.adContainer_.removeAttribute('ad-active');
       this.video_.play();
     }


### PR DESCRIPTION
If onAdError is called before onAdStart_ then onAdComplete_ uses
this.ad_ which is undefined.

This can happen if a VAST XML file contains no ads.

fixes #4004