### PR TITLE
fix: mitigate uncaught type error in media_source_engine

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -391,7 +391,22 @@ shaka.media.MediaSourceEngine = class {
           }
         }
         const type = mimeType + this.config_.sourceBufferExtraFeatures;
-        const sourceBuffer = this.mediaSource_.addSourceBuffer(type);
+
+        this.destroyer_.ensureNotDestroyed();
+
+        let sourceBuffer;
+
+        try {
+          sourceBuffer = this.mediaSource_.addSourceBuffer(type);
+        } catch (exception) {
+          throw new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.MEDIA,
+              shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_THREW,
+              exception,
+              'The mediaSource_ status was' + this.mediaSource_.readyState +
+              'expected \'open\'');
+        }
 
         this.eventManager_.listen(
             sourceBuffer, 'error',


### PR DESCRIPTION
Closes #4903

Does not fix the underlying root cause of the `init` function being called on a `closed` or `ended` MediaSource, but attempts to mitigate the throwing of an uncaught TypeError.

Thoughts on a proper fix:

Would it make sense to rework `mediaSourceOpen_` to await `sourceopen`, or reject/return false when it isn't, can't, or won't open? This would improve control flow by moving the responsibility of handling the MediaSource state to the caller.

For illustrative purposes:

```javascript
    this.mediaSourceOpen_ = () => {
      // there is no media source, so it cannot be open
      if (!this.mediaSource_) {
        return Promise.resolve(false);
      }

      // MediaSource was previously open, but
      // MediaSource.endOfStream() has been called
      if (this.mediaSource_.readyState === 'ended') {
        return Promise.resolve(false);
      }

      // it's open, go ahead
      if (this.mediaSource_.readyState === 'open') {
        return Promise.resolve(true);
      }

      // the source is 'closed': not currently attached to a media element
      // it could either open, or the player could close before it opens
      return new Promise((resolve) => {
        // handle when source attaches and is opened
        this.eventManager_.listenOnce(
            this.mediaSource_, 'sourceopen', () => {
              try {
                // ensure not destroyed after async action
                this.destroyer_.ensureNotDestroyed();

                // source is now open!
                resolve(true);
              } catch (_) {
                // player destroyed while waiting
                resolve(false);
              }
            });

        // handle when source is never attached and never opens
        this.eventManager_.listenOnce(
            mediaSource, 'sourceended', () => resolve(false));
        /** The above listener is invalid, this cannot happen.
        *   
        *   Calling mediaSource.endOfStream() when it is not attached to a video
        *   element will throw:
        *
        *   > Uncaught DOMException: An attempt was made to use an object that
        *   > is not, or is no longer, usable
        *
        *   which is, interestingly, another uncaught error we're seeing from
        *   Shaka in our logs.
        * 
        *  This promise would instead need to listen to the player closing down to
        *  reject in cases where 'sourceopen' never triggers, to not leave it dangling.
        **/
      });
    };


  async init(streamsByType, sequenceMode=false,
      manifestType=shaka.media.ManifestParser.UNKNOWN) {
    const ContentType = shaka.util.ManifestParserUtils.ContentType;

    const isOpen = await this.mediaSourceOpen_;
    
    if (isOpen) {
      // ...
    } else {
      // ... assert that this should not happen(?)
    };
```
