### PR TITLE
ci: Update the version index nightly

### DIFF
--- a/.github/workflows/demo-version-index.yaml
+++ b/.github/workflows/demo-version-index.yaml
@@ -11,6 +11,12 @@ on:
       - app-engine/demo-version-index/**
   release:
     types: [published]
+  # NOTE: So long as releases are made without a personal access token (PAT),
+  # they will not activate this workflow's release trigger.  For now, the
+  # schedule trigger will compensate for that by updating the index nightly.
+  schedule:
+    # Run every night at 10pm PST / 6am UTC.
+    - cron: '0 6 * * *'
 
 jobs:
   appspot:


### PR DESCRIPTION
The release trigger does not work yet, so compensate with a nightly schedule.

Closes #4361