### PR TITLE
fix(cast): Added existence checks for MediaDecodingConfig.{audio|video} in decodingInfo().

### DIFF
--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -203,8 +203,10 @@ shaka.polyfill.MediaCapabilities = class {
 
       const cacheKey = shaka.polyfill.MediaCapabilities
           .generateKeySystemCacheKey_(
-              mediaDecodingConfig.video.contentType,
-              mediaDecodingConfig.audio.contentType,
+              mediaDecodingConfig.video ?
+                  mediaDecodingConfig.video.contentType : '',
+              mediaDecodingConfig.audio ?
+                  mediaDecodingConfig.audio.contentType : '',
               mediaDecodingConfig.keySystemConfiguration.keySystem);
 
       let keySystemAccess;


### PR DESCRIPTION
See https://github.com/shaka-project/shaka-player/issues/4790.

To be honest, I'm failing to understand how a `TypeError` can happen here (this is occurring in a Casted Apple Music, non-`AES-128` stream, so `EME`), since:
1. The problematic code lines aren't reachable unless `MediaDecodingConfig.keySystemConfiguration` is set.
2. `MediaDecodingConfig.keySystemConfiguration` is only set if `drmInfos` are provided:
https://github.com/shaka-project/shaka-player/blob/68f10a1969b3ae639cd58b76b30b223cd4a08a5c/lib/util/stream_utils.js#L659-L666

during manifest parsing (showing HLS for example):
https://github.com/shaka-project/shaka-player/blob/68f10a1969b3ae639cd58b76b30b223cd4a08a5c/lib/hls/hls_parser.js#L1003-L1016

Regardless, `requestMediaKeySystemAccess()` will never report a variant is `supported` if `contentType` is null/empty string (as per https://w3c.github.io/encrypted-media/#get-supported-capabilities-for-audio-video-type). So the polyfill implementation behaves the same as before this change.