### PR TITLE
test: Fix platform detection for Xbox

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -174,7 +174,7 @@ shaka.util.Platform = class {
    * @return {?number} A major version number or null if not Chromium-based.
    */
   static chromeVersion() {
-    if (!shaka.util.Platform.userAgentContains_('Chrome')) {
+    if (!shaka.util.Platform.isChrome()) {
       return null;
     }
 


### PR DESCRIPTION
Xbox One was being misdetected as Chrome, causing some mistakes in which tests are skipped.

This does not appear to affect the library itself, since isChrome() and chromeVersion() are only used in tests currently.