### PR TITLE
fix: Fix HLS lazy-loading exception on switch

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1559,14 +1559,16 @@ shaka.hls.HlsParser = class {
       firstSequenceNumber: -1,
       loadedOnce: false,
     };
-    const downloadSegmentIndex = async () => {
-      // Un-assign this function, so that if it's called a second time we don't
-      // download twice.
-      stream.createSegmentIndex = () => Promise.resolve();
 
+    /** @param {!AbortSignal} abortSignal */
+    const downloadSegmentIndex = async (abortSignal) => {
       // Download the actual manifest.
       const response = await this.requestManifest_(
           streamInfo.absoluteMediaPlaylistUri);
+      if (abortSignal.aborted) {
+        return;
+      }
+
       // Record the final URI after redirects.
       const absoluteMediaPlaylistUri = response.uri;
 
@@ -1581,6 +1583,10 @@ shaka.hls.HlsParser = class {
           playlist, verbatimMediaPlaylistUri, absoluteMediaPlaylistUri, codecs,
           type, language, primary, name, channelsCount, closedCaptions,
           characteristics, forced, spatialAudio);
+      if (abortSignal.aborted) {
+        return;
+      }
+
       const realStream = realStreamInfo.stream;
 
       if (this.isLive_() && !wasLive) {
@@ -1645,16 +1651,46 @@ shaka.hls.HlsParser = class {
         }
       }
     };
-    stream.createSegmentIndex = downloadSegmentIndex;
+
+    /** @type {Promise} */
+    let creationPromise = null;
+    /** @type {!AbortController} */
+    let abortController = new AbortController();
+    const safeCreateSegmentIndex = () => {
+      // An operation is already in progress.  The second and subsequent
+      // callers receive the same Promise as the first caller, and only one
+      // download operation will occur.
+      if (creationPromise) {
+        return creationPromise;
+      }
+
+      // Create a new AbortController to be able to cancel this specific
+      // download.
+      abortController = new AbortController();
+
+      // Create a Promise tied to the outcome of downloadSegmentIndex().  If
+      // downloadSegmentIndex is rejected, creationPromise will also be
+      // rejected.
+      creationPromise = new Promise((resolve) => {
+        resolve(downloadSegmentIndex(abortController.signal));
+      });
+      return creationPromise;
+    };
+
+    stream.createSegmentIndex = safeCreateSegmentIndex;
+
     stream.closeSegmentIndex = () => {
+      // If we're mid-creation, cancel it.
+      if (creationPromise && !stream.segmentIndex) {
+        abortController.abort();
+      }
+      // If we have a segment index, release it.
       if (stream.segmentIndex) {
         stream.segmentIndex.release();
         stream.segmentIndex = null;
       }
-
-      // Now that we have closed the segment index, calling createSegmentIndex
-      // should download it again.
-      stream.createSegmentIndex = downloadSegmentIndex;
+      // Clear the creation Promise so that a new operation can begin.
+      creationPromise = null;
     };
 
     return streamInfo;


### PR DESCRIPTION
For HLS lazy-loading, there was a race.  If a call to switch streams occurred during a fetch-and-append operation in StreamingEngine, there would be two calls to createSegmentIndex() for the same stream.  This was being mishandled in the HLS parser, such that the second call would return immediately without waiting on the creation of the segment index.

This fixes HLS's createSegmentIndex() method to ensure that multiple calls on the same stream return the same Promise.

Closes #4621