### PR TITLE
fix: Fix WebVTT parser failure on REGION blocks

### DIFF
--- a/lib/text/vtt_text_parser.js
+++ b/lib/text/vtt_text_parser.js
@@ -337,8 +337,8 @@ shaka.text.VttTextParser = class {
       return null;
     }
 
-    // Skip style blocks.
-    if (text[0] == 'STYLE') {
+    // Skip style and region blocks.
+    if (text[0] == 'STYLE' || text[0] == 'REGION') {
       return null;
     }
 

--- a/test/text/vtt_text_parser_unit.js
+++ b/test/text/vtt_text_parser_unit.js
@@ -1181,6 +1181,22 @@ describe('VttTextParser', () => {
         {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
   });
 
+  it('does not fail on REGION blocks', () => {
+    verifyHelper(
+        [
+          {
+            startTime: 10, endTime: 20,
+            payload: 'test',
+          },
+        ],
+        'WEBVTT\n\n' +
+        'REGION\n' +
+        'id:1\n\n' +
+        '00:00:10.000 --> 00:00:20.000\n' +
+        'test\n\n',
+        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+  });
+
   /**
    * @param {!Array} cues
    * @param {string} text


### PR DESCRIPTION
We do not yet support VTT region settings, but we should still not fail when a region block appears in a VTT file.

Related to work on PR #4767