### PR TITLE
test: Flatten test environment to one frame

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -171,6 +171,7 @@ module.exports = (config) => {
       'node_modules/eme-encryption-scheme-polyfill/dist/eme-encryption-scheme-polyfill.js',
 
       // load closure base, the deps tree, and the uncompiled library
+      'test/test/closure-boot.js',
       'node_modules/google-closure-library/closure/goog/base.js',
       'dist/deps.js',
       'shaka-player.uncompiled.js',
@@ -233,6 +234,12 @@ module.exports = (config) => {
       // Hide the list of connected clients in Karma, to make screenshots more
       // stable.
       clientDisplayNone: true,
+      // Run directly in the top frame, instead of in an iframe.  This makes it
+      // easier to work around cross-origin frame issues when testing platforms
+      // like Chromecast, where there is already an iframe involved in the test
+      // framework.
+      runInParent: true,
+      useIframe: false,
       // Only capture the client's logs if the settings want logging.
       captureConsole: !!settings.logging && settings.logging != 'none',
       // |args| must be an array; pass a key-value map as the sole client

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -230,6 +230,15 @@ module.exports = (config) => {
     captureTimeout: settings.capture_timeout,
     // https://support.saucelabs.com/customer/en/portal/articles/2440724
 
+    // Allow Karma's files to be loaded cross-origin.  This is important for
+    // the Chromecast test infrastructure, starting with v1.2 of Chromecast
+    // WebDriver Server.
+    customHeaders: [{
+      match: '.',
+      name: 'Access-Control-Allow-Origin',
+      value: '*',
+    }],
+
     client: {
       // Hide the list of connected clients in Karma, to make screenshots more
       // stable.

--- a/test/test/closure-boot.js
+++ b/test/test/closure-boot.js
@@ -10,6 +10,6 @@
 // document.write().  This is more compatible with a wider variety of setups,
 // and allows us to enable Karma options {useIframe: false, runInParent: true}
 // to test in a single frame.
-window.CLOSURE_UNCOMPILED_DEFINES = {
+window['CLOSURE_UNCOMPILED_DEFINES'] = {
   'goog.ENABLE_CHROME_APP_SAFE_SCRIPT_LOADING': true,
 };

--- a/test/test/closure-boot.js
+++ b/test/test/closure-boot.js
@@ -1,0 +1,15 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// These definitions will override the defaults when the Closure base library
+// is loaded.  This is necessary to get Closure to load dependencies by
+// creating DOM elements in JavaScript, rather than the legacy default of using
+// document.write().  This is more compatible with a wider variety of setups,
+// and allows us to enable Karma options {useIframe: false, runInParent: true}
+// to test in a single frame.
+window.CLOSURE_UNCOMPILED_DEFINES = {
+  'goog.ENABLE_CHROME_APP_SAFE_SCRIPT_LOADING': true,
+};

--- a/test/test/util/util.js
+++ b/test/test/util/util.js
@@ -403,15 +403,9 @@ shaka.test.Util = class {
     const parentUrlParams = window.parent.location.search;
     goog.asserts.assert(parentUrlParams.includes('id='), 'No ID in URL!');
 
-    // Tests run in an iframe.  So we also need the coordinates of that iframe
-    // within the page, so that the screenshot can be consistently cropped to
-    // the element we care about.
-    const iframe = /** @type {HTMLIFrameElement} */(
-      window.parent.document.getElementById('context'));
-    const iframeRect = iframe.getBoundingClientRect();
     const elementRect = element.getBoundingClientRect();
-    const x = iframeRect.left + elementRect.left;
-    const y = iframeRect.top + elementRect.top;
+    const x = elementRect.left;
+    const y = elementRect.top;
     const width = elementRect.width;
     const height = elementRect.height;
 


### PR DESCRIPTION
By default, Karma runs tests in an iframe.  This complicated an issue on Chromecast, where certain platform APIs are only available on the main frame.

The Chromecast backend in Generic WebDriver Server also requires an iframe, and three frames was too many to work around cross-origin frame issues.  Flattening Karma's environment will allow us to make an additional change to Generic WebDriver Server to pass Chromecast platform APIs from the top-level frame into the iframe hosting Karma.

See also https://github.com/shaka-project/generic-webdriver-server/pull/63