### PR TITLE
fix(cast): Use cast platform APIs in MediaCapabilties polyfill

### DIFF
--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -267,10 +267,6 @@ shaka.polyfill.MediaCapabilities = class {
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.CAST,
           shaka.util.Error.Code.CAST_API_UNAVAILABLE);
-    } else if (!(cast.__platform__ && cast.__platform__.canDisplayType)) {
-      shaka.log.warning('Expected cast APIs to be available! Falling back to ' +
-          'MediaSource.isTypeSupported() for type support.');
-      return MediaSource.isTypeSupported(contentType);
     }
 
     let displayType = contentType;

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -110,18 +110,19 @@ shaka.polyfill.MediaCapabilities = class {
       // See: https://github.com/shaka-project/shaka-player/issues/4726
       if (videoConfig) {
         const contentType = videoConfig.contentType;
-        let isSupported;
-        if (shaka.util.Platform.isChromecast()) {
-          isSupported = shaka.polyfill.MediaCapabilities.canCastDisplayType_({
-            contentType,
-            width: videoConfig.width,
-            height: videoConfig.height,
-            frameRate: videoConfig.framerate,
-            transferFunction: videoConfig.transferFunction,
-          });
-        } else {
-          isSupported = MediaSource.isTypeSupported(contentType);
-        }
+        const isSupported = MediaSource.isTypeSupported(contentType);
+        // let isSupported;
+        // if (shaka.util.Platform.isChromecast()) {
+        // isSupported = shaka.polyfill.MediaCapabilities.canCastDisplayType_({
+        // contentType,
+        // width: videoConfig.width,
+        // height: videoConfig.height,
+        // frameRate: videoConfig.framerate,
+        // transferFunction: videoConfig.transferFunction,
+        // });
+        // } else {
+        // isSupported = MediaSource.isTypeSupported(contentType);
+        // }
         if (!isSupported) {
           return res;
         }

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -109,18 +109,12 @@ shaka.polyfill.MediaCapabilities = class {
       // accepts extended MIME type parameters.
       // See: https://github.com/shaka-project/shaka-player/issues/4726
       if (videoConfig) {
-        const contentType = videoConfig.contentType;
         let isSupported;
         if (shaka.util.Platform.isChromecast()) {
-          isSupported = shaka.polyfill.MediaCapabilities.canCastDisplayType_({
-            contentType,
-            width: videoConfig.width,
-            height: videoConfig.height,
-            frameRate: videoConfig.framerate,
-            transferFunction: videoConfig.transferFunction,
-          });
+          isSupported =
+              shaka.polyfill.MediaCapabilities.canCastDisplayType_(videoConfig);
         } else {
-          isSupported = MediaSource.isTypeSupported(contentType);
+          isSupported = MediaSource.isTypeSupported(videoConfig.contentType);
         }
         if (!isSupported) {
           return res;
@@ -238,30 +232,13 @@ shaka.polyfill.MediaCapabilities = class {
   /**
    * Checks if the given media parameters of the video or audio streams are
    * supported by the Cast platform.
-   * @param {{
-   *   contentType: string,
-   *   width: (number|undefined),
-   *   height: (number|undefined),
-   *   frameRate: (number|undefined),
-   *   transferFunction: (string|undefined)
-   * }} options canCastDisplayType() options.
-   *     contentType: A valid MIME type and (optionally) a codecs parameter.
-   *     width: Describes the stream horizontal resolution in pixels.
-   *     height: Describes the stream vertical resolution in pixels.
-   *     frameRate: Describes the frame rate of the stream.
-   *     transferFunction: Describes the video transfer function supported by
-   *         the rendering capabilities of the user agent.
+   * @param {!VideoConfiguration} videoConfig The 'video' field of the
+   *     MediaDecodingConfiguration.
    * @return {boolean} `true` when the stream can be displayed on a Cast device.
    * @private
    */
-  static canCastDisplayType_({
-    contentType,
-    width = undefined,
-    height = undefined,
-    frameRate = undefined,
-    transferFunction = undefined,
-  }) {
-    if (!(window.cast && cast)) {
+  static canCastDisplayType_(videoConfig) {
+    if (!(window.cast)) {
       shaka.log.error('Expected cast namespace to be available!');
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
@@ -270,17 +247,18 @@ shaka.polyfill.MediaCapabilities = class {
     } else if (!(cast.__platform__ && cast.__platform__.canDisplayType)) {
       shaka.log.warning('Expected cast APIs to be available! Falling back to ' +
           'MediaSource.isTypeSupported() for type support.');
-      return MediaSource.isTypeSupported(contentType);
+      return MediaSource.isTypeSupported(videoConfig.contentType);
     }
 
-    let displayType = contentType;
-    if (width && height) {
-      displayType += `; width=${width}; height=${height}`;
+    let displayType = videoConfig.contentType;
+    if (videoConfig.width && videoConfig.height) {
+      displayType +=
+          `; width=${videoConfig.width}; height=${videoConfig.height}`;
     }
-    if (frameRate) {
-      displayType += `; framerate=${frameRate}`;
+    if (videoConfig.framerate) {
+      displayType += `; framerate=${videoConfig.framerate}`;
     }
-    if (transferFunction === 'pq') {
+    if (videoConfig.transferFunction === 'pq') {
       // A "PQ" transfer function indicates this is an HDR-capable stream;
       // "smpte2084" is the published standard. We need to inform the platform
       // this query is specifically for HDR.

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -257,7 +257,9 @@ shaka.polyfill.MediaCapabilities = class {
       displayType += `; framerate=${frameRate}`;
     }
     if (transferFunction.toLowerCase() === 'pq') {
-      // Necessary to properly check for HDR support on Cast.
+      // A "PQ" transfer function indicates this is an HDR-capable stream;
+      // "smpte2084" is the published standard. We need to inform the platform
+      // this query is specifically for HDR.
       displayType += '; eotf=smpte2084';
     }
     return cast.__platform__.canDisplayType(displayType);

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -267,6 +267,10 @@ shaka.polyfill.MediaCapabilities = class {
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.CAST,
           shaka.util.Error.Code.CAST_API_UNAVAILABLE);
+    } else if (!(cast.__platform__ && cast.__platform__.canDisplayType)) {
+      shaka.log.warning('Expected cast APIs to be available! Falling back to ' +
+          'MediaSource.isTypeSupported() for type support.');
+      return MediaSource.isTypeSupported(contentType);
     }
 
     let displayType = contentType;

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -96,37 +96,54 @@ shaka.polyfill.MediaCapabilities = class {
       return res;
     }
 
+    const videoConfig = mediaDecodingConfig['video'];
+    const audioConfig = mediaDecodingConfig['audio'];
+
     if (mediaDecodingConfig.type == 'media-source') {
       if (!shaka.util.Platform.supportsMediaSource()) {
         return res;
       }
       // Use 'MediaSource.isTypeSupported' to check if the stream is supported.
-      if (mediaDecodingConfig['video']) {
-        const contentType = mediaDecodingConfig['video'].contentType;
-        const isSupported = MediaSource.isTypeSupported(contentType);
+      // Cast platforms will instead use canDisplayType() which accepts extended
+      // MIME type parameters.
+      // See: https://github.com/shaka-project/shaka-player/issues/4726
+      if (videoConfig) {
+        const contentType = videoConfig.contentType;
+        let isSupported;
+        if (shaka.util.Platform.isChromecast()) {
+          isSupported = shaka.polyfill.MediaCapabilities.canDisplayType_({
+            contentType,
+            width: videoConfig.width,
+            height: videoConfig.height,
+            frameRate: videoConfig.frameRate,
+            transferFunction: videoConfig.transferFunction,
+          });
+        } else {
+          isSupported = MediaSource.isTypeSupported(contentType);
+        }
         if (!isSupported) {
           return res;
         }
       }
 
-      if (mediaDecodingConfig['audio']) {
-        const contentType = mediaDecodingConfig['audio'].contentType;
+      if (audioConfig) {
+        const contentType = audioConfig.contentType;
         const isSupported = MediaSource.isTypeSupported(contentType);
         if (!isSupported) {
           return res;
         }
       }
     } else if (mediaDecodingConfig.type == 'file') {
-      if (mediaDecodingConfig['video']) {
-        const contentType = mediaDecodingConfig['video'].contentType;
+      if (videoConfig) {
+        const contentType = videoConfig.contentType;
         const isSupported = shaka.util.Platform.supportsMediaType(contentType);
         if (!isSupported) {
           return res;
         }
       }
 
-      if (mediaDecodingConfig['audio']) {
-        const contentType = mediaDecodingConfig['audio'].contentType;
+      if (audioConfig) {
+        const contentType = audioConfig.contentType;
         const isSupported = shaka.util.Platform.supportsMediaType(contentType);
         if (!isSupported) {
           return res;
@@ -200,6 +217,110 @@ shaka.polyfill.MediaCapabilities = class {
     }
 
     return res;
+  }
+
+
+  /**
+   * Checks if the given media parameters of the video or audio streams are
+   * supported by the platform.
+   * @param {{
+   *   contentType: string,
+   *   width: (number|undefined),
+   *   height: (number|undefined),
+   *   frameRate: (number|undefined),
+   *   transferFunction: (string|undefined)
+   * }} options canDisplayType() options.
+   *     contentType: A valid MIME type and (optionally) a codecs parameter.
+   *     width: Describes the stream horizontal resolution in pixels.
+   *     height: Describes the stream vertical resolution in pixels.
+   *     frameRate: Describes the frame rate of the stream.
+   *     transferFunction: Describes the video transfer function supported by
+   *         the rendering capabilities of the user agent.
+   * @return {boolean} `true` when the stream can be displayed on a Cast device.
+   * @private
+   */
+  static canDisplayType_({
+    contentType,
+    width = undefined,
+    height = undefined,
+    frameRate = undefined,
+    transferFunction = undefined,
+  }) {
+    if (!cast.__platform__) {
+      return true;
+    }
+    let displayType = contentType;
+    if (width && height) {
+      displayType += `; width=${width}; height=${height}`;
+    }
+    if (frameRate) {
+      displayType += `; framerate=${frameRate}`;
+    }
+    if (transferFunction.toLowerCase() === 'pq') {
+      // Necessary to properly check for HDR support on Cast.
+      displayType += '; eotf=smpte2084';
+    }
+    console.log(`#########################################################`);
+    console.log(`[JULIAN]: Checking canDisplayType for: ${displayType}`);
+    console.log('[JULIAN]: canDisplayType(' +
+      'video/mp4; codecs="hev1.2.4.L153.B0"; width=1920; height=1080;' +
+          ' eotf="smpte2084"\') => ' +
+        `${cast.__platform__.canDisplayType(
+            'video/mp4; codecs="hev1.2.4.L153.B0"; width=1920; height=1080;' +
+            ' eotf="smpte2084"')}`);
+    console.log('[JULIAN]: canDisplayType(' +
+      'video/mp4; codecs="hev1.2.4.L153.B0"; width=3840; height=2160;' +
+          ' eotf="smpte2084"\') => ' +
+        `${cast.__platform__.canDisplayType(
+            'video/mp4; codecs="hev1.2.4.L153.B0"; width=3840; height=2160;' +
+            ' eotf="smpte2084"')}`);
+    console.log('[JULIAN]: canDisplayType(' +
+      'video/mp4; codecs="hev1.2.4.L153.B0"; width=1920; height=1080\') => ' +
+      `${cast.__platform__.canDisplayType(
+          'video/mp4; codecs="hev1.2.4.L153.B0"; width=1920; height=1080')}`);
+    console.log('[JULIAN]: canDisplayType(' +
+      'video/mp4; codecs="hev1.2.4.L153.B0"; width=3840; height=2160\') => ' +
+      `${cast.__platform__.canDisplayType(
+          'video/mp4; codecs="hev1.2.4.L153.B0"; width=3840; height=2160')}`);
+    console.log('[JULIAN]: canDisplayType(' +
+      'video/mp4; codecs="hev1.2.4.L153.B0"\') => ' +
+      `${cast.__platform__.canDisplayType(
+          'video/mp4; codecs="hev1.2.4.L153.B0"')}`);
+    console.log('[JULIAN]: canDisplayType(' +
+      'video/mp4; codecs="hev1.2.4.L153.B0; eotf="smpte2084"\') => ' +
+      `${cast.__platform__.canDisplayType(
+          'video/mp4; codecs="hev1.2.4.L153.B0"; eotf="smpte2084"')}`);
+
+    console.log('[JULIAN]: canDisplayType(' +
+      'video/mp4; codecs="hvc1.2.4.L153.B0"; width=1920; height=1080;' +
+          ' eotf="smpte2084"\') => ' +
+        `${cast.__platform__.canDisplayType(
+            'video/mp4; codecs="hvc1.2.4.L153.B0"; width=1920; height=1080;' +
+            ' eotf="smpte2084"')}`);
+    console.log('[JULIAN]: canDisplayType(' +
+      'video/mp4; codecs="hvc1.2.4.L153.B0"; width=3840; height=2160;' +
+          ' eotf="smpte2084"\') => ' +
+        `${cast.__platform__.canDisplayType(
+            'video/mp4; codecs="hvc1.2.4.L153.B0"; width=3840; height=2160;' +
+            ' eotf="smpte2084"')}`);
+    console.log('[JULIAN]: canDisplayType(' +
+      'video/mp4; codecs="hvc1.2.4.L153.B0"; width=1920; height=1080\') => ' +
+      `${cast.__platform__.canDisplayType(
+          'video/mp4; codecs="hvc1.2.4.L153.B0"; width=1920; height=1080')}`);
+    console.log('[JULIAN]: canDisplayType(' +
+      'video/mp4; codecs="hvc1.2.4.L153.B0"; width=3840; height=2160\') => ' +
+      `${cast.__platform__.canDisplayType(
+          'video/mp4; codecs="hvc1.2.4.L153.B0"; width=3840; height=2160')}`);
+    console.log('[JULIAN]: canDisplayType(' +
+      'video/mp4; codecs="hvc1.2.4.L153.B0"\') => ' +
+      `${cast.__platform__.canDisplayType(
+          'video/mp4; codecs="hvc1.2.4.L153.B0"')}`);
+    console.log('[JULIAN]: canDisplayType(' +
+      'video/mp4; codecs="hvc1.2.4.L153.B0; eotf="smpte2084"\') => ' +
+      `${cast.__platform__.canDisplayType(
+          'video/mp4; codecs="hvc1.2.4.L153.B0"; eotf="smpte2084"')}`);
+    console.log(`#########################################################`);
+    return cast.__platform__.canDisplayType(displayType);
   }
 };
 

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -270,7 +270,7 @@ shaka.polyfill.MediaCapabilities = class {
     if (frameRate) {
       displayType += `; framerate=${frameRate}`;
     }
-    if (transferFunction.toLowerCase() === 'pq') {
+    if (transferFunction && transferFunction.toLowerCase() === 'pq') {
       // A "PQ" transfer function indicates this is an HDR-capable stream;
       // "smpte2084" is the published standard. We need to inform the platform
       // this query is specifically for HDR.

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -8,6 +8,7 @@ goog.provide('shaka.polyfill.MediaCapabilities');
 
 goog.require('shaka.log');
 goog.require('shaka.polyfill');
+goog.require('shaka.util.Error');
 goog.require('shaka.util.Platform');
 
 
@@ -111,11 +112,11 @@ shaka.polyfill.MediaCapabilities = class {
         const contentType = videoConfig.contentType;
         let isSupported;
         if (shaka.util.Platform.isChromecast()) {
-          isSupported = shaka.polyfill.MediaCapabilities.canDisplayType_({
+          isSupported = shaka.polyfill.MediaCapabilities.canCastDisplayType_({
             contentType,
             width: videoConfig.width,
             height: videoConfig.height,
-            frameRate: videoConfig.frameRate,
+            frameRate: videoConfig.framerate,
             transferFunction: videoConfig.transferFunction,
           });
         } else {
@@ -236,14 +237,14 @@ shaka.polyfill.MediaCapabilities = class {
 
   /**
    * Checks if the given media parameters of the video or audio streams are
-   * supported by the platform.
+   * supported by the Cast platform.
    * @param {{
    *   contentType: string,
    *   width: (number|undefined),
    *   height: (number|undefined),
    *   frameRate: (number|undefined),
    *   transferFunction: (string|undefined)
-   * }} options canDisplayType() options.
+   * }} options canCastDisplayType() options.
    *     contentType: A valid MIME type and (optionally) a codecs parameter.
    *     width: Describes the stream horizontal resolution in pixels.
    *     height: Describes the stream vertical resolution in pixels.
@@ -253,15 +254,20 @@ shaka.polyfill.MediaCapabilities = class {
    * @return {boolean} `true` when the stream can be displayed on a Cast device.
    * @private
    */
-  static canDisplayType_({
+  static canCastDisplayType_({
     contentType,
     width = undefined,
     height = undefined,
     frameRate = undefined,
     transferFunction = undefined,
   }) {
-    if (!cast.__platform__) {
-      return true;
+    if (!(window.cast && cast.__platform__ &&
+          cast.__platform__.canDisplayType)) {
+      shaka.log.error('Expected cast namespace to be available!');
+      throw new shaka.util.Error(
+            shaka.util.Error.Severity.CRITICAL,
+            shaka.util.Error.Category.CAST,
+            shaka.util.Error.Code.CAST_UNEXPECTED_PLATFORM);
     }
     let displayType = contentType;
     if (width && height) {
@@ -270,7 +276,7 @@ shaka.polyfill.MediaCapabilities = class {
     if (frameRate) {
       displayType += `; framerate=${frameRate}`;
     }
-    if (transferFunction && transferFunction.toLowerCase() === 'pq') {
+    if (transferFunction === 'pq') {
       // A "PQ" transfer function indicates this is an HDR-capable stream;
       // "smpte2084" is the published standard. We need to inform the platform
       // this query is specifically for HDR.

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -261,7 +261,7 @@ shaka.polyfill.MediaCapabilities = class {
     frameRate = undefined,
     transferFunction = undefined,
   }) {
-    if (!(window.cast && cast.__platform__ &&
+    if (!(cast && cast.__platform__ &&
           cast.__platform__.canDisplayType)) {
       shaka.log.error('Expected cast namespace to be available!');
       throw new shaka.util.Error(

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -260,66 +260,6 @@ shaka.polyfill.MediaCapabilities = class {
       // Necessary to properly check for HDR support on Cast.
       displayType += '; eotf=smpte2084';
     }
-    console.log(`#########################################################`);
-    console.log(`[JULIAN]: Checking canDisplayType for: ${displayType}`);
-    console.log('[JULIAN]: canDisplayType(' +
-      'video/mp4; codecs="hev1.2.4.L153.B0"; width=1920; height=1080;' +
-          ' eotf="smpte2084"\') => ' +
-        `${cast.__platform__.canDisplayType(
-            'video/mp4; codecs="hev1.2.4.L153.B0"; width=1920; height=1080;' +
-            ' eotf="smpte2084"')}`);
-    console.log('[JULIAN]: canDisplayType(' +
-      'video/mp4; codecs="hev1.2.4.L153.B0"; width=3840; height=2160;' +
-          ' eotf="smpte2084"\') => ' +
-        `${cast.__platform__.canDisplayType(
-            'video/mp4; codecs="hev1.2.4.L153.B0"; width=3840; height=2160;' +
-            ' eotf="smpte2084"')}`);
-    console.log('[JULIAN]: canDisplayType(' +
-      'video/mp4; codecs="hev1.2.4.L153.B0"; width=1920; height=1080\') => ' +
-      `${cast.__platform__.canDisplayType(
-          'video/mp4; codecs="hev1.2.4.L153.B0"; width=1920; height=1080')}`);
-    console.log('[JULIAN]: canDisplayType(' +
-      'video/mp4; codecs="hev1.2.4.L153.B0"; width=3840; height=2160\') => ' +
-      `${cast.__platform__.canDisplayType(
-          'video/mp4; codecs="hev1.2.4.L153.B0"; width=3840; height=2160')}`);
-    console.log('[JULIAN]: canDisplayType(' +
-      'video/mp4; codecs="hev1.2.4.L153.B0"\') => ' +
-      `${cast.__platform__.canDisplayType(
-          'video/mp4; codecs="hev1.2.4.L153.B0"')}`);
-    console.log('[JULIAN]: canDisplayType(' +
-      'video/mp4; codecs="hev1.2.4.L153.B0; eotf="smpte2084"\') => ' +
-      `${cast.__platform__.canDisplayType(
-          'video/mp4; codecs="hev1.2.4.L153.B0"; eotf="smpte2084"')}`);
-
-    console.log('[JULIAN]: canDisplayType(' +
-      'video/mp4; codecs="hvc1.2.4.L153.B0"; width=1920; height=1080;' +
-          ' eotf="smpte2084"\') => ' +
-        `${cast.__platform__.canDisplayType(
-            'video/mp4; codecs="hvc1.2.4.L153.B0"; width=1920; height=1080;' +
-            ' eotf="smpte2084"')}`);
-    console.log('[JULIAN]: canDisplayType(' +
-      'video/mp4; codecs="hvc1.2.4.L153.B0"; width=3840; height=2160;' +
-          ' eotf="smpte2084"\') => ' +
-        `${cast.__platform__.canDisplayType(
-            'video/mp4; codecs="hvc1.2.4.L153.B0"; width=3840; height=2160;' +
-            ' eotf="smpte2084"')}`);
-    console.log('[JULIAN]: canDisplayType(' +
-      'video/mp4; codecs="hvc1.2.4.L153.B0"; width=1920; height=1080\') => ' +
-      `${cast.__platform__.canDisplayType(
-          'video/mp4; codecs="hvc1.2.4.L153.B0"; width=1920; height=1080')}`);
-    console.log('[JULIAN]: canDisplayType(' +
-      'video/mp4; codecs="hvc1.2.4.L153.B0"; width=3840; height=2160\') => ' +
-      `${cast.__platform__.canDisplayType(
-          'video/mp4; codecs="hvc1.2.4.L153.B0"; width=3840; height=2160')}`);
-    console.log('[JULIAN]: canDisplayType(' +
-      'video/mp4; codecs="hvc1.2.4.L153.B0"\') => ' +
-      `${cast.__platform__.canDisplayType(
-          'video/mp4; codecs="hvc1.2.4.L153.B0"')}`);
-    console.log('[JULIAN]: canDisplayType(' +
-      'video/mp4; codecs="hvc1.2.4.L153.B0; eotf="smpte2084"\') => ' +
-      `${cast.__platform__.canDisplayType(
-          'video/mp4; codecs="hvc1.2.4.L153.B0"; eotf="smpte2084"')}`);
-    console.log(`#########################################################`);
     return cast.__platform__.canDisplayType(displayType);
   }
 };

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -105,30 +105,22 @@ shaka.polyfill.MediaCapabilities = class {
         return res;
       }
       // Use 'MediaSource.isTypeSupported' to check if the stream is supported.
+      // Cast platforms will additionally check canDisplayType(), which
+      // accepts extended MIME type parameters.
+      // See: https://github.com/shaka-project/shaka-player/issues/4726
       if (videoConfig) {
         const contentType = videoConfig.contentType;
-        let isSupported = MediaSource.isTypeSupported(contentType);
+        let isSupported;
         if (shaka.util.Platform.isChromecast()) {
-          // Cast platforms will additionally check canDisplayType(), which
-          // accepts extended MIME type parameters.
-          // There will be at most 2 calls:
-          // - The first call determines the stability of
-          // the API by validating a contentType input limited only to MIME type
-          // and codecs is identical to MediaSource.isTypeSupported().
-          // - If the same result is observed, a second call will be executed
-          // containing resolution, frame rate, and transfer function support.
-          // See: https://github.com/shaka-project/shaka-player/issues/4726
-          if (isSupported ===
-              shaka.polyfill.MediaCapabilities.canCastDisplayType_({
-                contentType})) {
-            isSupported = shaka.polyfill.MediaCapabilities.canCastDisplayType_({
-              contentType,
-              width: videoConfig.width,
-              height: videoConfig.height,
-              frameRate: videoConfig.framerate,
-              transferFunction: videoConfig.transferFunction,
-            });
-          }
+          isSupported = shaka.polyfill.MediaCapabilities.canCastDisplayType_({
+            contentType,
+            width: videoConfig.width,
+            height: videoConfig.height,
+            frameRate: videoConfig.framerate,
+            transferFunction: videoConfig.transferFunction,
+          });
+        } else {
+          isSupported = MediaSource.isTypeSupported(contentType);
         }
         if (!isSupported) {
           return res;
@@ -269,14 +261,18 @@ shaka.polyfill.MediaCapabilities = class {
     frameRate = undefined,
     transferFunction = undefined,
   }) {
-    if (!(window.cast && cast.__platform__ &&
-          cast.__platform__.canDisplayType)) {
+    if (!(window.cast && cast)) {
       shaka.log.error('Expected cast namespace to be available!');
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.CAST,
-          shaka.util.Error.Code.CAST_UNEXPECTED_PLATFORM);
+          shaka.util.Error.Code.CAST_API_UNAVAILABLE);
+    } else if (!(cast.__platform__ && cast.__platform__.canDisplayType)) {
+      shaka.log.warning('Expected cast APIs to be available! Falling back to ' +
+          'MediaSource.isTypeSupported() for type support.');
+      return MediaSource.isTypeSupported(contentType);
     }
+
     let displayType = contentType;
     if (width && height) {
       displayType += `; width=${width}; height=${height}`;

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -105,24 +105,31 @@ shaka.polyfill.MediaCapabilities = class {
         return res;
       }
       // Use 'MediaSource.isTypeSupported' to check if the stream is supported.
-      // Cast platforms will instead use canDisplayType() which accepts extended
-      // MIME type parameters.
-      // See: https://github.com/shaka-project/shaka-player/issues/4726
       if (videoConfig) {
         const contentType = videoConfig.contentType;
-        const isSupported = MediaSource.isTypeSupported(contentType);
-        // let isSupported;
-        // if (shaka.util.Platform.isChromecast()) {
-        // isSupported = shaka.polyfill.MediaCapabilities.canCastDisplayType_({
-        // contentType,
-        // width: videoConfig.width,
-        // height: videoConfig.height,
-        // frameRate: videoConfig.framerate,
-        // transferFunction: videoConfig.transferFunction,
-        // });
-        // } else {
-        // isSupported = MediaSource.isTypeSupported(contentType);
-        // }
+        let isSupported = MediaSource.isTypeSupported(contentType);
+        if (shaka.util.Platform.isChromecast()) {
+          // Cast platforms will additionally check canDisplayType(), which
+          // accepts extended MIME type parameters.
+          // There will be at most 2 calls:
+          // - The first call determines the stability of
+          // the API by validating a contentType input limited only to MIME type
+          // and codecs is identical to MediaSource.isTypeSupported().
+          // - If the same result is observed, a second call will be executed
+          // containing resolution, frame rate, and transfer function support.
+          // See: https://github.com/shaka-project/shaka-player/issues/4726
+          if (isSupported ===
+              shaka.polyfill.MediaCapabilities.canCastDisplayType_({
+                contentType})) {
+            isSupported = shaka.polyfill.MediaCapabilities.canCastDisplayType_({
+              contentType,
+              width: videoConfig.width,
+              height: videoConfig.height,
+              frameRate: videoConfig.framerate,
+              transferFunction: videoConfig.transferFunction,
+            });
+          }
+        }
         if (!isSupported) {
           return res;
         }

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -261,7 +261,7 @@ shaka.polyfill.MediaCapabilities = class {
     frameRate = undefined,
     transferFunction = undefined,
   }) {
-    if (!(cast && cast.__platform__ &&
+    if (!(window.cast && cast.__platform__ &&
           cast.__platform__.canDisplayType)) {
       shaka.log.error('Expected cast namespace to be available!');
       throw new shaka.util.Error(

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -265,9 +265,9 @@ shaka.polyfill.MediaCapabilities = class {
           cast.__platform__.canDisplayType)) {
       shaka.log.error('Expected cast namespace to be available!');
       throw new shaka.util.Error(
-            shaka.util.Error.Severity.CRITICAL,
-            shaka.util.Error.Category.CAST,
-            shaka.util.Error.Code.CAST_UNEXPECTED_PLATFORM);
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.CAST,
+          shaka.util.Error.Code.CAST_UNEXPECTED_PLATFORM);
     }
     let displayType = contentType;
     if (width && height) {

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -932,13 +932,6 @@ shaka.util.Error.Code = {
    */
   'CAST_RECEIVER_APP_UNAVAILABLE': 8006,
 
-  /**
-   * The Cast platform namespace was expected to be available, but wasn't.
-   * <br> This may be caused by Shaka failing to identify the correct platform
-   * through the userAgent string.
-   */
-  'CAST_UNEXPECTED_PLATFORM': 8007,
-
 
   // RETIRED: CAST_RECEIVER_APP_ID_MISSING': 8007,
 

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -932,6 +932,13 @@ shaka.util.Error.Code = {
    */
   'CAST_RECEIVER_APP_UNAVAILABLE': 8006,
 
+  /**
+   * The Cast platform namespace was expected to be available, but wasn't.
+   * <br> This may be caused by Shaka failing to identify the correct platform
+   * through the userAgent string.
+   */
+  'CAST_UNEXPECTED_PLATFORM': 8007,
+
 
   // RETIRED: CAST_RECEIVER_APP_ID_MISSING': 8007,
 

--- a/test/polyfill/media_capabilities_unit.js
+++ b/test/polyfill/media_capabilities_unit.js
@@ -11,6 +11,8 @@ describe('MediaCapabilities', () => {
   const originalRequestMediaKeySystemAccess =
     navigator.requestMediaKeySystemAccess;
   const originalMediaCapabilities = navigator.mediaCapabilities;
+  const originalCast = window['cast'];
+
   /** @type {MediaDecodingConfiguration} */
   let mockDecodingConfig;
   /** @type {!jasmine.Spy} */
@@ -73,6 +75,7 @@ describe('MediaCapabilities', () => {
   });
 
   afterAll(() => {
+    window['cast'] = originalCast;
     Object.defineProperty(window['navigator'],
         'userAgent', {value: originalUserAgent});
     Object.defineProperty(window['navigator'],

--- a/test/polyfill/media_capabilities_unit.js
+++ b/test/polyfill/media_capabilities_unit.js
@@ -74,6 +74,10 @@ describe('MediaCapabilities', () => {
     mockCanDisplayType.and.returnValue(false);
   });
 
+  afterEach(() => {
+    window['cast'] = originalCast;
+  });
+
   afterAll(() => {
     window['cast'] = originalCast;
     Object.defineProperty(window['navigator'],
@@ -183,7 +187,8 @@ describe('MediaCapabilities', () => {
     });
 
     it('throws when the cast namespace is not available', async () => {
-      // We don't set a mock cast namespace here to signal an error.
+      delete window['cast'];
+
       const isChromecastSpy =
           spyOn(shaka['util']['Platform'],
               'isChromecast').and.returnValue(true);

--- a/test/polyfill/media_capabilities_unit.js
+++ b/test/polyfill/media_capabilities_unit.js
@@ -187,6 +187,8 @@ describe('MediaCapabilities', () => {
     });
 
     it('throws when the cast namespace is not available', async () => {
+      // Temporarily remove window.cast to trigger error. It's restored after
+      // every test.
       delete window['cast'];
 
       const isChromecastSpy =
@@ -208,28 +210,6 @@ describe('MediaCapabilities', () => {
       // 1 (during install()) + 1 (for video config check).
       expect(isChromecastSpy).toHaveBeenCalledTimes(2);
     });
-
-    it('falls back to isTypeSupported() when canDisplayType() missing',
-        async () => {
-          // We only set the cast namespace, but not the canDisplayType() API.
-          window['cast'] = {};
-          const isChromecastSpy =
-              spyOn(shaka['util']['Platform'],
-                  'isChromecast').and.returnValue(true);
-          const isTypeSupportedSpy =
-              spyOn(window['MediaSource'], 'isTypeSupported')
-                  .and.returnValue(true);
-
-          shaka.polyfill.MediaCapabilities.install();
-          await navigator.mediaCapabilities.decodingInfo(mockDecodingConfig);
-
-          expect(mockCanDisplayType).not.toHaveBeenCalled();
-          // 1 (during install()) + 1 (for video config check).
-          expect(isChromecastSpy).toHaveBeenCalledTimes(2);
-          // 1 (fallback in canCastDisplayType()) +
-          // 1 (mockDecodingConfig.audio).
-          expect(isTypeSupportedSpy).toHaveBeenCalledTimes(2);
-        });
 
     it('should use cast.__platform__.canDisplayType for "supported" field ' +
         'when platform is Cast', async () => {

--- a/test/polyfill/media_capabilities_unit.js
+++ b/test/polyfill/media_capabilities_unit.js
@@ -194,8 +194,14 @@ describe('MediaCapabilities', () => {
 
       shaka.polyfill.MediaCapabilities.install();
       await expectAsync(
-          navigator.mediaCapabilities.decodingInfo(mockDecodingConfig)).
-              toBeRejectedWith(expected);
+          navigator.mediaCapabilities.decodingInfo(mockDecodingConfig))
+          .toBeRejectedWith(expected);
+
+      // 1 (during install()) + 1 (for video config check).
+      expect(isChromecastSpy).toHaveBeenCalledTimes(2);
+      // Called for decodingConfig.audio. This is never reached because of the
+      // error throw.
+      expect(isTypeSupportedSpy).not.toHaveBeenCalled();
     });
 
     it('should use cast.__platform__.canDisplayType for "supported" field ' +
@@ -230,10 +236,12 @@ describe('MediaCapabilities', () => {
       shaka.polyfill.MediaCapabilities.install();
       await navigator.mediaCapabilities.decodingInfo(mockDecodingConfig);
 
-      // Called once for audioConfig. Resolution, frame rate, and EOTF aren't
-      // applicable for audio, so isTypeSupported() is sufficient.
+      // 1 (during install()) + 1 (for video config check).
+      expect(isChromecastSpy).toHaveBeenCalledTimes(2);
+      // Called once for mockDecodingConfig.audio. Resolution, frame rate, and
+      // EOTF aren't applicable for audio, so isTypeSupported() is sufficient.
       expect(isTypeSupportedSpy).toHaveBeenCalledTimes(1);
-      // Called once for videoConfig.
+      // Called once for mockDecodingConfig.video.
       expect(mockCanDisplayType).toHaveBeenCalledTimes(1);
     });
   });

--- a/test/polyfill/media_capabilities_unit.js
+++ b/test/polyfill/media_capabilities_unit.js
@@ -211,6 +211,28 @@ describe('MediaCapabilities', () => {
       expect(isChromecastSpy).toHaveBeenCalledTimes(2);
     });
 
+    it('falls back to isTypeSupported() when canDisplayType() missing',
+        async () => {
+          // We only set the cast namespace, but not the canDisplayType() API.
+          window['cast'] = {};
+          const isChromecastSpy =
+              spyOn(shaka['util']['Platform'],
+                  'isChromecast').and.returnValue(true);
+          const isTypeSupportedSpy =
+              spyOn(window['MediaSource'], 'isTypeSupported')
+                  .and.returnValue(true);
+
+          shaka.polyfill.MediaCapabilities.install();
+          await navigator.mediaCapabilities.decodingInfo(mockDecodingConfig);
+
+          expect(mockCanDisplayType).not.toHaveBeenCalled();
+          // 1 (during install()) + 1 (for video config check).
+          expect(isChromecastSpy).toHaveBeenCalledTimes(2);
+          // 1 (fallback in canCastDisplayType()) +
+          // 1 (mockDecodingConfig.audio).
+          expect(isTypeSupportedSpy).toHaveBeenCalledTimes(2);
+        });
+
     it('should use cast.__platform__.canDisplayType for "supported" field ' +
         'when platform is Cast', async () => {
       // We're using quotes to access window.cast because the compiler

--- a/test/polyfill/media_capabilities_unit.js
+++ b/test/polyfill/media_capabilities_unit.js
@@ -251,13 +251,16 @@ describe('MediaCapabilities', () => {
       mockDecodingConfig.video.transferFunction = 'pq';
       mockDecodingConfig.video.contentType =
           'video/mp4; codecs="hev1.2.4.L153.B0"';
+      // Round to a whole number since we can't rely on number => string
+      // conversion precision on all devices.
+      mockDecodingConfig.video.framerate = 24;
       mockCanDisplayType.and.callFake((type) => {
         expect(type).toBe(
             'video/mp4; ' +
             'codecs="hev1.2.4.L153.B0"; ' +
             'width=512; ' +
             'height=288; ' +
-            'framerate=23.976023976023978; ' +
+            'framerate=24; ' +
             'eotf=smpte2084');
         return true;
       });


### PR DESCRIPTION
See https://github.com/shaka-project/shaka-player/issues/4726 for more context.

This allows Cast devices to properly filter stream variants with a resolution surpassing that of the device's capabilities.

We place the fix in the `MediaCapabilities` polyfill since it's intended to be the right way to check for anything related to platform support.

--- 

HDR support checks will require `eotf=smpte2048`, as indicated in https://github.com/shaka-project/shaka-player/issues/2813#issue-684874730. Specifically, a `{hev|hvc}1.2` profile is only an *indication* of an HDR transfer function, but *may* be a non-HDR 10-bit color stream. Take for instance this publicly available hls.js HEVC stream (https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8) which contains stream variants with the `hvc1.2.4.L123.B0` codecs, but with a resolution < 4K:

```
#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=1996813,BANDWIDTH=2194827,CODECS="hvc1.2.4.L123.B0,ec-3",RESOLUTION=960x540,FRAME-RATE=60.000,CLOSED-CAPTIONS="cc",AUDIO="a3",SUBTITLES="sub1"
v14/prog_index.m3u8
#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=6135662,BANDWIDTH=6694727,CODECS="hvc1.2.4.L123.B0,ec-3",RESOLUTION=1920x1080,FRAME-RATE=60.000,CLOSED-CAPTIONS="cc",AUDIO="a3",SUBTITLES="sub1"
v18/prog_index.m3u8
#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=4831572,BANDWIDTH=5458398,CODECS="hvc1.2.4.L123.B0,ec-3",RESOLUTION=1920x1080,FRAME-RATE=60.000,CLOSED-CAPTIONS="cc",AUDIO="a3",SUBTITLES="sub1"
v17/prog_index.m3u8
#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=3471811,BANDWIDTH=4110269,CODECS="hvc1.2.4.L123.B0,ec-3",RESOLUTION=1920x1080,FRAME-RATE=60.000,CLOSED-CAPTIONS="cc",AUDIO="a3",SUBTITLES="sub1"
v16/prog_index.m3u8
#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=2666432,BANDWIDTH=2795200,CODECS="hvc1.2.4.L123.B0,ec-3",RESOLUTION=1280x720,FRAME-RATE=60.000,CLOSED-CAPTIONS="cc",AUDIO="a3",SUBTITLES="sub1"
v15/prog_index.m3u8
#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=1169111,BANDWIDTH=1256754,CODECS="hvc1.2.4.L123.B0,ec-3",RESOLUTION=768x432,FRAME-RATE=30.000,CLOSED-CAPTIONS="cc",AUDIO="a3",SUBTITLES="sub1"
v13/prog_index.m3u8
#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=859838,BANDWIDTH=932269,CODECS="hvc1.2.4.L123.B0,ec-3",RESOLUTION=640x360,FRAME-RATE=30.000,CLOSED-CAPTIONS="cc",AUDIO="a3",SUBTITLES="sub1"
v12/prog_index.m3u8
#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=552728,BANDWIDTH=579426,CODECS="hvc1.2.4.L123.B0,ec-3",RESOLUTION=480x270,FRAME-RATE=30.000,CLOSED-CAPTIONS="cc",AUDIO="a3",SUBTITLES="sub1"
v11/prog_index.m3u8
#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=345440,BANDWIDTH=371212,CODECS="hvc1.2.4.L123.B0,ec-3",RESOLUTION=416x234,FRAME-RATE=30.000,CLOSED-CAPTIONS="cc",AUDIO="a3",SUBTITLES="sub1"
v10/prog_index.m3u8
```

In Cast, the platform can distinguish between the two by explicitly providing the transfer function; it uses `smpte2048` (`"PQ"`) because this is the "basis of HDR video formats..." (https://en.wikipedia.org/wiki/Perceptual_quantizer). Below you can see the platform correctly distinguishing between an HDR-capable and non-HDR capable HDMI sink device (using a 4K-capable Chromecast):

`canDisplayType()` results on a 1920x1080 ASUS monitor:
```
[JULIAN]: canDisplayType(video/mp4; codecs="hev1.2.4.L153.B0"; width=1920; height=1080; eotf="smpte2084"') => false
[JULIAN]: canDisplayType(video/mp4; codecs="hev1.2.4.L153.B0"; width=3840; height=2160; eotf="smpte2084"') => false
VM10:1 New style VP9 codec string must start with vp09. codecId:hev1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hev1.2.4.L153.B0"; width=1920; height=1080') => true
[JULIAN]: canDisplayType(video/mp4; codecs="hev1.2.4.L153.B0"; width=3840; height=2160') => false
VM10:1 New style VP9 codec string must start with vp09. codecId:hev1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hev1.2.4.L153.B0"') => true
[JULIAN]: canDisplayType(video/mp4; codecs="hev1.2.4.L153.B0; eotf="smpte2084"') => false
[JULIAN]: canDisplayType(video/mp4; codecs="hvc1.2.4.L153.B0"; width=1920; height=1080; eotf="smpte2084"') => false
[JULIAN]: canDisplayType(video/mp4; codecs="hvc1.2.4.L153.B0"; width=3840; height=2160; eotf="smpte2084"') => false
VM10:1 New style VP9 codec string must start with vp09. codecId:hvc1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hvc1.2.4.L153.B0"; width=1920; height=1080') => true
[JULIAN]: canDisplayType(video/mp4; codecs="hvc1.2.4.L153.B0"; width=3840; height=2160') => false
VM10:1 New style VP9 codec string must start with vp09. codecId:hvc1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hvc1.2.4.L153.B0"') => true
[JULIAN]: canDisplayType(video/mp4; codecs="hvc1.2.4.L153.B0; eotf="smpte2084"') => false
```

`canDisplayType()` results on a 4K HDR TCL 2017 Roku TV (43"):
```
New style VP9 codec string must start with vp09. codecId:hev1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hev1.2.4.L153.B0"; width=1920; height=1080; eotf="smpte2084"') => true
VM10:1 New style VP9 codec string must start with vp09. codecId:hev1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hev1.2.4.L153.B0"; width=3840; height=2160; eotf="smpte2084"') => true
VM10:1 New style VP9 codec string must start with vp09. codecId:hev1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hev1.2.4.L153.B0"; width=1920; height=1080') => true
VM10:1 New style VP9 codec string must start with vp09. codecId:hev1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hev1.2.4.L153.B0"; width=3840; height=2160') => true
VM10:1 New style VP9 codec string must start with vp09. codecId:hev1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hev1.2.4.L153.B0"') => true
VM10:1 New style VP9 codec string must start with vp09. codecId:hev1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hev1.2.4.L153.B0; eotf="smpte2084"') => true
VM10:1 New style VP9 codec string must start with vp09. codecId:hvc1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hvc1.2.4.L153.B0"; width=1920; height=1080; eotf="smpte2084"') => true
VM10:1 New style VP9 codec string must start with vp09. codecId:hvc1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hvc1.2.4.L153.B0"; width=3840; height=2160; eotf="smpte2084"') => true
VM10:1 New style VP9 codec string must start with vp09. codecId:hvc1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hvc1.2.4.L153.B0"; width=1920; height=1080') => true
VM10:1 New style VP9 codec string must start with vp09. codecId:hvc1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hvc1.2.4.L153.B0"; width=3840; height=2160') => true
VM10:1 New style VP9 codec string must start with vp09. codecId:hvc1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hvc1.2.4.L153.B0"') => true
VM10:1 New style VP9 codec string must start with vp09. codecId:hvc1.2.4.L153.B0
[JULIAN]: canDisplayType(video/mp4; codecs="hvc1.2.4.L153.B0; eotf="smpte2084"') => true
```