### PR TITLE
ci: Disable Tizen

### DIFF
--- a/build/shaka-lab.yaml
+++ b/build/shaka-lab.yaml
@@ -164,7 +164,10 @@ Chromebook:
 
 Tizen:
   browser: tizen
+  # TODO: Re-enable Tizen (https://github.com/shaka-project/generic-webdriver-server/issues/57)
+  disabled: true
 
 XboxOne:
   browser: xboxone
+  # TODO: Re-enable Xbox (https://github.com/shaka-project/shaka-player/issues/4234)
   disabled: true


### PR DESCRIPTION
Due to shaka-project/generic-webdriver-server#57, we can not communicate with our Tizen TV in the lab.  Until this is resolved, we must disable the device in our Selenium grid config.