### PR TITLE
docs: add error handling tutorial

### DIFF
--- a/docs/tutorials/errors.md
+++ b/docs/tutorials/errors.md
@@ -20,7 +20,7 @@ const handleError = (error) => {
 const player = new shaka.Player(video);
 
 // handle errors that occur after load
-player.addEventListener("error", handleError);
+player.addEventListener('error', handleError);
 
 // handle errors that occur during load
 
@@ -40,7 +40,7 @@ try {
 The `streaming.failureCallback` property of ({@link shaka.extern.PlayerConfiguration}) can be used to add custom handling or error conversion of errors that occur during streaming.
 
 ```typescript
-player.configure("streaming.failureCallback", (error) => {
+player.configure('streaming.failureCallback', (error) => {
   if (error.severity === shaka.util.Error.Severity.CRITICAL) {
     // custom handling of critical error
     // e.g. player.retryStreaming();
@@ -79,16 +79,16 @@ const vodManifestNotFoundHandler = (error) => {
       // throw new shaka.util.Error(
       //   shaka.util.Error.Severity.CRITICAL,
       //   shaka.util.Error.Category.NETWORK,
-      //   "RECOGNIZABLE_ERROR_MESSAGE"
+      //   'RECOGNIZABLE_ERROR_MESSAGE'
       // );
     }
-  }
+          }
 };
 
-nwEngine.addEventListener("retry", vodManifestNotFoundHandler);
+nwEngine.addEventListener('retry', vodManifestNotFoundHandler);
 
-player.addEventListener("loaded", () => {
-  nwEngine.removeEventListener("retry", vodManifestNotFoundHandler);
+player.addEventListener('load'() => {
+  nwEngine.removeEventListe'e;(ör't;yö, vodManifestNotFoundHandler);
 });
 
 ```

--- a/docs/tutorials/errors.md
+++ b/docs/tutorials/errors.md
@@ -56,7 +56,7 @@ When configuring retry parameters in Shaka there may be known error codes that s
 
 For example, if a VOD manifest is missing, unlike when a LIVE manifest is missing, it can be expected to not show up and there is no need to retry.
 
-This is how to convert a retry into a critical error, see {@link shaka.net.NetworkingEngine.RetryEvent} and {@link shaka.util.Error}:
+This is how to convert a retry into a critical error, see {@link shaka.net.NetworkingEngine.RetryEvent} and {@link shaka.util.Error} to decipher how the event can be parsed:
 
 ```javascript
 const nwEngine = player.getNetworkingEngine();

--- a/docs/tutorials/errors.md
+++ b/docs/tutorials/errors.md
@@ -4,7 +4,7 @@ The basics for handling native Error and {@link shaka.util.Error} thrown by Shak
 
 ## Listening To and Handling Errors
 
-```typescript
+```javascript
 const handleError = (error) => {
   if (error instanceof Error) {
     // shaka crashed with an unhandled native error
@@ -39,7 +39,7 @@ try {
 
 The `streaming.failureCallback` property of ({@link shaka.extern.PlayerConfiguration}) can be used to add custom handling or error conversion of errors that occur during streaming.
 
-```typescript
+```javascript
 player.configure('streaming.failureCallback', (error) => {
   if (error.severity === shaka.util.Error.Severity.CRITICAL) {
     // custom handling of critical error
@@ -58,7 +58,7 @@ For example, if a VOD manifest is missing, unlike when a LIVE manifest is missin
 
 This is how to convert a retry into a critical error:
 
-```typescript
+```javascript
 const nwEngine = player.getNetworkingEngine();
 
 const vodManifestNotFoundHandler = (error) => {

--- a/docs/tutorials/errors.md
+++ b/docs/tutorials/errors.md
@@ -81,13 +81,13 @@ const vodManifestNotFoundHandler = (event /* shaka.net.NetworkingEngine.RetryEve
       //   'RECOGNIZABLE_ERROR_MESSAGE'
       // );
     }
-          }
+  }
 };
 
 nwEngine.addEventListener('retry', vodManifestNotFoundHandler);
 
 player.addEventListener('load'() => {
-  nwEngine.removeEventListe'e;(ör't;yö, vodManifestNotFoundHandler);
+  nwEngine.removeEventListener('retry', vodManifestNotFoundHandler);
 });
 
 ```

--- a/docs/tutorials/errors.md
+++ b/docs/tutorials/errors.md
@@ -1,0 +1,90 @@
+# Error Handling
+
+The basics for handling native Error and {@link shaka.util.Error} thrown by Shaka.
+
+## Listening To and Handling Errors
+
+```typescript
+const handleError = (error) => {
+  if (error instanceof Error) {
+    // shaka crashed with an unhandled native error
+  }
+
+  if (error.severity === shaka.util.Error.Severity.CRITICAL) {
+    // handle fatal error, playback can not continue
+  } else {
+    // handle non-fatal error, playback can continue
+  }
+};
+
+const player = new shaka.Player(video);
+
+// handle errors that occur after load
+player.addEventListener("error", handleError);
+
+// handle errors that occur during load
+
+// listening directly on the promise
+player.load(url).catch(handleError);
+
+// listening with async/await
+try {
+  await player.load(url);
+} catch (e) {
+  errorHandler(e);
+}
+```
+
+## Custom Handling of Streaming Errors
+
+The `streaming.failureCallback` property of ({@link shaka.extern.PlayerConfiguration}) can be used to add custom handling or error conversion of errors that occur during streaming.
+
+```typescript
+player.configure("streaming.failureCallback", (error) => {
+  if (error.severity === shaka.util.Error.Severity.CRITICAL) {
+    // custom handling of critical error
+    // e.g. player.retryStreaming();
+  } else {
+    // custom handling of recoverable error
+  }
+});
+```
+
+## Custom Handling of Retries
+
+When configuring retry parameters in Shaka there may be known error codes that should not be retried, or the need to break out of an infinite retry loop in a live context. Retries for failed network requests are not reported as `RECOVERABLE` errors.
+
+For example, if a VOD manifest is missing, unlike when a LIVE manifest is missing, it can be expected to not show up and there is no need to retry.
+
+This is how to convert a retry into a critical error:
+
+```typescript
+const nwEngine = player.getNetworkingEngine();
+
+const vodManifestNotFoundHandler = (error) => {
+  const {
+    error: { code, data },
+  } = error;
+
+  if (code === shaka.util.Error.Code.BAD_HTTP_STATUS) {
+    if (
+      Array.isArray(data) &&
+      data[1] === 404 &&
+      data[4] === shaka.net.NetworkingEngine.RequestType.MANIFEST
+    ) {
+      throw new shaka.util.Error(
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.NETWORK,
+        "MANIFEST_NOT_FOUND",
+      )
+    }
+  }
+};
+
+nwEngine.addEventListener("retry", vodManifestNotFoundHandler);
+
+player.addEventListener("loaded", () => {
+  nwEngine.removeEventListener("retry", vodManifestNotFoundHandler);
+});
+
+```

--- a/docs/tutorials/errors.md
+++ b/docs/tutorials/errors.md
@@ -56,15 +56,14 @@ When configuring retry parameters in Shaka there may be known error codes that s
 
 For example, if a VOD manifest is missing, unlike when a LIVE manifest is missing, it can be expected to not show up and there is no need to retry.
 
-This is how to convert a retry into a critical error, see {@link shaka.util.Error} for error structure:
+This is how to convert a retry into a critical error, see {@link shaka.net.NetworkingEngine.RetryEvent} and {@link shaka.util.Error}:
 
 ```javascript
 const nwEngine = player.getNetworkingEngine();
 
-const vodManifestNotFoundHandler = (error) => {
-  const {
-    error: { code, data },
-  } = error;
+const vodManifestNotFoundHandler = (event /* shaka.net.NetworkingEngine.RetryEvent */) => {
+  const code = event.error.code;
+  const data = event.error.data;
 
   if (code === shaka.util.Error.Code.BAD_HTTP_STATUS) {
     if (

--- a/docs/tutorials/errors.md
+++ b/docs/tutorials/errors.md
@@ -56,7 +56,7 @@ When configuring retry parameters in Shaka there may be known error codes that s
 
 For example, if a VOD manifest is missing, unlike when a LIVE manifest is missing, it can be expected to not show up and there is no need to retry.
 
-This is how to convert a retry into a critical error:
+This is how to convert a retry into a critical error, see {@link shaka.util.Error} for error structure:
 
 ```javascript
 const nwEngine = player.getNetworkingEngine();

--- a/docs/tutorials/errors.md
+++ b/docs/tutorials/errors.md
@@ -31,7 +31,7 @@ player.load(url).catch(handleError);
 try {
   await player.load(url);
 } catch (e) {
-  errorHandler(e);
+  handleError(e);
 }
 ```
 

--- a/docs/tutorials/errors.md
+++ b/docs/tutorials/errors.md
@@ -67,6 +67,7 @@ const vodManifestNotFoundHandler = (event /* shaka.net.NetworkingEngine.RetryEve
 
   if (code === shaka.util.Error.Code.BAD_HTTP_STATUS) {
     if (
+      // each type of error has its own data structure (or none at all), tread with care
       Array.isArray(data) &&
       data[1] === 404 &&
       data[4] === shaka.net.NetworkingEngine.RequestType.MANIFEST

--- a/docs/tutorials/errors.md
+++ b/docs/tutorials/errors.md
@@ -37,7 +37,7 @@ try {
 
 ## Custom Handling of Streaming Errors
 
-The `streaming.failureCallback` property of ({@link shaka.extern.PlayerConfiguration}) can be used to add custom handling or error conversion of errors that occur during streaming.
+The `streaming.failureCallback` property of {@link shaka.extern.PlayerConfiguration} can be used to add custom handling or error conversion of errors that occur during streaming.
 
 ```javascript
 player.configure('streaming.failureCallback', (error) => {

--- a/docs/tutorials/errors.md
+++ b/docs/tutorials/errors.md
@@ -72,11 +72,15 @@ const vodManifestNotFoundHandler = (error) => {
       data[1] === 404 &&
       data[4] === shaka.net.NetworkingEngine.RequestType.MANIFEST
     ) {
-      throw new shaka.util.Error(
-        shaka.util.Error.Severity.CRITICAL,
-        shaka.util.Error.Category.NETWORK,
-        "MANIFEST_NOT_FOUND",
-      )
+      // Throwing inside a retry callback will immediately stop retries
+      throw error;
+
+      // A proprietary error code can also be thrown
+      // throw new shaka.util.Error(
+      //   shaka.util.Error.Severity.CRITICAL,
+      //   shaka.util.Error.Category.NETWORK,
+      //   "RECOGNIZABLE_ERROR_MESSAGE"
+      // );
     }
   }
 };

--- a/docs/tutorials/errors.md
+++ b/docs/tutorials/errors.md
@@ -22,12 +22,12 @@ const player = new shaka.Player(video);
 // handle errors that occur after load
 player.addEventListener('error', handleError);
 
-// handle errors that occur during load
+// there are two options for catching errors that occur during load
 
-// listening directly on the promise
+// it's possible to listen directly on the promise
 player.load(url).catch(handleError);
 
-// listening with async/await
+// or to use async/await with a try/catch
 try {
   await player.load(url);
 } catch (e) {


### PR DESCRIPTION
Closes #4484

Shaka error handling is getting increasingly more complex in order to "catch them all", I've tried to put together my current understanding of handling various cases in a tutorial. To read it with github md formatting: [errors.md](https://github.com/martinstark/shaka-player/blob/error-tutorial/docs/tutorials/errors.md)