### PR TITLE
fix: Prevent error and incorrect duration

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -308,7 +308,10 @@ shaka.hls.HlsParser = class {
       const PresentationType = shaka.hls.HlsParser.PresentationType_;
       this.setPresentationType_(PresentationType.VOD);
 
-      const maxTimestamps = streamInfos.map((s) => s.maxTimestamp);
+      // The duration is the minimum of the end times of all active streams.
+      // Non-active streams are not guaranteed to have useful maxTimestamp
+      // values, due to the lazy-loading system, so they are ignored.
+      const maxTimestamps = activeStreamInfos.map((s) => s.maxTimestamp);
       // The duration is the minimum of the end times of all streams.
       this.presentationTimeline_.setDuration(Math.min(...maxTimestamps));
       this.playerInterface_.updateDuration();


### PR DESCRIPTION
The duration is the minimum of the end times of all active streams.
Non-active streams are not guaranteed to have useful maxTimestamp
values, due to the lazy-loading system, so they are ignored.
