### PR TITLE
feat: Adds ChannelCount as a filter to the Player Select Audio Track Method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,5 +86,4 @@ V-Nova Limited <*@v-nova.com>
 Wayne Morgan <wayne.morgan.dev@gmail.com>
 Raymond Cheng <raycheng100@gmail.com>
 Blue Billywig <*@bluebillywig.com>
-João Nabais <joao.nabais@sky.uk>
-Sky Uk <*@sky.uk>
+João Nabais <jlnabais@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -86,3 +86,5 @@ V-Nova Limited <*@v-nova.com>
 Wayne Morgan <wayne.morgan.dev@gmail.com>
 Raymond Cheng <raycheng100@gmail.com>
 Blue Billywig <*@bluebillywig.com>
+João Nabais <joao.nabais@sky.uk>
+Sky Uk <*@sky.uk>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -126,4 +126,4 @@ Wayne Morgan <wayne.morgan.dev@gmail.com>
 Yohann Connell <robinconnell@google.com>
 Raymond Cheng <raycheng100@gmail.com>
 Janroel Koppen <j.koppen@bluebillywig.com>
-João Nabais <joao.nabais@sky.uk>
+João Nabais <jlnabais@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -126,3 +126,4 @@ Wayne Morgan <wayne.morgan.dev@gmail.com>
 Yohann Connell <robinconnell@google.com>
 Raymond Cheng <raycheng100@gmail.com>
 Janroel Koppen <j.koppen@bluebillywig.com>
+João Nabais <joao.nabais@sky.uk>

--- a/lib/player.js
+++ b/lib/player.js
@@ -4047,15 +4047,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * @param {string} language
    * @param {string=} role
+   * @param {number=} channelsCount
    * @export
    */
-  selectAudioLanguage(language, role) {
+  selectAudioLanguage(language, role, channelsCount = 0) {
     const LanguageUtils = shaka.util.LanguageUtils;
 
     if (this.manifest_ && this.playhead_) {
       this.currentAdaptationSetCriteria_ =
           new shaka.media.PreferenceBasedCriteria(language, role || '',
-          /* channelCount= */ 0, /* label= */ '');
+              channelsCount, /* label= */ '');
 
       const diff = (a, b) => {
         if (!a.video && !b.video) {

--- a/lib/player.js
+++ b/lib/player.js
@@ -4042,8 +4042,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
   /**
    * Sets the current audio language and current variant role to the selected
-   * language and role, and chooses a new variant if need be. If the player has
-   * not loaded any content, this will be a no-op.
+   * language, role and channel count, and chooses a new variant if need be.
+   * If the player has not loaded any content, this will be a no-op.
    *
    * @param {string} language
    * @param {string=} role


### PR DESCRIPTION
Adds channelCount to the Select Audio Track method, this allows for selecting a audio track based on the channel count when the language, codec and role are the same.

Issue: https://github.com/shaka-project/shaka-player/issues/4550