### PR TITLE
fix: Tizen video error fixed by checking the extended MIME type

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -462,23 +462,33 @@ shaka.util.StreamUtils = class {
           // Update the codec string with the (possibly) converted codecs.
           videoCodecs = [videoCodecs, audioCodecs].join(',');
         }
+        const fullType = shaka.util.MimeUtils.getFullOrConvertedType(
+            video.mimeType, videoCodecs, ContentType.VIDEO);
+        // Update the codec and mimeType strings with their (possibly)
+        // converted values.
+        video.codecs = shaka.util.MimeUtils.getCodecs(fullType);
+        video.mimeType = shaka.util.MimeUtils.getBasicType(fullType);
+
         const extendedMimeType = shaka.util.MimeUtils.getExtendedType(video);
         if (!Capabilities.isTypeSupported(extendedMimeType)) {
           return false;
         }
-        // Update the codec string with the (possibly) converted codecs.
-        video.codecs = videoCodecs;
       }
       const audio = variant.audio;
       if (audio) {
         const codecs =
             shaka.util.StreamUtils.getCorrectAudioCodecs_(audio.codecs);
+        const fullType = shaka.util.MimeUtils.getFullOrConvertedType(
+            audio.mimeType, codecs, ContentType.AUDIO);
+        // Update the codec and mimeType strings with their (possibly)
+        // converted values.
+        audio.codecs = shaka.util.MimeUtils.getCodecs(fullType);
+        audio.mimeType = shaka.util.MimeUtils.getBasicType(fullType);
+
         const extendedMimeType = shaka.util.MimeUtils.getExtendedType(audio);
         if (!Capabilities.isTypeSupported(extendedMimeType)) {
           return false;
         }
-        // Update the codec string with the (possibly) converted codecs.
-        audio.codecs = codecs;
       }
 
       // See: https://github.com/shaka-project/shaka-player/issues/3380

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -462,9 +462,8 @@ shaka.util.StreamUtils = class {
           // Update the codec string with the (possibly) converted codecs.
           videoCodecs = [videoCodecs, audioCodecs].join(',');
         }
-        const fullType = shaka.util.MimeUtils.getFullOrConvertedType(
-            video.mimeType, videoCodecs, ContentType.VIDEO);
-        if (!Capabilities.isTypeSupported(fullType)) {
+        const extendedMimeType = shaka.util.MimeUtils.getExtendedType(video);
+        if (!Capabilities.isTypeSupported(extendedMimeType)) {
           return false;
         }
         // Update the codec string with the (possibly) converted codecs.
@@ -474,9 +473,8 @@ shaka.util.StreamUtils = class {
       if (audio) {
         const codecs =
             shaka.util.StreamUtils.getCorrectAudioCodecs_(audio.codecs);
-        const fullType = shaka.util.MimeUtils.getFullOrConvertedType(
-            audio.mimeType, codecs, ContentType.AUDIO);
-        if (!Capabilities.isTypeSupported(fullType)) {
+        const extendedMimeType = shaka.util.MimeUtils.getExtendedType(audio);
+        if (!Capabilities.isTypeSupported(extendedMimeType)) {
           return false;
         }
         // Update the codec string with the (possibly) converted codecs.


### PR DESCRIPTION
We have reproduced an issue in some tizen tv's, and we think it's the cause of #4634 and possibly #4503 

It happens with some streams that have 3 variants, 2 of them are supported on these TVs, but the one with higher resolution isn't. This variant uses this video: video/mp4;codecs="avc1.64002a";framerate="25";bitrate="6000000";width="**1980**";height="1080" and in this TV the higher resolution that is supported is **1920**x1080

At **filterManifestByMediaCapabilities** function from **stream_utils.js** we were checking `Capabilities.isTypeSupported(fullType)` , where this "fullType" only includes the mime type and the codecs (`video/mp4; codecs="avc1.64002a"` for example). This is currently returning true, so the player believes that this variant is supported, but then it fails when it tries to play it.

However, there was an older implementation that used **shaka.media.MediaSourceEngine.isStreamSupported()** function which internally checks `Capabilities.isTypeSupported(extendedMimeType)`, where "extendedMimeType" includes also the width, height, bitrate and framerate (for example, `video/mp4;codecs="avc1.64002a";framerate="25";bitrate="6000000";width="1980";height="1080"`), which in this specific case returns false because in this case the 1980 width is not supported (it should be 1920), the variant is filtered out, and the playback is started with the other 2 variants.

In this proposed change I'm basically changing isTypeSupported(fullType) by isTypeSupported(extendedMimeType), keeping in mind that the codecs and mimeType could have been modified in the call to getFullOrConvertedType and we must keep using those modified values.
In this change I haven't modified the mutiplexed streams case (the case from the `if (video.codecs.includes(','))` at filterManifestByMediaCapabilities), because the getExtendedType function gets the whole variant as parameter, I don't have any good way of testing the case, and also I think that the audio tracks are less likely to be affected by this issue, so it's probably not that important.