### PR TITLE
fix: Fix hang when seeking to the last segment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,6 +70,7 @@ SameGoal Inc. <*@samegoal.com>
 Sanborn Hilland <sanbornh@rogers.com>
 Sander Saares <sander@saares.eu>
 Sanil Raut <sr1990003@gmail.com>
+Seongryun Jo <ocipap0531@gmail.com>
 Swank Motion Pictures Inc. <*@swankmp.com>
 TalkTalk Plc <*@talktalkplc.com>
 Tatsiana Gelahova <tatsiana.gelahova@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -105,6 +105,7 @@ Sandra Lokshina <ismena@google.com>
 Sanil Raut <sr1990003@gmail.com>
 Satheesh Velmurugan <satheesh@philo.com>
 Semih Gokceoglu <semih.gkcoglu@gmail.com>
+Seongryun Jo <ocipap0531@gmail.com>
 Seth Madison <seth@philo.com>
 Tatsiana Gelahova <tatsiana.gelahova@gmail.com>
 Theodore Abshire <theodab@google.com>

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1003,7 +1003,11 @@ shaka.media.StreamingEngine = class {
     const timeUntilEnd =
         this.manifest_.presentationTimeline.getDuration() - timeNeeded;
     const oneMicrosecond = 1e-6;
-    if (timeUntilEnd < oneMicrosecond) {
+
+    const bufferEnd =
+      this.playerInterface_.mediaSourceEngine.bufferEnd(mediaState.type);
+
+    if (timeUntilEnd < oneMicrosecond && !!bufferEnd) {
       // We shouldn't rebuffer if the playhead is close to the end of the
       // presentation.
       shaka.log.debug(logPrefix, 'buffered to end of presentation');
@@ -1033,8 +1037,6 @@ shaka.media.StreamingEngine = class {
       return this.config_.updateIntervalSeconds / 2;
     }
 
-    const bufferEnd =
-        this.playerInterface_.mediaSourceEngine.bufferEnd(mediaState.type);
     const reference = this.getSegmentReferenceNeeded_(
         mediaState, presentationTime, bufferEnd);
     if (!reference) {


### PR DESCRIPTION
### Problem

The player does not operate normally when the last segment seek in the hls. (Chrome)
The fetchAndAppend_ function does not appear to be running on the last segment.

https://user-images.githubusercontent.com/25482071/193399014-6fced3ee-5bd3-4c7e-87da-f4e010d794c0.mp4

1. Click test link.
https://shaka-player-demo.appspot.com/demo/#audiolang=en-US;textlang=en-US;uilang=en-US;asset=https://storage.googleapis.com/shaka-demo-assets/apple-advanced-stream-ts/master.m3u8;panel=ALL_CONTENT;panelData=HLS,MP2TS;build=compiled
2. Seek last segment.

