### PR TITLE
chore: Clean up unused AES-128 failure paths

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -180,10 +180,6 @@ shaka.hls.HlsParser = class {
      */
     this.groupIdToClosedCaptionsMap_ = new Map();
 
-    /** True if some of the variants in  the playlist is encrypted with AES-128.
-     * @private {boolean} */
-    this.aesEncrypted_ = false;
-
     /** @private {Map.<string, string>} */
     this.groupIdToCodecsMap_ = new Map();
 
@@ -651,17 +647,6 @@ shaka.hls.HlsParser = class {
       this.syncStreamsWithSequenceNumber_();
     } else {
       this.syncStreamsWithProgramDateTime_();
-    }
-
-    if (this.aesEncrypted_ && variants.length == 0) {
-      // We do not support AES-128 encryption with HLS yet. Variants is null
-      // when the playlist is encrypted with AES-128.
-      shaka.log.info('No stream is created, because we don\'t support AES-128',
-          'encryption yet');
-      throw new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.MANIFEST,
-          shaka.util.Error.Code.HLS_AES_128_ENCRYPTION_NOT_SUPPORTED);
     }
 
     // Find the min and max timestamp of the earliest segment in all streams.
@@ -1609,6 +1594,8 @@ shaka.hls.HlsParser = class {
     }
 
     let encrypted = false;
+    let aesEncrypted = false;
+
     /** @type {!Array.<shaka.extern.DrmInfo>}*/
     const drmInfos = [];
     const keyIds = new Set();
@@ -1621,7 +1608,7 @@ shaka.hls.HlsParser = class {
 
         if (method == 'AES-128') {
           // These keys are handled separately.
-          this.aesEncrypted_ = true;
+          aesEncrypted = true;
         } else {
           const keyFormat = drmTag.getRequiredAttrValue('KEYFORMAT');
           const drmParser =
@@ -1642,7 +1629,7 @@ shaka.hls.HlsParser = class {
       }
     }
 
-    if (encrypted && !drmInfos.length && !this.aesEncrypted_) {
+    if (encrypted && !drmInfos.length && !aesEncrypted) {
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MANIFEST,

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -656,11 +656,7 @@ shaka.util.Error.Code = {
    */
   'CANNOT_ADD_EXTERNAL_TEXT_TO_LIVE_STREAM': 4033,
 
-  /**
-   * We do not support AES-128 encryption with HLS yet.
-   */
-  'HLS_AES_128_ENCRYPTION_NOT_SUPPORTED': 4034,
-
+  // RETIRED: 'HLS_AES_128_ENCRYPTION_NOT_SUPPORTED': 4034,
   // RETIRED: 'HLS_INTERNAL_SKIP_STREAM': 4035,
 
   /** The Manifest contained no Variants. */


### PR DESCRIPTION
Now that we support AES-128, some older AES-128 code paths in the HLS
parser have become obsolete.  This cleans up those unneeded code paths
and adds a test to ensure that the correct failure handling is used
when AES-128 cannot be supported by the platform.