### PR TITLE
fix: Fix parsing error on Chromecast when resyncing HLS

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -906,7 +906,18 @@ shaka.media.MediaSourceEngine = class {
    */
   async resync(contentType, timestampOffset) {
     goog.asserts.assert(this.sequenceMode_,
-        'resyncAudio only used with sequence mode!');
+        'resync only used with sequence mode!');
+    // Queue an abort() to help MSE splice together overlapping segments.
+    // We set appendWindowEnd when we change periods in DASH content, and the
+    // period transition may result in overlap.
+    //
+    // An abort() also helps with MPEG2-TS.  When we append a TS segment, we
+    // always enter a PARSING_MEDIA_SEGMENT state and we can't change the
+    // timestamp offset.  By calling abort(), we reset the state so we can
+    // set it.
+    this.enqueueOperation_(
+        contentType,
+        () => this.abort_(contentType)),
     await this.enqueueOperation_(
         contentType,
         () => this.setTimestampOffset_(contentType, timestampOffset));


### PR DESCRIPTION
Setting the timestampOffset requires an abort() in some cases on Chromecast.

Issue #4589