### PR TITLE
test: Disable XboxOne

### DIFF
--- a/build/shaka-lab.yaml
+++ b/build/shaka-lab.yaml
@@ -159,3 +159,4 @@ Tizen:
 
 XboxOne:
   browser: xboxone
+  disabled: true


### PR DESCRIPTION
Since we have been unable to solve #4234 (Xbox One disconnects from test runner), let's temporarily disable XboxOne from the lab to cut down on noise in our nightly tests.