### PR TITLE
ci: Upload screenshots on test failures

### DIFF
--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -241,6 +241,20 @@ jobs:
           # there.
           if-no-files-found: error
 
+      # Upload new screenshots and diffs on failure; ignore if missing
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          # In this workflow, "browser" is the selenium node name, which can
+          # contain both browser and OS, such as "ChromeLinux".
+          name: screenshots-${{ matrix.browser }}
+          path: |
+            test/test/assets/screenshots/*/*.png-new
+            test/test/assets/screenshots/*/*.png-diff
+          if-no-files-found: ignore
+          retention-days: 5
+
       - name: Report final commit status
         # Will run on success or failure, but not if the workflow is cancelled.
         if: ${{ success() || failure() }}


### PR DESCRIPTION
This will upload screenshots when the Selenium lab tests fail.  This can be used to get screenshot changes either for examination or for updating the test expectations.