### PR TITLE
fix: DrmEngine exception thrown when using FairPlay

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -480,8 +480,10 @@ shaka.media.DrmEngine = class {
           () => this.closeOpenSessions_());
     }
 
-    const manifestInitData = this.currentDrmInfo_.initData.find(
-        (initDataOverride) => initDataOverride.initData.length > 0);
+    const manifestInitData = this.currentDrmInfo_ ?
+      this.currentDrmInfo_.initData.find(
+          (initDataOverride) => initDataOverride.initData.length > 0,
+      ) : null;
 
     /**
      * We can attach media keys before the playback actually begins when:


### PR DESCRIPTION
Closes #4902

This is not intended to be a complete fix for the issue, I do not understand the effect this new ternary on the shaka player as a whole. I have not found the root cause for `this.currentDrmInfo_` being `undefined` when accessed. It does, however, look like it has previously been acceptable for this property to be `undefined`. I opened this PR more as a point of discussion around the issue at hand.

During the work to add Fairplay support in 2022, accessing `this.currentDrmInfo_` was added on line 483. This line **does not** accept that `this.currentDrmInfo_` can be undefined. A few lines below this, `this.createOrLoad()` is called, which **does** accept that `this.currentDrmInfo_` can be `undefined`. The latter piece of code was last modified in 2019.

https://github.com/shaka-project/shaka-player/blob/c471d23bc25db11dda85a18870ebd3fe37971848/lib/media/drm_engine.js#L483-L498

https://github.com/shaka-project/shaka-player/blob/c471d23bc25db11dda85a18870ebd3fe37971848/lib/media/drm_engine.js#L626-L629

