### PR TITLE
fix: Fix HLS dynamic to static transition

### DIFF
--- a/externs/shaka/manifest_parser.js
+++ b/externs/shaka/manifest_parser.js
@@ -111,7 +111,8 @@ shaka.extern.ManifestParser = class {
  *   onError: function(!shaka.util.Error),
  *   isLowLatencyMode: function():boolean,
  *   isAutoLowLatencyMode: function():boolean,
- *   enableLowLatencyMode: function()
+ *   enableLowLatencyMode: function(),
+ *   updateDuration: function()
  * }}
  *
  * @description
@@ -147,6 +148,8 @@ shaka.extern.ManifestParser = class {
  *   Return true if auto low latency streaming mode is enabled.
  * @property {function()} enableLowLatencyMode
  *   Enable low latency streaming mode.
+ * @property {function()} updateDuration
+ *   Update the presentation duration based on PresentationTimeline.
  * @exportDoc
  */
 shaka.extern.ManifestParser.PlayerInterface;

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -284,6 +284,21 @@ shaka.hls.HlsParser = class {
     }
 
     await Promise.all(updates);
+
+    this.notifySegments_();
+
+    // If any hasEndList is false, the stream is still live.
+    const stillLive = streamInfos.some((s) => s.hasEndList == false);
+    if (!stillLive) {
+      // Convert the presentation to VOD and set the duration.
+      const PresentationType = shaka.hls.HlsParser.PresentationType_;
+      this.setPresentationType_(PresentationType.VOD);
+
+      const maxTimestamps = streamInfos.map((s) => s.maxTimestamp);
+      // The duration is the minimum of the end times of all streams.
+      this.presentationTimeline_.setDuration(Math.min(...maxTimestamps));
+      this.playerInterface_.updateDuration();
+    }
   }
 
   /**
@@ -294,7 +309,6 @@ shaka.hls.HlsParser = class {
    * @private
    */
   async updateStream_(streamInfo) {
-    const PresentationType = shaka.hls.HlsParser.PresentationType_;
     const manifestUri = streamInfo.absoluteMediaPlaylistUri;
     const uriObj = new goog.Uri(manifestUri);
     if (this.lowLatencyMode_ && streamInfo.canSkipSegments) {
@@ -327,6 +341,7 @@ shaka.hls.HlsParser = class {
         streamInfo.verbatimMediaPlaylistUri, playlist, stream.type,
         stream.mimeType, streamInfo.mediaSequenceToStartTime, mediaVariables,
         stream.codecs);
+    this.segmentsToNotifyByStream_.push(segments);
 
     stream.segmentIndex.mergeAndEvict(
         segments, this.presentationTimeline_.getSegmentAvailabilityStart());
@@ -347,10 +362,10 @@ shaka.hls.HlsParser = class {
         shaka.hls.Utils.getFirstTagWithName(playlist.tags, 'EXT-X-ENDLIST');
 
     if (endListTag) {
-      // Convert the presentation to VOD and set the duration to the last
-      // segment's end time.
-      this.setPresentationType_(PresentationType.VOD);
-      this.presentationTimeline_.setDuration(newestSegment.endTime);
+      // Flag this for later.  We don't convert the whole presentation into VOD
+      // until we've seen the ENDLIST tag for all active playlists.
+      streamInfo.hasEndList = true;
+      streamInfo.maxTimestamp = newestSegment.endTime;
     }
   }
 
@@ -1711,6 +1726,7 @@ shaka.hls.HlsParser = class {
       maxTimestamp: lastEndTime,
       mediaSequenceToStartTime,
       canSkipSegments,
+      hasEndList: false,
     };
   }
 
@@ -2561,8 +2577,11 @@ shaka.hls.HlsParser = class {
     try {
       await this.update();
 
-      const delay = this.updatePlaylistDelay_;
-      this.updatePlaylistTimer_.tickAfter(/* seconds= */ delay);
+      // This may have converted to VOD, in which case we stop updating.
+      if (this.isLive_()) {
+        const delay = this.updatePlaylistDelay_;
+        this.updatePlaylistTimer_.tickAfter(/* seconds= */ delay);
+      }
     } catch (error) {
       // Detect a call to stop() during this.update()
       if (!this.playerInterface_) {
@@ -2780,7 +2799,8 @@ shaka.hls.HlsParser = class {
  *   absoluteMediaPlaylistUri: string,
  *   maxTimestamp: number,
  *   mediaSequenceToStartTime: !Map.<number, number>,
- *   canSkipSegments: boolean
+ *   canSkipSegments: boolean,
+ *   hasEndList: boolean
  * }}
  *
  * @description
@@ -2803,6 +2823,8 @@ shaka.hls.HlsParser = class {
  * @property {boolean} canSkipSegments
  *  True if the server supports delta playlist updates, and we can send a
  *  request for a playlist that can skip older media segments.
+ * @property {boolean} hasEndList
+ *  True if the stream has an EXT-X-ENDLIST tag.
  */
 shaka.hls.HlsParser.StreamInfo;
 

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -849,21 +849,25 @@ shaka.media.MediaSourceEngine = class {
   }
 
   /**
-   * We only support increasing duration at this time.  Decreasing duration
-   * causes the MSE removal algorithm to run, which results in an 'updateend'
-   * event.  Supporting this scenario would be complicated, and is not currently
-   * needed.
-   *
    * @param {number} duration
    * @return {!Promise}
    */
   async setDuration(duration) {
-    goog.asserts.assert(
-        isNaN(this.mediaSource_.duration) ||
-            this.mediaSource_.duration <= duration,
-        'duration cannot decrease: ' + this.mediaSource_.duration + ' -> ' +
-            duration);
     await this.enqueueBlockingOperation_(() => {
+      // Reducing the duration causes the MSE removal algorithm to run, which
+      // triggers an 'updateend' event to fire.  To handle this scenario, we
+      // have to insert a dummy operation into the beginning of each queue,
+      // which the 'updateend' handler will remove.
+      if (duration < this.mediaSource_.duration) {
+        for (const contentType in this.sourceBuffers_) {
+          const dummyOperation = {
+            start: () => {},
+            p: new shaka.util.PublicPromise(),
+          };
+          this.queues_[contentType].unshift(dummyOperation);
+        }
+      }
+
       this.mediaSource_.duration = duration;
     });
   }

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -774,7 +774,7 @@ shaka.media.StreamingEngine = class {
         this.manifest_.sequenceMode);
     this.destroyer_.ensureNotDestroyed();
 
-    this.setDuration_();
+    this.updateDuration();
 
     for (const type of streamsByType.keys()) {
       const stream = streamsByType.get(type);
@@ -824,9 +824,8 @@ shaka.media.StreamingEngine = class {
 
   /**
    * Sets the MediaSource's duration.
-   * @private
    */
-  setDuration_() {
+  updateDuration() {
     const duration = this.manifest_.presentationTimeline.getDuration();
     if (duration < Infinity) {
       this.playerInterface_.mediaSourceEngine.setDuration(duration);

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -1169,6 +1169,7 @@ shaka.offline.Storage = class {
       isLowLatencyMode: () => false,
       isAutoLowLatencyMode: () => false,
       enableLowLatencyMode: () => {},
+      updateDuration: () => {},
     };
 
     parser.configure(config.manifest);

--- a/lib/player.js
+++ b/lib/player.js
@@ -1785,6 +1785,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       enableLowLatencyMode: () => {
         this.configure('streaming.lowLatencyMode', true);
       },
+      updateDuration: () => {
+        if (this.streamingEngine_) {
+          this.streamingEngine_.updateDuration();
+        }
+      },
     };
 
     const startTime = Date.now() / 1000;

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -43,6 +43,7 @@ describe('DashParser ContentProtection', () => {
       isLowLatencyMode: () => false,
       isAutoLowLatencyMode: () => false,
       enableLowLatencyMode: () => {},
+      updateDuration: () => {},
     };
 
     const actual = await dashParser.start(

--- a/test/dash/dash_parser_live_unit.js
+++ b/test/dash/dash_parser_live_unit.js
@@ -36,6 +36,7 @@ describe('DashParser Live', () => {
       isLowLatencyMode: () => false,
       isAutoLowLatencyMode: () => false,
       enableLowLatencyMode: () => {},
+      updateDuration: () => {},
     };
   });
 

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -52,6 +52,7 @@ describe('DashParser Manifest', () => {
       isLowLatencyMode: () => false,
       isAutoLowLatencyMode: () => false,
       enableLowLatencyMode: () => {},
+      updateDuration: () => {},
     };
   });
 

--- a/test/dash/dash_parser_segment_base_unit.js
+++ b/test/dash/dash_parser_segment_base_unit.js
@@ -38,6 +38,7 @@ describe('DashParser SegmentBase', () => {
       isLowLatencyMode: () => false,
       isAutoLowLatencyMode: () => false,
       enableLowLatencyMode: () => {},
+      updateDuration: () => {},
     };
   });
 

--- a/test/dash/dash_parser_segment_list_unit.js
+++ b/test/dash/dash_parser_segment_list_unit.js
@@ -348,6 +348,7 @@ describe('DashParser SegmentList', () => {
       isLowLatencyMode: () => false,
       isAutoLowLatencyMode: () => false,
       enableLowLatencyMode: () => {},
+      updateDuration: () => {},
     };
     const manifest = await dashParser.start('dummy://foo', playerInterface);
     const stream = manifest.variants[0].video;

--- a/test/dash/dash_parser_segment_template_unit.js
+++ b/test/dash/dash_parser_segment_template_unit.js
@@ -47,6 +47,7 @@ describe('DashParser SegmentTemplate', () => {
       isLowLatencyMode: () => false,
       isAutoLowLatencyMode: () => false,
       enableLowLatencyMode: () => {},
+      updateDuration: () => {},
     };
   });
 

--- a/test/hls/hls_live_unit.js
+++ b/test/hls/hls_live_unit.js
@@ -101,13 +101,11 @@ describe('HlsParser live', () => {
   /**
    * @param {string} master
    * @param {string} initialMedia
-   * @param {!Array} initialReferences
-   * @param {string} updatedMedia
-   * @param {!Array} updatedReferences
+   * @param {Array=} initialReferences
+   * @return {!Promise.<shaka.extern.Manifest>}
    */
-  async function testUpdate(
-      master, initialMedia, initialReferences, updatedMedia,
-      updatedReferences) {
+  async function testInitialManifest(
+      master, initialMedia, initialReferences=null) {
     fakeNetEngine
         .setResponseText('test:/master', master)
         .setResponseText('test:/video', initialMedia)
@@ -119,32 +117,52 @@ describe('HlsParser live', () => {
         .setResponseValue('test:/main2.mp4', segmentData)
         .setResponseValue('test:/main3.mp4', segmentData)
         .setResponseValue('test:/main4.mp4', segmentData)
+        .setResponseValue('test:/partial.mp4', segmentData)
+        .setResponseValue('test:/partial2.mp4', segmentData)
         .setResponseValue('test:/selfInit.mp4', selfInitializingSegmentData);
 
     const manifest = await parser.start('test:/master', playerInterface);
 
-    await Promise.all(manifest.variants.map(async (variant) => {
-      await variant.video.createSegmentIndex();
-      ManifestParser.verifySegmentIndex(variant.video, initialReferences);
-      if (variant.audio) {
-        await variant.audio.createSegmentIndex();
-        ManifestParser.verifySegmentIndex(variant.audio, initialReferences);
-      }
-    }));
+    if (initialReferences) {
+      await Promise.all(manifest.variants.map(async (variant) => {
+        await variant.video.createSegmentIndex();
 
+        // The compiler doesn't count null checks done outside this callback,
+        // so we need an assertion here.
+        goog.asserts.assert(initialReferences != null, 'references non-null');
+        ManifestParser.verifySegmentIndex(variant.video, initialReferences);
+
+        if (variant.audio) {
+          await variant.audio.createSegmentIndex();
+          ManifestParser.verifySegmentIndex(variant.audio, initialReferences);
+        }
+      }));
+    }
+
+    return manifest;
+  }
+
+  /**
+   * @param {shaka.extern.Manifest} manifest
+   * @param {string} updatedMedia
+   * @param {Array=} updatedReferences
+   */
+  async function testUpdate(manifest, updatedMedia, updatedReferences=null) {
     // Replace the entries with the updated values.
     fakeNetEngine
         .setResponseText('test:/video', updatedMedia)
         .setResponseText('test:/redirected/video', updatedMedia)
         .setResponseText('test:/video2', updatedMedia)
-        .setResponseText('test:/audio', updatedMedia)
-        .setResponseText('test:/video?_HLS_skip=YES', updatedMedia);
+        .setResponseText('test:/audio', updatedMedia);
 
     await delayForUpdatePeriod();
-    for (const variant of manifest.variants) {
-      ManifestParser.verifySegmentIndex(variant.video, updatedReferences);
-      if (variant.audio) {
-        ManifestParser.verifySegmentIndex(variant.audio, updatedReferences);
+
+    if (updatedReferences) {
+      for (const variant of manifest.variants) {
+        ManifestParser.verifySegmentIndex(variant.video, updatedReferences);
+        if (variant.audio) {
+          ManifestParser.verifySegmentIndex(variant.audio, updatedReferences);
+        }
       }
     }
   }
@@ -171,13 +189,8 @@ describe('HlsParser live', () => {
     ].join('');
 
     it('treats already ended presentation like VOD', async () => {
-      fakeNetEngine
-          .setResponseText('test:/master', master)
-          .setResponseText('test:/video', media + '#EXT-X-ENDLIST')
-          .setResponseValue('test:/init.mp4', initSegmentData)
-          .setResponseValue('test:/main.mp4', segmentData);
-
-      const manifest = await parser.start('test:/master', playerInterface);
+      const manifest = await testInitialManifest(
+          master, media + '#EXT-X-ENDLIST');
       expect(manifest.presentationTimeline.isLive()).toBe(false);
       expect(manifest.presentationTimeline.isInProgress()).toBe(false);
     });
@@ -189,8 +202,8 @@ describe('HlsParser live', () => {
         const ref2 = makeReference(
             'test:/main2.mp4', 2, 4, /* syncTime= */ null);
 
-        await testUpdate(
-            master, media, [ref1], mediaWithAdditionalSegment, [ref1, ref2]);
+        const manifest = await testInitialManifest(master, media, [ref1]);
+        await testUpdate(manifest, mediaWithAdditionalSegment, [ref1, ref2]);
       });
 
       it('updates all variants', async () => {
@@ -206,9 +219,9 @@ describe('HlsParser live', () => {
         const ref2 = makeReference(
             'test:/main2.mp4', 2, 4, /* syncTime= */ null);
 
-        await testUpdate(
-            masterWithTwoVariants, media, [ref1], mediaWithAdditionalSegment,
-            [ref1, ref2]);
+        const manifest = await testInitialManifest(
+            masterWithTwoVariants, media, [ref1]);
+        await testUpdate(manifest, mediaWithAdditionalSegment, [ref1, ref2]);
       });
 
       it('updates all streams', async () => {
@@ -229,9 +242,9 @@ describe('HlsParser live', () => {
         const ref2 = makeReference(
             'test:/main2.mp4', 2, 4, /* syncTime= */ null);
 
-        await testUpdate(
-            masterWithAudio, media, [ref1], mediaWithAdditionalSegment,
-            [ref1, ref2]);
+        const manifest = await testInitialManifest(
+            masterWithAudio, media, [ref1]);
+        await testUpdate(manifest, mediaWithAdditionalSegment, [ref1, ref2]);
       });
 
       it('handles multiple updates', async () => {
@@ -254,72 +267,28 @@ describe('HlsParser live', () => {
         const ref3 = makeReference(
             'test:/main3.mp4', 4, 6, /* syncTime= */ null);
 
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video', media)
-            .setResponseValue('test:/init.mp4', initSegmentData)
-            .setResponseValue('test:/main.mp4', segmentData);
-
-        const manifest = await parser.start('test:/master', playerInterface);
-
-        const video = manifest.variants[0].video;
-        await video.createSegmentIndex();
-        ManifestParser.verifySegmentIndex(video, [ref1]);
-
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video', updatedMedia1);
-
-        await delayForUpdatePeriod();
-        ManifestParser.verifySegmentIndex(video, [ref1, ref2]);
-
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video', updatedMedia2);
-
-        await delayForUpdatePeriod();
-        ManifestParser.verifySegmentIndex(video, [ref1, ref2, ref3]);
+        const manifest = await testInitialManifest(master, media, [ref1]);
+        await testUpdate(manifest, updatedMedia1, [ref1, ref2]);
+        await testUpdate(manifest, updatedMedia2, [ref1, ref2, ref3]);
       });
 
       it('converts presentation to VOD when it is finished', async () => {
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video', media)
-            .setResponseValue('test:/init.mp4', initSegmentData)
-            .setResponseValue('test:/main.mp4', segmentData);
-
-        const manifest = await parser.start('test:/master', playerInterface);
-
+        const manifest = await testInitialManifest(master, media);
         expect(manifest.presentationTimeline.isLive()).toBe(true);
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video',
-                mediaWithAdditionalSegment + '#EXT-X-ENDLIST\n');
 
-        await delayForUpdatePeriod();
+        await testUpdate(
+            manifest, mediaWithAdditionalSegment + '#EXT-X-ENDLIST\n');
         expect(manifest.presentationTimeline.isLive()).toBe(false);
       });
 
       it('starts presentation as VOD when ENDLIST is present', async () => {
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video', media + '#EXT-X-ENDLIST')
-            .setResponseValue('test:/init.mp4', initSegmentData)
-            .setResponseValue('test:/main.mp4', segmentData);
-
-        const manifest = await parser.start('test:/master', playerInterface);
+        const manifest = await testInitialManifest(
+            master, media + '#EXT-X-ENDLIST');
         expect(manifest.presentationTimeline.isLive()).toBe(false);
       });
 
       it('does not throw when interrupted by stop', async () => {
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video', media)
-            .setResponseValue('test:/init.mp4', initSegmentData)
-            .setResponseValue('test:/main.mp4', segmentData);
-
-        const manifest = await parser.start('test:/master', playerInterface);
-
+        const manifest = await testInitialManifest(master, media);
         expect(manifest.presentationTimeline.isLive()).toBe(true);
 
         // Block the next request so that update() is still happening when we
@@ -414,47 +383,27 @@ describe('HlsParser live', () => {
     ].join('');
 
     it('starts presentation as VOD when ENDLIST is present', async () => {
-      fakeNetEngine
-          .setResponseText('test:/master', master)
-          .setResponseText('test:/video', media + '#EXT-X-ENDLIST')
-          .setResponseValue('test:/init.mp4', initSegmentData)
-          .setResponseValue('test:/main.mp4', segmentData);
-
-      const manifest = await parser.start('test:/master', playerInterface);
+      const manifest = await testInitialManifest(
+          master, media + '#EXT-X-ENDLIST');
       expect(manifest.presentationTimeline.isLive()).toBe(false);
     });
 
     it('does not fail on a missing sequence number', async () => {
-      fakeNetEngine
-          .setResponseText('test:/master', master)
-          .setResponseText('test:/video', mediaWithoutSequenceNumber)
-          .setResponseValue('test:/init.mp4', initSegmentData)
-          .setResponseValue('test:/main.mp4', segmentData);
-
-      await parser.start('test:/master', playerInterface);
+      await testInitialManifest(master, mediaWithoutSequenceNumber);
     });
 
     it('sets presentation delay as configured', async () => {
-      fakeNetEngine
-          .setResponseText('test:/master', master)
-          .setResponseText('test:/video', media)
-          .setResponseValue('test:/init.mp4', initSegmentData)
-          .setResponseValue('test:/main.mp4', segmentData);
       config.defaultPresentationDelay = 10;
       parser.configure(config);
-      const manifest = await parser.start('test:/master', playerInterface);
+
+      const manifest = await testInitialManifest(master, media);
       expect(manifest.presentationTimeline.getDelay()).toBe(
           config.defaultPresentationDelay);
     });
 
     it('sets 3 times target duration as presentation delay if not configured',
         async () => {
-          fakeNetEngine
-              .setResponseText('test:/master', master)
-              .setResponseText('test:/video', media)
-              .setResponseValue('test:/init.mp4', initSegmentData)
-              .setResponseValue('test:/main.mp4', segmentData);
-          const manifest = await parser.start('test:/master', playerInterface);
+          const manifest = await testInitialManifest(master, media);
           expect(manifest.presentationTimeline.getDelay()).toBe(15);
         });
 
@@ -470,15 +419,9 @@ describe('HlsParser live', () => {
         'main.mp4\n',
       ].join('');
 
-      fakeNetEngine
-          .setResponseText('test:/master', master)
-          .setResponseText('test:/video', mediaWithLowLatency)
-          .setResponseValue('test:/init.mp4', initSegmentData)
-          .setResponseValue('test:/main.mp4', segmentData);
-
       playerInterface.isLowLatencyMode = () => true;
 
-      const manifest = await parser.start('test:/master', playerInterface);
+      const manifest = await testInitialManifest(master, mediaWithLowLatency);
       // Presentation delay should be the value of 'PART-HOLD-BACK' if not
       // configured.
       expect(manifest.presentationTimeline.getDelay()).toBe(1.8);
@@ -486,13 +429,8 @@ describe('HlsParser live', () => {
 
     describe('availabilityWindowOverride', () => {
       async function testWindowOverride(expectedWindow) {
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video', mediaWithManySegments)
-            .setResponseValue('test:/init.mp4', initSegmentData)
-            .setResponseValue('test:/main.mp4', segmentData);
-
-        const manifest = await parser.start('test:/master', playerInterface);
+        const manifest = await testInitialManifest(
+            master, mediaWithManySegments);
         expect(manifest).toBeTruthy();
         const timeline = manifest.presentationTimeline;
         expect(timeline).toBeTruthy();
@@ -515,13 +453,6 @@ describe('HlsParser live', () => {
     });
 
     it('sets timestamp offset for segments with discontinuity', async () => {
-      fakeNetEngine
-          .setResponseText('test:/master', master)
-          .setResponseText('test:/video', mediaWithDiscontinuity)
-          .setResponseValue('test:/init.mp4', initSegmentData)
-          .setResponseValue('test:/main.mp4', segmentData)
-          .setResponseValue('test:/main2.mp4', segmentData);
-
       const ref1 = makeReference(
           'test:/main.mp4', 0, 2, /* syncTime= */ null,
           /* baseUri= */ '', /* startByte= */ 0, /* endByte= */ null,
@@ -534,10 +465,7 @@ describe('HlsParser live', () => {
           /* baseUri= */ '', /* startByte= */ 0, /* endByte= */ null,
           /* timestampOffset= */ 0);
 
-      const manifest = await parser.start('test:/master', playerInterface);
-      const video = manifest.variants[0].video;
-      await video.createSegmentIndex();
-      ManifestParser.verifySegmentIndex(video, [ref1, ref2]);
+      await testInitialManifest(master, mediaWithDiscontinuity, [ref1, ref2]);
     });
 
     // Test for https://github.com/shaka-project/shaka-player/issues/4223
@@ -562,14 +490,6 @@ describe('HlsParser live', () => {
         // preloadRef
         '#EXT-X-PRELOAD-HINT:TYPE=PART,URI="partial.mp4",BYTERANGE-START=210\n',
       ].join('');
-
-      fakeNetEngine
-          .setResponseText('test:/master', master)
-          .setResponseText('test:/video', mediaWithPartialSegments)
-          .setResponseValue('test:/init.mp4', initSegmentData)
-          .setResponseValue('test:/main.mp4', segmentData)
-          .setResponseValue('test:/partial.mp4', segmentData)
-          .setResponseValue('test:/partial2.mp4', segmentData);
 
       const partialRef = makeReference(
           'test:/partial.mp4', 0, 2, /* syncTime= */ null,
@@ -598,10 +518,7 @@ describe('HlsParser live', () => {
           /* baseUri= */ '', /* startByte= */ 0, /* endByte= */ null,
           /* timestampOffset= */ 0, [partialRef3, preloadRef]);
 
-      const manifest = await parser.start('test:/master', playerInterface);
-      const video = manifest.variants[0].video;
-      await video.createSegmentIndex();
-      ManifestParser.verifySegmentIndex(video, [ref, ref2]);
+      await testInitialManifest(master, mediaWithPartialSegments, [ref, ref2]);
     });
 
     // Test for https://github.com/shaka-project/shaka-player/issues/4223
@@ -624,14 +541,6 @@ describe('HlsParser live', () => {
         '#EXT-X-PRELOAD-HINT:TYPE=PART,URI="partial.mp4",BYTERANGE-START=210\n',
       ].join('');
 
-      fakeNetEngine
-          .setResponseText('test:/master', master)
-          .setResponseText('test:/video', mediaWithPartialSegments)
-          .setResponseValue('test:/init.mp4', initSegmentData)
-          .setResponseValue('test:/main.mp4', segmentData)
-          .setResponseValue('test:/partial.mp4', segmentData)
-          .setResponseValue('test:/partial2.mp4', segmentData);
-
       const ref = makeReference(
           'test:/main.mp4', 0, 4, /* syncTime= */ null,
           /* baseUri= */ '', /* startByte= */ 0, /* endByte= */ null,
@@ -647,10 +556,7 @@ describe('HlsParser live', () => {
           /* baseUri= */ '', /* startByte= */ 0, /* endByte= */ 209,
           /* timestampOffset= */ 0, [partialRef]);
 
-      const manifest = await parser.start('test:/master', playerInterface);
-      const video = manifest.variants[0].video;
-      await video.createSegmentIndex();
-      ManifestParser.verifySegmentIndex(video, [ref, ref2]);
+      await testInitialManifest(master, mediaWithPartialSegments, [ref, ref2]);
     });
 
     // Test for https://github.com/shaka-project/shaka-player/issues/4185
@@ -668,12 +574,8 @@ describe('HlsParser live', () => {
         '#EXT-X-PRELOAD-HINT:TYPE=PART,URI="partial.mp4",BYTERANGE-START=210\n',
       ].join('');
 
-      fakeNetEngine
-          .setResponseText('test:/master', master)
-          .setResponseText('test:/video', mediaWithPartialSegments);
-
       // If this throws, the test fails.  Otherwise, it passes.
-      await parser.start('test:/master', playerInterface);
+      await testInitialManifest(master, mediaWithPartialSegments);
     });
 
     describe('update', () => {
@@ -683,8 +585,8 @@ describe('HlsParser live', () => {
         const ref2 = makeReference(
             'test:/main2.mp4', 2, 4, /* syncTime= */ null);
 
-        await testUpdate(
-            master, media, [ref1], mediaWithAdditionalSegment, [ref1, ref2]);
+        const manifest = await testInitialManifest(master, media, [ref1]);
+        await testUpdate(manifest, mediaWithAdditionalSegment, [ref1, ref2]);
       });
 
       it('evicts removed segments', async () => {
@@ -693,9 +595,9 @@ describe('HlsParser live', () => {
         const ref2 = makeReference(
             'test:/main2.mp4', 2, 4, /* syncTime= */ null);
 
-        await testUpdate(
-            master, mediaWithAdditionalSegment, [ref1, ref2],
-            mediaWithRemovedSegment, [ref2]);
+        const manifest = await testInitialManifest(
+            master, mediaWithAdditionalSegment, [ref1, ref2]);
+        await testUpdate(manifest, mediaWithRemovedSegment, [ref2]);
       });
 
       it('handles updates with redirects', async () => {
@@ -720,58 +622,32 @@ describe('HlsParser live', () => {
           }
         });
 
+        const manifest = await testInitialManifest(master, media, [oldRef1]);
         await testUpdate(
-            master, media, [oldRef1], mediaWithAdditionalSegment,
-            [newRef1, newRef2]);
+            manifest, mediaWithAdditionalSegment, [newRef1, newRef2]);
       });
 
       it('parses start time from mp4 segments', async () => {
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video', media)
-            .setResponseValue('test:/init.mp4', initSegmentData)
-            .setResponseValue('test:/main.mp4', segmentData);
-
-        const expectedRef = makeReference(
+        const ref = makeReference(
             'test:/main.mp4', 0, 2, /* syncTime= */ null);
         // In live content, we do not set timestampOffset.
-        expectedRef.timestampOffset = 0;
+        ref.timestampOffset = 0;
 
-        const manifest = await parser.start('test:/master', playerInterface);
-        const video = manifest.variants[0].video;
-        await video.createSegmentIndex();
-        ManifestParser.verifySegmentIndex(video, [expectedRef]);
+        await testInitialManifest(master, media, [ref]);
       });
 
       it('gets start time on update without segment request', async () => {
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video', mediaWithAdditionalSegment)
-            .setResponseValue('test:/init.mp4', initSegmentData)
-            .setResponseValue('test:/main.mp4', segmentData);
-
         const ref1 = makeReference(
             'test:/main.mp4', 0, 2, /* syncTime= */ null);
 
         const ref2 = makeReference(
             'test:/main2.mp4', 2, 4, /* syncTime= */ null);
 
-        const manifest = await parser.start('test:/master', playerInterface);
-        const video = manifest.variants[0].video;
-        await video.createSegmentIndex();
-        ManifestParser.verifySegmentIndex(video, [ref1, ref2]);
-
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video', mediaWithRemovedSegment)
-            .setResponseValue('test:/init.mp4', initSegmentData)
-            .setResponseValue('test:/main.mp4', segmentData)
-            .setResponseValue('test:/main2.mp4', segmentData);
+        const manifest = await testInitialManifest(
+            master, mediaWithAdditionalSegment, [ref1, ref2]);
 
         fakeNetEngine.request.calls.reset();
-        await delayForUpdatePeriod();
-
-        ManifestParser.verifySegmentIndex(video, [ref2]);
+        await testUpdate(manifest, mediaWithRemovedSegment, [ref2]);
 
         // Only one request was made, and it was for the playlist.
         // No segment requests were needed to get the start time.
@@ -783,37 +659,17 @@ describe('HlsParser live', () => {
 
       it('reuses cached timestamp offset for segments with discontinuity',
           async () => {
-            fakeNetEngine
-                .setResponseText('test:/master', master)
-                .setResponseText('test:/video', mediaWithDiscontinuity)
-                .setResponseValue('test:/init.mp4', initSegmentData)
-                .setResponseValue('test:/main.mp4', segmentData)
-                .setResponseValue('test:/main2.mp4', segmentData);
-
             const ref1 = makeReference(
                 'test:/main.mp4', 0, 2, /* syncTime= */ null);
-
             const ref2 = makeReference(
                 'test:/main2.mp4', 2, 4, /* syncTime= */ null);
 
-            const manifest =
-                await parser.start('test:/master', playerInterface);
-
-            const video = manifest.variants[0].video;
-            await video.createSegmentIndex();
-            ManifestParser.verifySegmentIndex(video, [ref1, ref2]);
-
-            fakeNetEngine
-                .setResponseText('test:/master', master)
-                .setResponseText('test:/video',
-                    mediaWithUpdatedDiscontinuitySegment)
-                .setResponseValue('test:/init.mp4', initSegmentData)
-                .setResponseValue('test:/main2.mp4', segmentData);
+            const manifest = await testInitialManifest(
+                master, mediaWithDiscontinuity, [ref1, ref2]);
 
             fakeNetEngine.request.calls.reset();
-            await delayForUpdatePeriod();
-
-            ManifestParser.verifySegmentIndex(video, [ref2]);
+            await testUpdate(
+                manifest, mediaWithUpdatedDiscontinuitySegment, [ref2]);
 
             // Only one request should be made, and it's for the playlist.
             // Expect to use the cached timestamp offset for the main2.mp4
@@ -854,19 +710,12 @@ describe('HlsParser live', () => {
           'main3.mp4\n',
         ].join('');
 
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video', mediaWithDeltaUpdates)
-            .setResponseText('test:/video?_HLS_skip=YES',
-                mediaWithSkippedSegments)
-            .setResponseValue('test:/init.mp4', initSegmentData)
-            .setResponseValue('test:/main.mp4', segmentData)
-            .setResponseValue('test:/main2.mp4', segmentData)
-            .setResponseValue('test:/main3.mp4', segmentData);
+        fakeNetEngine.setResponseText(
+            'test:/video?_HLS_skip=YES', mediaWithSkippedSegments);
 
         playerInterface.isLowLatencyMode = () => true;
-        await parser.start('test:/master', playerInterface);
-        // Replace the entries with the updated values.
+
+        await testInitialManifest(master, mediaWithDeltaUpdates);
 
         fakeNetEngine.request.calls.reset();
         await delayForUpdatePeriod();
@@ -875,7 +724,6 @@ describe('HlsParser live', () => {
             'test:/video?_HLS_skip=YES',
             shaka.net.NetworkingEngine.RequestType.MANIFEST);
       });
-
 
       it('skips older segments', async () => {
         const mediaWithSkippedSegments = [
@@ -897,12 +745,15 @@ describe('HlsParser live', () => {
             'test:/main2.mp4', 2, 4, /* syncTime= */ null);
         const ref3 = makeReference(
             'test:/main3.mp4', 4, 6, /* syncTime= */ null);
+
+        const manifest = await testInitialManifest(
+            master, mediaWithAdditionalSegment, [ref1, ref2]);
+
         // With 'SKIPPED-SEGMENTS', ref1 is skipped from the playlist,
         // and ref1 should be in the SegmentReferences list.
         // ref3 should be appended to the SegmentReferences list.
         await testUpdate(
-            master, mediaWithAdditionalSegment, [ref1, ref2],
-            mediaWithSkippedSegments, [ref1, ref2, ref3]);
+            manifest, mediaWithSkippedSegments, [ref1, ref2, ref3]);
       });
 
       it('skips older segments with discontinuity', async () => {
@@ -960,12 +811,14 @@ describe('HlsParser live', () => {
             /* baseUri= */ '', /* startByte= */ 0, /* endByte= */ null,
             /* timestampOffset= */ 0);
 
+        const manifest = await testInitialManifest(
+            master, mediaWithDiscontinuity2, [ref1, ref2, ref3]);
+
         // With 'SKIPPED-SEGMENTS', ref1, ref2 are skipped from the playlist,
         // and ref1,ref2 should be in the SegmentReferences list.
         // ref3,ref4 should be appended to the SegmentReferences list.
         await testUpdate(
-            master, mediaWithDiscontinuity2, [ref1, ref2, ref3],
-            mediaWithSkippedSegments2, [ref1, ref2, ref3, ref4]);
+            manifest, mediaWithSkippedSegments2, [ref1, ref2, ref3, ref4]);
       });
     });  // describe('update')
   });  // describe('playlist type LIVE')

--- a/test/hls/hls_live_unit.js
+++ b/test/hls/hls_live_unit.js
@@ -77,6 +77,7 @@ describe('HlsParser live', () => {
       isLowLatencyMode: () => false,
       isAutoLowLatencyMode: () => false,
       enableLowLatencyMode: () => {},
+      updateDuration: () => {},
     };
 
     parser = new shaka.hls.HlsParser();

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -98,6 +98,7 @@ describe('HlsParser', () => {
       isLowLatencyMode: () => false,
       isAutoLowLatencyMode: () => false,
       enableLowLatencyMode: () => {},
+      updateDuration: () => {},
     };
 
     parser = new shaka.hls.HlsParser();

--- a/test/test/util/dash_parser_util.js
+++ b/test/test/util/dash_parser_util.js
@@ -43,6 +43,7 @@ shaka.test.Dash = class {
       isLowLatencyMode: () => false,
       isAutoLowLatencyMode: () => false,
       enableLowLatencyMode: () => {},
+      updateDuration: () => {},
     };
     const manifest = await dashParser.start('dummy://foo', playerInterface);
     const stream = manifest.variants[0].video;
@@ -77,6 +78,7 @@ shaka.test.Dash = class {
       isLowLatencyMode: () => false,
       isAutoLowLatencyMode: () => false,
       enableLowLatencyMode: () => {},
+      updateDuration: () => {},
     };
     const p = dashParser.start('dummy://foo', playerInterface);
     await expectAsync(p).toBeRejectedWith(


### PR DESCRIPTION
fix: Fix HLS dynamic to static transition

 - Keep maxSegmentEndTime_ updated in PresentationTimeline by calling
   notifySegments on each HLS playlist update, so that the seek range
   doesn't revert to the original playlist size when it becomes
   static.
 - Wait to change the presentation type to VOD until after _all_
   active playlists have an ENDLIST tag, to avoid missing the final
   segments in one type or the other.
 - Stop updating the playlists after transition to VOD.
 - Update the MSE duration at exactly the same time as we transition
   to VOD, to avoid a loophole where the UI knows it's VOD, but
   doesn't have any way to get the correct duration.  Previously, this
   state would persist until the final segments were appended.

Closes #4431