### PR TITLE
feat(logs): Add extra logging for 3015 errors

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1265,6 +1265,7 @@ shaka.media.MediaSourceEngine = class {
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MEDIA,
           shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_THREW,
+          this.video_.error || 'No error in the media element',
           exception);
     } finally {
       // Unblock the queues.
@@ -1308,6 +1309,7 @@ shaka.media.MediaSourceEngine = class {
               shaka.util.Error.Severity.CRITICAL,
               shaka.util.Error.Category.MEDIA,
               shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_THREW,
+              this.video_.error || 'No error in the media element',
               exception));
         }
         this.popFromQueue_(contentType);

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1265,8 +1265,8 @@ shaka.media.MediaSourceEngine = class {
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MEDIA,
           shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_THREW,
-          this.video_.error || 'No error in the media element',
-          exception);
+          exception,
+          this.video_.error || 'No error in the media element');
     } finally {
       // Unblock the queues.
       for (const contentType in this.sourceBuffers_) {
@@ -1309,8 +1309,8 @@ shaka.media.MediaSourceEngine = class {
               shaka.util.Error.Severity.CRITICAL,
               shaka.util.Error.Category.MEDIA,
               shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_THREW,
-              this.video_.error || 'No error in the media element',
-              exception));
+              exception,
+              this.video_.error || 'No error in the media element'));
         }
         this.popFromQueue_(contentType);
       }

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -462,6 +462,7 @@ shaka.util.Error.Code = {
   /**
    * A MediaSource operation threw an exception.
    * <br> error.data[0] is the exception that was thrown.
+   * <br> error.data[1] is the error object from the video element.
    */
   'MEDIA_SOURCE_OPERATION_THREW': 3015,
 

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -374,11 +374,12 @@ describe('MediaSourceEngine', () => {
 
     it('rejects promise when operation throws', async () => {
       audioSourceBuffer.appendBuffer.and.throwError('fail!');
-      mockVideo.error = {code: 5};
+      mockVideo.error = {code: 5, message: 'something failed'};
       const expected = Util.jasmineError(new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MEDIA,
           shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_THREW,
+          {code: 5, message: 'something failed'},
           jasmine.objectContaining({message: 'fail!'})));
       await expectAsync(
           mediaSourceEngine.appendBuffer(
@@ -712,6 +713,7 @@ describe('MediaSourceEngine', () => {
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MEDIA,
           shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_THREW,
+          {code: 5},
           jasmine.objectContaining({message: 'fail!'})));
       await expectAsync(mediaSourceEngine.remove(ContentType.AUDIO, 1, 5))
           .toBeRejectedWith(expected);

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -379,8 +379,8 @@ describe('MediaSourceEngine', () => {
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MEDIA,
           shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_THREW,
-          {code: 5, message: 'something failed'},
-          jasmine.objectContaining({message: 'fail!'})));
+          jasmine.objectContaining({message: 'fail!'}),
+          {code: 5, message: 'something failed'}));
       await expectAsync(
           mediaSourceEngine.appendBuffer(
               ContentType.AUDIO, buffer, null,
@@ -713,8 +713,8 @@ describe('MediaSourceEngine', () => {
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MEDIA,
           shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_THREW,
-          {code: 5},
-          jasmine.objectContaining({message: 'fail!'})));
+          jasmine.objectContaining({message: 'fail!'}),
+          {code: 5}));
       await expectAsync(mediaSourceEngine.remove(ContentType.AUDIO, 1, 5))
           .toBeRejectedWith(expected);
       expect(audioSourceBuffer.remove).toHaveBeenCalledWith(1, 5);


### PR DESCRIPTION
Our PROD app has been getting some 3015 errors where the exception message is as follows:
`Error: Failed to execute 'appendBuffer' on 'SourceBuffer': The HTMLMediaElement.error attribute is not null`

We have added some extra logging to add what is inside the error property in hopes of having a better ideia of what is causing it since we ourselves haven't quite been able to reproduce the issue.

Wanted to bring this back to the main repo in case it could help others. Because the exception Shaka gets only has that message so could be useful to know what was the exact error that the media element got that caused the `appendBuffer` call to fail.