### PR TITLE
ci: Auto-deflake nightly selenium tests

### DIFF
--- a/.github/workflows/deflake.yaml
+++ b/.github/workflows/deflake.yaml
@@ -1,0 +1,26 @@
+name: Deflake Tests
+
+# Runs when the Selenum nightly test workflow completes.  This will run with
+# full privileges, even if the other workflow doesn't.  That allows us to
+# trigger re-runs if we think the results might be flaky.
+on:
+  workflow_run:
+    workflows: [Selenium Lab Tests]
+    types: [completed]
+
+jobs:
+  deflake:
+    if: ${{ github.event.workflow_run.event == 'schedule' && github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check run count and re-run workflow
+        run: |
+          gh api /repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }} > run.json
+          RUNS=$(jq -r .run_attempt < run.json)
+          if [[ "$RUNS" -lt 3 ]]; then
+            echo "$RUNS failed runs so far; re-running workflow."
+            gh run rerun ${{ github.event.workflow_run.id }} --failed -R ${{ github.repository }}
+          else
+            echo "$RUNS failed runs so far; not re-running workflow."
+          fi


### PR DESCRIPTION
This workflow will trigger after the nightly Selenium tests.  If those tests failed, this "deflake" workflow will automatically re-run the failed jobs up to 3 times (total, including the original scheduled run).

This should help cut down on noise and help highlight actual platform-specific failures.  The flakiness of our tests and infrastructure will be tracked separately and addressed at a somewhat lower priority than test greenness.