### PR TITLE
ci: Fix missing coverage data from integration tests

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -41,9 +41,11 @@ jobs:
         include:
           # Run Linux browsers with xvfb, so they're in a headless X session.
           # Additionally, generate a code coverage report from Linux Chrome.
+          # It should be the uncompiled build, or else we won't execute any
+          # coverage instrumentation on full-stack player integration tests.
           - os: ubuntu-latest
             browser: Chrome
-            extra_flags: "--use-xvfb --html-coverage-report"
+            extra_flags: "--use-xvfb --html-coverage-report --uncompiled"
           - os: ubuntu-latest
             browser: Firefox
             extra_flags: "--use-xvfb"

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -180,6 +180,15 @@ jobs:
       # the container.
       - name: Test Player
         run: |
+          # Generate a coverage report from uncompiled code on ChromeLinux.
+          # It should be the uncompiled build, or else we won't execute any
+          # coverage instrumentation on full-stack player integration tests.
+          if [[ "${{ matrix.browser }}" == "ChromeLinux" ]]; then
+            extra_flags="--html-coverage-report --uncompiled"
+          else
+            extra_flags=""
+          fi
+
           python3 build/test.py \
               --no-build \
               --reporters spec --spec-hide-passed \
@@ -189,7 +198,7 @@ jobs:
               --grid-config build/shaka-lab.yaml \
               --grid-address selenium-grid.lab:4444 \
               --browsers ${{ matrix.browser }} \
-              --html-coverage-report
+              $extra_flags
 
       - name: Find coverage report (ChromeLinux only)
         id: coverage


### PR DESCRIPTION
Player integration tests use the compiled bundle by default.  This prevents us from getting coverage data in these tests, since the instrumentation was added to the uncompiled library only.

By collecting coverage data in uncompiled mode, we can fix this.