### PR TITLE
chore: Add missing license header

### DIFF
--- a/test/polyfill/patchedmediakeys_apple_unit.js
+++ b/test/polyfill/patchedmediakeys_apple_unit.js
@@ -1,3 +1,9 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 describe('PatchedMediaKeys_Apple', () => {
   const PatchedMediaKeysApple = shaka.polyfill.PatchedMediaKeysApple;
   let originalMediaKeys;


### PR DESCRIPTION
An internal build system spotted this issue after being synced to the v4.3.0 release.