### PR TITLE
[DO NOT MERGE] DRM integration test for maintaining MediaKeySession across reload

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -33,8 +33,10 @@ shaka.media.DrmEngine = class {
   /**
    * @param {shaka.media.DrmEngine.PlayerInterface} playerInterface
    * @param {number=} updateExpirationTime
+   * @param {shaka.media.MediaKeysData=} mediaKeysData
    */
-  constructor(playerInterface, updateExpirationTime = 1) {
+  constructor(playerInterface, updateExpirationTime = 1,
+      mediaKeysData = {mediaKeysInstance: null, activeSessions: null}) {
     /** @private {?shaka.media.DrmEngine.PlayerInterface} */
     this.playerInterface_ = playerInterface;
 
@@ -42,7 +44,10 @@ shaka.media.DrmEngine = class {
     this.supportedTypes_ = new Set();
 
     /** @private {MediaKeys} */
-    this.mediaKeys_ = null;
+    this.mediaKeys_ = mediaKeysData.mediaKeysInstance;
+
+    /** @private {boolean} */
+    this.externalMediaKeys_ = Boolean(mediaKeysData.mediaKeysInstance);
 
     /** @private {HTMLMediaElement} */
     this.video_ = null;
@@ -66,7 +71,8 @@ shaka.media.DrmEngine = class {
      * @private {!Map.<MediaKeySession,
      *           shaka.media.DrmEngine.SessionMetaData>}
      */
-    this.activeSessions_ = new Map();
+    this.activeSessions_ = this.adaptExternalActiveSessions_(
+        mediaKeysData.activeSessions || new Map());
 
     /** @private {!Array.<string>} */
     this.offlineSessionIds_ = [];
@@ -76,6 +82,9 @@ shaka.media.DrmEngine = class {
 
     /** @private {?shaka.extern.DrmConfiguration} */
     this.config_ = null;
+
+    /** @private {boolean} */
+    this.shouldPreserveMediaKeySessions_ = false;
 
     /** @private {function(!shaka.util.Error)} */
     this.onError_ = (err) => {
@@ -818,6 +827,64 @@ shaka.media.DrmEngine = class {
     return Array.from(this.activeSessions_.keys());
   }
 
+  /**
+   * Get the MediaKeys and active Media Key Sessions
+   *
+   * @return {shaka.media.MediaKeysData}
+   */
+  getMediaKeysData() {
+    /** @type {Map<MediaKeySession, shaka.media.MediaKeySessionInitData>} */
+    const adaptedSessions = new Map();
+    const activeSessions = Array.from(this.activeSessions_.entries());
+    for (const [session, metadata] of activeSessions) {
+      adaptedSessions.set(session, {
+        initData: metadata.initData,
+        initDataType: metadata.initDataType,
+        type: metadata.type,
+      });
+    }
+    return {
+      mediaKeysInstance: this.mediaKeys_,
+      activeSessions: adaptedSessions,
+    };
+  }
+
+  /**
+   * Set whether the media key session is preserved on next destroy.
+   *
+   * @param {boolean} preserve
+   *   Whether the media key session should be preserved when drm engine is
+   *   destroyed.
+   */
+  setShouldPreserveMediaKeySessions(preserve) {
+    this.shouldPreserveMediaKeySessions_ = preserve;
+  }
+
+  /**
+   * Adapt external active session data
+   * @param {Map<MediaKeySession, shaka.media.MediaKeySessionInitData>} sessions
+   * @return {!Map.<MediaKeySession, shaka.media.DrmEngine.SessionMetaData>}
+   * @private
+   */
+  adaptExternalActiveSessions_(sessions) {
+    /** @type {!Map<MediaKeySession, shaka.media.DrmEngine.SessionMetaData>} */
+    const adaptedSessions = new Map();
+
+    const activeSessions = Array.from((sessions).entries());
+    for (const [session, initMetadata] of activeSessions) {
+      adaptedSessions.set(session, {
+        loaded: true,
+        initData: initMetadata.initData,
+        initDataType: initMetadata.initDataType,
+        session,
+        oldExpiration: Infinity,
+        type: initMetadata.type,
+        updatePromise: null,
+      });
+    }
+    return adaptedSessions;
+  }
+
 
   /**
    * @param {shaka.extern.Stream} stream
@@ -901,6 +968,11 @@ shaka.media.DrmEngine = class {
             shaka.util.Error.Category.DRM,
             shaka.util.Error.Code.NO_LICENSE_SERVER_GIVEN,
             this.currentDrmInfo_.keySystem);
+      }
+
+      if (this.externalMediaKeys_) {
+        this.initialized_ = true;
+        return;
       }
 
       const mediaKeys = await mediaKeySystemAccess.createMediaKeys();
@@ -1780,6 +1852,9 @@ shaka.media.DrmEngine = class {
 
   /** @private */
   async closeOpenSessions_() {
+    if (this.shouldPreserveMediaKeySessions_) {
+      return;
+    }
     // Close all open sessions.
     const openSessions = Array.from(this.activeSessions_.entries());
     this.activeSessions_.clear();
@@ -2387,6 +2462,42 @@ shaka.media.DrmEngine.SessionMetaData;
  *   Called when an event occurs that should be sent to the app.
  */
 shaka.media.DrmEngine.PlayerInterface;
+
+
+/**
+ * @typedef {{
+ *   initData: Uint8Array,
+ *   initDataType: ?string,
+ *   type: string
+ * }}
+ *
+ * @description The init data required for a given Media Key Session.
+ * @property {Uint8Array} initData
+ *   The init data used to create the session.
+ * @property {?string} initDataType
+ *   The init data type used to create the session.
+ * @property {string} type
+ *   The session type.
+ */
+shaka.media.MediaKeySessionInitData;
+
+
+/**
+ * @typedef {{
+ *   mediaKeysInstance: ?MediaKeys,
+ *   activeSessions: ?Map.<MediaKeySession, shaka.media.MediaKeySessionInitData>
+ * }}
+ *
+ * @property {?MediaKeys} mediaKeysInstance
+ *   A MediaKeys instance which can be provided and will be used instead of
+ *   creating a new instance in the DRM Engine.
+ * @property {
+ *   ?Map.<MediaKeySession, shaka.media.MediaKeySessionInitData>
+ * } activeSessions
+ *   A Map of active Media Key Sessions and their init data.
+ */
+shaka.media.MediaKeysData;
+
 
 /**
  * The amount of time, in seconds, we wait to consider a session closed.


### PR DESCRIPTION
This commit introduces an integration test that tries to prove that it is possible to maintain an active MediaKeySession from one media source to another. It is not intended that this gets merged into main branch. The hope is that this test can get run across a large breadth of devices in order to test whether this usage of MSE+EME is universally valid.

This is in relation to:
https://github.com/shaka-project/shaka-player/issues/4379