### PR TITLE
feat: Enable variant failover for BAD_HTTP_STATUS and TIMEOUT

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@
 
 Adrián Gómez Llorente <adgllorente@gmail.com>
 AdsWizz <*@adswizz.com>
+Albin Larsson <albin.larsson@eyevinn.se>
 Alex Jones <alexedwardjones@gmail.com>
 Alugha GmbH <*@alugha.com>
 Alvaro Velad Galvan <alvaro.velad@mirada.tv>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,6 +26,7 @@ Aaron Vaage <vaage@google.com>
 Adrián Gómez Llorente <adgllorente@gmail.com>
 Agajan Jumakuliyev <agajan.tm@gmail.com>
 Aidan Ridley <aidan.ridley@charter.com>
+Albin Larsson <albin.larsson@eyevinn.se>
 Alex Jones <alexedwardjones@gmail.com>
 Alvaro Velad Galvan <alvaro.velad@mirada.tv>
 Amila Sampath <lucksy@gmail.com>

--- a/lib/player.js
+++ b/lib/player.js
@@ -6030,8 +6030,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   tryToRecoverFromError_(error) {
-    if ((error.code != shaka.util.Error.Code.HTTP_ERROR &&
-      error.code != shaka.util.Error.Code.SEGMENT_MISSING) ||
+    if (![
+      shaka.util.Error.Code.HTTP_ERROR,
+      shaka.util.Error.Code.SEGMENT_MISSING,
+      shaka.util.Error.Code.BAD_HTTP_STATUS,
+      shaka.util.Error.Code.TIMEOUT,
+    ].includes(error.code) ||
       error.category != shaka.util.Error.Category.NETWORK) {
       return false;
     }

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -345,10 +345,18 @@ describe('Player', () => {
           shaka.util.Error.Severity.RECOVERABLE,
           shaka.util.Error.Category.NETWORK,
           shaka.util.Error.Code.HTTP_ERROR);
-      const nonHttpError = new shaka.util.Error(
+      const badHttpStatusError = new shaka.util.Error(
+          shaka.util.Error.Severity.RECOVERABLE,
+          shaka.util.Error.Category.NETWORK,
+          shaka.util.Error.Code.BAD_HTTP_STATUS);
+      const timeoutError = new shaka.util.Error(
           shaka.util.Error.Severity.RECOVERABLE,
           shaka.util.Error.Category.NETWORK,
           shaka.util.Error.Code.TIMEOUT);
+      const operationAbortedError = new shaka.util.Error(
+          shaka.util.Error.Severity.RECOVERABLE,
+          shaka.util.Error.Category.NETWORK,
+          shaka.util.Error.Code.OPERATION_ABORTED);
       /** @type {?jasmine.Spy} */
       let dispatchEventSpy;
 
@@ -371,9 +379,9 @@ describe('Player', () => {
         dispatchEventSpy.calls.reset();
       });
 
-      it('does not handle non NETWORK HTTP_ERROR', () => {
-        onErrorCallback(nonHttpError);
-        expect(nonHttpError.handled).toBeFalsy();
+      it('does not handle non recoverable network error', () => {
+        onErrorCallback(operationAbortedError);
+        expect(operationAbortedError.handled).toBeFalsy();
         expect(player.dispatchEvent).toHaveBeenCalled();
       });
 
@@ -438,6 +446,16 @@ describe('Player', () => {
           it('handles HTTP_ERROR', () => {
             onErrorCallback(httpError);
             expect(httpError.handled).toBeTruthy();
+          });
+
+          it('handles BAD_HTTP_STATUS', () => {
+            onErrorCallback(badHttpStatusError);
+            expect(badHttpStatusError.handled).toBeTruthy();
+          });
+
+          it('handles TIMEOUT', () => {
+            onErrorCallback(timeoutError);
+            expect(timeoutError.handled).toBeTruthy();
           });
 
           it('does not dispatch any error', () => {


### PR DESCRIPTION
This enables #4189 for two more error types. As mentioned in #4728 404 status results in `BAD_HTTP_STATUS` rather than `HTTP_ERROR`. I also think `TIMEOUT` should be included, and another issue was just created for this (#4764), so I included that as well.

If we don't want this, then an alternative is to make which errors to handle here configurable, but I thought I'd start with this suggestion.

Closes https://github.com/shaka-project/shaka-player/issues/4728
Closes https://github.com/shaka-project/shaka-player/issues/4764