### PR TITLE
fix: Fix potential duplicate segments, AV sync issues

### DIFF
--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -225,8 +225,11 @@ shaka.media.SegmentIndex = class {
     // Partial segments are used for live edge, and should be removed when they
     // get older. Remove the old SegmentReferences after the first new
     // reference's start time.
+    // Use times rounded to the millisecond for filtering purposes, so that
+    // tiny rounding errors will not result in duplicate segments in the index.
+    const firstStartTime = Math.round(references[0].startTime * 1000) / 1000;
     this.references = this.references.filter((r) => {
-      return r.startTime < references[0].startTime;
+      return (Math.round(r.startTime * 1000) / 1000) < firstStartTime;
     });
 
     this.references.push(...references);


### PR DESCRIPTION
Make SegmentIndex robust against rounding errors so that we don't end up with duplicate segments on merge.  In sequence mode, this would cause a massive AV sync issue of 1 segment duration.

Issue #4589