### PR TITLE
fix: Fix vanishing tracks while offline

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5625,6 +5625,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return false;
     }
 
+    if (!navigator.onLine) {
+      // Don't restrict variants if we're completely offline, or else we end up
+      // rapidly restricting all of them.
+      return false;
+    }
+
     let maxDisabledTime = this.config_.streaming.maxDisabledTime;
     if (maxDisabledTime == 0) {
       if (error.code == shaka.util.Error.Code.SEGMENT_MISSING) {

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -467,11 +467,13 @@ describe('Player', () => {
           describe('but browser is truly offline', () => {
             let navigatorOnLineDescriptor;
             beforeEach(() => {
+              // eslint-disable-next-line no-restricted-syntax
               navigatorOnLineDescriptor = Object.getOwnPropertyDescriptor(
                   Navigator.prototype, 'onLine');
 
               // Redefine the property, replacing only the getter.
-              Object.defineProperty(navigator, 'onLine',
+              // eslint-disable-next-line no-restricted-syntax
+              Object.defineProperty(Navigator.prototype, 'onLine',
                   Object.assign(navigatorOnLineDescriptor, {
                     get: () => false,
                   }));
@@ -479,8 +481,9 @@ describe('Player', () => {
 
             afterEach(() => {
               // Restore the original property definition.
+              // eslint-disable-next-line no-restricted-syntax
               Object.defineProperty(
-                  navigator, 'onLine', navigatorOnLineDescriptor);
+                  Navigator.prototype, 'onLine', navigatorOnLineDescriptor);
             });
 
             it('does not handle HTTP_ERROR', () => {

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -465,15 +465,21 @@ describe('Player', () => {
           });
 
           describe('but browser is truly offline', () => {
+            /** @type {!Object} */
             let navigatorOnLineDescriptor;
-            beforeEach(() => {
-              // eslint-disable-next-line no-restricted-syntax
-              navigatorOnLineDescriptor = Object.getOwnPropertyDescriptor(
-                  Navigator.prototype, 'onLine');
 
+            // eslint-disable-next-line no-restricted-syntax
+            const navigatorPrototype = Navigator.prototype;
+
+            beforeAll(() => {
+              navigatorOnLineDescriptor =
+                /** @type {!Object} */(Object.getOwnPropertyDescriptor(
+                    navigatorPrototype, 'onLine'));
+            });
+
+            beforeEach(() => {
               // Redefine the property, replacing only the getter.
-              // eslint-disable-next-line no-restricted-syntax
-              Object.defineProperty(Navigator.prototype, 'onLine',
+              Object.defineProperty(navigatorPrototype, 'onLine',
                   Object.assign(navigatorOnLineDescriptor, {
                     get: () => false,
                   }));
@@ -481,9 +487,8 @@ describe('Player', () => {
 
             afterEach(() => {
               // Restore the original property definition.
-              // eslint-disable-next-line no-restricted-syntax
               Object.defineProperty(
-                  Navigator.prototype, 'onLine', navigatorOnLineDescriptor);
+                  navigatorPrototype, 'onLine', navigatorOnLineDescriptor);
             });
 
             it('does not handle HTTP_ERROR', () => {

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -422,7 +422,6 @@ describe('Player', () => {
             dispatchEventSpy.calls.reset();
             player.configure({streaming: {maxDisabledTime}});
             player.setMaxHardwareResolution(123, 456);
-            onErrorCallback(httpError);
           });
 
           afterEach(() => {
@@ -434,14 +433,18 @@ describe('Player', () => {
           });
 
           it('handles HTTP_ERROR', () => {
+            onErrorCallback(httpError);
             expect(httpError.handled).toBeTruthy();
           });
 
           it('does not dispatch any error', () => {
+            onErrorCallback(httpError);
             expect(dispatchEventSpy).not.toHaveBeenCalled();
           });
 
           it('disables the current variant and applies restrictions', () => {
+            onErrorCallback(httpError);
+
             const foundDisabledVariant =
                 manifest.variants.some(({disabledUntilTime}) =>
                   disabledUntilTime == currentTime + maxDisabledTime);
@@ -453,10 +456,37 @@ describe('Player', () => {
           });
 
           it('switches the variant', () => {
+            onErrorCallback(httpError);
+
             expect(chooseVariantSpy).toHaveBeenCalled();
             expect(getBufferedInfoSpy).toHaveBeenCalled();
             expect(switchVariantSpy)
                 .toHaveBeenCalledWith(chosenVariant, false, true, 14);
+          });
+
+          describe('but browser is truly offline', () => {
+            let navigatorOnLineDescriptor;
+            beforeEach(() => {
+              navigatorOnLineDescriptor = Object.getOwnPropertyDescriptor(
+                  Navigator.prototype, 'onLine');
+
+              // Redefine the property, replacing only the getter.
+              Object.defineProperty(navigator, 'onLine',
+                  Object.assign(navigatorOnLineDescriptor, {
+                    get: () => false,
+                  }));
+            });
+
+            afterEach(() => {
+              // Restore the original property definition.
+              Object.defineProperty(
+                  navigator, 'onLine', navigatorOnLineDescriptor);
+            });
+
+            it('does not handle HTTP_ERROR', () => {
+              onErrorCallback(httpError);
+              expect(httpError.handled).toBe(false);
+            });
           });
         });
       });


### PR DESCRIPTION
Introduced in #4189, as a side-effect of restricting tracks when a
network failure occurs.  We should not trigger such restrictions when
the browser is known to be offline.

Closes #4408