### PR TITLE
ci: Update workflow syntax

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -150,7 +150,7 @@ jobs:
             cp "$coverage_folder"/coverage-details.json coverage/staging/
             echo "${{ github.event.number }}" > coverage/staging/pr-number.json
 
-            echo "::set-output name=coverage_found::true"
+            echo "coverage_found=true" >> $GITHUB_OUTPUT
             echo "Coverage report staged."
           else
             echo "No coverage report generated."

--- a/.github/workflows/compute-incremental-coverage.py
+++ b/.github/workflows/compute-incremental-coverage.py
@@ -221,6 +221,16 @@ def IncrementalCoverage(pr, coverage_details):
     return None
   return num_covered / num_changed
 
+def set_output(name, value):
+  path = os.environ.get("GITHUB_OUTPUT")
+  if path:
+    # Inside GitHub Actions, output the data to a special file GitHub provides.
+    with open(path, "a") as f:
+      f.write("{}={}\n".format(name, value))
+  else:
+    # Outside of GitHub Actions, just print the data.
+    print("OUTPUT {}={}".format(name, value))
+
 def main():
   parser = argparse.ArgumentParser(
       description="Compute incremental code coverage for a PR",
@@ -241,11 +251,11 @@ def main():
   pr = PullRequest(args.repo, pr_number)
   coverage = IncrementalCoverage(pr, coverage_details)
 
-  print("::set-output name=pr_number::%d" % pr_number)
+  set_output("pr_number", str(pr_number))
   if coverage is None:
-    print("::set-output name=coverage::No instrumented code was changed.")
+    set_output("coverage", "No instrumented code was changed.")
   else:
-    print("::set-output name=coverage::%.2f%%" % (coverage * 100.0))
+    set_output("coverage", "%.2f%%" % (coverage * 100.0))
 
 if __name__ == "__main__":
   main()

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -32,7 +32,7 @@ jobs:
           else
             LAB_TEST_REF="main"
           fi
-          echo "::set-output name=REF::$LAB_TEST_REF"
+          echo "REF=$LAB_TEST_REF" >> $GITHUB_OUTPUT
 
   # Configure the build matrix based on our grid's YAML config.
   # The matrix contents will be computed by this first job and deserialized
@@ -77,7 +77,9 @@ jobs:
           }
 
           // Output JSON object consumed by the build matrix below.
-          console.log(`::set-output name=INCLUDE::${ JSON.stringify(include) }`);
+          fs.appendFileSync(
+              process.env['GITHUB_OUTPUT'],
+              `INCLUDE=${ JSON.stringify(include) }\n`);
 
           // Log the output, for the sake of debugging this script.
           console.log({include});
@@ -218,7 +220,7 @@ jobs:
 
           if [ -f "$coverage_report" ]; then
             echo "Found coverage report: $coverage_report"
-            echo "::set-output name=coverage_report::$coverage_report"
+            echo "coverage_report=$coverage_report" >> $GITHUB_OUTPUT
           else
             echo "Could not locate coverage report!"
             exit 1


### PR DESCRIPTION
GitHub is deprecating the set-output syntax and moving to writing outputs to a file.  This updates our workflows to match.

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/