### PR TITLE
fix: Resolve load failures for TS-based content on Android-based Cast devices (#4569).

### DIFF
--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -50,8 +50,7 @@ shaka.polyfill.MediaCapabilities = class {
         shaka.util.Platform.isPS4() ||
         shaka.util.Platform.isWebOS() ||
         shaka.util.Platform.isTizen() ||
-        shaka.util.Platform.isChromecast() ||
-        shaka.util.Platform.isAndroidCastDevice()) {
+        shaka.util.Platform.isChromecast()) {
       canUseNativeMCap = false;
     }
     if (canUseNativeMCap && navigator.mediaCapabilities) {

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -24,8 +24,9 @@ shaka.polyfill.MediaCapabilities = class {
    * @export
    */
   static install() {
-    // Since MediaCapabilities is not fully supported on some Chromecast yet,
-    // we should always install polyfill for all Chromecast not Android-based.
+    // Since MediaCapabilities implementation is buggy on the Chromecast
+    // platform (see https://github.com/shaka-project/shaka-player/issues/4569),
+    // we should always install polyfills on all Chromecast models.
     // TODO: re-evaluate MediaCapabilities in the future versions of Chromecast.
     // Since MediaCapabilities implementation is buggy in Apple browsers, we
     // should always install polyfill for Apple browsers.
@@ -49,11 +50,9 @@ shaka.polyfill.MediaCapabilities = class {
         shaka.util.Platform.isPS4() ||
         shaka.util.Platform.isWebOS() ||
         shaka.util.Platform.isTizen() ||
-        shaka.util.Platform.isChromecast()) {
+        shaka.util.Platform.isChromecast() ||
+        shaka.util.Platform.isAndroidCastDevice()) {
       canUseNativeMCap = false;
-    }
-    if (shaka.util.Platform.isAndroidCastDevice()) {
-      canUseNativeMCap = true;
     }
     if (canUseNativeMCap && navigator.mediaCapabilities) {
       shaka.log.info(

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -164,16 +164,6 @@ shaka.util.Platform = class {
   }
 
   /**
-   * Check if the current platform is a Android-based Cast devices.
-   *
-   * @return {boolean}
-   */
-  static isAndroidCastDevice() {
-    return shaka.util.Platform.isChromecast() &&
-        shaka.util.Platform.userAgentContains_('Android');
-  }
-
-  /**
    * Returns a major version number for Chrome, or Chromium-based browsers.
    *
    * For example:


### PR DESCRIPTION
See https://github.com/shaka-project/shaka-player/issues/4569 for more context.

This affects any Chromecast model which contains the substring `Android` in their userAgent. For TS content, this causes Shaka to incorrectly filter all stream variants leaving nothing for the player to select for playback (resulting in a `4032` error): https://github.com/shaka-project/shaka-player/blob/757b34e5959f14c9a5b5aed173cc99d98a794a40/lib/util/stream_utils.js#L484-L491.