### PR TITLE
ci: Re-enable Tizen in the lab

### DIFF
--- a/build/shaka-lab.yaml
+++ b/build/shaka-lab.yaml
@@ -164,8 +164,6 @@ Chromebook:
 
 Tizen:
   browser: tizen
-  # TODO: Re-enable Tizen (https://github.com/shaka-project/generic-webdriver-server/issues/57)
-  disabled: true
 
 XboxOne:
   browser: xboxone


### PR DESCRIPTION
An upgrade to Tizen Studio and the Docker image for it have solved our Tizen lab infra issues.