### PR TITLE
chore: the implementation of abort() on SourceBuffer in Safari, now works

### DIFF
--- a/lib/polyfill/mediasource.js
+++ b/lib/polyfill/mediasource.js
@@ -53,8 +53,8 @@ shaka.polyfill.MediaSource = class {
         // Offsetting the end of the removal range seems to help.
         // Bug filed: https://bugs.webkit.org/show_bug.cgi?id=177884
         shaka.polyfill.MediaSource.patchRemovalRange_();
-      } else {
-        shaka.log.info('Patching Safari 13 MSE bugs.');
+      } else if (safariVersion <= 15) {
+        shaka.log.info('Patching Safari 13 & 14 & 15 MSE bugs.');
         // Safari 13 does not correctly implement abort() on SourceBuffer.
         // Calling abort() before appending a segment causes that segment to be
         // incomplete in the buffer.


### PR DESCRIPTION
See: https://bugs.webkit.org/show_bug.cgi?id=165342

Tested on Safari 16 with http://storage.googleapis.com/shaka-demo-assets/_bugs/safari-10-mse-abort/index.html