### PR TITLE
fix(playhead): safeguard getStallsDetected as stallDetector can be null

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,3 +87,4 @@ Wayne Morgan <wayne.morgan.dev@gmail.com>
 Raymond Cheng <raycheng100@gmail.com>
 Blue Billywig <*@bluebillywig.com>
 João Nabais <jlnabais@gmail.com>
+Koen Romers <koenromers@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -127,3 +127,4 @@ Yohann Connell <robinconnell@google.com>
 Raymond Cheng <raycheng100@gmail.com>
 Janroel Koppen <j.koppen@bluebillywig.com>
 João Nabais <jlnabais@gmail.com>
+Koen Romers <koenromers@gmail.com>

--- a/lib/media/playhead.js
+++ b/lib/media/playhead.js
@@ -294,7 +294,7 @@ shaka.media.MediaSourcePlayhead = class {
 
   /** @override */
   getStallsDetected() {
-    return this.stallDetector_.getStallsDetected();
+    return this.stallDetector_ ? this.stallDetector_.getStallsDetected() : 0;
   }
 
   /** @override */


### PR DESCRIPTION
`player.getStats()` currently fails when `stallEnabled` is set to false in Player configuration. In this PR I've added a safeguard to make sure `getStallsDetected` returns 0 when `stallDetector` is null.