### PR TITLE
docs: Remove next links from tutorials

### DIFF
--- a/docs/tutorials/a11y.md
+++ b/docs/tutorials/a11y.md
@@ -56,10 +56,6 @@ this.eventManager.listen(this.button_, 'click', () => {
 });
 ```
 
-#### Continue the Tutorials
-
-Next, check out {@tutorial ad_monetization}.
-
 
 
 [Web Accessibility Standards]: https://www.w3.org/WAI/standards-guidelines/wcag/

--- a/docs/tutorials/ad_monetization.md
+++ b/docs/tutorials/ad_monetization.md
@@ -222,7 +222,3 @@ before instantiating the player.
 // myapp.CustomAdManager is a placeholder name for your ad manager implementation.
 shaka.Player.setAdManagerFactory(() => new myapp.CustomAdManager());
 ```
-
-#### Continue the Tutorials
-
-Next, check out {@tutorial plugins}.

--- a/docs/tutorials/basic-usage.md
+++ b/docs/tutorials/basic-usage.md
@@ -86,8 +86,3 @@ document.addEventListener('DOMContentLoaded', initApp);
 ```
 
 That's it!
-
-
-#### Continue the Tutorials
-
-Next, check out {@tutorial debugging}.

--- a/docs/tutorials/config.md
+++ b/docs/tutorials/config.md
@@ -144,8 +144,3 @@ player.configure({
 
 For more detail on individual configuration options, please see the API docs for
 {@link shaka.extern.PlayerConfiguration} and {@link shaka.Player#configure}.
-
-
-#### Continue the Tutorials
-
-Next, check out {@tutorial network-and-buffering-config}.

--- a/docs/tutorials/debugging.md
+++ b/docs/tutorials/debugging.md
@@ -187,8 +187,3 @@ To sum up, remember these points when debugging your application:
  - Use the debug version of Shaka Player for debugging and integration work
  - Refer to the docs for error codes
  - Increase the log level when you need more detail
-
-
-#### Continue the Tutorials
-
-Next, check out {@tutorial config}.

--- a/docs/tutorials/drm-config.md
+++ b/docs/tutorials/drm-config.md
@@ -208,8 +208,3 @@ you should provide an empty string as robustness
 ##### Other key-systems
 
 Values for other key systems are not known to us at this time.
-
-#### Continue the Tutorials
-
-Next, check out {@tutorial license-server-auth}.
-Or check out {@tutorial fairplay}.

--- a/docs/tutorials/license-server-auth.md
+++ b/docs/tutorials/license-server-auth.md
@@ -246,8 +246,3 @@ License request can now continue.
 
 If you need them, you can also create asynchronous response filters in the same
 way.
-
-
-#### Continue the Tutorials
-
-Next, check out {@tutorial license-wrapping}.

--- a/docs/tutorials/license-wrapping.md
+++ b/docs/tutorials/license-wrapping.md
@@ -166,8 +166,3 @@ using a request filter:
 
 Load the page again, and the license response will be accepted by the Widevine
 CDM.  Open the JavaScript console to see what the server sent back.
-
-
-#### Continue the Tutorials
-
-Next, check out {@tutorial ui}.

--- a/docs/tutorials/network-and-buffering-config.md
+++ b/docs/tutorials/network-and-buffering-config.md
@@ -117,8 +117,3 @@ URLs in your manifests always use `https:`, or by having it not include the
 scheme (e.g., `//example.com/file.mp4`).
 
 [CORS]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
-
-
-#### Continue the Tutorials
-
-Next, check out {@tutorial drm-config}.

--- a/docs/tutorials/ui-customization.md
+++ b/docs/tutorials/ui-customization.md
@@ -269,8 +269,3 @@ PR contributions to [the gallery repo][] are welcome.
 [@lucksy]: https://github.com/lucksy
 [pre-packaged Shaka UI themes]: https://lucksy.github.io/shaka-player-themes/
 [the gallery repo]: https://github.com/lucksy/shaka-player-themes
-
-
-#### Continue the Tutorials
-
-Next, check out {@tutorial a11y} to make your custom buttons accessible to screen readers.

--- a/docs/tutorials/ui.md
+++ b/docs/tutorials/ui.md
@@ -227,10 +227,3 @@ ui.configure({
   'castAndroidReceiverCompatible': true,
 });
 ```
-
-
-
-
-#### Continue the Tutorials
-
-Next, check out {@tutorial ui-customization}.

--- a/docs/tutorials/welcome.md
+++ b/docs/tutorials/welcome.md
@@ -106,8 +106,3 @@ To subscribe to new releases on GitHub, you can follow
 To receive infrequent announcements and surveys from us, you can join our
 [mailing list](https://groups.google.com/forum/#!forum/shaka-player-users).
 The list is very low volume, and can only be written to by us.
-
-
-#### Continue the Tutorials
-
-Next, check out {@tutorial basic-usage}.


### PR DESCRIPTION
The links to the next tutorial were out of date, and they no longer prescribed the actual order of tutorials. This just removes those links entirely.

Fixes #5078