### PR TITLE
fix: Fix duplicate updates in StreamingEngine

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -679,7 +679,7 @@ shaka.media.StreamingEngine = class {
 
   /**
    * Clear the buffer for a given stream.  Unlike clearBuffer_, this will handle
-   * cases where a MediaState is performing an update.  After this runs, every
+   * cases where a MediaState is performing an update.  After this runs, the
    * MediaState will have a pending update.
    * @param {!shaka.media.StreamingEngine.MediaState_} mediaState
    * @private
@@ -793,9 +793,10 @@ shaka.media.StreamingEngine = class {
     for (const type of streamsByType.keys()) {
       const stream = streamsByType.get(type);
       if (!this.mediaStates_.has(type)) {
-        const state = this.createMediaState_(stream);
-        this.mediaStates_.set(type, state);
-        this.scheduleUpdate_(state, 0);
+        const mediaState = this.createMediaState_(stream);
+        this.mediaStates_.set(type, mediaState);
+        const logPrefix = shaka.media.StreamingEngine.logPrefix_(mediaState);
+        this.scheduleUpdate_(mediaState, 0);
       }
     }
   }
@@ -907,7 +908,7 @@ shaka.media.StreamingEngine = class {
               'mediastate.stream should not have segmentIndex yet.');
           thisStream.closeSegmentIndex();
         }
-        if (mediaState.updateTimer == null) {
+        if (!mediaState.performingUpdate && !mediaState.updateTimer) {
           this.scheduleUpdate_(mediaState, 0);
         }
         return;
@@ -1392,7 +1393,7 @@ shaka.media.StreamingEngine = class {
         // If the network slows down, abort the current fetch request and start
         // a new one, and ignore the error message.
         mediaState.performingUpdate = false;
-        mediaState.updateTimer = null;
+        this.cancelUpdate_(mediaState);
         this.scheduleUpdate_(mediaState, 0);
       } else if (mediaState.type == ContentType.TEXT &&
           this.config_.ignoreTextStreamFailures) {
@@ -1465,9 +1466,13 @@ shaka.media.StreamingEngine = class {
 
     for (const mediaState of this.mediaStates_.values()) {
       const logPrefix = shaka.media.StreamingEngine.logPrefix_(mediaState);
-      if (mediaState.hasError) {
+      // Only schedule an update if it has an error, but it's not mid-update
+      // and there is not already an update scheduled.
+      if (mediaState.hasError && !mediaState.performingUpdate &&
+          !mediaState.updateTimer) {
         shaka.log.info(logPrefix, 'Retrying after failure...');
         mediaState.hasError = false;
+        this.cancelUpdate_(mediaState);
         this.scheduleUpdate_(mediaState, delaySeconds);
       }
     }
@@ -2088,7 +2093,11 @@ shaka.media.StreamingEngine = class {
     shaka.log.debug(logPrefix, 'cleared buffer');
     mediaState.clearingBuffer = false;
     mediaState.endOfStream = false;
-    this.scheduleUpdate_(mediaState, 0);
+    // Since the clear operation was async, check to make sure we're not doing
+    // another update and we don't have one scheduled yet.
+    if (!mediaState.performingUpdate && !mediaState.updateTimer) {
+      this.scheduleUpdate_(mediaState, 0);
+    }
   }
 
 

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1471,7 +1471,6 @@ shaka.media.StreamingEngine = class {
           !mediaState.updateTimer) {
         shaka.log.info(logPrefix, 'Retrying after failure...');
         mediaState.hasError = false;
-        this.cancelUpdate_(mediaState);
         this.scheduleUpdate_(mediaState, delaySeconds);
       }
     }

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -795,7 +795,6 @@ shaka.media.StreamingEngine = class {
       if (!this.mediaStates_.has(type)) {
         const mediaState = this.createMediaState_(stream);
         this.mediaStates_.set(type, mediaState);
-        const logPrefix = shaka.media.StreamingEngine.logPrefix_(mediaState);
         this.scheduleUpdate_(mediaState, 0);
       }
     }


### PR DESCRIPTION
There were several places where certain StreamingEngine events and timing could result in duplicate update requests for streams.  This caused some inconsistent test failures, in particular on Chromecast.

This change adds some additional checks before scheduling and cancelling updates, to ensure that the proper conditions are maintained.

Closes #4831