### PR TITLE
perf: Caching mediaSource support for browser engine

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -94,3 +94,4 @@ Raymond Cheng <raycheng100@gmail.com>
 Blue Billywig <*@bluebillywig.com>
 João Nabais <jlnabais@gmail.com>
 Koen Romers <koenromers@gmail.com>
+Zhenghang Chen <czhtju@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -134,3 +134,4 @@ Raymond Cheng <raycheng100@gmail.com>
 Janroel Koppen <j.koppen@bluebillywig.com>
 João Nabais <jlnabais@gmail.com>
 Koen Romers <koenromers@gmail.com>
+Zhenghang Chen <czhtju@gmail.com>

--- a/build/types/core
+++ b/build/types/core
@@ -24,6 +24,7 @@
 +../../lib/media/drm_engine.js
 +../../lib/media/gap_jumping_controller.js
 +../../lib/media/manifest_parser.js
++../../lib/media/media_source_capabilities.js
 +../../lib/media/media_source_engine.js
 +../../lib/media/mp4_segment_index_parser.js
 +../../lib/media/play_rate_controller.js

--- a/lib/media/media_source_capabilities.js
+++ b/lib/media/media_source_capabilities.js
@@ -19,7 +19,7 @@ shaka.media.Capabilities = class {
    * @return {boolean}
    */
   static isTypeSupported(type) {
-    const supportMap = shaka.media.Capabilities.MediaSourceTypeSupportMap_;
+    const supportMap = shaka.media.Capabilities.MediaSourceTypeSupportMap;
     if (supportMap.has(type)) {
       return supportMap.get(type);
     }
@@ -30,6 +30,7 @@ shaka.media.Capabilities = class {
 };
 
 /**
-  * @private {!Map.<string, boolean>}
-*/
-shaka.media.Capabilities.MediaSourceTypeSupportMap_ = new Map();
+ * Public it for unit test, and developer could also check the support map.
+ * @type {!Map.<string, boolean>}
+ */
+shaka.media.Capabilities.MediaSourceTypeSupportMap = new Map();

--- a/lib/media/media_source_capabilities.js
+++ b/lib/media/media_source_capabilities.js
@@ -1,0 +1,35 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.provide('shaka.media.Capabilities');
+
+/**
+ * @summary
+ * This is for capturing all media source capabilities on current platform.
+ * And this is for static check and can not be constructed.
+ */
+shaka.media.Capabilities = class {
+  /**
+   * Cache browser engine call to improve performance on some poor platforms
+   *
+   * @param {string} type
+   * @return {boolean}
+   */
+  static isTypeSupported(type) {
+    const supportMap = shaka.media.Capabilities.MediaSourceTypeSupportMap_;
+    if (supportMap.has(type)) {
+      return supportMap.get(type);
+    }
+    const currentSupport = MediaSource.isTypeSupported(type);
+    supportMap.set(type, currentSupport);
+    return currentSupport;
+  }
+};
+
+/**
+  * @private {!Map.<string, boolean>}
+*/
+shaka.media.Capabilities.MediaSourceTypeSupportMap_ = new Map();

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -8,6 +8,7 @@ goog.provide('shaka.media.MediaSourceEngine');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
+goog.require('shaka.media.Capabilities');
 goog.require('shaka.media.ContentWorkarounds');
 goog.require('shaka.media.ClosedCaptionParser');
 goog.require('shaka.media.IClosedCaptionParser');
@@ -175,24 +176,8 @@ shaka.media.MediaSourceEngine = class {
         stream.mimeType, stream.codecs);
     const extendedMimeType = shaka.util.MimeUtils.getExtendedType(stream);
     return shaka.text.TextEngine.isTypeSupported(fullMimeType) ||
-        shaka.media.MediaSourceEngine.isTypeSupported(extendedMimeType) ||
+        shaka.media.Capabilities.isTypeSupported(extendedMimeType) ||
         shaka.media.Transmuxer.isSupported(fullMimeType, stream.type);
-  }
-
-  /**
-   * Cache browser engine call to improve performance on some poor platforms
-   *
-   * @param {string} type
-   * @return {boolean}
-   */
-  static isTypeSupported(type) {
-    const supportMap = shaka.media.MediaSourceEngine.MediaSourceTypeSupportMap_;
-    if (supportMap.has(type)) {
-      return supportMap.get(type);
-    }
-    const currentSupport = MediaSource.isTypeSupported(type);
-    supportMap.set(type, currentSupport);
-    return currentSupport;
   }
 
   /**
@@ -247,7 +232,7 @@ shaka.media.MediaSourceEngine = class {
         if (shaka.text.TextEngine.isTypeSupported(type)) {
           support[type] = true;
         } else {
-          support[type] = shaka.media.MediaSourceEngine.isTypeSupported(type) ||
+          support[type] = shaka.media.Capabilities.isTypeSupported(type) ||
                           shaka.media.Transmuxer.isSupported(type);
         }
       } else {
@@ -382,7 +367,7 @@ shaka.media.MediaSourceEngine = class {
         this.reinitText(mimeType, sequenceMode);
       } else {
         if ((forceTransmux ||
-            !shaka.media.MediaSourceEngine.isTypeSupported(mimeType)) &&
+            !shaka.media.Capabilities.isTypeSupported(mimeType)) &&
             shaka.media.Transmuxer.isSupported(mimeType, contentType)) {
           this.transmuxers_[contentType] =
               new shaka.media.Transmuxer(mimeType);
@@ -1406,8 +1391,3 @@ shaka.media.MediaSourceEngine.RAW_FORMATS = [
   'audio/ec3',
   'audio/mpeg',
 ];
-
-/**
-  * @private {!Map.<string, boolean>}
-*/
-shaka.media.MediaSourceEngine.MediaSourceTypeSupportMap_ = new Map();

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -175,8 +175,24 @@ shaka.media.MediaSourceEngine = class {
         stream.mimeType, stream.codecs);
     const extendedMimeType = shaka.util.MimeUtils.getExtendedType(stream);
     return shaka.text.TextEngine.isTypeSupported(fullMimeType) ||
-        MediaSource.isTypeSupported(extendedMimeType) ||
+        shaka.media.MediaSourceEngine.isTypeSupported(extendedMimeType) ||
         shaka.media.Transmuxer.isSupported(fullMimeType, stream.type);
+  }
+
+  /**
+   * Cache browser engine call to improve performance on some poor platforms
+   *
+   * @param {string} type
+   * @return {boolean}
+   */
+  static isTypeSupported(type) {
+    const supportMap = shaka.media.MediaSourceEngine.MediaSourceTypeSupportMap_;
+    if (supportMap.has(type)) {
+      return supportMap.get(type);
+    }
+    const currentSupport = MediaSource.isTypeSupported(type);
+    supportMap.set(type, currentSupport);
+    return currentSupport;
   }
 
   /**
@@ -231,7 +247,7 @@ shaka.media.MediaSourceEngine = class {
         if (shaka.text.TextEngine.isTypeSupported(type)) {
           support[type] = true;
         } else {
-          support[type] = MediaSource.isTypeSupported(type) ||
+          support[type] = shaka.media.MediaSourceEngine.isTypeSupported(type) ||
                           shaka.media.Transmuxer.isSupported(type);
         }
       } else {
@@ -365,7 +381,8 @@ shaka.media.MediaSourceEngine = class {
       if (contentType == ContentType.TEXT) {
         this.reinitText(mimeType, sequenceMode);
       } else {
-        if ((forceTransmux || !MediaSource.isTypeSupported(mimeType)) &&
+        if ((forceTransmux ||
+            !shaka.media.MediaSourceEngine.isTypeSupported(mimeType)) &&
             shaka.media.Transmuxer.isSupported(mimeType, contentType)) {
           this.transmuxers_[contentType] =
               new shaka.media.Transmuxer(mimeType);
@@ -1389,3 +1406,8 @@ shaka.media.MediaSourceEngine.RAW_FORMATS = [
   'audio/ec3',
   'audio/mpeg',
 ];
+
+/**
+  * @private {!Map.<string, boolean>}
+*/
+shaka.media.MediaSourceEngine.MediaSourceTypeSupportMap_ = new Map();

--- a/lib/media/transmuxer.js
+++ b/lib/media/transmuxer.js
@@ -7,6 +7,7 @@
 goog.provide('shaka.media.Transmuxer');
 
 goog.require('goog.asserts');
+goog.require('shaka.media.Capabilities');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.IDestroyable');
@@ -71,6 +72,7 @@ shaka.media.Transmuxer = class {
    */
   static isSupported(mimeType, contentType) {
     const Transmuxer = shaka.media.Transmuxer;
+    const Capabilities = shaka.media.Capabilities;
 
     const isTs = Transmuxer.isTsContainer_(mimeType);
     const isAac = Transmuxer.isAacContainer_(mimeType);
@@ -80,11 +82,11 @@ shaka.media.Transmuxer = class {
     }
 
     if (isAac) {
-      return MediaSource.isTypeSupported(Transmuxer.convertAacCodecs_());
+      return Capabilities.isTypeSupported(Transmuxer.convertAacCodecs_());
     }
 
     if (contentType) {
-      return MediaSource.isTypeSupported(
+      return Capabilities.isTypeSupported(
           Transmuxer.convertTsCodecs_(contentType, mimeType));
     }
 
@@ -92,8 +94,8 @@ shaka.media.Transmuxer = class {
 
     const audioMime = Transmuxer.convertTsCodecs_(ContentType.AUDIO, mimeType);
     const videoMime = Transmuxer.convertTsCodecs_(ContentType.VIDEO, mimeType);
-    return MediaSource.isTypeSupported(audioMime) ||
-        MediaSource.isTypeSupported(videoMime);
+    return Capabilities.isTypeSupported(audioMime) ||
+        Capabilities.isTypeSupported(videoMime);
   }
 
 

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -7,6 +7,7 @@
 goog.provide('shaka.polyfill.MediaCapabilities');
 
 goog.require('shaka.log');
+goog.require('shaka.media.Capabilities');
 goog.require('shaka.polyfill');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.Platform');
@@ -100,11 +101,14 @@ shaka.polyfill.MediaCapabilities = class {
     const videoConfig = mediaDecodingConfig['video'];
     const audioConfig = mediaDecodingConfig['audio'];
 
+    const Capabilities = shaka.media.Capabilities;
+
     if (mediaDecodingConfig.type == 'media-source') {
       if (!shaka.util.Platform.supportsMediaSource()) {
         return res;
       }
-      // Use 'MediaSource.isTypeSupported' to check if the stream is supported.
+      // Use 'shaka.media.Capabilities.isTypeSupported'to check if
+      // the stream is supported.
       // Cast platforms will additionally check canDisplayType(), which
       // accepts extended MIME type parameters.
       // See: https://github.com/shaka-project/shaka-player/issues/4726
@@ -114,7 +118,7 @@ shaka.polyfill.MediaCapabilities = class {
           isSupported =
               shaka.polyfill.MediaCapabilities.canCastDisplayType_(videoConfig);
         } else {
-          isSupported = MediaSource.isTypeSupported(videoConfig.contentType);
+          isSupported = Capabilities.isTypeSupported(videoConfig.contentType);
         }
         if (!isSupported) {
           return res;
@@ -123,7 +127,7 @@ shaka.polyfill.MediaCapabilities = class {
 
       if (audioConfig) {
         const contentType = audioConfig.contentType;
-        const isSupported = MediaSource.isTypeSupported(contentType);
+        const isSupported = Capabilities.isTypeSupported(contentType);
         if (!isSupported) {
           return res;
         }
@@ -246,8 +250,8 @@ shaka.polyfill.MediaCapabilities = class {
           shaka.util.Error.Code.CAST_API_UNAVAILABLE);
     } else if (!(cast.__platform__ && cast.__platform__.canDisplayType)) {
       shaka.log.warning('Expected cast APIs to be available! Falling back to ' +
-          'MediaSource.isTypeSupported() for type support.');
-      return MediaSource.isTypeSupported(videoConfig.contentType);
+          'shaka.media.Capabilities.isTypeSupported() for type support.');
+      return shaka.media.Capabilities.isTypeSupported(videoConfig.contentType);
     }
 
     let displayType = videoConfig.contentType;

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -8,7 +8,7 @@ goog.provide('shaka.util.StreamUtils');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
-goog.require('shaka.media.MediaSourceEngine');
+goog.require('shaka.media.Capabilities');
 goog.require('shaka.text.TextEngine');
 goog.require('shaka.util.Functional');
 goog.require('shaka.util.LanguageUtils');
@@ -438,6 +438,7 @@ shaka.util.StreamUtils = class {
       // See: https://github.com/shaka-project/shaka-player/issues/3860
       const video = variant.video;
       const ContentType = shaka.util.ManifestParserUtils.ContentType;
+      const Capabilities = shaka.media.Capabilities;
       if (video) {
         let videoCodecs =
             shaka.util.StreamUtils.getCorrectVideoCodecs_(video.codecs);
@@ -455,13 +456,13 @@ shaka.util.StreamUtils = class {
               shaka.util.StreamUtils.getCorrectAudioCodecs_(audioCodecs);
           const audioFullType = shaka.util.MimeUtils.getFullOrConvertedType(
               video.mimeType, audioCodecs, ContentType.AUDIO);
-          if (!shaka.media.MediaSourceEngine.isTypeSupported(audioFullType)) {
+          if (!Capabilities.isTypeSupported(audioFullType)) {
             return false;
           }
         }
         const fullType = shaka.util.MimeUtils.getFullOrConvertedType(
             video.mimeType, videoCodecs, ContentType.VIDEO);
-        if (!shaka.media.MediaSourceEngine.isTypeSupported(fullType)) {
+        if (!Capabilities.isTypeSupported(fullType)) {
           return false;
         }
       }
@@ -471,7 +472,7 @@ shaka.util.StreamUtils = class {
             shaka.util.StreamUtils.getCorrectAudioCodecs_(audio.codecs);
         const fullType = shaka.util.MimeUtils.getFullOrConvertedType(
             audio.mimeType, codecs, ContentType.AUDIO);
-        if (!shaka.media.MediaSourceEngine.isTypeSupported(fullType)) {
+        if (!Capabilities.isTypeSupported(fullType)) {
           return false;
         }
       }

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -8,6 +8,7 @@ goog.provide('shaka.util.StreamUtils');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
+goog.require('shaka.media.MediaSourceEngine');
 goog.require('shaka.text.TextEngine');
 goog.require('shaka.util.Functional');
 goog.require('shaka.util.LanguageUtils');
@@ -454,13 +455,13 @@ shaka.util.StreamUtils = class {
               shaka.util.StreamUtils.getCorrectAudioCodecs_(audioCodecs);
           const audioFullType = shaka.util.MimeUtils.getFullOrConvertedType(
               video.mimeType, audioCodecs, ContentType.AUDIO);
-          if (!MediaSource.isTypeSupported(audioFullType)) {
+          if (!shaka.media.MediaSourceEngine.isTypeSupported(audioFullType)) {
             return false;
           }
         }
         const fullType = shaka.util.MimeUtils.getFullOrConvertedType(
             video.mimeType, videoCodecs, ContentType.VIDEO);
-        if (!MediaSource.isTypeSupported(fullType)) {
+        if (!shaka.media.MediaSourceEngine.isTypeSupported(fullType)) {
           return false;
         }
       }
@@ -470,7 +471,7 @@ shaka.util.StreamUtils = class {
             shaka.util.StreamUtils.getCorrectAudioCodecs_(audio.codecs);
         const fullType = shaka.util.MimeUtils.getFullOrConvertedType(
             audio.mimeType, codecs, ContentType.AUDIO);
-        if (!MediaSource.isTypeSupported(fullType)) {
+        if (!shaka.media.MediaSourceEngine.isTypeSupported(fullType)) {
           return false;
         }
       }

--- a/test/polyfill/media_capabilities_unit.js
+++ b/test/polyfill/media_capabilities_unit.js
@@ -12,6 +12,7 @@ describe('MediaCapabilities', () => {
   const originalRequestMediaKeySystemAccess =
     navigator.requestMediaKeySystemAccess;
   const originalMediaCapabilities = navigator.mediaCapabilities;
+  const supportMap = shaka.media.Capabilities.MediaSourceTypeSupportMap;
 
   /** @type {MediaDecodingConfiguration} */
   let mockDecodingConfig;
@@ -102,18 +103,12 @@ describe('MediaCapabilities', () => {
   describe('decodingInfo', () => {
     it('should check codec support when MediaDecodingConfiguration.type ' +
       'is "media-source"', () => {
-      const isTypeSupportedSpy =
-          spyOn(window['MediaSource'], 'isTypeSupported').and.returnValue(true);
+      expect(window['MediaSource']['isTypeSupported']).toBeDefined();
       shaka.polyfill.MediaCapabilities.install();
       navigator.mediaCapabilities.decodingInfo(mockDecodingConfig);
 
-      expect(isTypeSupportedSpy).toHaveBeenCalledTimes(2);
-      expect(isTypeSupportedSpy).toHaveBeenCalledWith(
-          mockDecodingConfig.video.contentType,
-      );
-      expect(isTypeSupportedSpy).toHaveBeenCalledWith(
-          mockDecodingConfig.audio.contentType,
-      );
+      expect(supportMap.has(mockDecodingConfig.video.contentType)).toBe(true);
+      expect(supportMap.has(mockDecodingConfig.audio.contentType)).toBe(true);
     });
 
     it('should check codec support when MediaDecodingConfiguration.type ' +
@@ -218,9 +213,7 @@ describe('MediaCapabilities', () => {
           const isChromecastSpy =
               spyOn(shaka['util']['Platform'],
                   'isChromecast').and.returnValue(true);
-          const isTypeSupportedSpy =
-              spyOn(window['MediaSource'], 'isTypeSupported')
-                  .and.returnValue(true);
+          expect(window['MediaSource']['isTypeSupported']).toBeDefined();
 
           shaka.polyfill.MediaCapabilities.install();
           await navigator.mediaCapabilities.decodingInfo(mockDecodingConfig);
@@ -230,7 +223,10 @@ describe('MediaCapabilities', () => {
           expect(isChromecastSpy).toHaveBeenCalledTimes(2);
           // 1 (fallback in canCastDisplayType()) +
           // 1 (mockDecodingConfig.audio).
-          expect(isTypeSupportedSpy).toHaveBeenCalledTimes(2);
+          expect(supportMap.has(mockDecodingConfig.video.contentType))
+              .toBe(true);
+          expect(supportMap.has(mockDecodingConfig.audio.contentType))
+              .toBe(true);
         });
 
     it('should use cast.__platform__.canDisplayType for "supported" field ' +
@@ -244,8 +240,7 @@ describe('MediaCapabilities', () => {
       const isChromecastSpy =
           spyOn(shaka['util']['Platform'],
               'isChromecast').and.returnValue(true);
-      const isTypeSupportedSpy =
-          spyOn(window['MediaSource'], 'isTypeSupported').and.returnValue(true);
+      expect(window['MediaSource']['isTypeSupported']).toBeDefined();
 
       // Tests an HDR stream's extended MIME type is correctly provided.
       mockDecodingConfig.video.transferFunction = 'pq';
@@ -254,14 +249,17 @@ describe('MediaCapabilities', () => {
       // Round to a whole number since we can't rely on number => string
       // conversion precision on all devices.
       mockDecodingConfig.video.framerate = 24;
+
+      const chromecastType =
+          'video/mp4; ' +
+          'codecs="hev1.2.4.L153.B0"; ' +
+          'width=512; ' +
+          'height=288; ' +
+          'framerate=24; ' +
+          'eotf=smpte2084';
       mockCanDisplayType.and.callFake((type) => {
-        expect(type).toBe(
-            'video/mp4; ' +
-            'codecs="hev1.2.4.L153.B0"; ' +
-            'width=512; ' +
-            'height=288; ' +
-            'framerate=24; ' +
-            'eotf=smpte2084');
+        expect(type).toBe(chromecastType);
+        supportMap.set(type, true);
         return true;
       });
 
@@ -271,7 +269,7 @@ describe('MediaCapabilities', () => {
       // 1 (during install()) + 1 (for video config check).
       expect(isChromecastSpy).toHaveBeenCalledTimes(2);
       // 1 (mockDecodingConfig.audio).
-      expect(isTypeSupportedSpy).toHaveBeenCalledTimes(1);
+      expect(supportMap.has(chromecastType)).toBe(true);
       // Called once in canCastDisplayType.
       expect(mockCanDisplayType).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
We have just derived the repository by the old shaka version and found there seems the same optimization could be implemented on the latest shaka player.

When developing on each web core livingroom platform (Tizen, WebOS, Chromecast, etc.), we found that there takes a long time to parse the manifest between downloading the manifest and downloading the first content segment. After profiling it, we found that there was a frequent function called `MediaSource.isTypeSupported` in it, up to hundreds or even thousands (the pic attached below). But this situation does not happen on the latest Chrome or Safari.

![image](https://user-images.githubusercontent.com/24735241/205285814-3f935b8c-9d75-430c-8f9c-60d8b1b9f777.png)

We concluded that it must be related to the old browser engine (Chromium) that does not do optimization on it.

And we just cached the function call results and let it not calls that API so frequently. The data showed that it did help reduce the start lag by 40% on Chromecast, 15% on WebOS, and 12% on Tizen on average within 2 months.

We think it is constructive and want to share it. And we think the more variants the contents have, the more time they could be reduced on living room apps.

Thanks!