### PR TITLE
fix: add strictMissingProperties suppressions to unblock strict missing properties on union types.

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1790,6 +1790,8 @@ shaka.media.StreamingEngine = class {
    *
    * @return {!Promise.<BufferSource>}
    * @private
+   * @suppress {strictMissingProperties} TODO(b/214874268): Remove
+   * strictMissingProperties suppression after b/214427036 is fixed
    */
   async fetch_(mediaState, reference, streamDataCallback) {
     const requestType = shaka.net.NetworkingEngine.RequestType.SEGMENT;

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1790,8 +1790,7 @@ shaka.media.StreamingEngine = class {
    *
    * @return {!Promise.<BufferSource>}
    * @private
-   * @suppress {strictMissingProperties} TODO(b/214874268): Remove
-   * strictMissingProperties suppression after b/214427036 is fixed
+   * @suppress {strictMissingProperties}
    */
   async fetch_(mediaState, reference, streamDataCallback) {
     const requestType = shaka.net.NetworkingEngine.RequestType.SEGMENT;

--- a/lib/util/buffer_utils.js
+++ b/lib/util/buffer_utils.js
@@ -20,6 +20,7 @@ shaka.util.BufferUtils = class {
    * @param {?BufferSource} arr2
    * @return {boolean}
    * @export
+   * @suppress {strictMissingProperties}
    */
   static equal(arr1, arr2) {
     const BufferUtils = shaka.util.BufferUtils;
@@ -135,8 +136,10 @@ shaka.util.BufferUtils = class {
   static view_(data, offset, length, Type) {
     const buffer = shaka.util.BufferUtils.unsafeGetArrayBuffer_(data);
     // Absolute end of the |data| view within |buffer|.
+    /** @suppress {strictMissingProperties} */
     const dataEnd = (data.byteOffset || 0) + data.byteLength;
     // Absolute start of the result within |buffer|.
+    /** @suppress {strictMissingProperties} */
     const rawStart = (data.byteOffset || 0) + offset;
     const start = Math.max(0, Math.min(rawStart, dataEnd));
     // Absolute end of the result within |buffer|.

--- a/lib/util/object_utils.js
+++ b/lib/util/object_utils.js
@@ -22,6 +22,7 @@ shaka.util.ObjectUtils = class {
     const seenObjects = new Set();
     // This recursively clones the value |val|, using the captured variable
     // |seenObjects| to track the objects we have already cloned.
+    /** @suppress {strictMissingProperties} */
     const clone = (val) => {
       switch (typeof val) {
         case 'undefined':


### PR DESCRIPTION
JSCompiler's strict missing properties on union types change improves the missing properties check to report properties that do not exist on all members of union types (excluding null or undefined and after boxing primitives).