### PR TITLE
test: Be more generous with timeouts

### DIFF
--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -506,7 +506,7 @@ describe('Player', () => {
       // Seek the video, and see if it can continue playing from that point.
       video.currentTime = 20;
       // Expect that we can then reach the end of the video.
-      await waiter.timeoutAfter(20).waitForEnd(video);
+      await waiter.timeoutAfter(40).waitForEnd(video);
     });
 
     // Regression test for #2326.
@@ -857,7 +857,7 @@ describe('Player', () => {
       /** @type {shaka.test.Waiter} */
       const waiter = new shaka.test.Waiter(eventManager)
           .setPlayer(player)
-          .timeoutAfter(20)
+          .timeoutAfter(40)
           .failOnTimeout(true);
       await waiter.waitForEnd(video);
 


### PR DESCRIPTION
Some timeouts in Player integration tests seem a little too short. This seems to have caused an intermittent test failure in a recent PR.

This expands those timeouts a bit, specifically before waitForEnd() calls.