### PR TITLE
test: Fix Tizen test failures due to ES6 in polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "eme-encryption-scheme-polyfill": "^2.1.0"
+        "eme-encryption-scheme-polyfill": "^2.1.1"
       },
       "devDependencies": {
         "@babel/core": "^7.17.5",
@@ -3599,9 +3599,9 @@
       "dev": true
     },
     "node_modules/eme-encryption-scheme-polyfill": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-2.1.0.tgz",
-      "integrity": "sha512-vdkP1WyZTBI2LEU+FvbYrjawkz+5fOgSY0qicaWjs/ouVzBKvdbUHfbZ1mLHFOi3l+cdvSq4U6K55mD7J/SEbg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-2.1.1.tgz",
+      "integrity": "sha512-njD17wcUrbqCj0ArpLu5zWXtaiupHb/2fIUQGdInf83GlI+Q6mmqaPGLdrke4savKAu15J/z1Tg/ivDgl14g0g=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -11226,9 +11226,9 @@
       "dev": true
     },
     "eme-encryption-scheme-polyfill": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-2.1.0.tgz",
-      "integrity": "sha512-vdkP1WyZTBI2LEU+FvbYrjawkz+5fOgSY0qicaWjs/ouVzBKvdbUHfbZ1mLHFOi3l+cdvSq4U6K55mD7J/SEbg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eme-encryption-scheme-polyfill/-/eme-encryption-scheme-polyfill-2.1.1.tgz",
+      "integrity": "sha512-njD17wcUrbqCj0ArpLu5zWXtaiupHb/2fIUQGdInf83GlI+Q6mmqaPGLdrke4savKAu15J/z1Tg/ivDgl14g0g=="
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "prepublishOnly": "python build/checkversion.py && python build/all.py --force"
   },
   "dependencies": {
-    "eme-encryption-scheme-polyfill": "^2.1.0"
+    "eme-encryption-scheme-polyfill": "^2.1.1"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
The upgraded polyfill fixes this.

See shaka-project/eme-encryption-scheme-polyfill#49