### PR TITLE
fix(HLS): Return 0-0 seek range until fully loaded

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -550,6 +550,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @private {?string} */
     this.assetUri_ = null;
 
+    /** @private {boolean} */
+    this.fullyLoaded_ = false;
+
     /** @private {shaka.extern.AbrManager} */
     this.abrManager_ = null;
 
@@ -1148,6 +1151,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return Promise.reject(this.createAbortLoadError_());
     }
 
+    this.fullyLoaded_ = false;
+
     // If the platform does not support media source, we will never want to
     // initialize media source.
     if (!shaka.util.Platform.supportsMediaSource()) {
@@ -1241,6 +1246,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    */
   load(assetUri, startTime, mimeType) {
     this.updatedStartTime_ = null;
+
+    this.fullyLoaded_ = false;
 
     // Do not allow the player to be used after |destroy| is called.
     if (this.loadMode_ == shaka.Player.LoadMode.DESTROYED) {
@@ -2249,6 +2256,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
                         'arbitrary language initially');
     }
 
+    this.fullyLoaded_ = true;
+
     // Wait for the 'loadedmetadata' event to measure load() latency.
     this.loadEventManager_.listenOnce(mediaElement, 'loadedmetadata', () => {
       const now = Date.now() / 1000;
@@ -2594,6 +2603,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           shaka.util.Error.Code.OPERATION_ABORTED);
       fullyLoaded.reject(abortedError);
       return Promise.resolve();  // Abort complete.
+    }).chain(() => {
+      this.fullyLoaded_ = true;
     });
   }
 
@@ -3501,6 +3512,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @export
    */
   seekRange() {
+    if (!this.fullyLoaded_) {
+      return {'start': 0, 'end': 0};
+    }
+
     if (this.manifest_) {
       const timeline = this.manifest_.presentationTimeline;
 


### PR DESCRIPTION
With HLS lazy-loading, there were some situations where the manifest had partially loaded, enough to move onto further load stages, but no segments had been loaded, so the duration is still unknown. This could cause the UI seek bar to try to determine the seek range, fail, and cause an assertion failure.
These were not fatal errors, but they still fill up the console and make it look like something worse is happening, so they should be fixed.
With this change, the player returns a seek range of 0 to 0 until the asset is fully loaded.