### PR TITLE
fix: Fix choppy HLS startup

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -665,10 +665,17 @@ shaka.media.MediaSourceEngine = class {
         const textOffset = (reference.startTime || 0) - (mediaStartTime || 0);
         this.textSequenceModeOffset_.resolve(textOffset);
 
-        // Finally, clear the buffer.
+        // Clear the buffer.
         await this.enqueueOperation_(
             contentType,
             () => this.remove_(contentType, 0, this.mediaSource_.duration));
+
+        // Finally, flush the buffer in case of choppy video start on HLS fMP4.
+        if (contentType == ContentType.VIDEO) {
+          await this.enqueueOperation_(
+              contentType,
+              () => this.flush_(contentType));
+        }
       }
 
       // Now switch to sequence mode and fall through to our normal operations.


### PR DESCRIPTION
Clearing the buffer seems to be not enough for this case.
This avoids the choppy video start on HLS fMP4 playback.

Tested with Chrome 106 & Edge 106.

Closes #4516