### PR TITLE
fix: embed cc not shown when seeking back

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Edgeware AB <*@edgeware.tv>
 Enson Choy <enson.choy@harmonicinc.com>
 Esteban Dosztal <edosztal@gmail.com>
 Fadomire <fadomire@gmail.com>
+Gerardo Meola <meola.gerardo@gmail.com>
 Gil Gonen <gil.gonen@gmail.com>
 Giorgio Gamberoni <giorgio.gamberoni@gmail.com>
 Giuseppe Samela <giuseppe.samela@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -50,6 +50,7 @@ Enson Choy <enson.choy@harmonicinc.com>
 Esteban Dosztal <edosztal@gmail.com>
 Fadomire <fadomire@gmail.com>
 François Beaufort <fbeaufort@google.com>
+Gerardo Meola <meola.gerardo@gmail.com>
 Gil Gonen <gil.gonen@gmail.com>
 Giorgio Gamberoni <giorgio.gamberoni@gmail.com>
 Giuseppe Samela <giuseppe.samela@gmail.com>

--- a/externs/mux.js
+++ b/externs/mux.js
@@ -74,6 +74,9 @@ muxjs.mp4.Transmuxer = class {
 
   /** Remove all handlers and clean up. */
   dispose() {}
+
+  /** Reset captions. */
+  resetCaptions() {}
 };
 
 
@@ -167,4 +170,3 @@ muxjs.mp4.ParsedClosedCaptions;
  * @property {string} text The content of the closed caption.
  */
 muxjs.mp4.ClosedCaption;
-

--- a/lib/ads/client_side_ad_manager.js
+++ b/lib/ads/client_side_ad_manager.js
@@ -15,7 +15,6 @@ goog.require('goog.asserts');
 goog.require('shaka.ads.ClientSideAd');
 goog.require('shaka.util.IReleasable');
 
-
 /**
  * A class responsible for client-side ad interactions.
  * @implements {shaka.util.IReleasable}
@@ -218,7 +217,11 @@ shaka.ads.ClientSideAdManager = class {
       // TODO (ismena): Need a better inderstanding of what this does.
       // The docs say it's called to 'start playing the ads,' but I haven't
       // seen the ads actually play until requestAds() is called.
-      this.imaAdsManager_.start();
+      // Note: We listen for a play event to avoid autoplay issues that might
+      // crash IMA.
+      this.video_.addEventListener('play', () => {
+        this.imaAdsManager_.start();
+      }, {once: true});
     } catch (adError) {
       // If there was a problem with the VAST response,
       // we we won't be getting an ad. Hide ad UI if we showed it already

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -601,6 +601,12 @@ shaka.media.MediaSourceEngine = class {
     }
 
     if (this.transmuxers_[contentType]) {
+      // When seeked we should reset the transmuxer captionstreams
+      // so it does not ignores the captions from previous segments
+      if (seeked) {
+        this.transmuxers_[contentType].resetCaptions();
+      }
+
       const transmuxedData =
           await this.transmuxers_[contentType].transmux(data);
       // For HLS CEA-608/708 CLOSED-CAPTIONS, text data is embedded in

--- a/lib/media/transmuxer.js
+++ b/lib/media/transmuxer.js
@@ -223,6 +223,12 @@ shaka.media.Transmuxer = class {
     return this.transmuxPromise_;
   }
 
+  /**
+   * Reset captions from Transport stream to MP4, using the mux.js library.
+  */
+  resetCaptions() {
+    this.muxTransmuxer_.resetCaptions();
+  }
 
   /**
    * Handles the 'data' event of the transmuxer.
@@ -255,4 +261,3 @@ shaka.media.Transmuxer = class {
     this.isTransmuxing_ = false;
   }
 };
-

--- a/lib/media/transmuxer.js
+++ b/lib/media/transmuxer.js
@@ -261,3 +261,4 @@ shaka.media.Transmuxer = class {
     this.isTransmuxing_ = false;
   }
 };
+

--- a/test/media/media_source_engine_integration.js
+++ b/test/media/media_source_engine_integration.js
@@ -408,9 +408,9 @@ describe('MediaSourceEngine', () => {
     const initObject = new Map();
     initObject.set(ContentType.VIDEO, getFakeStream(metadata.video));
     initObject.set(ContentType.TEXT, getFakeStream(metadata.text));
-    // Call with forceTransmuxTS = true, so that it will transmux even on
+    // Call with forceTransmux = true, so that it will transmux even on
     // platforms with native TS support.
-    await mediaSourceEngine.init(initObject, /* forceTransmuxTS= */ true);
+    await mediaSourceEngine.init(initObject, /* forceTransmux= */ true);
     mediaSourceEngine.setSelectedClosedCaptionId('CC1');
 
     await append(ContentType.VIDEO, 2);


### PR DESCRIPTION
For HLS non native, Shaka gets the captions from mux.js transmuxer. This
 works until you seek back before the buffered range. In mux.js there is
 a condition that ignores a caption if this belongs to a DTS that is
behind the latest it already has parsed.

To handle seeks, it adds a reset method that is called by the transmuxer.resetCaptions() method in mp4\transmuxer.js in mux.js. But Shaka Player is not calling it. So I added the resetCaptions() method to the mux.js extern definition and we called it in the appendBuffer method in media_source_engine.js before sending the data to transmux and only if the seeked parameter is True.

Closes #4641 