### PR TITLE
fix: Prevent content from being restarted after Postroll ads

### DIFF
--- a/lib/ads/client_side_ad_manager.js
+++ b/lib/ads/client_side_ad_manager.js
@@ -48,6 +48,9 @@ shaka.ads.ClientSideAdManager = class {
     /** @private {shaka.util.EventManager} */
     this.eventManager_ = new shaka.util.EventManager();
 
+    /** @private {boolean} */
+    this.contentCompletedCalled_ = false;
+
     google.ima.settings.setLocale(locale);
 
     const adDisplayContainer = new google.ima.AdDisplayContainer(
@@ -80,6 +83,7 @@ shaka.ads.ClientSideAdManager = class {
 
     // Notify the SDK when the video has ended, so it can play post-roll ads.
     this.video_.onended = () => {
+      this.contentCompletedCalled_ = true;
       this.adsLoader_.contentComplete();
     };
   }
@@ -154,6 +158,7 @@ shaka.ads.ClientSideAdManager = class {
         (new Map()).set('loadTime', loadTime)));
 
     this.imaAdsManager_ = e.getAdsManager(this.video_);
+    this.contentCompletedCalled_ = false;
 
     this.onEvent_(new shaka.util.FakeEvent(
         shaka.ads.AdManager.IMA_AD_MANAGER_LOADED,
@@ -452,7 +457,9 @@ shaka.ads.ClientSideAdManager = class {
         (new Map()).set('originalEvent', e)));
     if (this.ad_ && this.ad_.isLinear()) {
       this.adContainer_.removeAttribute('ad-active');
-      this.video_.play();
+      if (!this.contentCompletedCalled_) {
+        this.video_.play();
+      }
     }
   }
 };

--- a/lib/ads/client_side_ad_manager.js
+++ b/lib/ads/client_side_ad_manager.js
@@ -48,9 +48,6 @@ shaka.ads.ClientSideAdManager = class {
     /** @private {shaka.util.EventManager} */
     this.eventManager_ = new shaka.util.EventManager();
 
-    /** @private {boolean} */
-    this.contentCompletedCalled_ = false;
-
     google.ima.settings.setLocale(locale);
 
     const adDisplayContainer = new google.ima.AdDisplayContainer(
@@ -83,7 +80,6 @@ shaka.ads.ClientSideAdManager = class {
 
     // Notify the SDK when the video has ended, so it can play post-roll ads.
     this.video_.onended = () => {
-      this.contentCompletedCalled_ = true;
       this.adsLoader_.contentComplete();
     };
   }
@@ -158,7 +154,6 @@ shaka.ads.ClientSideAdManager = class {
         (new Map()).set('loadTime', loadTime)));
 
     this.imaAdsManager_ = e.getAdsManager(this.video_);
-    this.contentCompletedCalled_ = false;
 
     this.onEvent_(new shaka.util.FakeEvent(
         shaka.ads.AdManager.IMA_AD_MANAGER_LOADED,
@@ -457,7 +452,7 @@ shaka.ads.ClientSideAdManager = class {
         (new Map()).set('originalEvent', e)));
     if (this.ad_ && this.ad_.isLinear()) {
       this.adContainer_.removeAttribute('ad-active');
-      if (!this.contentCompletedCalled_) {
+      if (!this.video_.ended) {
         this.video_.play();
       }
     }


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/4445

After watching post roll ads, `this.video_.play()` was called on a completed content in the `onAdComplete` event. The content would then restart from the beginning.

We now flag that the content is completed before we call `this.adsLoader_.contentComplete()`. On the callback, we prevent the video element from replaying if this flag is set.

This fix is based on the Advanced Sample on the [googleads-ima-html5 repo](https://github.com/googleads/googleads-ima-html5/blob/main/advanced/ads.js#L128)

