### PR TITLE
fix: Fix potential AV sync issues after seek or adaptation

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -834,6 +834,7 @@ shaka.media.StreamingEngine = class {
       // The playhead might be seeking on startup, if a start time is set, so
       // start "seeked" as true.
       seeked: true,
+      needsResync: false,
       recovering: false,
       hasError: false,
       operation: null,
@@ -1157,6 +1158,11 @@ shaka.media.StreamingEngine = class {
       shaka.log.v1(
           logPrefix, 'looking up segment from new stream endTime:', time);
 
+      // Using a new iterator means we need to resync the stream in sequence
+      // mode.  The buffered range might not align perfectly with the last
+      // segment end time, so we may end up repeating a segment.  Resyncing
+      // makes this safe to do.
+      mediaState.needsResync = true;
       mediaState.segmentIterator =
           mediaState.stream.segmentIndex.getIteratorForTime(time);
       const ref = mediaState.segmentIterator &&
@@ -1674,7 +1680,9 @@ shaka.media.StreamingEngine = class {
       const lastDiscontinuitySequence =
           mediaState.lastSegmentReference ?
               mediaState.lastSegmentReference.discontinuitySequence : null;
-      if (reference.discontinuitySequence != lastDiscontinuitySequence) {
+      if (reference.discontinuitySequence != lastDiscontinuitySequence ||
+          mediaState.needsResync) {
+        mediaState.needsResync = false;
         operations.push(this.playerInterface_.mediaSourceEngine.resync(
             mediaState.type, reference.startTime));
       }
@@ -2279,6 +2287,7 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   clearBufferSafeMargin: number,
  *   clearingBuffer: boolean,
  *   seeked: boolean,
+ *   needsResync: boolean,
  *   adaptation: boolean,
  *   recovering: boolean,
  *   hasError: boolean,
@@ -2324,10 +2333,13 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   The amount of buffer to retain when clearing the buffer after the update.
  * @property {boolean} clearingBuffer
  *   True indicates that the buffer is being cleared.
-  * @property {boolean} seeked
+ * @property {boolean} seeked
  *   True indicates that the presentation just seeked.
-  * @property {boolean} adaptation
+ * @property {boolean} adaptation
  *   True indicates that the presentation just automatically switched variants.
+ * @property {boolean} needsResync
+ *   True indicates that the stream needs to be resynced in sequence mode,
+ *   regardless of discontinuity sequence.
  * @property {boolean} recovering
  *   True indicates that the last segment was not appended because it could not
  *   fit in the buffer.


### PR DESCRIPTION
After seeking or adaptation, StreamingEngine will create a new SegmentIterator.  However, if the buffered ranges are different enough from the references in the iterator, the lookup in the index can produce a duplicate segment.  If this happens when sequence mode is active, StreamingEngine will append the duplicate segment instead of overwriting the end of the original one.

Any time a new iterator is created, we force the stream to resync, so that unaligned segments or slightly-inaccurate segments are written to the correct place in the buffer.

Issue #4589