### PR TITLE
fix(hls): Fix single-variant HLS streams

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -710,6 +710,19 @@ shaka.hls.HlsParser = class {
         /* presentationStartTime= */ null, /* delay= */ 0);
     this.presentationTimeline_.setStatic(true);
 
+    // Single-variant streams aren't lazy-loaded, so for them we already have
+    // enough info here to determine the presentation type and duration.
+    if (playlist.type == shaka.hls.PlaylistType.MEDIA) {
+      if (this.isLive_()) {
+        this.changePresentationTimelineToLive_();
+        const delay = this.updatePlaylistDelay_;
+        this.updatePlaylistTimer_.tickAfter(/* seconds= */ delay);
+      }
+      const streamInfos = Array.from(this.uriToStreamInfosMap_.values());
+      this.finalizeStreams_(streamInfos);
+      this.determineDuration_();
+    }
+
     this.manifest_ = {
       presentationTimeline: this.presentationTimeline_,
       variants,
@@ -1604,11 +1617,6 @@ shaka.hls.HlsParser = class {
       stream.roles = realStream.roles;
       stream.mimeType = realStream.mimeType;
 
-      // MediaSource expects no codec strings combined with raw formats.
-      if (shaka.media.MediaSourceEngine.RAW_FORMATS.includes(stream.mimeType)) {
-        stream.codecs = '';
-      }
-
       // Add finishing touches to the stream that can only be done once we have
       // more full context on the media as a whole.
       if (this.hasEnoughInfoToFinalizeStreams_()) {
@@ -1690,6 +1698,13 @@ shaka.hls.HlsParser = class {
       const minDuration = this.getMinDuration_();
       for (const streamInfo of streamInfos) {
         streamInfo.stream.segmentIndex.fit(/* periodStart= */ 0, minDuration);
+      }
+    }
+    // MediaSource expects no codec strings combined with raw formats.
+    for (const streamInfo of streamInfos) {
+      const stream = streamInfo.stream;
+      if (shaka.media.MediaSourceEngine.RAW_FORMATS.includes(stream.mimeType)) {
+        stream.codecs = '';
       }
     }
     this.notifySegmentsForStreams_(streamInfos.map((s) => s.stream));
@@ -1872,7 +1887,7 @@ shaka.hls.HlsParser = class {
 
     return {
       stream,
-      type: '', // Not set here
+      type,
       verbatimMediaPlaylistUri,
       absoluteMediaPlaylistUri,
       maxTimestamp: lastEndTime,

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -3841,7 +3841,9 @@ describe('HlsParser', () => {
       });
     });
 
-    await testHlsParser(media, '', manifest);
+    const actualManifest = await testHlsParser(media, '', manifest);
+
+    expect(actualManifest.presentationTimeline.getDuration()).toBe(5);
   });
 
   it('honors hls.mediaPlaylistFullMimeType', async () => {


### PR DESCRIPTION
The changes to implement lazy-loading broke the previous functionality to load media playlists directly, as they are not lazy loaded. This fixes that case, so that lazy-loaded media playlists will correctly set their duration and presentation type.

Issue #1936
Issue #3536