### PR TITLE
test: Fix StreamingEngine tests on Tizen

### DIFF
--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -997,7 +997,7 @@ describe('Player', () => {
     }
 
     async function waitUntilBuffered(amount) {
-      for (let i = 0; i < 30; i++) {
+      for (let i = 0; i < 50; i++) {
         // We buffer from an internal segment, so this shouldn't take long to
         // buffer.
         await Util.delay(0.1);  // eslint-disable-line no-await-in-loop

--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -970,7 +970,7 @@ describe('Player', () => {
       expect(getBufferedBehind()).toBe(20);  // Buffered to start still.
       video.currentTime = 50;
       await waitUntilBuffered(30);
-      expect(getBufferedBehind()).toBeLessThan(30);
+      expect(getBufferedBehind()).toBeLessThan(40);  // 30 + segment_size
 
       player.configure('streaming.bufferBehind', 10);
       // We only evict content when we append a segment, so increase the
@@ -997,7 +997,7 @@ describe('Player', () => {
     }
 
     async function waitUntilBuffered(amount) {
-      for (let i = 0; i < 25; i++) {
+      for (let i = 0; i < 30; i++) {
         // We buffer from an internal segment, so this shouldn't take long to
         // buffer.
         await Util.delay(0.1);  // eslint-disable-line no-await-in-loop
@@ -1005,7 +1005,14 @@ describe('Player', () => {
           return;
         }
       }
-      throw new Error('Timeout waiting to buffer');
+
+      const ranges =
+          shaka.media.TimeRangesUtils.getBufferedInfo(video.buffered);
+      const currentTime = video.currentTime;
+      const target = currentTime + amount;
+
+      throw new Error('Timeout waiting to buffer! ' +
+          JSON.stringify({ranges, currentTime, target}));
     }
   });  // describe('buffering')
 

--- a/test/test/util/test_scheme.js
+++ b/test/test/util/test_scheme.js
@@ -413,7 +413,7 @@ const sintelAudioSegment = {
   mdhdOffset: 0x1b6,
   segmentUri: '/base/test/test/assets/sintel-audio-segment.mp4',
   tfdtOffset: 0x3c,
-  segmentDuration: 10.005,
+  segmentDuration: 10,
   mimeType: 'audio/mp4',
   codecs: 'mp4a.40.2',
 };
@@ -439,7 +439,7 @@ const sintelEncryptedAudio = {
   mdhdOffset: 0x1b6,
   segmentUri: '/base/test/test/assets/encrypted-sintel-audio-segment.mp4',
   tfdtOffset: 0x3c,
-  segmentDuration: 10.005,
+  segmentDuration: 10,
   mimeType: 'audio/mp4',
   codecs: 'mp4a.40.2',
   initData:


### PR DESCRIPTION
For some unknown reason, using precise durations for these audio segments on Tizen creates gaps that can't be survived.  I don't know why that creates a 150ms gap, and I don't know why we can't seem to jump over it.  It feels very much like a bug in Tizen itself.

Experimentally, I found that rounding these durations to 10s even removes the gap completely.  I tried many other things, but this is the only reasonable thing I have found that works.

More details on my investigations can be found in the issue on GitHub.

This change in durations exposed some brittle tests in Player which had to be adjusted to be more robust.

Closes #4806