### PR TITLE
fix: return width and height in the stats when we are using src=

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -4476,6 +4476,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.stats_.setBandwidthEstimate(estimate);
     }
 
+    if (this.loadMode_ == shaka.Player.LoadMode.SRC_EQUALS) {
+      this.stats_.setResolution(
+          /* width= */ element.videoWidth || NaN,
+          /* height= */ element.videoHeight || NaN);
+    }
+
     return this.stats_.getBlob();
   }
 

--- a/test/player_src_equals_integration.js
+++ b/test/player_src_equals_integration.js
@@ -305,6 +305,8 @@ describe('Player Src Equals', () => {
     expect(stats.loadLatency).toBeGreaterThan(0);
     expect(stats.manifestTimeSeconds).toBeNaN(); // There's no manifest.
     expect(stats.drmTimeSeconds).toBeNaN(); // There's no DRM.
+    expect(stats.height).toBe(110);
+    expect(stats.width).toBe(258);
   });
 
   it('plays with external text tracks', async () => {


### PR DESCRIPTION
related to https://github.com/shaka-project/shaka-player/issues/4434