### PR TITLE
fix(HLS): preserve discontinuitySequence in SegmentIndex#fit

### DIFF
--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -363,6 +363,8 @@ shaka.media.SegmentIndex = class {
             lastReference.status,
             lastReference.hlsAes128Key,
         );
+    this.references[this.references.length - 1].discontinuitySequence =
+        lastReference.discontinuitySequence;
   }
 
 


### PR DESCRIPTION
The `discontinuitySequence` field of the last `SegmentReference` was getting reset to `0` in this function, even if it was originally set to something other than 0. This was causing unnecessary resyncs for the final segment of the video in sequence mode.