### PR TITLE
fix: register missing polyfill

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,6 +46,7 @@ Jun Hong Chong <chongjunhong@gmail.com>
 Jürgen Kartnaller <kartnaller@lovelysystems.com>
 JW Player <*@jwplayer.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>
+Martin Stark <martin.stark@eyevinn.se>
 Matthias Van Parijs <matvp91@gmail.com>
 Mattias Wadman <mattias.wadman@gmail.com>
 Mohamed Rashid <ge_rashid@hotmail.co.uk>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -73,6 +73,7 @@ Jun Hong Chong <chongjunhong@gmail.com>
 Jürgen Kartnaller <kartnaller@lovelysystems.com>
 Leandro Ribeiro Moreira <leandro.ribeiro.moreira@gmail.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>
+Martin Stark <martin.stark@eyevinn.se>
 Matias Russitto <russitto@gmail.com>
 Matthias Van Parijs <matvp91@gmail.com>
 Mattias Wadman <mattias.wadman@gmail.com>

--- a/lib/polyfill/patchedmediakeys_apple.js
+++ b/lib/polyfill/patchedmediakeys_apple.js
@@ -727,3 +727,5 @@ shaka.polyfill.PatchedMediaKeysApple.MediaKeyStatusMap = class {
     goog.asserts.assert(false, 'Not used!  Provided only for the compiler.');
   }
 };
+
+shaka.polyfill.register(shaka.polyfill.PatchedMediaKeysApple.install);


### PR DESCRIPTION
PatchedMediaKeysApple used to not be registered, meaning it does not get installed when shaka.polyfill.installAll() gets called.