### PR TITLE
feat(text): Adds text cue filter.

### DIFF
--- a/externs/shaka/text.js
+++ b/externs/shaka/text.js
@@ -545,3 +545,14 @@ shaka.extern.TextDisplayer = class {
  * @exportDoc
  */
 shaka.extern.TextDisplayer.Factory;
+
+
+/**
+ * Defines a filter for text cues.  This filter takes the cue object and changes
+ * it before it is sent to the text displayer. This allows for default values to
+ * be set, or pre-processing to happen, without making a custom text displayer.
+ *
+ * @typedef {!function(shaka.text.Cue)}
+ * @exportDoc
+ */
+shaka.extern.TextCueFilter;

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -74,6 +74,14 @@ shaka.text.TextEngine = class {
   }
 
   /**
+   * @param {?shaka.extern.TextCueFilter} cueFilter
+   * @export
+   */
+  static setCueFilter(cueFilter) {
+    shaka.text.TextEngine.cueFilter_ = cueFilter;
+  }
+
+  /**
    * @param {string} mimeType
    * @export
    */
@@ -197,7 +205,7 @@ shaka.text.TextEngine = class {
           cue.startTime < this.appendWindowEnd_;
     });
 
-    this.displayer_.append(cuesToAppend);
+    this.filterAndAppendCues_(cuesToAppend);
 
     // NOTE: We update the buffered range from the start and end times
     // passed down from the segment reference, not with the start and end
@@ -338,10 +346,25 @@ shaka.text.TextEngine = class {
         const cues = captionsMap.get(startAndEndTime)
             .filter((c) => c.endTime <= bufferEndTime);
         if (cues) {
-          this.displayer_.append(cues);
+          this.filterAndAppendCues_(cues);
         }
       }
     }
+  }
+
+  /**
+   * Apply all cue filters to each cue in the array, then append them all to the
+   * displayer.
+   * @param {!Array.<!shaka.text.Cue>} cues
+   * @private
+   */
+  filterAndAppendCues_(cues) {
+    if (shaka.text.TextEngine.cueFilter_) {
+      for (const cue of cues) {
+        shaka.text.TextEngine.cueFilter_(cue);
+      }
+    }
+    this.displayer_.append(cues);
   }
 
   /**
@@ -396,7 +419,7 @@ shaka.text.TextEngine = class {
 
       captionsMap.get(id).get(startAndEndTime).push(cue);
       if (id == this.selectedClosedCaptionId_) {
-        this.displayer_.append([cue]);
+        this.filterAndAppendCues_([cue]);
       }
     }
 
@@ -449,3 +472,6 @@ shaka.text.TextEngine = class {
 
 /** @private {!Object.<string, !shaka.extern.TextParserPlugin>} */
 shaka.text.TextEngine.parserMap_ = {};
+
+/** @private {?shaka.extern.TextCueFilter} */
+shaka.text.TextEngine.cueFilter_ = null;


### PR DESCRIPTION
This filter is applied to all text cues before they are passed to the text displayer. This gives developers a simple way to apply custom modifications to cues programmatically, such as by setting default css styles, without having to define an entire text displayer plugin just to set these values.