### PR TITLE
fix: Fix subtitles not added to DOM region

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -203,13 +203,13 @@ shaka.text.UITextDisplayer = class {
    * @private
    */
   isElementUnderTextContainer_(elemToCheck) {
-    if (elemToCheck == null) {
-      return false;
+    while (elemToCheck != null) {
+      if (elemToCheck == this.textContainer_) {
+        return true;
+      }
+      elemToCheck = elemToCheck.parentElement;
     }
-    if (elemToCheck == this.textContainer_) {
-      return true;
-    }
-    return this.isElementUnderTextContainer_(elemToCheck.parentElement);
+    return false;
   }
 
   /**

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -200,7 +200,6 @@ shaka.text.UITextDisplayer = class {
   }
 
   /**
-   * @param {!HTMLElement} elemToCheck
    * @private
    */
   isElementUnderTextContainer_(elemToCheck) {

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -200,6 +200,20 @@ shaka.text.UITextDisplayer = class {
   }
 
   /**
+   * @param {!HTMLElement} elemToCheck
+   * @private
+   */
+  isElementUnderTextContainer_(elemToCheck) {
+    if (elemToCheck == null) {
+      return false;
+    }
+    if (elemToCheck == this.textContainer_) {
+      return true;
+    }
+    return this.isElementUnderTextContainer_(elemToCheck.parentElement);
+  }
+
+  /**
    * @param {!Array.<!shaka.extern.Cue>} cues
    * @param {!HTMLElement} container
    * @param {number} currentTime
@@ -260,6 +274,9 @@ shaka.text.UITextDisplayer = class {
           cueRegistry = this.currentCuesMap_.get(cue);
           wrapper = cueRegistry.wrapper;
           updateDOM = true;
+        } else if (!this.isElementUnderTextContainer_(wrapper)) {
+          // We found that the wrapper needs to be in the DOM
+          updateDOM = true;
         }
       }
 
@@ -276,6 +293,7 @@ shaka.text.UITextDisplayer = class {
       const topCue = parents.pop();
       goog.asserts.assert(topCue == cue, 'Parent cues should be kept in order');
     }
+
     if (updateDOM) {
       for (const element of toUproot) {
         // NOTE: Because we uproot shared region elements, too, we might hit an


### PR DESCRIPTION
Proposed fix closes #4680

Reinstate previously removed region elements when next caption finds it is not there: Detect the absence and ensure `updateDOM` is true so its reinstated and the next caption can be shown.