### PR TITLE
fix: Fix compiler error on static use of "this"

### DIFF
--- a/lib/polyfill/patchedmediakeys_apple.js
+++ b/lib/polyfill/patchedmediakeys_apple.js
@@ -27,18 +27,21 @@ goog.require('shaka.util.StringUtils');
 shaka.polyfill.PatchedMediaKeysApple = class {
   /**
    * Installs the polyfill if needed.
-   * @param {boolean} enableUninstall enables uninstalling the polyfill
+   * @param {boolean=} enableUninstall enables uninstalling the polyfill
    * @export
    */
   static install(enableUninstall = false) {
+    // Alias
+    const PatchedMediaKeysApple = shaka.polyfill.PatchedMediaKeysApple;
+
     if (!window.HTMLVideoElement || !window.WebKitMediaKeys) {
       // No HTML5 video or no prefixed EME.
       return;
     }
 
     if (enableUninstall) {
-      this.enableUninstall = true;
-      this.originalHTMLMediaElementPrototypeMediaKeys =
+      PatchedMediaKeysApple.enableUninstall = true;
+      PatchedMediaKeysApple.originalHTMLMediaElementPrototypeMediaKeys =
         /** @type {!Object} */ (
           Object.getOwnPropertyDescriptor(
               // eslint-disable-next-line no-restricted-syntax
@@ -46,18 +49,16 @@ shaka.polyfill.PatchedMediaKeysApple = class {
           )
         );
       // eslint-disable-next-line no-restricted-syntax
-      this.originalHTMLMediaElementPrototypeSetMediaKeys = HTMLMediaElement
-          .prototype.setMediaKeys;
-      this.originalWindowMediaKeys = window.MediaKeys;
-      this.originalWindowMediaKeySystemAccess = window.MediaKeySystemAccess;
-      this.originalNavigatorRequestMediaKeySystemAccess = navigator
-          .requestMediaKeySystemAccess;
+      PatchedMediaKeysApple.originalHTMLMediaElementPrototypeSetMediaKeys =
+          HTMLMediaElement.prototype.setMediaKeys;
+      PatchedMediaKeysApple.originalWindowMediaKeys = window.MediaKeys;
+      PatchedMediaKeysApple.originalWindowMediaKeySystemAccess =
+          window.MediaKeySystemAccess;
+      PatchedMediaKeysApple.originalNavigatorRequestMediaKeySystemAccess =
+          navigator.requestMediaKeySystemAccess;
     }
 
     shaka.log.info('Using Apple-prefixed EME');
-
-    // Alias
-    const PatchedMediaKeysApple = shaka.polyfill.PatchedMediaKeysApple;
 
     // Delete mediaKeys to work around strict mode compatibility issues.
     // eslint-disable-next-line no-restricted-syntax
@@ -83,32 +84,36 @@ shaka.polyfill.PatchedMediaKeysApple = class {
    * @export
    */
   static uninstall() {
-    if (!this.enableUninstall) {
+    // Alias
+    const PatchedMediaKeysApple = shaka.polyfill.PatchedMediaKeysApple;
+
+    if (!PatchedMediaKeysApple.enableUninstall) {
       return;
     }
 
     shaka.log.info('Un-installing Apple-prefixed EME');
 
-    this.enableUninstall = false;
+    PatchedMediaKeysApple.enableUninstall = false;
     Object.defineProperty(
         // eslint-disable-next-line no-restricted-syntax
         HTMLMediaElement.prototype,
         'mediaKeys',
-        this.originalHTMLMediaElementPrototypeMediaKeys,
+        PatchedMediaKeysApple.originalHTMLMediaElementPrototypeMediaKeys,
     );
     // eslint-disable-next-line no-restricted-syntax
-    HTMLMediaElement.prototype.setMediaKeys = this
-        .originalHTMLMediaElementPrototypeSetMediaKeys;
-    window.MediaKeys = this.originalWindowMediaKeys;
-    window.MediaKeySystemAccess = this.originalWindowMediaKeySystemAccess;
-    navigator.requestMediaKeySystemAccess = this
-        .originalNavigatorRequestMediaKeySystemAccess;
+    HTMLMediaElement.prototype.setMediaKeys =
+        PatchedMediaKeysApple.originalHTMLMediaElementPrototypeSetMediaKeys;
+    window.MediaKeys = PatchedMediaKeysApple.originalWindowMediaKeys;
+    window.MediaKeySystemAccess =
+        PatchedMediaKeysApple.originalWindowMediaKeySystemAccess;
+    navigator.requestMediaKeySystemAccess =
+        PatchedMediaKeysApple.originalNavigatorRequestMediaKeySystemAccess;
 
-    this.originalWindowMediaKeys = null;
-    this.originalWindowMediaKeySystemAccess = null;
-    this.originalHTMLMediaElementPrototypeSetMediaKeys = null;
-    this.originalNavigatorRequestMediaKeySystemAccess = null;
-    this.originalHTMLMediaElementPrototypeMediaKeys = null;
+    PatchedMediaKeysApple.originalWindowMediaKeys = null;
+    PatchedMediaKeysApple.originalWindowMediaKeySystemAccess = null;
+    PatchedMediaKeysApple.originalHTMLMediaElementPrototypeSetMediaKeys = null;
+    PatchedMediaKeysApple.originalNavigatorRequestMediaKeySystemAccess = null;
+    PatchedMediaKeysApple.originalHTMLMediaElementPrototypeMediaKeys = null;
 
     window.shakaMediaKeysPolyfill = false;
   }

--- a/lib/polyfill/patchedmediakeys_apple.js
+++ b/lib/polyfill/patchedmediakeys_apple.js
@@ -48,8 +48,8 @@ shaka.polyfill.PatchedMediaKeysApple = class {
               HTMLMediaElement.prototype, 'mediaKeys',
           )
         );
-      // eslint-disable-next-line no-restricted-syntax
       PatchedMediaKeysApple.originalHTMLMediaElementPrototypeSetMediaKeys =
+          // eslint-disable-next-line no-restricted-syntax
           HTMLMediaElement.prototype.setMediaKeys;
       PatchedMediaKeysApple.originalWindowMediaKeys = window.MediaKeys;
       PatchedMediaKeysApple.originalWindowMediaKeySystemAccess =


### PR DESCRIPTION
An internal build system failed to compile v4.3.0 due to the use of static "this".  This change fixes it.

Unfortunately, we are already running the latest public compiler release, so there is no way we could have caught this on GitHub.