### PR TITLE
fix(VTT): Fix combining style selectors

### DIFF
--- a/lib/text/vtt_text_parser.js
+++ b/lib/text/vtt_text_parser.js
@@ -256,7 +256,15 @@ shaka.text.VttTextParser = class {
         }
       }
 
-      const cue = new shaka.text.Cue(0, 0, '');
+      // Continue styles over multiple selectors if necessary.
+      // For example,
+      //   ::cue(b) { background: white; } ::cue(b) { color: blue; }
+      // should set both the background and foreground of bold tags.
+      let cue = styles.get(styleSelector);
+      if (!cue) {
+        cue = new shaka.text.Cue(0, 0, '');
+      }
+
       let validStyle = false;
       for (let i = 0; i < propertyLines.length; i++) {
         // We look for CSS properties. As a general rule they are separated by


### PR DESCRIPTION
When multiple style blocks exist for the same selector, they should be combined.  For example,

  ::cue(b) { background: white; }
  ::cue(b) { color: blue; }

should set both the background and foreground of bold tags.