### PR TITLE
fix: Fix bitmap-based cue size

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -493,6 +493,14 @@ shaka.text.UITextDisplayer = class {
       style.backgroundRepeat = 'no-repeat';
       style.backgroundSize = 'contain';
       style.backgroundPosition = 'center';
+
+      // Quoting https://www.w3.org/TR/ttml-imsc1.2/:
+      // "The width and height (in pixels) of the image resource referenced by
+      // smpte:backgroundImage SHALL be equal to the width and height expressed
+      // by the tts:extent attribute of the region in which the div element is
+      // presented".
+      style.width = '100%';
+      style.height = '100%';
     } else {
       // If we have both text and nested cues, then style everything; otherwise
       // place the text in its own <span> so the background doesn't fill the


### PR DESCRIPTION
Without an explicit size, some platforms render bitmap-based cues as
0x0.  This effect was seen in Chrome on Mac in particular.  This
started with PR #4412, where we factored out regions into their own
element.

The TTML spec says that background images should fill their associated
region, so this fixes the issue by making the div explicitly the size
of its parent element (100% x 100%).