### PR TITLE
fix: Failed to set 'currentTime' property on 'HTMLMediaElement' on a Hisense TV

### DIFF
--- a/lib/media/video_wrapper.js
+++ b/lib/media/video_wrapper.js
@@ -135,15 +135,15 @@ shaka.media.VideoWrapper = class {
     // calling |Player.load|, meaning that |currentTime| is more meaningful than
     // |startTime|.
     //
-    // Seeking to the current time is a work around for Issue 1298. If we don't
-    // do this, the video may get stuck and not play.
+    // Seeking to the current time is a work around for Issue 1298 and 4888.
+    // If we don't do this, the video may get stuck and not play.
     //
     // TODO: Need further investigation why it happens. Before and after
     // setting the current time, video.readyState is 1, video.paused is true,
     // and video.buffered's TimeRanges length is 0.
     // See: https://github.com/shaka-project/shaka-player/issues/1298
     this.mover_.moveTo(
-        this.video_.currentTime == 0 ?
+        (!this.video_.currentTime || this.video_.currentTime == 0) ?
         startTime :
         this.video_.currentTime);
   }


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/4888