### PR TITLE
fix(cast): Don't register video/mp2t fallback plugin for cast platfor…

### DIFF
--- a/lib/transmuxer/muxjs_transmuxer.js
+++ b/lib/transmuxer/muxjs_transmuxer.js
@@ -264,6 +264,7 @@ shaka.transmuxer.TransmuxerEngine.registerTransmuxer(
     () => new shaka.transmuxer.MuxjsTransmuxer('audio/aac'),
     shaka.transmuxer.TransmuxerEngine.PluginPriority.FALLBACK);
 if (!shaka.util.Platform.isChromecast()) {
+  // Chromecast supports MPEG2-TS natively.
   shaka.transmuxer.TransmuxerEngine.registerTransmuxer(
       'video/mp2t',
       () => new shaka.transmuxer.MuxjsTransmuxer('video/mp2t'),

--- a/lib/transmuxer/muxjs_transmuxer.js
+++ b/lib/transmuxer/muxjs_transmuxer.js
@@ -7,14 +7,15 @@
 goog.provide('shaka.transmuxer.MuxjsTransmuxer');
 
 goog.require('goog.asserts');
+goog.require('shaka.dependencies');
 goog.require('shaka.media.Capabilities');
 goog.require('shaka.transmuxer.TransmuxerEngine');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.ManifestParserUtils');
+goog.require('shaka.util.Platform');
 goog.require('shaka.util.PublicPromise');
 goog.require('shaka.util.Uint8ArrayUtils');
-goog.require('shaka.dependencies');
 
 
 /**
@@ -262,7 +263,9 @@ shaka.transmuxer.TransmuxerEngine.registerTransmuxer(
     'audio/aac',
     () => new shaka.transmuxer.MuxjsTransmuxer('audio/aac'),
     shaka.transmuxer.TransmuxerEngine.PluginPriority.FALLBACK);
-shaka.transmuxer.TransmuxerEngine.registerTransmuxer(
-    'video/mp2t',
-    () => new shaka.transmuxer.MuxjsTransmuxer('video/mp2t'),
-    shaka.transmuxer.TransmuxerEngine.PluginPriority.FALLBACK);
+if (!shaka.util.Platform.isChromecast()) {
+  shaka.transmuxer.TransmuxerEngine.registerTransmuxer(
+      'video/mp2t',
+      () => new shaka.transmuxer.MuxjsTransmuxer('video/mp2t'),
+      shaka.transmuxer.TransmuxerEngine.PluginPriority.FALLBACK);
+}

--- a/lib/util/mime_utils.js
+++ b/lib/util/mime_utils.js
@@ -49,7 +49,7 @@ shaka.util.MimeUtils = class {
 
     if (TransmuxerEngine.isSupported(fullMimeType, contentType)) {
       return TransmuxerEngine.convertCodecs(contentType, fullMimeType);
-    } else if (contentType == ContentType.AUDIO) {
+    } else if (mimeType !== 'video/mp2t' && contentType == ContentType.AUDIO) {
       // video/mp2t is the correct mime type for TS audio, so only replace the
       // word "video" with "audio" for non-TS audio content.
       return fullMimeType.replace('video', 'audio');


### PR DESCRIPTION
See https://github.com/shaka-project/shaka-player/issues/5036.

Fixes it by preventing Shaka Player from registering a fallback `MuxJsTransmuxer(video/mp2t)` for Chromecast devices, since MPEG2-TS is supported natively on this platform.

This prevents buggy calls to `MimeUtils#getFullOrConvertedType()`, since it relies on some `TransmuxerEngine` APIs to determine support and/or convert codecs, but **cast receiver applications have not loaded mux.js library since Shaka `v3.1.0+`.**: https://github.com/shaka-project/shaka-player/blob/a22bdc51f46376d3cda02d2767388a2b19b61d58/lib/util/mime_utils.js#L34-L58