### PR TITLE
fix: Caption can not turn off at iOS Safari

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -2585,6 +2585,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
               // goes wrong.
               new shaka.util.Timer(resolve).tickAfter(1);
             });
+          } else if (textTracks.length > 0) {
+            this.isTextVisible_ = true;
           }
 
           // If we have moved on to another piece of content while waiting for


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/4940

This occurs when the operating system defaults to enabled subtitles in src= mode. The solution is to detect that there are active subtitles and set the internal visible flag to true.