### PR TITLE
fix: Fix VP9 codec checks on Mac Firefox

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -585,8 +585,16 @@ shaka.util.StreamUtils = class {
       // VideoConfiguration
       mediaDecodingConfig.video = {
         contentType: fullType,
-        width: video.width || 1,
-        height: video.height || 1,
+
+        // NOTE: Some decoders strictly check the width and height fields and
+        // won't decode smaller than 64x64.  So if we don't have this info (as
+        // is the case in some of our simpler tests), assume a 64x64 resolution
+        // to fill in this required field for MediaCapabilities.
+        //
+        // This became an issue specifically on Firefox on M1 Macs.
+        width: video.width || 64,
+        height: video.height || 64,
+
         bitrate: video.bandwidth || variant.bandwidth || 1,
         // framerate must be greater than 0, otherwise the config is invalid.
         framerate: video.frameRate || 1,
@@ -749,7 +757,19 @@ shaka.util.StreamUtils = class {
    */
   static patchVp9(codec) {
     if (codec == 'vp9') {
-      return 'vp09.00.10.08';
+      // This means profile 0, level 4.1, 8-bit color.  This supports 1080p @
+      // 60Hz.  See https://en.wikipedia.org/wiki/VP9#Levels
+      //
+      // If we don't have more detailed codec info, assume this profile and
+      // level because it's high enough to likely accommodate the parameters we
+      // do have, such as width and height.  If an implementation is checking
+      // the profile and level very strictly, we want older VP9 content to
+      // still work to some degree.  But we don't want to set a level so high
+      // that it is rejected by a hardware decoder that can't handle the
+      // maximum requirements of the level.
+      //
+      // This became an issue specifically on Firefox on M1 Macs.
+      return 'vp09.00.41.08';
     }
     return codec;
   }


### PR DESCRIPTION
Tests for VP9 codec checks were failing on Firefox on our M1 Mac.  This
addresses the issue by changing some default values that get used in a testing
environment, and another default value that is used in production.

This fixes one source of nightly test failures.