### PR TITLE
fix: Simplify logging code for compatibility with webpack-terser-plugin

### DIFF
--- a/lib/debug/log.js
+++ b/lib/debug/log.js
@@ -134,23 +134,19 @@ shaka.log.MAX_LOG_LEVEL = 3;
 shaka.log.oneTimeWarningIssued_ = new Set();
 
 
-// IE8 has no console unless it is opened in advance.
-// IE9 console methods are not Functions and have no bind.
-if (window.console && window.console.log.bind) {
+if (window.console) {
   /** @private {!Object.<shaka.log.Level, function(...*)>} */
   shaka.log.logMap_ = {
-    /* eslint-disable no-restricted-syntax */
-    [shaka.log.Level.ERROR]: console.error.bind(console),
-    [shaka.log.Level.WARNING]: console.warn.bind(console),
-    [shaka.log.Level.INFO]: console.info.bind(console),
-    [shaka.log.Level.DEBUG]: console.log.bind(console),
-    [shaka.log.Level.V1]: console.debug.bind(console),
-    [shaka.log.Level.V2]: console.debug.bind(console),
-    /* eslint-enable no-restricted-syntax */
+    [shaka.log.Level.ERROR]: console.error,
+    [shaka.log.Level.WARNING]: console.warn,
+    [shaka.log.Level.INFO]: console.info,
+    [shaka.log.Level.DEBUG]: console.log,
+    [shaka.log.Level.V1]: console.debug,
+    [shaka.log.Level.V2]: console.debug,
   };
 
-  shaka.log.alwaysWarn = shaka.log.logMap_[shaka.log.Level.WARNING];
-  shaka.log.alwaysError = shaka.log.logMap_[shaka.log.Level.ERROR];
+  shaka.log.alwaysWarn = (...args) => console.warn(...args);
+  shaka.log.alwaysError = (...args) => console.error(...args);
 
   if (goog.DEBUG) {
     // Since we don't want to export shaka.log in production builds, we don't


### PR DESCRIPTION
This removes some workarounds that were in the logging code for the sake of Internet Explorer. We no longer support IE, so those workarounds are no longer necessary.

Closes #5032