### PR TITLE
ci: Update actions/checkout version

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
@@ -88,7 +88,7 @@ jobs:
         run: sudo apt -y update && sudo apt -y install ffmpeg
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 

--- a/.github/workflows/demo-version-index.yaml
+++ b/.github/workflows/demo-version-index.yaml
@@ -16,7 +16,7 @@ jobs:
   appspot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # We need a list of all tags for this, so fetch the entire history.
           fetch-depth: 0

--- a/.github/workflows/nightly-demo.yaml
+++ b/.github/workflows/nightly-demo.yaml
@@ -11,7 +11,7 @@ jobs:
   appspot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,7 +23,7 @@ jobs:
           default-branch: ${{ github.ref_name }}
 
       # If we didn't create a release, we may have created or updated a PR.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: steps.release.outputs.release_created == false
       - name: Custom update Player version
         if: steps.release.outputs.release_created == false
@@ -53,7 +53,7 @@ jobs:
     needs: release
     if: needs.release.outputs.release_created && endsWith(needs.release.outputs.tag_name, '.0') == false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: main
       - name: Tag the main branch
@@ -70,7 +70,7 @@ jobs:
     needs: release
     if: needs.release.outputs.release_created
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -99,7 +99,7 @@ jobs:
     needs: release
     if: needs.release.outputs.release_created
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -152,7 +152,7 @@ jobs:
     needs: release
     if: needs.release.outputs.release_created && endsWith(needs.release.outputs.tag_name, '.0')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/report-incremental-coverage.yaml
+++ b/.github/workflows/report-incremental-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Compute incremental code coverage
         id: compute

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -45,7 +45,7 @@ jobs:
       INCLUDE: ${{ steps.configure.outputs.INCLUDE }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ needs.compute-ref.outputs.REF }}
 
@@ -92,7 +92,7 @@ jobs:
     needs: compute-ref
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ needs.compute-ref.outputs.REF }}
 
@@ -134,7 +134,7 @@ jobs:
     name: ${{ matrix.browser }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ needs.compute-ref.outputs.REF }}
 


### PR DESCRIPTION
v2 uses a deprecated node version (12), and v3 uses a current version (16).