### PR TITLE
fix: 4676 - Virgin Media set top box is incorrectly getting categorized as Apple/Safari

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -199,6 +199,7 @@ shaka.util.Platform = class {
     return !!navigator.vendor && navigator.vendor.includes('Apple') &&
         !shaka.util.Platform.isTizen() &&
         !shaka.util.Platform.isEOS() &&
+        !shaka.util.Platform.isVirginMedia() &&
         !shaka.util.Platform.isPS4();
   }
 
@@ -220,6 +221,13 @@ shaka.util.Platform = class {
    */
   static isPS4() {
     return shaka.util.Platform.userAgentContains_('PlayStation 4');
+  }
+
+  /**
+   * Check if the current platform is Virgin Media device.
+   */
+  static isVirginMedia() {
+    return shaka.util.Platform.userAgentContains_('VirginMedia');
   }
 
   /**


### PR DESCRIPTION
In order to get the playback working, I am excluding VirginMedia device from `isApple()` platform test, otherwise it incorrectly fails at `isBrowserSupported()`.