### PR TITLE
fix: Forbid MathML namespace in shaka.util.XmlUtils

### DIFF
--- a/externs/mathml.js
+++ b/externs/mathml.js
@@ -14,4 +14,4 @@
  * @extends {Element}
  * @see https://w3c.github.io/mathml-core/#webidl-1630693908
  */
-function MathMLElement(){}
+function MathMLElement() {}

--- a/externs/mathml.js
+++ b/externs/mathml.js
@@ -1,0 +1,17 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Externs for MathML markup.
+ * @externs
+ */
+
+/**
+ * @constructor
+ * @extends {Element}
+ * @see https://w3c.github.io/mathml-core/#webidl-1630693908
+ */
+function MathMLElement(){}

--- a/lib/util/xml_utils.js
+++ b/lib/util/xml_utils.js
@@ -385,7 +385,8 @@ shaka.util.XmlUtils = class {
     }
 
     // SECURITY: Verify that the document does not contain elements from the
-    // HTML, MathML or SVG namespaces, which could trigger script execution and XSS.
+    // HTML, MathML or SVG namespaces, which could trigger script execution
+    // and XSS.
     const iterator = document.createNodeIterator(
         unsafeXml,
         NodeFilter.SHOW_ALL,

--- a/lib/util/xml_utils.js
+++ b/lib/util/xml_utils.js
@@ -385,7 +385,7 @@ shaka.util.XmlUtils = class {
     }
 
     // SECURITY: Verify that the document does not contain elements from the
-    // HTML or SVG namespaces, which could trigger script execution and XSS.
+    // HTML, MathML or SVG namespaces, which could trigger script execution and XSS.
     const iterator = document.createNodeIterator(
         unsafeXml,
         NodeFilter.SHOW_ALL,
@@ -393,6 +393,7 @@ shaka.util.XmlUtils = class {
     let currentNode;
     while (currentNode = iterator.nextNode()) {
       if (currentNode instanceof HTMLElement ||
+          currentNode instanceof MathMLElement ||
           currentNode instanceof SVGElement) {
         shaka.log.error('XML document embeds unsafe content!');
         return null;

--- a/test/util/xml_utils_unit.js
+++ b/test/util/xml_utils_unit.js
@@ -439,6 +439,19 @@ describe('XmlUtils', () => {
       const doc = XmlUtils.parseXmlString(xmlString, 'Root');
       expect(doc).toBeNull();
     });
+
+    it('returns null on XML that embeds MathML', () => {
+      const xmlString = [
+        '<?xml version="1.0"?>',
+        '<Root>',
+        '  <math xmlns="http://www.w3.org/1998/Math/MathML">',
+        '    <mi onclick="alert(1)">CLICK ME</mi>',
+        '  </math>',
+        '</Root>',
+      ].join('\n');
+      const doc = XmlUtils.parseXmlString(xmlString, 'Root');
+      expect(doc).toBeNull();
+    });
   });
 });
 


### PR DESCRIPTION
This PR fixes #4912 by adding MathML to the list of forbidden namespaces. 