### PR TITLE
docs: Add support for documenting top-level enums

### DIFF
--- a/docs/jsdoc-template/tmpl/container.tmpl
+++ b/docs/jsdoc-template/tmpl/container.tmpl
@@ -144,7 +144,10 @@
                 return m.longname && m.longname.indexOf('module:') !== 0;
             });
         }
-        if (members && members.length && members.forEach) {
+
+        // Skip enums, since they already have their values listed under
+        // "Properties".
+        if (members && members.length && members.forEach && doc.kind != 'enum') {
     ?>
         <h3 class="subsection-title">Members</h3>
 

--- a/docs/jsdoc.conf.json
+++ b/docs/jsdoc.conf.json
@@ -16,6 +16,7 @@
       "navOrder": [
         "Tutorials",
         "Classes",
+        "Enums",
         "Interfaces",
         "Events"
       ]


### PR DESCRIPTION
Previously, top-level enums caused the generation of filenames like "shaka.config.html#AutoShowText" instead of
"shaka.config.AutoShowText.html".  This broke the generation of docs for top-level enums (attached to a namespace instead of a class).

This adds support for these into our jsdoc template.

Related to PR #3421