### PR TITLE
fix(HLS): Fix detection of WebVTT subtitles in HLS by extension

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -3367,7 +3367,7 @@ shaka.hls.HlsParser.TEXT_EXTENSIONS_TO_MIME_TYPES_ = {
   'm4f': 'application/mp4',
   'cmft': 'application/mp4',
   'vtt': 'text/vtt',
-  'webvtt': 'txt/vtt',
+  'webvtt': 'text/vtt',
   'ttml': 'application/ttml+xml',
 };
 


### PR DESCRIPTION
Was this a typo? We were seeing uncaught TypeErrors when changing subtitle tracks related to this, it seems `'txt/vtt'` is not a valid mime type for webvtt subtitles.

Closes #4929 