### PR TITLE
fix: Fix drm.keySystemsMapping config

### DIFF
--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -314,6 +314,7 @@ shaka.util.PlayerConfiguration = class {
    */
   static mergeConfigObjects(destination, updates, template) {
     const overrides = {
+      '.drm.keySystemsMapping': '',
       '.drm.servers': '',
       '.drm.clearKeys': '',
       '.drm.advanced': {


### PR DESCRIPTION
This fixes the config by adding a missing override in the config parser.  This also adds test coverage for the feature.

Closes #4422