### PR TITLE
fix(HLS): IMSC1 subtitles not working in a HLS stream

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1195,6 +1195,8 @@ shaka.hls.HlsParser = class {
       }
     });
 
+    const type = shaka.util.ManifestParserUtils.ContentType.TEXT;
+
     // Set the codecs for text streams.
     for (const tag of subtitleTags) {
       const groupId = tag.getRequiredAttrValue('GROUP-ID');
@@ -1204,6 +1206,9 @@ shaka.hls.HlsParser = class {
         if (textStreamInfos) {
           for (const textStreamInfo of textStreamInfos) {
             textStreamInfo.stream.codecs = codecs;
+            textStreamInfo.stream.mimeType =
+                this.guessMimeTypeBeforeLoading_(type, codecs) ||
+                this.guessMimeTypeFallback_(type);
           }
         }
       }


### PR DESCRIPTION
Fixes #4350

The current code initially parses the subtitle track as text/vtt (mimetype) since it has no codec. Subsequently, the stpp.ttml.im1t codec is assigned but the mimetype of text/vtt is not changed to application/mp4. This PR changes this so that once the codec is assigned, the mimetype is recalculated.