### PR TITLE
fix(subs): Avoid removing in-use region elements

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -581,7 +581,7 @@ shaka.text.UITextDisplayer = class {
     //   (for vertical growing left) is aligned at the line.
     // TODO: Implement line alignment with line number.
     // TODO: Implement lineAlignment of 'CENTER'.
-    if (cue.line) {
+    if (cue.line != null) {
       if (cue.lineInterpretation == Cue.lineInterpretation.PERCENTAGE) {
         // When setting absolute positioning, you need to set x/y/width/height
         // so the element is positioned correctly.  Set these as default and
@@ -594,21 +594,21 @@ shaka.text.UITextDisplayer = class {
           if (cue.lineAlign == Cue.lineAlign.START) {
             style.top = cue.line + '%';
           } else if (cue.lineAlign == Cue.lineAlign.END) {
-            style.bottom = cue.line + '%';
+            style.bottom = (100 - cue.line) + '%';
           }
         } else if (cue.writingMode == Cue.writingMode.VERTICAL_LEFT_TO_RIGHT) {
           style.height = '100%';
           if (cue.lineAlign == Cue.lineAlign.START) {
             style.left = cue.line + '%';
           } else if (cue.lineAlign == Cue.lineAlign.END) {
-            style.right = cue.line + '%';
+            style.right = (100 - cue.line) + '%';
           }
         } else {
           style.height = '100%';
           if (cue.lineAlign == Cue.lineAlign.START) {
             style.right = cue.line + '%';
           } else if (cue.lineAlign == Cue.lineAlign.END) {
-            style.left = cue.line + '%';
+            style.left = (100 - cue.line) + '%';
           }
         }
       }
@@ -618,7 +618,7 @@ shaka.text.UITextDisplayer = class {
 
     // The position defines the indent of the text container in the
     // direction defined by the writing direction.
-    if (cue.position) {
+    if (cue.position != null) {
       if (cue.writingMode == Cue.writingMode.HORIZONTAL_TOP_TO_BOTTOM) {
         style.paddingLeft = cue.position;
       } else {

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -280,7 +280,10 @@ shaka.text.UITextDisplayer = class {
       for (const element of toUproot) {
         // NOTE: Because we uproot shared region elements, too, we might hit an
         // element here that has no parent because we've already processed it.
-        if (element.parentElement) {
+        // But avoid removing regions here due to risk of missing out
+        // subsequent captions.
+        if (element.parentElement &&
+            !element.id.includes('shaka-text-region')) {
           element.parentElement.removeChild(element);
         }
       }
@@ -578,7 +581,7 @@ shaka.text.UITextDisplayer = class {
     //   (for vertical growing left) is aligned at the line.
     // TODO: Implement line alignment with line number.
     // TODO: Implement lineAlignment of 'CENTER'.
-    if (cue.line != null) {
+    if (cue.line) {
       if (cue.lineInterpretation == Cue.lineInterpretation.PERCENTAGE) {
         // When setting absolute positioning, you need to set x/y/width/height
         // so the element is positioned correctly.  Set these as default and
@@ -591,21 +594,21 @@ shaka.text.UITextDisplayer = class {
           if (cue.lineAlign == Cue.lineAlign.START) {
             style.top = cue.line + '%';
           } else if (cue.lineAlign == Cue.lineAlign.END) {
-            style.bottom = (100 - cue.line) + '%';
+            style.bottom = cue.line + '%';
           }
         } else if (cue.writingMode == Cue.writingMode.VERTICAL_LEFT_TO_RIGHT) {
           style.height = '100%';
           if (cue.lineAlign == Cue.lineAlign.START) {
             style.left = cue.line + '%';
           } else if (cue.lineAlign == Cue.lineAlign.END) {
-            style.right = (100 - cue.line) + '%';
+            style.right = cue.line + '%';
           }
         } else {
           style.height = '100%';
           if (cue.lineAlign == Cue.lineAlign.START) {
             style.right = cue.line + '%';
           } else if (cue.lineAlign == Cue.lineAlign.END) {
-            style.left = (100 - cue.line) + '%';
+            style.left = cue.line + '%';
           }
         }
       }
@@ -615,7 +618,7 @@ shaka.text.UITextDisplayer = class {
 
     // The position defines the indent of the text container in the
     // direction defined by the writing direction.
-    if (cue.position != null) {
+    if (cue.position) {
       if (cue.writingMode == Cue.writingMode.HORIZONTAL_TOP_TO_BOTTOM) {
         style.paddingLeft = cue.position;
       } else {


### PR DESCRIPTION
Proposed fix: Closes #4680 

Avoid removing region elements from the DOM due to risk of failing to put them back with imminent captions in the same region.