### PR TITLE
ci: Re-run PR tests when leaving draft mode

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -2,7 +2,7 @@ name: Build and Test PR
 
 on:
   pull_request: # Trigger for pull requests.
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
       - v[0-9]*


### PR DESCRIPTION
Because our release PRs are created with the default GitHub token, they do not trigger test runs.  This is a feature of GitHub that prevents recursive loops of workflows.

This change makes it so that marking a PR "ready for review" will trigger the tests to run again.  This gives us an easy way to trigger test runs on a release PR, by marking it a draft, then marking it "ready" again.