### PR TITLE
ci: Fix reporting status from lab tests to PRs

### DIFF
--- a/.github/workflows/custom-actions/set-commit-status/action.yaml
+++ b/.github/workflows/custom-actions/set-commit-status/action.yaml
@@ -11,10 +11,6 @@ inputs:
   state:
     description: Either "pending", "error", "success", or "failure".
     required: true
-  ref:
-    description: A git ref for which to set the commit status.  For PRs, use the head commit, not the merge commit.  Defaults to HEAD.
-    required: false
-    default: HEAD
   token:
     description: A GitHub access token.
     required: true
@@ -30,7 +26,7 @@ runs:
         # next to the status on the PR, it will link to this run where they can
         # see the logs.
         RUN_URL="https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
-        SHA1=$(git rev-parse "${{ inputs.ref }}")
+        SHA1=$(git rev-parse HEAD)
 
         GITHUB_TOKEN=${{ inputs.token }} \
         gh api \

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.compute-ref.REF }}
+          ref: ${{ needs.compute-ref.outputs.REF }}
 
       - name: Install dependencies
         run: npm ci
@@ -92,7 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.compute-ref.REF }}
+          ref: ${{ needs.compute-ref.outputs.REF }}
 
       - name: Set commit status to pending
         uses: ./.github/workflows/custom-actions/set-commit-status
@@ -134,7 +134,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ needs.compute-ref.REF }}
+          ref: ${{ needs.compute-ref.outputs.REF }}
 
       - name: Set commit status to pending
         uses: ./.github/workflows/custom-actions/set-commit-status


### PR DESCRIPTION
We were misreading the computed ref for tests (missing "outputs" in the variable name), which led us to check out and test main instead of the PR's head.  This also led us to set status on the latest commit in main, instead of on the PR.

Once the variable was read correctly and the correct ref was checked out, I found that the ref argument to set-commit-status was actually not usable, since "git rev-parse refs/pull/4528/head" would fail. But now that we are checking out the correct commit, the ref argument turns out to be unnecessary.  Whatever we checked out is what we should report status on.