### PR TITLE
fix: prevent bad calls to MediaSource.endOfStream

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1041,8 +1041,10 @@ shaka.media.MediaSourceEngine = class {
   async endOfStream(reason) {
     await this.enqueueBlockingOperation_(() => {
       // If endOfStream() has already been called on the media source,
-      // don't call it again.
-      if (this.ended()) {
+      // don't call it again. Also do not call if readyState is
+      // 'closed' (not attached to video element) since it is not a
+      // valid operation.
+      if (this.ended() || this.mediaSource_.readyState === 'closed') {
         return;
       }
       // Tizen won't let us pass undefined, but it will let us omit the


### PR DESCRIPTION
closes #5070

maybe it would make more sense to only call it when the readyState is `'open'`?