### PR TITLE
fix: Allow overriding special handling of 404s

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1408,16 +1408,6 @@ shaka.media.StreamingEngine = class {
         this.mediaStates_.delete(ContentType.TEXT);
       } else if (error.code == shaka.util.Error.Code.QUOTA_EXCEEDED_ERROR) {
         this.handleQuotaExceeded_(mediaState, error);
-      } else if (error.code == shaka.util.Error.Code.BAD_HTTP_STATUS &&
-          error.data && error.data[1] == 404) {
-        // The segment could not be found, does not exist, or is not available.
-        // In any case just try again.
-        // The current segment is not available. Schedule another update to
-        // fetch the segment again.
-        shaka.log.v2(logPrefix, 'segment not available.');
-        mediaState.performingUpdate = false;
-        mediaState.updateTimer = null;
-        this.scheduleUpdate_(mediaState, 1);
       } else {
         shaka.log.error(logPrefix, 'failed fetch and append: code=' +
             error.code);
@@ -1460,9 +1450,10 @@ shaka.media.StreamingEngine = class {
 
   /**
    * Clear per-stream error states and retry any failed streams.
+   * @param {number} delaySeconds
    * @return {boolean} False if unable to retry.
    */
-  retry() {
+  retry(delaySeconds) {
     if (this.destroyer_.destroyed()) {
       shaka.log.error('Unable to retry after StreamingEngine is destroyed!');
       return false;
@@ -1479,7 +1470,7 @@ shaka.media.StreamingEngine = class {
       if (mediaState.hasError) {
         shaka.log.info(logPrefix, 'Retrying after failure...');
         mediaState.hasError = false;
-        this.scheduleUpdate_(mediaState, 0.1);
+        this.scheduleUpdate_(mediaState, delaySeconds);
       }
     }
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -5166,12 +5166,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * If the player has loaded content, and streaming seen an error, but the
    * could not resume streaming, this will return <code>false</code>.
    *
+   * @param {number=} retryDelaySeconds
    * @return {boolean}
    * @export
    */
-  retryStreaming() {
+  retryStreaming(retryDelaySeconds = 0.1) {
     return this.loadMode_ == shaka.Player.LoadMode.MEDIA_SOURCE ?
-           this.streamingEngine_.retry() :
+           this.streamingEngine_.retry(retryDelaySeconds) :
            false;
   }
 
@@ -5267,17 +5268,26 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   defaultStreamingFailureCallback_(error) {
-    const retryErrorCodes = [
-      shaka.util.Error.Code.BAD_HTTP_STATUS,
-      shaka.util.Error.Code.HTTP_ERROR,
-      shaka.util.Error.Code.TIMEOUT,
-    ];
+    // For live streams, we retry streaming automatically for certain errors.
+    // For VOD streams, all streaming failures are fatal.
+    if (!this.isLive()) {
+      return;
+    }
 
-    if (this.isLive() && retryErrorCodes.includes(error.code)) {
+    let retryDelaySeconds = null;
+    if (error.code == shaka.util.Error.Code.BAD_HTTP_STATUS ||
+        error.code == shaka.util.Error.Code.HTTP_ERROR) {
+      // These errors can be near-instant, so delay a bit before retrying.
+      retryDelaySeconds = 1;
+    } else if (error.code == shaka.util.Error.Code.TIMEOUT) {
+      // We already waited for a timeout, so retry quickly.
+      retryDelaySeconds = 0.1;
+    }
+
+    if (retryDelaySeconds != null) {
       error.severity = shaka.util.Error.Severity.RECOVERABLE;
-
       shaka.log.warning('Live streaming error.  Retrying automatically...');
-      this.retryStreaming();
+      this.retryStreaming(retryDelaySeconds);
     }
   }
 

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -157,6 +157,19 @@ describe('StreamingEngine', () => {
         /* presentationDuration= */ Infinity);
     setupPlayhead();
 
+    // Retry on failure for live streams.
+    config.failureCallback = () => streamingEngine.retry(0.1);
+
+    // Ignore 404 errors in live stream tests.
+    onError.and.callFake((error) => {
+      if (error.code == shaka.util.Error.Code.BAD_HTTP_STATUS &&
+          error.data[1] == 404) {
+        // 404 error
+      } else {
+        fail(error);
+      }
+    });
+
     createStreamingEngine();
   }
 

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -882,7 +882,7 @@ describe('StreamingEngine', () => {
 
     const config = shaka.util.PlayerConfiguration.createDefault().streaming;
     config.bufferingGoal = 60;
-    config.failureCallback = () => streamingEngine.retry();
+    config.failureCallback = () => streamingEngine.retry(0.1);
     createStreamingEngine(config);
 
     // Make requests for different types take different amounts of time.
@@ -1741,8 +1741,23 @@ describe('StreamingEngine', () => {
     beforeEach(() => {
       setupLive();
       mediaSourceEngine = new shaka.test.FakeMediaSourceEngine(segmentData, 0);
-      createStreamingEngine();
+
+      // Retry on failure for live streams.
+      const config = shaka.util.PlayerConfiguration.createDefault().streaming;
+      config.failureCallback = () => streamingEngine.retry(0.1);
+
+      createStreamingEngine(config);
       presentationTimeInSeconds = 100;
+
+      // Ignore 404 errors in live stream tests.
+      onError.and.callFake((error) => {
+        if (error.code == shaka.util.Error.Code.BAD_HTTP_STATUS &&
+            error.data[1] == 404) {
+          // 404 error
+        } else {
+          fail(error);
+        }
+      });
     });
 
     it('outside segment availability window', async () => {
@@ -1772,24 +1787,22 @@ describe('StreamingEngine', () => {
       const originalAppendBuffer =
           // eslint-disable-next-line no-restricted-syntax
           shaka.test.FakeMediaSourceEngine.prototype.appendBufferImpl;
-      mediaSourceEngine.appendBuffer.and.callFake(
-          (type, data, reference) => {
-            expect(presentationTimeInSeconds).toBe(125);
-            if (reference && reference.startTime >= 100) {
-              // Ignore a possible call for the first Period.
-              expect(Util.invokeSpy(timeline.getSegmentAvailabilityStart))
-                  .toBe(100);
-              expect(Util.invokeSpy(timeline.getSegmentAvailabilityEnd))
-                  .toBe(120);
-              playing = true;
-              mediaSourceEngine.appendBuffer.and.callFake(
-                  originalAppendBuffer);
-            }
+      mediaSourceEngine.appendBuffer.and.callFake((type, data, reference) => {
+        expect(presentationTimeInSeconds).toBe(125);
+        // Ignore a possible call for the first Period.
+        if (reference && reference.startTime >= 100) {
+          expect(Util.invokeSpy(timeline.getSegmentAvailabilityStart))
+              .not.toBeLessThan(100);
+          expect(Util.invokeSpy(timeline.getSegmentAvailabilityEnd))
+              .not.toBeLessThan(120);
+          playing = true;
+          mediaSourceEngine.appendBuffer.and.callFake(originalAppendBuffer);
+        }
 
-            // eslint-disable-next-line no-restricted-syntax
-            return originalAppendBuffer.call(
-                mediaSourceEngine, type, data, reference);
-          });
+        // eslint-disable-next-line no-restricted-syntax
+        return originalAppendBuffer.call(
+            mediaSourceEngine, type, data, reference);
+      });
 
       await runTest(slideSegmentAvailabilityWindow);
       // Verify buffers.
@@ -2005,7 +2018,7 @@ describe('StreamingEngine', () => {
       mediaSourceEngine = new shaka.test.FakeMediaSourceEngine(segmentData);
 
       const config = shaka.util.PlayerConfiguration.createDefault().streaming;
-      config.failureCallback = () => streamingEngine.retry();
+      config.failureCallback = () => streamingEngine.retry(0.1);
       createStreamingEngine(config);
 
       presentationTimeInSeconds = 100;
@@ -2166,7 +2179,7 @@ describe('StreamingEngine', () => {
         netEngine.request.calls.reset();
 
         // Retry streaming.
-        expect(streamingEngine.retry()).toBe(true);
+        expect(streamingEngine.retry(0.1)).toBe(true);
       });
 
       // Here we go!
@@ -2196,7 +2209,7 @@ describe('StreamingEngine', () => {
 
         // Retry streaming, which should fail and return false.
         netEngine.request.calls.reset();
-        expect(streamingEngine.retry()).toBe(false);
+        expect(streamingEngine.retry(0.1)).toBe(false);
       });
 
       // Here we go!
@@ -2248,7 +2261,7 @@ describe('StreamingEngine', () => {
 
           // Retry streaming, which should fail and return false.
           netEngine.request.calls.reset();
-          expect(streamingEngine.retry()).toBe(false);
+          expect(streamingEngine.retry(0.1)).toBe(false);
         }
       });
 


### PR DESCRIPTION
In general, streaming.failureCallback is meant to give applications control over error handling at the level of streaming.  However, there was a special case for HTTP 404s built into StreamingEngine in a way that applications could not override.  This was in spite of the fact that the default failureCallback would already check for and retry on the error code BAD_HTTP_STATUS.

This removes the special case in StreamingEngine and refactors failureCallback and retryStreaming to preserve the special delay imposed in the old 404 handler.  With this, applications can override failureCallback to have complete control over 404 handling.

Closes #4548