### PR TITLE
feat: Improve gap-detection robustness

### DIFF
--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -147,7 +147,7 @@ shaka.util.PlayerConfiguration = class {
       ignoreTextStreamFailures: false,
       alwaysStreamText: false,
       startAtSegmentBoundary: false,
-      gapDetectionThreshold: 0.1,
+      gapDetectionThreshold: 0.5,
       durationBackoff: 1,
       forceTransmuxTS: false,
       // Offset by 5 seconds since Chromecast takes a few seconds to start
@@ -172,15 +172,6 @@ shaka.util.PlayerConfiguration = class {
       observeQualityChanges: false,
       maxDisabledTime: 30,
     };
-
-    // Some browsers will stop earlier than others before a gap (e.g., Edge
-    // stops 0.5 seconds before a gap). So for some browsers we need to use a
-    // larger threshold. See: https://bit.ly/2K5xmJO
-    if (shaka.util.Platform.isLegacyEdge() ||
-        shaka.util.Platform.isTizen() ||
-        shaka.util.Platform.isChromecast()) {
-      streaming.gapDetectionThreshold = 0.5;
-    }
 
     // WebOS, Tizen, and Chromecast have long hardware pipelines that respond
     // slowly to seeking.  Therefore we should not seek when we detect a stall


### PR DESCRIPTION
This raises the default gap-detection threshold from 0.1 seconds for
some platforms and 0.5 seconds for others to 0.5 seconds universally.
This fixes test flake in gap-jumping tests on Android and may improve
gap-jumping generally for certain platforms or content.