### PR TITLE
fix: Fix duplicate cues around segment boundaries

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -8,6 +8,7 @@
 goog.provide('shaka.text.UITextDisplayer');
 
 goog.require('goog.asserts');
+goog.require('shaka.log');
 goog.require('shaka.text.Cue');
 goog.require('shaka.text.CueRegion');
 goog.require('shaka.util.Dom');
@@ -113,6 +114,9 @@ shaka.text.UITextDisplayer = class {
     // list growing during the comparisons for duplicate cues.
     // See: https://github.com/shaka-project/shaka-player/issues/3018
     const cuesList = [...this.cues_];
+
+    /** @type {Array.<!shaka.text.Cue>} */
+    const additionalCues = [];
     for (const cue of cues) {
       // When a VTT cue spans a segment boundary, the cue will be duplicated
       // into two segments.
@@ -121,8 +125,49 @@ shaka.text.UITextDisplayer = class {
       const containsCue = cuesList.some(
           (cueInList) => shaka.text.Cue.equal(cueInList, cue));
       if (!containsCue) {
-        this.cues_.push(cue);
+        additionalCues.push(cue);
       }
+    }
+
+    // But we need to check if there are nested duplicates that this
+    // equality check would not catch, e.g. cue spanning a segment
+    // could appear as the last nested in one cue and the first nested in
+    // that being added.
+    const lastExistingCue = cuesList[cuesList.length-1];
+    const firstNewCue = additionalCues[0];
+    if (cuesList.length > 0 && firstNewCue &&
+      lastExistingCue.endTime >= firstNewCue.startTime) {
+      shaka.log.info(
+          `Found potential overlap: new start at ${firstNewCue.startTime
+          } vs prev end at ${lastExistingCue.endTime}`);
+      if (
+        lastExistingCue.nestedCues &&
+        firstNewCue.nestedCues) {
+        const childNestedLen = lastExistingCue.nestedCues.length;
+
+        if (lastExistingCue
+            .nestedCues[childNestedLen-1] &&
+            lastExistingCue
+                .nestedCues[childNestedLen-1].nestedCues) {
+          const grandchildNestedLen = lastExistingCue
+              .nestedCues[childNestedLen-1].nestedCues.length;
+
+          const existingTrailingCue = lastExistingCue
+              .nestedCues[childNestedLen-1].nestedCues[grandchildNestedLen-1];
+          const newLeadingCue = firstNewCue.nestedCues[0].nestedCues[0];
+          if (newLeadingCue && shaka.text.Cue.equal(existingTrailingCue,
+              newLeadingCue)) {
+            shaka.log.info(
+                `Slicing out dupl cue ${existingTrailingCue.startTime}-${
+                  existingTrailingCue.endTime}`);
+            additionalCues[0].nestedCues[0].nestedCues.shift();
+          }
+        }
+      }
+    }
+
+    for (const cue of additionalCues) {
+      this.cues_.push(cue);
     }
 
     this.updateCaptions_();


### PR DESCRIPTION
Proposed fix for issue #4631 to eliminate duplicate cues lying near segment boundaries.
This supplements the existing cue equality check which does not find those that are nested deeper than literal duplicate cues.

Closes https://github.com/shaka-project/shaka-player/issues/4631