### PR TITLE
feat: allow reuse of persistent license sessions

### DIFF
--- a/docs/tutorials/drm-config.md
+++ b/docs/tutorials/drm-config.md
@@ -208,3 +208,64 @@ you should provide an empty string as robustness
 ##### Other key-systems
 
 Values for other key systems are not known to us at this time.
+
+#### Re-use persistent license DRM for online playback
+
+If your DRM provider configuration allows you to deliver persistent license,
+you could re-use the created MediaKeys session for the next online playback.
+
+Configure Shaka to start DRM sessions with the `persistent-license` type
+instead of the `temporary` one:
+
+```js
+player.configure({
+  drm: {
+    advanced: {
+      'com.widevine.alpha': {
+        'sessionType': 'persistent-license'
+      }
+    }
+  }
+});
+```
+
+**Using `persistent-license` might now work on every devices, use this feature
+carefully.**
+
+When the playback starts, you can retrieve the sessions metadata:
+
+```js
+const activeDrmSessions = this.player.getActiveSessionsMetadata();
+const persistentDrmSessions = activeDrmSessions.filter(
+  ({ sessionType }) => sessionType === 'persistent-license');
+
+// Add your own storage mechanism here, give it an unique known identifier for
+// the playing video
+```
+
+When starting the same video again, retrieve the metadata from the storage, and
+set it back to Shaka's configuration.
+
+Shaka will load the given DRM persistent sessions and will only request a
+license if some keys are missing for the content.
+
+```js
+player.configure({
+  drm: {
+    persistentSessionOnlinePlayback: true,
+    persistentSessionsMetadata: [{
+      sessionId: 'deadbeefdeadbeefdeadbeefdeadbeef',
+      initData: new InitData(0),
+      initDataType: 'cenc'
+    }]
+  }
+});
+```
+
+NB: Shaka doesn't provide a out-of-the-box storage mechanism for the sessions
+metadata.
+
+#### Continue the Tutorials
+
+Next, check out {@tutorial license-server-auth}.
+Or check out {@tutorial fairplay}.

--- a/docs/tutorials/drm-config.md
+++ b/docs/tutorials/drm-config.md
@@ -229,7 +229,7 @@ player.configure({
 });
 ```
 
-**Using `persistent-license` might now work on every devices, use this feature
+**Using `persistent-license` might not work on every devices, use this feature
 carefully.**
 
 When the playback starts, you can retrieve the sessions metadata:

--- a/externs/shaka/manifest.js
+++ b/externs/shaka/manifest.js
@@ -184,7 +184,6 @@ shaka.extern.InitDataOverride;
  */
 shaka.extern.DrmInfo;
 
-
 /**
  * @typedef {{
  *   id: number,

--- a/externs/shaka/manifest.js
+++ b/externs/shaka/manifest.js
@@ -184,6 +184,7 @@ shaka.extern.InitDataOverride;
  */
 shaka.extern.DrmInfo;
 
+
 /**
  * @typedef {{
  *   id: number,

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -687,6 +687,7 @@ shaka.extern.AdvancedDrmConfiguration;
  *   servers: !Object.<string, string>,
  *   clearKeys: !Object.<string, string>,
  *   delayLicenseRequestUntilPlayed: boolean,
+ *   persistentSessionOnlinePlayback: boolean,
  *   advanced: Object.<string, shaka.extern.AdvancedDrmConfiguration>,
  *   initDataTransform:
  *       ((function(!Uint8Array, string, ?shaka.extern.DrmInfo):!Uint8Array)|
@@ -713,6 +714,11 @@ shaka.extern.AdvancedDrmConfiguration;
  *   <i>Defaults to false.</i> <br>
  *   True to configure drm to delay sending a license request until a user
  *   actually starts playing content.
+ * @property {boolean} persistentSessionOnlinePlayback
+ *   <i>Defaults to false.</i> <br>
+ *   True to configure drm to try playback with given persistent session ids
+ *   before requesting a license. Also prevents the session removal at playback
+ *   stop, as-to be able to re-use it later.
  * @property {Object.<string, shaka.extern.AdvancedDrmConfiguration>} advanced
  *   <i>Optional.</i> <br>
  *   A dictionary which maps key system IDs to advanced DRM configuration for
@@ -935,11 +941,14 @@ shaka.extern.MssManifestConfiguration;
  *   segmentRelativeVttTiming: boolean,
  *   dash: shaka.extern.DashManifestConfiguration,
  *   hls: shaka.extern.HlsManifestConfiguration,
- *   mss: shaka.extern.MssManifestConfiguration
+ *   mss: shaka.extern.MssManifestConfiguration,
+ *   persistentSessionIds: !Array.<string>
  * }}
  *
  * @property {shaka.extern.RetryParameters} retryParameters
  *   Retry parameters for manifest requests.
+ * @property {!Array.<string>} persistentSessionIds
+ *   Persistent session ids to load before starting playback
  * @property {number} availabilityWindowOverride
  *   A number, in seconds, that overrides the availability window in the
  *   manifest, or <code>NaN</code> if the default value should be used.  This is

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -990,8 +990,7 @@ shaka.extern.MssManifestConfiguration;
  *   segmentRelativeVttTiming: boolean,
  *   dash: shaka.extern.DashManifestConfiguration,
  *   hls: shaka.extern.HlsManifestConfiguration,
- *   mss: shaka.extern.MssManifestConfiguration,
- *   persistentSessionIds: !Array.<string>
+ *   mss: shaka.extern.MssManifestConfiguration
  * }}
  *
  * @property {shaka.extern.RetryParameters} retryParameters

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -683,11 +683,58 @@ shaka.extern.AdvancedDrmConfiguration;
 
 /**
  * @typedef {{
+ *   sessionId: string,
+ *   sessionType: string,
+ *   initData: ?Uint8Array,
+ *   initDataType: ?string
+ * }}
+ *
+ * @description
+ * DRM Session Metadata for as session
+ *
+ * @property {string} sessionId
+ *   Session id
+ * @property {string} sessionType
+ *   Session type
+ * @property {?Uint8Array} initData
+ *   Initialization data in the format indicated by initDataType.
+ * @property {string} initDataType
+ *   A string to indicate what format initData is in.
+ * @exportDoc
+ */
+shaka.extern.DrmSessionMetadata;
+
+
+/**
+ * @typedef {{
+ *   sessionId: string,
+ *   initData: ?Uint8Array,
+ *   initDataType: ?string
+ * }}
+ *
+ * @description
+ * DRM Session Metadata for as session
+ *
+ * @property {string} sessionId
+ *   Session id
+ * @property {?Uint8Array} initData
+ *   Initialization data in the format indicated by initDataType.
+ * @property {?string} initDataType
+ *   A string to indicate what format initData is in.
+ * @exportDoc
+ */
+shaka.extern.PersistentSessionMetadata;
+
+
+/**
+ * @typedef {{
  *   retryParameters: shaka.extern.RetryParameters,
  *   servers: !Object.<string, string>,
  *   clearKeys: !Object.<string, string>,
  *   delayLicenseRequestUntilPlayed: boolean,
  *   persistentSessionOnlinePlayback: boolean,
+ *   persistentSessionsMetadata:
+ *       !Array.<shaka.extern.PersistentSessionMetadata>,
  *   advanced: Object.<string, shaka.extern.AdvancedDrmConfiguration>,
  *   initDataTransform:
  *       ((function(!Uint8Array, string, ?shaka.extern.DrmInfo):!Uint8Array)|
@@ -719,6 +766,8 @@ shaka.extern.AdvancedDrmConfiguration;
  *   True to configure drm to try playback with given persistent session ids
  *   before requesting a license. Also prevents the session removal at playback
  *   stop, as-to be able to re-use it later.
+ * @property {!Array.<PersistentSessionMetadata>} persistentSessionsMetadata
+ *   Persistent sessions metadata to load before starting playback
  * @property {Object.<string, shaka.extern.AdvancedDrmConfiguration>} advanced
  *   <i>Optional.</i> <br>
  *   A dictionary which maps key system IDs to advanced DRM configuration for
@@ -947,8 +996,6 @@ shaka.extern.MssManifestConfiguration;
  *
  * @property {shaka.extern.RetryParameters} retryParameters
  *   Retry parameters for manifest requests.
- * @property {!Array.<string>} persistentSessionIds
- *   Persistent session ids to load before starting playback
  * @property {number} availabilityWindowOverride
  *   A number, in seconds, that overrides the availability window in the
  *   manifest, or <code>NaN</code> if the default value should be used.  This is

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -690,7 +690,7 @@ shaka.extern.AdvancedDrmConfiguration;
  * }}
  *
  * @description
- * DRM Session Metadata for as session
+ * DRM Session Metadata for an active session
  *
  * @property {string} sessionId
  *   Session id
@@ -713,7 +713,7 @@ shaka.extern.DrmSessionMetadata;
  * }}
  *
  * @description
- * DRM Session Metadata for as session
+ * DRM Session Metadata for saved persistent session
  *
  * @property {string} sessionId
  *   Session id

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -71,8 +71,11 @@ shaka.media.DrmEngine = class {
      */
     this.activeSessions_ = new Map();
 
-    /** @private {!Array.<string>} */
-    this.offlineSessionIds_ = [];
+    /**
+     * @private {!Map<string,
+     *           {initData: ?Uint8Array, initDataType: ?string}>}
+     */
+    this.storedPersistentSessions_ = new Map();
 
     /** @private {!shaka.util.PublicPromise} */
     this.allSessionsLoaded_ = new shaka.util.PublicPromise();
@@ -184,7 +187,7 @@ shaka.media.DrmEngine = class {
     this.currentDrmInfo_ = null;
     this.supportedTypes_.clear();
     this.mediaKeys_ = null;
-    this.offlineSessionIds_ = [];
+    this.storedPersistentSessions_ = new Map();
     this.config_ = null;
     this.onError_ = () => {};
     this.playerInterface_ = null;
@@ -228,7 +231,7 @@ shaka.media.DrmEngine = class {
     //  2. We are about to remove the offline sessions for this manifest - in
     //     that case, we don't need to know about them right now either as
     //     we will be told which ones to remove later.
-    this.offlineSessionIds_ = [];
+    this.storedPersistentSessions_ = new Map();
 
     // What we really need to know is whether or not they are expecting to use
     // persistent licenses.
@@ -246,8 +249,20 @@ shaka.media.DrmEngine = class {
    * @return {!Promise}
    */
   initForPlayback(variants, offlineSessionIds) {
-    this.offlineSessionIds_ = offlineSessionIds;
-    this.usePersistentLicenses_ = offlineSessionIds.length > 0;
+    this.storedPersistentSessions_ = new Map();
+
+    for (const sessionId of offlineSessionIds) {
+      this.storedPersistentSessions_.set(
+          sessionId, {initData: null, initDataType: null});
+    }
+
+    for (const metadata of this.config_.persistentSessionsMetadata) {
+      this.storedPersistentSessions_.set(
+          metadata.sessionId,
+          {initData: metadata.initData, initDataType: metadata.initDataType});
+    }
+
+    this.usePersistentLicenses_ = this.storedPersistentSessions_.size > 0;
 
     return this.init_(variants);
   }
@@ -301,7 +316,7 @@ shaka.media.DrmEngine = class {
   /**
    * Negotiate for a key system and set up MediaKeys.
    * This will assume that both |usePersistentLicences_| and
-   * |offlineSessionIds_| have been properly set.
+   * |storedPersistentSessions_| have been properly set.
    *
    * @param {!Array.<shaka.extern.Variant>} variants
    *    The variants that we expect to operate with during the drm engine's
@@ -493,7 +508,7 @@ shaka.media.DrmEngine = class {
      */
     if (manifestInitData ||
         this.currentDrmInfo_.keySystem !== 'com.apple.fps' ||
-        this.offlineSessionIds_.length) {
+        this.storedPersistentSessions_.size) {
       await this.attachMediaKeys_();
     }
 
@@ -504,7 +519,7 @@ shaka.media.DrmEngine = class {
     // Also suppress 'encrypted' events when parsing in-band ppsh
     // from media segments because that serves the same purpose as the
     // 'encrypted' events.
-    if (!manifestInitData && !this.offlineSessionIds_.length &&
+    if (!manifestInitData && !this.storedPersistentSessions_.size &&
         !this.config_.parseInbandPsshEnabled) {
       this.eventManager_.listen(
           this.video_, 'encrypted', (e) => this.onEncryptedEvent_(e));
@@ -592,7 +607,8 @@ shaka.media.DrmEngine = class {
     goog.asserts.assert(this.mediaKeys_,
         'Must call init() before removeSession');
 
-    const session = await this.loadOfflineSession_(sessionId);
+    const session = await this.loadOfflineSession_(
+        sessionId, {initData: null, initDataType: null});
 
     // This will be null on error, such as session not found.
     if (!session) {
@@ -626,11 +642,10 @@ shaka.media.DrmEngine = class {
    * @return {!Promise}
    */
   async createOrLoad() {
-    if (this.offlineSessionIds_.length) {
-      // Load each session.
-      for (const sessionId of this.offlineSessionIds_) {
-        this.loadOfflineSession_(sessionId);
-      }
+    if (this.storedPersistentSessions_.size) {
+      this.storedPersistentSessions_.forEach((metadata, sessionId) => {
+        this.loadOfflineSession_(sessionId, metadata);
+      });
 
       await this.allSessionsLoaded_;
 
@@ -659,7 +674,7 @@ shaka.media.DrmEngine = class {
 
     // If we have no sessions, we need to resolve the promise right now or else
     // it will never get resolved.
-    if (!initDatas.length && !this.offlineSessionIds_.length) {
+    if (!initDatas.length) {
       this.allSessionsLoaded_.resolve();
     }
 
@@ -785,6 +800,28 @@ shaka.media.DrmEngine = class {
 
     // TODO: Make |getSessionIds| return |Iterable| instead of |Array|.
     return Array.from(ids);
+  }
+
+  /**
+   * Returns the active sessions metadata
+   *
+   * @return {!Array.<shaka.extern.DrmSessionMetadata>}
+   */
+  getActiveSessionsMetadata() {
+    const sessions = this.activeSessions_.keys();
+
+    const metadata = shaka.util.Iterables.map(sessions, (session) => {
+      const metadata = this.activeSessions_.get(session);
+
+      return {
+        sessionId: session.sessionId,
+        sessionType: metadata.type,
+        initData: metadata.initData,
+        initDataType: metadata.initDataType,
+      };
+    });
+
+    return Array.from(metadata);
   }
 
   /**
@@ -1207,10 +1244,11 @@ shaka.media.DrmEngine = class {
 
   /**
    * @param {string} sessionId
+   * @param {{initData: ?Uint8Array, initDataType: ?string}} sessionMetadata
    * @return {!Promise.<MediaKeySession>}
    * @private
    */
-  async loadOfflineSession_(sessionId) {
+  async loadOfflineSession_(sessionId, sessionMetadata) {
     let session;
 
     const sessionType = 'persistent-license';
@@ -1234,24 +1272,9 @@ shaka.media.DrmEngine = class {
     this.eventManager_.listen(session, 'keystatuseschange',
         (event) => this.onKeyStatusesChange_(event));
 
-    let initData = null;
-    let initDataType = null;
-
-    // Our persistent license sessions should cover the initData already
-    // advertised up in the manifest / currentDrmInfo_. We set up initData to
-    // prevent other processes to try and load new key sessions.
-    // If the persistent session doesn't cover the keys asked in the initData,
-    // DRMEngine will start a new key session.
-    if (this.currentDrmInfo_ && this.currentDrmInfo_.initData.length > 0) {
-      const initDataOverride = this.currentDrmInfo_.initData[0];
-
-      initData = initDataOverride.initData;
-      initDataType = initDataOverride.initDataType;
-    }
-
     const metadata = {
-      initData,
-      initDataType,
+      initData: sessionMetadata.initData,
+      initDataType: sessionMetadata.initDataType,
       loaded: false,
       oldExpiration: Infinity,
       updatePromise: null,
@@ -1879,7 +1902,7 @@ shaka.media.DrmEngine = class {
          * the playback session ends
          */
         if (!this.initializedForStorage_ &&
-            !this.offlineSessionIds_.includes(session.sessionId) &&
+            !this.storedPersistentSessions_.has(session.sessionId) &&
             metadata.type === 'persistent-license' &&
             !this.config_.persistentSessionOnlinePlayback) {
           shaka.log.v1('Removing session', session.sessionId);

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -85,7 +85,10 @@ shaka.media.DrmEngine = class {
 
     /** @private {function(!shaka.util.Error)} */
     this.onError_ = (err) => {
-      this.allSessionsLoaded_.reject(err);
+      if (err.severity == shaka.util.Error.Severity.CRITICAL) {
+        this.allSessionsLoaded_.reject(err);
+      }
+
       playerInterface.onError(err);
     };
 
@@ -1246,6 +1249,34 @@ shaka.media.DrmEngine = class {
   }
 
   /**
+   * Resolves the allSessionsLoaded_ promise when all the sessions are loaded
+   *
+   * @private
+   */
+  checkSessionsLoaded_() {
+    if (this.areAllSessionsLoaded_()) {
+      this.allSessionsLoaded_.resolve();
+    }
+  }
+
+  /**
+   * In case there are no key statuses, consider this session loaded
+   * after a reasonable timeout.  It should definitely not take 5
+   * seconds to process a license.
+   * @param {!shaka.media.DrmEngine.SessionMetaData} metadata
+   * @private
+   */
+  setLoadSessionTimeoutTimer_(metadata) {
+    const timer = new shaka.util.Timer(() => {
+      metadata.loaded = true;
+      this.checkSessionsLoaded_();
+    });
+
+    timer.tickAfter(
+        /* seconds= */ shaka.media.DrmEngine.SESSION_LOAD_TIMEOUT_);
+  }
+
+  /**
    * @param {string} sessionId
    * @param {{initData: ?Uint8Array, initDataType: ?string}} sessionMetadata
    * @return {!Promise.<MediaKeySession>}
@@ -1293,21 +1324,20 @@ shaka.media.DrmEngine = class {
       if (!present) {
         this.activeSessions_.delete(session);
 
-        if (this.config_.persistentSessionOnlinePlayback) {
-          shaka.log.warning('Persistent session', sessionId, 'not available');
-        } else {
-          this.onError_(new shaka.util.Error(
-              shaka.util.Error.Severity.CRITICAL,
-              shaka.util.Error.Category.DRM,
-              shaka.util.Error.Code.OFFLINE_SESSION_REMOVED));
+        const severity = this.config_.persistentSessionOnlinePlayback ?
+            shaka.util.Error.Severity.RECOVERABLE :
+            shaka.util.Error.Severity.CRITICAL;
 
-          return Promise.resolve();
-        }
+        this.onError_(new shaka.util.Error(
+            severity,
+            shaka.util.Error.Category.DRM,
+            shaka.util.Error.Code.OFFLINE_SESSION_REMOVED));
+
+        metadata.loaded = true;
       }
 
-      if (this.areAllSessionsLoaded_()) {
-        this.allSessionsLoaded_.resolve();
-      }
+      this.setLoadSessionTimeoutTimer_(metadata);
+      this.checkSessionsLoaded_();
 
       return session;
     } catch (error) {
@@ -1315,12 +1345,21 @@ shaka.media.DrmEngine = class {
 
       this.activeSessions_.delete(session);
 
+      const severity = this.config_.persistentSessionOnlinePlayback ?
+          shaka.util.Error.Severity.RECOVERABLE :
+          shaka.util.Error.Severity.CRITICAL;
+
       this.onError_(new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
+          severity,
           shaka.util.Error.Category.DRM,
           shaka.util.Error.Code.FAILED_TO_CREATE_SESSION,
           error.message));
+
+      metadata.loaded = true;
+
+      this.checkSessionsLoaded_();
     }
+
     return Promise.resolve();
   }
 
@@ -1546,18 +1585,8 @@ shaka.media.DrmEngine = class {
       if (metadata.updatePromise) {
         metadata.updatePromise.resolve();
       }
-      // In case there are no key statuses, consider this session loaded
-      // after a reasonable timeout.  It should definitely not take 5
-      // seconds to process a license.
-      const timer = new shaka.util.Timer(() => {
-        metadata.loaded = true;
-        if (this.areAllSessionsLoaded_()) {
-          this.allSessionsLoaded_.resolve();
-        }
-      });
 
-      timer.tickAfter(
-          /* seconds= */ shaka.media.DrmEngine.SESSION_LOAD_TIMEOUT_);
+      this.setLoadSessionTimeoutTimer_(metadata);
     }
   }
 

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -625,18 +625,36 @@ shaka.media.DrmEngine = class {
    *
    * @return {!Promise}
    */
-  createOrLoad() {
-    // Create temp sessions.
+  async createOrLoad() {
+    if (this.offlineSessionIds_.length) {
+      // Load each session.
+      for (const sessionId of this.offlineSessionIds_) {
+        this.loadOfflineSession_(sessionId);
+      }
+
+      await this.allSessionsLoaded_;
+
+      const keyIds = (this.currentDrmInfo_ && this.currentDrmInfo_.keyIds) ||
+          new Set([]);
+
+      // All the needed keys are already loaded, we don't need another license
+      // Therefore we prevent starting a new session
+      if (keyIds.size > 0 && this.areAllKeysUsable_()) {
+        return this.allSessionsLoaded_;
+      }
+
+      // Reset the promise for the next sessions to come if key needs aren't
+      // satisfied with persistent sessions
+      this.allSessionsLoaded_ = new shaka.util.PublicPromise();
+      this.allSessionsLoaded_.catch(() => {});
+    }
+
+    // Create sessions.
     const initDatas =
         (this.currentDrmInfo_ ? this.currentDrmInfo_.initData : []) || [];
     for (const initDataOverride of initDatas) {
       this.newInitData(
           initDataOverride.initDataType, initDataOverride.initData);
-    }
-
-    // Load each session.
-    for (const sessionId of this.offlineSessionIds_) {
-      this.loadOfflineSession_(sessionId);
     }
 
     // If we have no sessions, we need to resolve the promise right now or else
@@ -1216,9 +1234,24 @@ shaka.media.DrmEngine = class {
     this.eventManager_.listen(session, 'keystatuseschange',
         (event) => this.onKeyStatusesChange_(event));
 
+    let initData = null;
+    let initDataType = null;
+
+    // Our persistent license sessions should cover the initData already
+    // advertised up in the manifest / currentDrmInfo_. We set up initData to
+    // prevent other processes to try and load new key sessions.
+    // If the persistent session doesn't cover the keys asked in the initData,
+    // DRMEngine will start a new key session.
+    if (this.currentDrmInfo_ && this.currentDrmInfo_.initData.length > 0) {
+      const initDataOverride = this.currentDrmInfo_.initData[0];
+
+      initData = initDataOverride.initData;
+      initDataType = initDataOverride.initDataType;
+    }
+
     const metadata = {
-      initData: null,
-      initDataType: null,
+      initData,
+      initDataType,
       loaded: false,
       oldExpiration: Infinity,
       updatePromise: null,
@@ -1234,16 +1267,18 @@ shaka.media.DrmEngine = class {
       if (!present) {
         this.activeSessions_.delete(session);
 
-        this.onError_(new shaka.util.Error(
-            shaka.util.Error.Severity.CRITICAL,
-            shaka.util.Error.Category.DRM,
-            shaka.util.Error.Code.OFFLINE_SESSION_REMOVED));
-        return Promise.resolve();
+        if (this.config_.persistentSessionOnlinePlayback) {
+          shaka.log.warning('Persistent session', sessionId, 'not available');
+        } else {
+          this.onError_(new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.DRM,
+              shaka.util.Error.Code.OFFLINE_SESSION_REMOVED));
+
+          return Promise.resolve();
+        }
       }
 
-      // TODO: We should get a key status change event.  Remove once Chrome CDM
-      // is fixed.
-      metadata.loaded = true;
       if (this.areAllSessionsLoaded_()) {
         this.allSessionsLoaded_.resolve();
       }
@@ -1845,7 +1880,8 @@ shaka.media.DrmEngine = class {
          */
         if (!this.initializedForStorage_ &&
             !this.offlineSessionIds_.includes(session.sessionId) &&
-            metadata.type === 'persistent-license') {
+            metadata.type === 'persistent-license' &&
+            !this.config_.persistentSessionOnlinePlayback) {
           shaka.log.v1('Removing session', session.sessionId);
 
           await session.remove();
@@ -2017,6 +2053,25 @@ shaka.media.DrmEngine = class {
   areAllSessionsLoaded_() {
     const metadatas = this.activeSessions_.values();
     return shaka.util.Iterables.every(metadatas, (data) => data.loaded);
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  areAllKeysUsable_() {
+    const keyIds = (this.currentDrmInfo_ && this.currentDrmInfo_.keyIds) ||
+        new Set([]);
+
+    for (const keyId of keyIds) {
+      const status = this.keyStatusByKeyId_.get(keyId);
+
+      if (status !== 'usable') {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -512,7 +512,10 @@ shaka.media.DrmEngine = class {
       await this.attachMediaKeys_();
     }
 
-    this.createOrLoad();
+    this.createOrLoad().catch(() => {
+      // Silence errors
+      // createOrLoad will run async, errors are triggered through onError_
+    });
 
     // Explicit init data for any one stream or an offline session is
     // sufficient to suppress 'encrypted' events for all streams.

--- a/lib/player.js
+++ b/lib/player.js
@@ -1999,9 +1999,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     this.drmEngine_.configure(this.config_.drm);
 
+    const persistentSessionIds = this.manifest_.offlineSessionIds.concat(
+        this.config_.manifest.persistentSessionIds);
+
     await this.drmEngine_.initForPlayback(
         this.manifest_.variants,
-        this.manifest_.offlineSessionIds);
+        persistentSessionIds);
 
     await this.drmEngine_.attach(has.mediaElement);
 
@@ -3657,6 +3660,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    */
   getExpiration() {
     return this.drmEngine_ ? this.drmEngine_.getExpiration() : Infinity;
+  }
+
+  /**
+   * Get the ID of the DRM sessions currently active.
+   *
+   * @return {!Array<string>}
+   * @export
+   */
+  getSessionIds() {
+    return this.drmEngine_ ? this.drmEngine_.getSessionIds() : [];
   }
 
   /**

--- a/lib/player.js
+++ b/lib/player.js
@@ -1999,12 +1999,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     this.drmEngine_.configure(this.config_.drm);
 
-    const persistentSessionIds = this.manifest_.offlineSessionIds.concat(
-        this.config_.manifest.persistentSessionIds);
-
     await this.drmEngine_.initForPlayback(
         this.manifest_.variants,
-        persistentSessionIds);
+        this.manifest_.offlineSessionIds);
 
     await this.drmEngine_.attach(has.mediaElement);
 
@@ -3663,13 +3660,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   }
 
   /**
-   * Get the ID of the DRM sessions currently active.
+   * Returns the active sessions metadata
    *
-   * @return {!Array<string>}
+   * @return {!Array.<shaka.extern.DrmSessionMetadata>}
    * @export
    */
-  getSessionIds() {
-    return this.drmEngine_ ? this.drmEngine_.getSessionIds() : [];
+  getActiveSessionsMetadata() {
+    return this.drmEngine_ ? this.drmEngine_.getActiveSessionsMetadata() : [];
   }
 
   /**

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -858,7 +858,8 @@ shaka.util.Error.Code = {
   'NO_LICENSE_SERVER_GIVEN': 6012,
 
   /**
-   * A required offline session was removed.  The content is not playable.
+   * A required offline session was removed. The content might not be playable
+   * depending of the playback context.
    */
   'OFFLINE_SESSION_REMOVED': 6013,
 

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -69,6 +69,7 @@ shaka.util.PlayerConfiguration = class {
       advanced: {},    // key is arbitrary key system ID, value is a record type
       delayLicenseRequestUntilPlayed: false,
       persistentSessionOnlinePlayback: false,
+      persistentSessionsMetadata: [],
       initDataTransform: (initData, initDataType, drmInfo) => {
         const keySystem = drmInfo.keySystem;
         if (keySystem == 'com.apple.fps.1_0' && initDataType == 'skd') {
@@ -106,7 +107,6 @@ shaka.util.PlayerConfiguration = class {
       disableVideo: false,
       disableText: false,
       disableThumbnails: false,
-      persistentSessionIds: [],
       defaultPresentationDelay: 0,
       segmentRelativeVttTiming: false,
       dash: {

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -68,6 +68,7 @@ shaka.util.PlayerConfiguration = class {
       clearKeys: {},  // key is arbitrary key system ID, value must be string
       advanced: {},    // key is arbitrary key system ID, value is a record type
       delayLicenseRequestUntilPlayed: false,
+      persistentSessionOnlinePlayback: false,
       initDataTransform: (initData, initDataType, drmInfo) => {
         const keySystem = drmInfo.keySystem;
         if (keySystem == 'com.apple.fps.1_0' && initDataType == 'skd') {
@@ -105,6 +106,7 @@ shaka.util.PlayerConfiguration = class {
       disableVideo: false,
       disableText: false,
       disableThumbnails: false,
+      persistentSessionIds: [],
       defaultPresentationDelay: 0,
       segmentRelativeVttTiming: false,
       dash: {

--- a/test/cast/cast_utils_unit.js
+++ b/test/cast/cast_utils_unit.js
@@ -25,6 +25,7 @@ describe('CastUtils', () => {
       'getManifest', // Too large to proxy
       'getManifestParserFactory',  // Would not serialize.
       'setVideoContainer',
+      'getActiveSessionsMetadata',
 
       // Test helper methods (not @export'd)
       'createDrmEngine',

--- a/test/demo/demo_unit.js
+++ b/test/demo/demo_unit.js
@@ -97,7 +97,9 @@ describe('Demo', () => {
           .add('manifest.hls.mediaPlaylistFullMimeType')
           .add('manifest.mss.keySystemsBySystemId')
           .add('drm.keySystemsMapping')
-          .add('streaming.parsePrftBox');
+          .add('streaming.parsePrftBox')
+          .add('drm.persistentSessionOnlinePlayback')
+          .add('drm.persistentSessionsMetadata');
 
       /**
        * @param {!Object} section

--- a/test/media/drm_engine_unit.js
+++ b/test/media/drm_engine_unit.js
@@ -135,6 +135,7 @@ describe('DrmEngine', () => {
   });
 
   afterEach(async () => {
+    console.warn('AFTER EACH');
     await drmEngine.destroy();
 
     navigator.requestMediaKeySystemAccess =
@@ -1095,6 +1096,151 @@ describe('DrmEngine', () => {
           shaka.util.Error.Code.FAILED_TO_GENERATE_LICENSE_REQUEST,
           message, nativeError, undefined));
     });
+
+    // it('should throw a OFFLINE_SESSION_REMOVED error', async () => {
+    //   // Given persistent session is not available
+    //   session1.load.and.returnValue(false);
+
+    //   onErrorSpy.and.stub();
+
+    //   await drmEngine.initForPlayback(
+    //       manifest.variants, ['persistent-session-id']);
+    //   await drmEngine.attach(mockVideo);
+
+    //   expect(drmEngine.initialized()).toBe(true);
+
+    //   await Util.shortDelay();
+
+    //   expect(mockMediaKeys.createSession).toHaveBeenCalledTimes(1);
+    //   expect(mockMediaKeys.createSession)
+    //       .toHaveBeenCalledWith('persistent-license');
+    //   expect(session1.load).toHaveBeenCalledWith('persistent-session-id');
+
+    //   expect(onErrorSpy).toHaveBeenCalled();
+    //   const error = onErrorSpy.calls.argsFor(0)[0];
+    //   shaka.test.Util.expectToEqualError(error, new shaka.util.Error(
+    //       shaka.util.Error.Severity.CRITICAL,
+    //       shaka.util.Error.Category.DRM,
+    //       shaka.util.Error.Code.OFFLINE_SESSION_REMOVED));
+    // });
+
+    it('uses persistent session ids when available', async () => {
+      const Uint8ArrayUtils = shaka.util.Uint8ArrayUtils;
+
+      const keyId1 = makeKeyId(1);
+      const keyId2 = makeKeyId(2);
+
+      /** @type {!Uint8Array} */
+      const initData1 = new Uint8Array(5);
+
+      // Key IDs in manifest
+      tweakDrmInfos((drmInfos) => {
+        drmInfos[0].keyIds = new Set([
+          Uint8ArrayUtils.toHex(keyId1), Uint8ArrayUtils.toHex(keyId2),
+        ]);
+        drmInfos[0].initData = [
+          {initData: initData1, initDataType: 'cenc', keyId: null},
+        ];
+      });
+
+      // Given persistent session is available
+      session1.load.and.returnValue(true);
+
+      manifest.offlineSessionIds = ['persistent-session-id'];
+      config.persistentSessionOnlinePlayback = true;
+
+      drmEngine.configure(config);
+
+      await initAndAttach();
+
+      await Util.shortDelay();
+
+      session1.keyStatuses.forEach.and.callFake((callback) => {
+        callback(keyId1, 'usable');
+        callback(keyId2, 'usable');
+      });
+
+      session1.on['keystatuseschange']({target: session1});
+
+      expect(mockMediaKeys.createSession).toHaveBeenCalledTimes(1);
+      expect(mockMediaKeys.createSession)
+          .toHaveBeenCalledWith('persistent-license');
+      expect(session1.load).toHaveBeenCalledWith('persistent-session-id');
+
+      expect(session2.generateRequest).not.toHaveBeenCalled();
+    });
+
+    it(
+        'tries persistent session ids before requesting a license',
+        async () => {
+          const Uint8ArrayUtils = shaka.util.Uint8ArrayUtils;
+
+          const keyId1 = makeKeyId(1);
+
+          /** @type {!Uint8Array} */
+          const initData1 = new Uint8Array(5);
+
+          // Key IDs in manifest
+          tweakDrmInfos((drmInfos) => {
+            drmInfos[0].keyIds = new Set([
+              Uint8ArrayUtils.toHex(keyId1),
+            ]);
+            drmInfos[0].sessionType = 'temporary';
+            drmInfos[0].initData = [
+              {initData: initData1, initDataType: 'cenc', keyId: null},
+            ];
+          });
+
+          // Given persistent sessions aren't available
+          session1.load.and.returnValue(Promise.resolve(false));
+          session2.load.and.returnValue(Promise.resolve(false));
+
+          manifest.offlineSessionIds =
+              ['persistent-session-id-1', 'persistent-session-id-2'];
+          config.persistentSessionOnlinePlayback = true;
+
+          drmEngine.configure(config);
+
+          await initAndAttach();
+
+          await Util.shortDelay();
+
+          // We need to go through the whole license request / update,
+          // otherwise the DrmEngine will be destroyed while waiting for
+          // sessions to be marked as loaded, throwing an unhandled exception
+          const operation = shaka.util.AbortableOperation.completed(
+              new Uint8Array(0));
+          fakeNetEngine.request.and.returnValue(operation);
+
+          session3.on['message']({
+            target: session3,
+            message: new Uint8Array(0),
+            messageType: 'license-request'});
+
+          session3.keyStatuses.forEach.and.callFake((callback) => {
+            callback(keyId1, 'usable');
+          });
+
+          session3.on['keystatuseschange']({target: session3});
+
+          await Util.shortDelay();
+
+          expect(mockMediaKeys.createSession).toHaveBeenCalledTimes(3);
+          expect(mockMediaKeys.createSession)
+              .toHaveBeenCalledWith('persistent-license');
+          expect(session1.load)
+              .toHaveBeenCalledWith('persistent-session-id-1');
+
+          expect(mockMediaKeys.createSession)
+              .toHaveBeenCalledWith('persistent-license');
+          expect(session2.load)
+              .toHaveBeenCalledWith('persistent-session-id-2');
+
+          expect(mockMediaKeys.createSession)
+              .toHaveBeenCalledWith('temporary');
+          expect(session3.generateRequest)
+              .toHaveBeenCalledWith('cenc', initData1);
+        });
   });  // describe('attach')
 
   describe('events', () => {
@@ -1631,6 +1777,31 @@ describe('DrmEngine', () => {
       expect(session2.close).not.toHaveBeenCalled();
       expect(session2.remove).toHaveBeenCalled();
     });
+
+    it(
+        // eslint-disable-next-line max-len
+        'tears down & does not remove active persistent sessions based on configuration flag',
+        async () => {
+          config.advanced['drm.abc'] = createAdvancedConfig(null);
+          config.advanced['drm.abc'].sessionType = 'persistent-license';
+          config.persistentSessionOnlinePlayback = true;
+
+          drmEngine.configure(config);
+
+          await initAndAttach();
+          await sendEncryptedEvent('cenc', new Uint8Array(2));
+
+          const message = new Uint8Array(0);
+          session1.on['message']({target: session1, message: message});
+          session1.update.and.returnValue(Promise.resolve());
+
+          await shaka.test.Util.shortDelay();
+          mockVideo.setMediaKeys.calls.reset();
+          await drmEngine.destroy();
+
+          expect(session1.close).toHaveBeenCalled();
+          expect(session1.remove).not.toHaveBeenCalled();
+        });
 
     it('swallows errors when closing sessions', async () => {
       await initAndAttach();

--- a/test/media/drm_engine_unit.js
+++ b/test/media/drm_engine_unit.js
@@ -135,7 +135,6 @@ describe('DrmEngine', () => {
   });
 
   afterEach(async () => {
-    console.warn('AFTER EACH');
     await drmEngine.destroy();
 
     navigator.requestMediaKeySystemAccess =
@@ -1146,8 +1145,11 @@ describe('DrmEngine', () => {
       // Given persistent session is available
       session1.load.and.returnValue(true);
 
-      manifest.offlineSessionIds = ['persistent-session-id'];
       config.persistentSessionOnlinePlayback = true;
+      config.persistentSessionsMetadata = [{
+        sessionId: 'persistent-session-id',
+        initData: initData1,
+        initDataType: 'cenc'}];
 
       drmEngine.configure(config);
 
@@ -1195,8 +1197,12 @@ describe('DrmEngine', () => {
           session1.load.and.returnValue(Promise.resolve(false));
           session2.load.and.returnValue(Promise.resolve(false));
 
-          manifest.offlineSessionIds =
-              ['persistent-session-id-1', 'persistent-session-id-2'];
+          manifest.offlineSessionIds = ['persistent-session-id-1'];
+
+          config.persistentSessionsMetadata = [{
+            sessionId: 'persistent-session-id-2',
+            initData: initData1,
+            initDataType: 'cenc'}];
           config.persistentSessionOnlinePlayback = true;
 
           drmEngine.configure(config);

--- a/test/media/drm_engine_unit.js
+++ b/test/media/drm_engine_unit.js
@@ -1096,32 +1096,32 @@ describe('DrmEngine', () => {
           message, nativeError, undefined));
     });
 
-    // it('should throw a OFFLINE_SESSION_REMOVED error', async () => {
-    //   // Given persistent session is not available
-    //   session1.load.and.returnValue(false);
+    it('should throw a OFFLINE_SESSION_REMOVED error', async () => {
+      // Given persistent session is not available
+      session1.load.and.returnValue(false);
 
-    //   onErrorSpy.and.stub();
+      onErrorSpy.and.stub();
 
-    //   await drmEngine.initForPlayback(
-    //       manifest.variants, ['persistent-session-id']);
-    //   await drmEngine.attach(mockVideo);
+      await drmEngine.initForPlayback(
+          manifest.variants, ['persistent-session-id']);
+      await drmEngine.attach(mockVideo);
 
-    //   expect(drmEngine.initialized()).toBe(true);
+      expect(drmEngine.initialized()).toBe(true);
 
-    //   await Util.shortDelay();
+      await Util.shortDelay();
 
-    //   expect(mockMediaKeys.createSession).toHaveBeenCalledTimes(1);
-    //   expect(mockMediaKeys.createSession)
-    //       .toHaveBeenCalledWith('persistent-license');
-    //   expect(session1.load).toHaveBeenCalledWith('persistent-session-id');
+      expect(mockMediaKeys.createSession).toHaveBeenCalledTimes(1);
+      expect(mockMediaKeys.createSession)
+          .toHaveBeenCalledWith('persistent-license');
+      expect(session1.load).toHaveBeenCalledWith('persistent-session-id');
 
-    //   expect(onErrorSpy).toHaveBeenCalled();
-    //   const error = onErrorSpy.calls.argsFor(0)[0];
-    //   shaka.test.Util.expectToEqualError(error, new shaka.util.Error(
-    //       shaka.util.Error.Severity.CRITICAL,
-    //       shaka.util.Error.Category.DRM,
-    //       shaka.util.Error.Code.OFFLINE_SESSION_REMOVED));
-    // });
+      expect(onErrorSpy).toHaveBeenCalled();
+      const error = onErrorSpy.calls.argsFor(0)[0];
+      shaka.test.Util.expectToEqualError(error, new shaka.util.Error(
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.DRM,
+          shaka.util.Error.Code.OFFLINE_SESSION_REMOVED));
+    });
 
     it('uses persistent session ids when available', async () => {
       const Uint8ArrayUtils = shaka.util.Uint8ArrayUtils;

--- a/test/offline/storage_integration.js
+++ b/test/offline/storage_integration.js
@@ -1751,7 +1751,8 @@ filterDescribe('Storage', storageSupport, () => {
    * @suppress {accessControls}
    */
   function loadOfflineSession(drmEngine, sessionName) {
-    return drmEngine.loadOfflineSession_(sessionName);
+    return drmEngine.loadOfflineSession_(
+        sessionName, {initData: null, initDataType: null});
   }
 
   /**


### PR DESCRIPTION
Add capability to re-use persistent license sessions across sessions.

DrmEngine will now always:
- try to start stored persistent sessions before trying to fetch a license, as-to be able to check if all needed keys are already loaded.
- ask for a new license when the persistent session doesn't have the needed keys for playback,

Given the flag `persistentSessionOnlinePlayback` is true, DrmEngine:
- won't remove the persistent session from the device at the end of the playback,
- won't throw an error when the persistent session isn't found on the device,

For now, it needs Shaka's users to persist session information by themselves (localStorage, IndexDB, ...) before giving it back for the next session. Still, it lays foundation to develop the feature to fully handling it on Shaka's side.

TBD:
- [x] Rename all `offlineSessionIds_` in DrmEngine to `storedPersistentSessionIds_` because we now use those in two different contexts, online / offline (and in comments too) (after full review to avoid noise over the feature)
- [ ] Rename `loadOfflineSession_` in DrmEngine to `loadStoredPersistentSession_` (after full review to avoid noise over the feature)
- [x] Add a public API to retrieve the session (ids and expiration) from DRM Engine if not already available
- [x] Refactor / Set up another way to give persistentSessionIds to also give associated initData with it
- [x] Test full offline to ensure no regressions
- [x] Document feature usage

Related to #1956