### PR TITLE
test: Fix exceptions in tests

### DIFF
--- a/test/ads/ad_manager_unit.js
+++ b/test/ads/ad_manager_unit.js
@@ -115,7 +115,9 @@ describe('Ad manager', () => {
         startedEventB = /** @type {!google.ima.AdEvent} */ (
           new shaka.util.FakeEvent(google.ima.AdEvent.Type.STARTED));
         startedEventB.getAd = () => {
-          return {};
+          return {
+            isLinear: () => true,
+          };
         };
       }
       makeMocks();

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -40,6 +40,7 @@ describe('HlsParser', () => {
 
   afterEach(() => {
     shaka.log.alwaysWarn = originalAlwaysWarn;
+    parser.stop();
   });
 
   beforeEach(() => {


### PR DESCRIPTION
This fixes test exceptions that did not fail their tests.  One was an HlsParser instance that outlived the test run and failed after server disconnection.  The other was an exception in AdManager that did not fail the test, but nonetheless caused an unexpected error to be logged.

Both of these issues were spotted while running the tests in a local browser in debug mode.  Neither caused test failures directly, but both were examples of poor hygiene in our tests.