### PR TITLE
chore(HLS): Retired unused error code

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -576,7 +576,6 @@ shaka.hls.HlsParser = class {
           playlist, uri, uri, codecs, type, language, primary, name,
           channelsCount, closedCaptions, characteristics, forced, spatialAudio,
           mimeType);
-      goog.asserts.assert(streamInfo != null, 'StreamInfo is null!');
       this.uriToStreamInfosMap_.set(uri, streamInfo);
 
       // Wrap the stream from that stream info with a variant.
@@ -856,16 +855,13 @@ shaka.hls.HlsParser = class {
     // Create text stream for each Subtitle media tag.
     const subtitleTags =
         shaka.hls.Utils.filterTagsByType(mediaTags, 'SUBTITLES');
-    const textStreamPromises = subtitleTags.map(async (tag) => {
+    const textStreamPromises = subtitleTags.map((tag) => {
       const disableText = this.config_.disableText;
       if (disableText) {
         return null;
       }
       try {
-        const streamInfo = await this.createStreamInfoFromMediaTag_(tag);
-        goog.asserts.assert(
-            streamInfo, 'Should always have a streamInfo for text');
-        return streamInfo.stream;
+        return this.createStreamInfoFromMediaTag_(tag);
       } catch (e) {
         if (this.config_.hls.ignoreTextStreamFailures) {
           return null;
@@ -900,16 +896,13 @@ shaka.hls.HlsParser = class {
    */
   async parseImages_(imageTags) {
     // Create image stream for each image tag.
-    const imageStreamPromises = imageTags.map(async (tag) => {
+    const imageStreamPromises = imageTags.map((tag) => {
       const disableThumbnails = this.config_.disableThumbnails;
       if (disableThumbnails) {
         return null;
       }
       try {
-        const streamInfo = await this.createStreamInfoFromImageTag_(tag);
-        goog.asserts.assert(
-            streamInfo, 'Should always have a streamInfo for image');
-        return streamInfo.stream;
+        return this.createStreamInfoFromImageTag_(tag);
       } catch (e) {
         if (this.config_.hls.ignoreImageStreamFailures) {
           return null;
@@ -1066,13 +1059,7 @@ shaka.hls.HlsParser = class {
     if (!ignoreStream) {
       streamInfo =
           await this.createStreamInfoFromVariantTag_(tag, allCodecs, type);
-    }
-    if (streamInfo) {
       res[streamInfo.stream.type] = [streamInfo];
-    } else if (streamInfo === null) {
-      // Triple-equals for undefined.
-      shaka.log.debug('streamInfo is null');
-      return null;
     }
     this.filterLegacyCodecs_(res);
     return res;
@@ -1364,7 +1351,7 @@ shaka.hls.HlsParser = class {
    * Parse EXT-X-MEDIA media tag into a Stream object.
    *
    * @param {shaka.hls.Tag} tag
-   * @return {!Promise.<?shaka.hls.HlsParser.StreamInfo>}
+   * @return {!Promise.<!shaka.hls.HlsParser.StreamInfo>}
    * @private
    */
   async createStreamInfoFromMediaTag_(tag) {
@@ -1418,9 +1405,6 @@ shaka.hls.HlsParser = class {
     } else {
       this.groupIdToStreamInfosMap_.set(groupId, [streamInfo]);
     }
-    if (streamInfo == null) {
-      return null;
-    }
 
     // TODO: This check is necessary because of the possibility of multiple
     // calls to createStreamInfoFromMediaTag_ before either has resolved.
@@ -1435,7 +1419,7 @@ shaka.hls.HlsParser = class {
    * Parse EXT-X-MEDIA media tag into a Stream object.
    *
    * @param {shaka.hls.Tag} tag
-   * @return {!Promise.<?shaka.hls.HlsParser.StreamInfo>}
+   * @return {!Promise.<!shaka.hls.HlsParser.StreamInfo>}
    * @private
    */
   async createStreamInfoFromImageTag_(tag) {
@@ -1463,9 +1447,6 @@ shaka.hls.HlsParser = class {
         verbatimImagePlaylistUri, codecs, type, language, /* primary= */ false,
         name, /* channelsCount= */ null, /* closedCaptions= */ null,
         characteristics, /* forced= */ false, /* spatialAudio= */ false);
-    if (streamInfo == null) {
-      return null;
-    }
 
     // TODO: This check is necessary because of the possibility of multiple
     // calls to createStreamInfoFromImageTag_ before either has resolved.
@@ -1506,7 +1487,7 @@ shaka.hls.HlsParser = class {
    * @param {!shaka.hls.Tag} tag
    * @param {!Array.<string>} allCodecs
    * @param {string} type
-   * @return {!Promise.<?shaka.hls.HlsParser.StreamInfo>}
+   * @return {!Promise.<!shaka.hls.HlsParser.StreamInfo>}
    * @private
    */
   async createStreamInfoFromVariantTag_(tag, allCodecs, type) {
@@ -1526,9 +1507,6 @@ shaka.hls.HlsParser = class {
         /* name= */ null, /* channelcount= */ null, closedCaptions,
         /* characteristics= */ null, /* forced= */ false,
         /* spatialAudio= */ false);
-    if (streamInfo == null) {
-      return null;
-    }
     // TODO: This check is necessary because of the possibility of multiple
     // calls to createStreamInfoFromVariantTag_ before either has resolved.
     if (this.uriToStreamInfosMap_.has(verbatimMediaPlaylistUri)) {
@@ -1552,7 +1530,7 @@ shaka.hls.HlsParser = class {
    * @param {?string} characteristics
    * @param {boolean} forced
    * @param {boolean} spatialAudio
-   * @return {!Promise.<?shaka.hls.HlsParser.StreamInfo>}
+   * @return {!Promise.<!shaka.hls.HlsParser.StreamInfo>}
    * @private
    */
   async createStreamInfo_(verbatimMediaPlaylistUri, codecs, type, language,
@@ -1592,7 +1570,7 @@ shaka.hls.HlsParser = class {
    * @param {boolean} forced
    * @param {boolean} spatialAudio
    * @param {(string|undefined)} mimeType
-   * @return {!Promise.<?shaka.hls.HlsParser.StreamInfo>}
+   * @return {!Promise.<!shaka.hls.HlsParser.StreamInfo>}
    * @private
    */
   async convertParsedPlaylistIntoStreamInfo_(playlist, verbatimMediaPlaylistUri,
@@ -1683,19 +1661,8 @@ shaka.hls.HlsParser = class {
     /** @type {!Map.<number, number>} */
     const mediaSequenceToStartTime = new Map();
 
-    let segments;
-    try {
-      segments = this.createSegments_(verbatimMediaPlaylistUri, playlist, type,
-          mimeType, mediaSequenceToStartTime, mediaVariables, codecs);
-    } catch (error) {
-      if (error.code == shaka.util.Error.Code.HLS_INTERNAL_SKIP_STREAM) {
-        shaka.log.alwaysWarn('Skipping unsupported HLS stream',
-            mimeType, verbatimMediaPlaylistUri);
-        return null;
-      }
-
-      throw error;
-    }
+    const segments = this.createSegments_(verbatimMediaPlaylistUri, playlist,
+        type, mimeType, mediaSequenceToStartTime, mediaVariables, codecs);
 
     const lastEndTime = segments[segments.length - 1].endTime;
     /** @type {!shaka.media.SegmentIndex} */

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -953,22 +953,17 @@ shaka.hls.HlsParser = class {
       const streamInfos = await this.createStreamInfosForVariantTag_(tag,
           resolution, frameRate);
 
-      if (streamInfos) {
-        goog.asserts.assert(streamInfos.audio.length ||
-            streamInfos.video.length, 'We should have created a stream!');
+      goog.asserts.assert(streamInfos.audio.length ||
+          streamInfos.video.length, 'We should have created a stream!');
 
-        return this.createVariants_(
-            streamInfos.audio,
-            streamInfos.video,
-            bandwidth,
-            width,
-            height,
-            frameRate,
-            videoRange);
-      }
-      // We do not support AES-128 encryption with HLS yet. If the streamInfos
-      // is null because of AES-128 encryption, do not create variants for that.
-      return [];
+      return this.createVariants_(
+          streamInfos.audio,
+          streamInfos.video,
+          bandwidth,
+          width,
+          height,
+          frameRate,
+          videoRange);
     });
 
     const allVariants = await Promise.all(variantsPromises);
@@ -985,7 +980,7 @@ shaka.hls.HlsParser = class {
    * @param {!shaka.hls.Tag} tag
    * @param {?string} resolution
    * @param {?string} frameRate
-   * @return {!Promise.<?shaka.hls.HlsParser.StreamInfos>}
+   * @return {!Promise.<!shaka.hls.HlsParser.StreamInfos>}
    * @private
    */
   async createStreamInfosForVariantTag_(tag, resolution, frameRate) {
@@ -1055,9 +1050,8 @@ shaka.hls.HlsParser = class {
       type = ContentType.VIDEO;
     }
 
-    let streamInfo;
     if (!ignoreStream) {
-      streamInfo =
+      const streamInfo =
           await this.createStreamInfoFromVariantTag_(tag, allCodecs, type);
       res[streamInfo.stream.type] = [streamInfo];
     }

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -855,13 +855,14 @@ shaka.hls.HlsParser = class {
     // Create text stream for each Subtitle media tag.
     const subtitleTags =
         shaka.hls.Utils.filterTagsByType(mediaTags, 'SUBTITLES');
-    const textStreamPromises = subtitleTags.map((tag) => {
+    const textStreamPromises = subtitleTags.map(async (tag) => {
       const disableText = this.config_.disableText;
       if (disableText) {
         return null;
       }
       try {
-        return this.createStreamInfoFromMediaTag_(tag);
+        const streamInfo = await this.createStreamInfoFromMediaTag_(tag);
+        return streamInfo.stream;
       } catch (e) {
         if (this.config_.hls.ignoreTextStreamFailures) {
           return null;
@@ -896,13 +897,14 @@ shaka.hls.HlsParser = class {
    */
   async parseImages_(imageTags) {
     // Create image stream for each image tag.
-    const imageStreamPromises = imageTags.map((tag) => {
+    const imageStreamPromises = imageTags.map(async (tag) => {
       const disableThumbnails = this.config_.disableThumbnails;
       if (disableThumbnails) {
         return null;
       }
       try {
-        return this.createStreamInfoFromImageTag_(tag);
+        const streamInfo = await this.createStreamInfoFromImageTag_(tag);
+        return streamInfo.stream;
       } catch (e) {
         if (this.config_.hls.ignoreImageStreamFailures) {
           return null;

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -661,11 +661,7 @@ shaka.util.Error.Code = {
    */
   'HLS_AES_128_ENCRYPTION_NOT_SUPPORTED': 4034,
 
-  /**
-   * An internal error code that should never be seen by applications, thrown
-   * to force the HLS parser to skip an unsupported stream.
-   */
-  'HLS_INTERNAL_SKIP_STREAM': 4035,
+  // RETIRED: 'HLS_INTERNAL_SKIP_STREAM': 4035,
 
   /** The Manifest contained no Variants. */
   'NO_VARIANTS': 4036,


### PR DESCRIPTION
Now that #2337 has been implemented, the error code HLS_INTERNAL_SKIP_STREAM
is no longer used anywhere in the code.
This retires that error, and also cleans up the code that previously
was responsible for handling that error being fired.

Pre-work for #1936