### PR TITLE
test: clear support map between tests

### DIFF
--- a/test/polyfill/media_capabilities_unit.js
+++ b/test/polyfill/media_capabilities_unit.js
@@ -69,6 +69,7 @@ describe('MediaCapabilities', () => {
       },
     };
     shaka.polyfill.MediaCapabilities.memoizedMediaKeySystemAccessRequests_ = {};
+    supportMap.clear();
 
     mockCanDisplayType = jasmine.createSpy('canDisplayType');
     mockCanDisplayType.and.returnValue(false);


### PR DESCRIPTION
Even though this was not causing any problem (afaik), not clearing the supportMap between tests could potentially lead to false positives, with some tests interfering in others. 
For example, if a test checks if the video contentType is supported by checking that it is contained in the supportMap, then even if a second test executed some bad code (or no code at all), and then did the same check, this second test would pass because the contentType would already be included in the supportMap from the previous test.