### PR TITLE
fix: Fix rare exception after StreamingEngine teardown

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -622,6 +622,11 @@ shaka.media.StreamingEngine = class {
    * within the presentation timeline.
    */
   seeked() {
+    if (!this.playerInterface_) {
+      // Already destroyed.
+      return;
+    }
+
     const presentationTime = this.playerInterface_.getPresentationTime();
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
     const newTimeIsBuffered = (type) => {


### PR DESCRIPTION
In some cases, the timing of certain events can cause a seek callback to fire on StreamingEngine after it has been destroyed.  This checks for that condition to avoid an exception.

Closes #4813