### PR TITLE
fix: Missing AES-128 key of last HLS segment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Giorgio Gamberoni <giorgio.gamberoni@gmail.com>
 Giuseppe Samela <giuseppe.samela@gmail.com>
 Google Inc. <*@google.com>
 Itay Kinnrot <Itay.Kinnrot@Kaltura.com>
+Jaeseok Lee <devsunb@gmail.com>
 Jason Palmer <jason@jason-palmer.com>
 Jesper Haug Karsrud <jesper.karsrud@gmail.com>
 Johan Sundström <oyasumi@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -57,6 +57,7 @@ Hichem Taoufik <hichem@code-it.fr>
 Itay Kinnrot <itay.kinnrot@kaltura.com>
 Isaac Ramirez <isaac.ramirez.herrera@gmail.com>
 Jacob Trimble <modmaker@google.com>
+Jaeseok Lee <devsunb@gmail.com>
 Jason Palmer <jason@jason-palmer.com>
 Jeffrey Swan <jeffdswan@gmail.com>
 Jesper Haug Karsrud <jesper.karsrud@gmail.com>

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -364,7 +364,10 @@ shaka.media.SegmentIndex = class {
             lastReference.partialReferences,
             lastReference.tilesLayout,
             lastReference.tileDuration,
-            lastReference.syncTime);
+            lastReference.syncTime,
+            /* status= */ shaka.media.SegmentReference.Status.AVAILABLE,
+            lastReference.hlsAes128Key,
+        );
   }
 
 

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -365,7 +365,7 @@ shaka.media.SegmentIndex = class {
             lastReference.tilesLayout,
             lastReference.tileDuration,
             lastReference.syncTime,
-            /* status= */ shaka.media.SegmentReference.Status.AVAILABLE,
+            lastReference.status,
             lastReference.hlsAes128Key,
         );
   }

--- a/test/media/segment_index_unit.js
+++ b/test/media/segment_index_unit.js
@@ -207,6 +207,25 @@ describe('SegmentIndex', /** @suppress {accessControls} */ () => {
       ];
       expect(index.references).toEqual(newReferences);
     });
+
+    it('preserves hls key of the last reference', () => {
+      // The hls key of the last segment should be preserved.
+      const references = [
+        makeReference(uri(0), 0, 5, [],
+            {method: 'AES-128', firstMediaSequenceNumber: 0}),
+        makeReference(uri(1), 5, 10, [],
+            {method: 'AES-128', firstMediaSequenceNumber: 0}),
+        makeReference(uri(2), 10, 15, [],
+            {method: 'AES-128', firstMediaSequenceNumber: 0}),
+      ];
+      const index = new shaka.media.SegmentIndex(references);
+      expect(index.references).toEqual(references);
+
+      index.fit(/* windowStart= */ 0, /* windowEnd= */ 10);
+      expect(
+          index.references[index.references.length - 1].hlsAes128Key,
+      ).toEqual({method: 'AES-128', firstMediaSequenceNumber: 0});
+    });
   });
 
   describe('merge', () => {
@@ -955,9 +974,11 @@ describe('SegmentIndex', /** @suppress {accessControls} */ () => {
    * @param {number} startTime
    * @param {number} endTime
    * @param {!Array.<!shaka.media.SegmentReference>=} partialReferences
+   * @param {?shaka.extern.HlsAes128Key=} hlsAes128Key
    * @return {shaka.media.SegmentReference}
    */
-  function makeReference(uri, startTime, endTime, partialReferences = []) {
+  function makeReference(uri, startTime, endTime, partialReferences = [],
+      hlsAes128Key = null) {
     return new shaka.media.SegmentReference(
         startTime,
         endTime,
@@ -968,6 +989,11 @@ describe('SegmentIndex', /** @suppress {accessControls} */ () => {
         /* timestampOffset= */ 0,
         /* appendWindowStart= */ 0,
         /* appendWindowEnd= */ Infinity,
-        /* partialReferences= */ partialReferences);
+        /* partialReferences= */ partialReferences,
+        /* tilesLayout= */ undefined,
+        /* tileDuration= */ undefined,
+        /* syncTime= */ undefined,
+        /* status= */ undefined,
+        /* hlsAes128Key= */ hlsAes128Key);
   }
 });


### PR DESCRIPTION
Closes #4517

## Problem

Fetching the last segment of HLS AES-128 stream fails with 3018 error
- `MediaSourceEngine` attempts to transmux encrypted TS data
- `StreamingEngine` does not decrypt TS data of the last segment
- `SegmentReference` of the last segment has `null` for `hlsAes128Key`
- `hlsAes128Key` is missing when adjusting the last SegmentReference in `SegmentIndex.fit()`

## Test

### Before

![2022-09-28 02-09-34](https://user-images.githubusercontent.com/23169202/192598313-2ea96859-2631-443c-89c7-b24cbdff859c.png)

### After

![2022-09-28 02-09-34](https://user-images.githubusercontent.com/23169202/192598422-aebf1fda-bc6e-429b-a3f4-f7c572fd1712.png)
