### PR TITLE
fix: Release region timeline when unloading

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -1537,6 +1537,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     has.startTime = null;
     has.uri = null;
 
+    // Release the region timeline, which is created when parsing the manifest.
+    if (this.regionTimeline_) {
+      this.regionTimeline_.release();
+      this.regionTimeline_ = null;
+    }
+
     // In most cases we should have a media element. The one exception would
     // be if there was an error and we, by chance, did not have a media element.
     if (has.mediaElement) {


### PR DESCRIPTION
This stops the timer inside region timeline from staying in memory, even after the player is destroyed.

Closes #4850