### PR TITLE
chore: Rename layout tests

### DIFF
--- a/test/text/text_displayer_layout_unit.js
+++ b/test/text/text_displayer_layout_unit.js
@@ -4,11 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// TODO: Move this suite to the text/ folder where it belongs
-
-const supported = () => shaka.test.TextLayoutTests.supported();
-
-filterDescribe('TextDisplayer layout', supported, () => {
+filterDescribe('Cue layout', shaka.test.TextLayoutTests.supported, () => {
   /** @type {shaka.test.TextLayoutTests} */
   let helper;
 

--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -338,15 +338,13 @@ describe('UITextDisplayer', () => {
   it('hides and shows nested cues at appropriate times', () => {
     const parentCue1 = new shaka.text.Cue(0, 100, '');
     const cue1 = new shaka.text.Cue(0, 50, 'One');
-    parentCue1.nestedCues.push(cue1);
     const cue2 = new shaka.text.Cue(25, 75, 'Two');
-    parentCue1.nestedCues.push(cue2);
     const cue3 = new shaka.text.Cue(50, 100, 'Three');
-    parentCue1.nestedCues.push(cue3);
+    parentCue1.nestedCues = [cue1, cue2, cue3];
 
     const parentCue2 = new shaka.text.Cue(90, 190, '');
     const cue4 = new shaka.text.Cue(90, 130, 'Four');
-    parentCue2.nestedCues.push(cue4);
+    parentCue2.nestedCues = [cue4];
 
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([parentCue1, parentCue2]);


### PR DESCRIPTION
Also fixes a compiler error that comes up for some reason when renaming the other tests.  The compiler will accept an assignment to nestedCues, but not pushing to it.  I was unable to fix the missing type information for this.

Related to work on PR #4767