### PR TITLE
fix(HLS): Fix lazy-loading of TS content

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1577,6 +1577,7 @@ shaka.hls.HlsParser = class {
       canSkipSegments: false,
       hasEndList: false,
       firstSequenceNumber: -1,
+      loadedOnce: false,
     };
     const downloadSegmentIndex = async () => {
       // Un-assign this function, so that if it's called a second time we don't
@@ -1615,6 +1616,7 @@ shaka.hls.HlsParser = class {
       streamInfo.hasEndList = realStreamInfo.hasEndList;
       streamInfo.mediaSequenceToStartTime =
           realStreamInfo.mediaSequenceToStartTime;
+      streamInfo.loadedOnce = true;
       stream.segmentIndex = realStream.segmentIndex;
       stream.encrypted = realStream.encrypted;
       stream.drmInfos = realStream.drmInfos;
@@ -1622,6 +1624,17 @@ shaka.hls.HlsParser = class {
       stream.kind = realStream.kind;
       stream.roles = realStream.roles;
       stream.mimeType = realStream.mimeType;
+
+      const ContentType = shaka.util.ManifestParserUtils.ContentType;
+      if (type == ContentType.VIDEO || type == ContentType.AUDIO) {
+        for (const otherStreamInfo of this.uriToStreamInfosMap_.values()) {
+          if (!otherStreamInfo.loadedOnce && otherStreamInfo.type == type) {
+            // To aid manifest filtering, assume before loading that all video
+            // renditions have the same MIME type.  (And likewise for audio.)
+            otherStreamInfo.stream.mimeType = realStream.mimeType;
+          }
+        }
+      }
 
       // Add finishing touches to the stream that can only be done once we have
       // more full context on the media as a whole.
@@ -1901,6 +1914,7 @@ shaka.hls.HlsParser = class {
       hasEndList: false,
       firstSequenceNumber: -1,
       mediaSequenceToStartTime,
+      loadedOnce: false,
     };
   }
 
@@ -3051,7 +3065,8 @@ shaka.hls.HlsParser = class {
  *   mediaSequenceToStartTime: !Map.<number, number>,
  *   canSkipSegments: boolean,
  *   hasEndList: boolean,
- *   firstSequenceNumber: number
+ *   firstSequenceNumber: number,
+ *   loadedOnce: boolean
  * }}
  *
  * @description
@@ -3075,12 +3090,14 @@ shaka.hls.HlsParser = class {
  *   A map of media sequence numbers to media start times.
  *   Only used for VOD content.
  * @property {boolean} canSkipSegments
- *  True if the server supports delta playlist updates, and we can send a
- *  request for a playlist that can skip older media segments.
+ *   True if the server supports delta playlist updates, and we can send a
+ *   request for a playlist that can skip older media segments.
  * @property {boolean} hasEndList
- *  True if the stream has an EXT-X-ENDLIST tag.
+ *   True if the stream has an EXT-X-ENDLIST tag.
  * @property {number} firstSequenceNumber
- *  The sequence number of the first reference. Only calculated if needed.
+ *   The sequence number of the first reference. Only calculated if needed.
+ * @property {boolean} loadedOnce
+ *   True if the stream has been loaded at least once.
  */
 shaka.hls.HlsParser.StreamInfo;
 

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -4012,4 +4012,65 @@ describe('HlsParser', () => {
       'test:/audio4.mp4',
     ]);
   });
+
+  it('lazy-loads TS content without filtering it out', async () => {
+    const master = [
+      '#EXTM3U\n',
+      '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aud1",LANGUAGE="eng",URI="audio"\n',
+      '#EXT-X-STREAM-INF:BANDWIDTH=200,CODECS="avc1,mp4a",',
+      'RESOLUTION=960x540,FRAME-RATE=60,AUDIO="aud1"\n',
+      'video\n',
+      '#EXT-X-STREAM-INF:BANDWIDTH=200,CODECS="avc1,mp4a",',
+      'RESOLUTION=960x540,FRAME-RATE=120,AUDIO="aud1"\n',
+      'video2\n',
+    ].join('');
+
+    const video = [
+      '#EXTM3U\n',
+      '#EXT-X-TARGETDURATION:5\n',
+      '#EXT-X-MAP:URI="init.mp4",BYTERANGE="616@0"\n',
+      '#EXT-X-MEDIA-SEQUENCE:1\n',
+      '#EXTINF:5,\n',
+      'video1.ts\n',
+      '#EXTINF:5,\n',
+      'video2.ts\n',
+    ].join('');
+
+    const audio = [
+      '#EXTM3U\n',
+      '#EXT-X-TARGETDURATION:5\n',
+      '#EXT-X-MAP:URI="init.mp4",BYTERANGE="616@0"\n',
+      '#EXT-X-MEDIA-SEQUENCE:3\n',
+      '#EXTINF:5,\n',
+      'audio1.ts\n',
+      '#EXTINF:5,\n',
+      'audio2.ts\n',
+    ].join('');
+
+    fakeNetEngine
+        .setResponseText('test:/master', master)
+        .setResponseText('test:/audio', audio)
+        .setResponseText('test:/video', video)
+        .setResponseText('test:/video2', video)
+        .setResponseValue('test:/init.mp4', initSegmentData);
+
+    const actualManifest = await parser.start('test:/master', playerInterface);
+    expect(actualManifest.variants.length).toBe(2);
+
+    const actualVideo0 = actualManifest.variants[0].video;
+    const actualVideo1 = actualManifest.variants[1].video;
+
+    // Before loading, all MIME types agree, and are defaulted to video/mp4.
+    expect(actualVideo0.mimeType).toBe('video/mp4');
+    expect(actualVideo1.mimeType).toBe('video/mp4');
+
+    await actualVideo0.createSegmentIndex();
+
+    // After loading just ONE stream, all MIME types agree again, and have been
+    // updated to reflect the TS content found inside the loaded playlist.
+    // This is how we avoid having the unloaded tracks filtered out during
+    // startup.
+    expect(actualVideo0.mimeType).toBe('video/mp2t');
+    expect(actualVideo1.mimeType).toBe('video/mp2t');
+  });
 });


### PR DESCRIPTION
We assume before a playlist is loaded that the content is MP4.  But once a single playlist is loaded with TS, we should then assume that all the other playlists of that type (video/audio) are also TS. Otherwise, as-yet-unloaded playlists are filtered out of the variants list as "incompatible".