### PR TITLE
fix: Make encoding problem detection more robust

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -753,8 +753,13 @@ shaka.media.MediaSourceEngine = class {
           bufferedBefore, bufferedAfter);
       if (newBuffered) {
         const segmentDuration = reference.endTime - reference.startTime;
-        if (Math.abs(newBuffered.start - reference.startTime) >
-            segmentDuration / 2) {
+        // Check end times instead of start times.  We may be overwriting a
+        // buffer and only the end changes, and that would be fine.
+        // Also, exclude tiny segments.  Sometimes alignment segments as small
+        // as 33ms are seen in Google DAI content.  For such tiny segments,
+        // half a segment duration would be no issue.
+        const offset = Math.abs(newBuffered.end - reference.endTime);
+        if (segmentDuration > 0.100 && offset > segmentDuration / 2) {
           shaka.log.error('Possible encoding problem detected!',
               'Unexpected buffered range for reference', reference,
               'from URIs', reference.getUris(),


### PR DESCRIPTION
Before, tiny segments (~33ms in practice) and overwritten segments (sometimes necessary) would register as encoding problems.  This makes the logic more robust and the error logs more reliable.

Issue #4589