### PR TITLE
fix: Explicitly specify @externs in transmuxer externs.

### DIFF
--- a/externs/shaka/transmuxer.js
+++ b/externs/shaka/transmuxer.js
@@ -1,4 +1,11 @@
 /**
+ * @fileoverview Externs for Transmuxer.
+ *
+ * @externs
+ */
+
+
+/**
  * An interface for transmuxer plugins.
  *
  * @interface


### PR DESCRIPTION
See https://github.com/shaka-project/shaka-player/issues/4998. 

Now, building Shaka debug build will correctly obfuscate `shaka.extern.Transmuxer.*` fields in the `shaka-player.compiled.debug.js` build like all the other externs provided in `externs/shaka/` directory (e.g., `aria.js`, etc.).