### PR TITLE
fix(HLS): Add `.tsa` and .`tsv` file extensions as valid MPEG2-TS.

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -3646,6 +3646,7 @@ shaka.hls.HlsParser.AUDIO_EXTENSIONS_TO_MIME_TYPES_ = {
   'cmfa': 'audio/mp4',
   // MPEG2-TS also uses video/ for audio: https://bit.ly/TsMse
   'ts': 'video/mp2t',
+  'tsa': 'video/mp2t',
 };
 
 
@@ -3662,6 +3663,7 @@ shaka.hls.HlsParser.VIDEO_EXTENSIONS_TO_MIME_TYPES_ = {
   'm4f': 'video/mp4',
   'cmfv': 'video/mp4',
   'ts': 'video/mp2t',
+  'tsv': 'video/mp2t',
 };
 
 


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/5033.