### PR TITLE
fix(ui): Fix exception on screen rotation if fullscreen is not supported

### DIFF
--- a/ui/controls.js
+++ b/ui/controls.js
@@ -1024,7 +1024,8 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
     if (!this.video_ ||
         this.video_.readyState == 0 ||
         this.castProxy_.isCasting() ||
-        !this.config_.enableFullscreenOnRotation) { return; }
+        !this.config_.enableFullscreenOnRotation ||
+    !this.isFullScreenSupported()) { return; }
 
     if (screen.orientation.type.includes('landscape') &&
         !document.fullscreenElement) {

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -1025,7 +1025,9 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
         this.video_.readyState == 0 ||
         this.castProxy_.isCasting() ||
         !this.config_.enableFullscreenOnRotation ||
-    !this.isFullScreenSupported()) { return; }
+        !this.isFullScreenSupported()) {
+      return;
+    }
 
     if (screen.orientation.type.includes('landscape') &&
         !document.fullscreenElement) {


### PR DESCRIPTION
### Problem description
Console error in environment where fullscreen is not possible when enableFullscreenOnRotation option is turned on

```console
TypeError: i.j.requestFullscreen is not a function. (In 'i.j.requestFullscreen({navigationUI:"hide"})', 'i.j.requestFullscreen' is undefined)
```

### How to fix
check `isFullScreenSupported` on `onScreenRotation`