### PR TITLE
fix(HLS): don't do sequence mode workaround unless there's a text stream

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -393,6 +393,13 @@ shaka.media.MediaSourceEngine = class {
         const type = mimeType + this.config_.sourceBufferExtraFeatures;
         const sourceBuffer = this.mediaSource_.addSourceBuffer(type);
 
+        if (sequenceMode && !streamsByType.has(ContentType.TEXT)) {
+          // There's no text stream, so we can set sequence mode early instead
+          // of setting it after the first segment is appended in appendBuffer_.
+          sourceBuffer.mode =
+              shaka.media.MediaSourceEngine.SourceBufferMode_.SEQUENCE;
+        }
+
         this.eventManager_.listen(
             sourceBuffer, 'error',
             () => this.onError_(contentType));

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -639,6 +639,7 @@ describe('MediaSourceEngine', () => {
       };
       const initObject = new Map();
       initObject.set(ContentType.VIDEO, fakeVideoStream);
+      initObject.set(ContentType.TEXT, fakeTextStream);
 
       await mediaSourceEngine.init(initObject, /* sequenceMode= */ true);
 


### PR DESCRIPTION
The VTT cue timing fix in https://github.com/shaka-project/shaka-player/pull/4217 seems to have caused a regression for videos without VTT streams, where the first segment would sometimes not play smoothly. It also appears to fix the gap jumping seen in the "Art of Motion (HLS, TS)" demo. This was partially fixed for fMP4 in https://github.com/shaka-project/shaka-player/pull/4553 but didn't fix the issue for MPEG-2 TS.

Fixes https://github.com/shaka-project/shaka-player/issues/4975.