### PR TITLE
fix(ui): check requestFullscreen function when screen rotation event

### DIFF
--- a/ui/controls.js
+++ b/ui/controls.js
@@ -1025,7 +1025,9 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
         this.video_.readyState == 0 ||
         this.castProxy_.isCasting() ||
         !this.config_.enableFullscreenOnRotation ||
-        !this.isFullScreenSupported()) {
+        !this.isFullScreenSupported()||
+        typeof (this.video_.requestFullscreen) !== 'function'
+    ) {
       return;
     }
 


### PR DESCRIPTION
### Related
#4669 

### Problem  
We recently added a check to see if it supports full screen when rotating the screen.
However, although the result of the isFullScreenSupported function on iPhone iOS is true, there is still a bug.
I checked and found that video.webkitSupportsFullscreen is true, but video.requestFullscreen is undefined.

![CleanShot 2022-11-10 at 18 00 05](https://user-images.githubusercontent.com/25482071/201047694-703f9d65-d723-4b1a-99e2-c300b5c4e064.png)