### PR TITLE
ci: Fix Safari 14 tests

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -86,10 +86,11 @@ jobs:
         run: |
           # Download Safari 14
           # See also https://www.macupdate.com/app/mac/15675/apple-safari/old-versions
-          curl -Lv https://www.macupdate.com/action/download/63550 > safari-14.1.2.pkg
+          curl -Lv https://www.macupdate.com/action/download/62946 > Safari14.0CatalinaAuto.pkg.zip
 
           # Install Safari 14 to homedir specifically.
-          installer -pkg safari-14.1.2.pkg -target CurrentUserHomeDirectory
+          unzip Safari14.0CatalinaAuto.pkg.zip
+          installer -pkg Safari14.0CatalinaAuto.pkg -target CurrentUserHomeDirectory
 
           # Install a launcher that can execute a shell script to launch this
           npm install karma-script-launcher --save-dev


### PR DESCRIPTION
The available package versions of Safari have changed.  This updates
to what is currently available.  This also updates to expect the
current format of the packages (pkg inside zip).