### PR TITLE
feat: add Amazon Fire TV platform support

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -199,7 +199,8 @@ shaka.util.Platform = class {
     return !!navigator.vendor && navigator.vendor.includes('Apple') &&
         !shaka.util.Platform.isTizen() &&
         !shaka.util.Platform.isEOS() &&
-        !shaka.util.Platform.isPS4();
+        !shaka.util.Platform.isPS4() &&
+        !shaka.util.Platform.isAmazonFireTV();
   }
 
   /**

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -223,6 +223,16 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is Amazon Fire TV.
+   * https://developer.amazon.com/docs/fire-tv/identify-amazon-fire-tv-devices.html
+   *
+   * @return {boolean}
+   */
+  static isAmazonFireTV() {
+    return shaka.util.Platform.userAgentContains_('AFT');
+  }
+
+  /**
    * Returns a major version number for Safari, or Safari-based iOS browsers.
    *
    * For example:


### PR DESCRIPTION
The `isBrowserSupported` function in the `utils/player.js` fails if the Safari Version is < 13. However, this check doesn't work for Amazon Fire TV devices. Even tho they have a `Version/4.0` in the user agent string, the browser still supports all other requirements to support playback with Shaka Player. 

Here are a couple of examples of the different FireTV device user agents:
#### Fire TV Stick 4K - 1st Gen:
```
'Mozilla/5.0 (Linux; Android 7.1.2; AFTMM Build/NS6289; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/100.0.4896.127 Mobile Safari/537.36'
```
#### Fire TV Stick - 3rd Gen:
```
'Mozilla/5.0 (Linux; Android 9; AFTSSS Build/PS7285.2877N; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/96.0.4664.92 Mobile Safari/537.36'
```

The fix involves identifying the Amazon Fire TV device based on the parameters described [in the Amazon Fire TV docs](https://developer.amazon.com/docs/fire-tv/identify-amazon-fire-tv-devices.html) and disabling the Safari version check for these devices.

### Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to
not work as expected)
 - [ ] This change requires a documentation update
### Checklist:
 - [x] I have signed the Google CLA https://cla.developers.google.com/
 - [x] My code follows the style guidelines of this project
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] I have verified my change on multiple browsers on different platforms (Amazon FireTV Stick 4k, and non-4k device)
 - [x] I have run ./build/all.py and the build passes
 - [ ] I have run ./build/test.py and all tests pass _(while most tests pass, some tests around `TextDisplayer` are failing even on the main branch for Edge and Firefox, even tho those tests seem irrelevant to the changes in this PR). I'll create an issue around that._ 
