### PR TITLE
ci: Fix reporting status from lab tests to PRs

### DIFF
--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -98,6 +98,7 @@ jobs:
         uses: ./.github/workflows/custom-actions/set-commit-status
         with:
           context: Selenium / Build
+          ref: ${{ needs.compute-ref.REF }}
           state: pending
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -117,6 +118,7 @@ jobs:
         uses: ./.github/workflows/custom-actions/set-commit-status
         with:
           context: Selenium / Build
+          ref: ${{ needs.compute-ref.REF }}
           state: ${{ job.status }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -140,6 +142,7 @@ jobs:
         uses: ./.github/workflows/custom-actions/set-commit-status
         with:
           context: Selenium / ${{ matrix.browser }}
+          ref: ${{ needs.compute-ref.REF }}
           state: pending
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -245,5 +248,6 @@ jobs:
         uses: ./.github/workflows/custom-actions/set-commit-status
         with:
           context: Selenium / ${{ matrix.browser }}
+          ref: ${{ needs.compute-ref.REF }}
           state: ${{ job.status }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The status reports were targetting main instead of the PR's HEAD.