### PR TITLE
fix(ui): Check event cancelable before event.preventDefault

### DIFF
--- a/ui/controls.js
+++ b/ui/controls.js
@@ -1192,7 +1192,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
       // The controls are hidden, so show them.
       this.onMouseMove_(event);
       // Stop this event from becoming a click event.
-      event.preventDefault();
+      event.cancelable && event.preventDefault();
     }
   }
 


### PR DESCRIPTION
### Problem
```
[Intervention] Ignored attempt to cancel a touchstart event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.
```

This error occurs when the first touch is initiated.
Added logic to confirm that the error can be cancelled before event.preventDefault.