### PR TITLE
fix(Tizen): Fix exceptions thrown from logging methods

### DIFF
--- a/lib/debug/log.js
+++ b/lib/debug/log.js
@@ -137,12 +137,12 @@ shaka.log.oneTimeWarningIssued_ = new Set();
 if (window.console) {
   /** @private {!Object.<shaka.log.Level, function(...*)>} */
   shaka.log.logMap_ = {
-    [shaka.log.Level.ERROR]: console.error,
-    [shaka.log.Level.WARNING]: console.warn,
-    [shaka.log.Level.INFO]: console.info,
-    [shaka.log.Level.DEBUG]: console.log,
-    [shaka.log.Level.V1]: console.debug,
-    [shaka.log.Level.V2]: console.debug,
+    [shaka.log.Level.ERROR]: (...args) => console.error(...args),
+    [shaka.log.Level.WARNING]: (...args) => console.warn(...args),
+    [shaka.log.Level.INFO]: (...args) => console.info(...args),
+    [shaka.log.Level.DEBUG]: (...args) => console.log(...args),
+    [shaka.log.Level.V1]: (...args) => console.debug(...args),
+    [shaka.log.Level.V2]: (...args) => console.debug(...args),
   };
 
   shaka.log.alwaysWarn = (...args) => console.warn(...args);


### PR DESCRIPTION
PR #5050 unboxed the console log methods, which broke logging on Tizen.  This change was never released.

This fixes the issue by using arrow functions to prevent unboxing.