### PR TITLE
test: Fix Xbox DRM tests

### DIFF
--- a/test/media/drm_engine_unit.js
+++ b/test/media/drm_engine_unit.js
@@ -120,11 +120,17 @@ describe('DrmEngine', () => {
     };
 
     drmEngine = new shaka.media.DrmEngine(playerInterface);
+
     config = shaka.util.PlayerConfiguration.createDefault().drm;
     config.servers = {
       'drm.abc': 'http://abc.drm/license',
       'drm.def': 'http://def.drm/license',
     };
+    // Some platforms, such as Xbox, default to parseInbandPssh: true, which
+    // ignores encrypted events.  So set it explicitly to false, and let
+    // individual tests set it to true where relevant.
+    config.parseInbandPsshEnabled = false;
+
     drmEngine.configure(config);
   });
 
@@ -2548,7 +2554,11 @@ describe('DrmEngine', () => {
    */
   async function sendEncryptedEvent(
       initDataType = 'cenc', initData = new Uint8Array(1), keyId = null) {
-    mockVideo.on['encrypted']({initDataType, initData, keyId});
+    // For some platforms, such as Xbox, where parseInbandPssh defaults to
+    // true, this listener may never be set.
+    if (mockVideo.on['encrypted']) {
+      mockVideo.on['encrypted']({initDataType, initData, keyId});
+    }
 
     await Util.shortDelay();
   }


### PR DESCRIPTION
Since we ended up with a different default config on Xbox, the tests for DRM broke.  That went unnoticed because Xbox is offline in our lab.  The issue was discovered while working to restore that platform in the lab test runs.