### PR TITLE
fix: Force using mcap polyfill on EOS browsers

### DIFF
--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -44,13 +44,16 @@ shaka.polyfill.MediaCapabilities = class {
     // should always install polyfill for Tizen browsers.
     // Since MediaCapabilities implementation is buggy in WebOS browsers, we
     // should always install polyfill for WebOS browsers.
+    // Since MediaCapabilities implementation is buggy in EOS browsers, we
+    // should always install polyfill for EOS browsers.
     let canUseNativeMCap = true;
     if (shaka.util.Platform.isApple() ||
         shaka.util.Platform.isPS5() ||
         shaka.util.Platform.isPS4() ||
         shaka.util.Platform.isWebOS() ||
         shaka.util.Platform.isTizen() ||
-        shaka.util.Platform.isChromecast()) {
+        shaka.util.Platform.isChromecast() ||
+        shaka.util.Platform.isEOS()) {
       canUseNativeMCap = false;
     }
     if (canUseNativeMCap && navigator.mediaCapabilities) {


### PR DESCRIPTION
The MCap API on the EOS set-top boxes is rather buggy thus we're relying on the polyfill instead.