### PR TITLE
fix(HLS): Adding support for DTS Express in HLS fMP4 (#5112)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -97,3 +97,4 @@ Blue Billywig <*@bluebillywig.com>
 João Nabais <jlnabais@gmail.com>
 Koen Romers <koenromers@gmail.com>
 Zhenghang Chen <czhtju@gmail.com>
+Xperi <*@xperi.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -137,3 +137,4 @@ Janroel Koppen <j.koppen@bluebillywig.com>
 João Nabais <jlnabais@gmail.com>
 Koen Romers <koenromers@gmail.com>
 Zhenghang Chen <czhtju@gmail.com>
+Ashley Manners <ashley.manners@xperi.com>

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -209,6 +209,9 @@ shaka.media.MediaSourceEngine = class {
       'audio/mp4; codecs="ec-3"',
       'audio/mp4; codecs="opus"',
       'audio/mp4; codecs="flac"',
+      'audio/mp4; codecs="dtsc"', // DTS Digital Surround
+      'audio/mp4; codecs="dtse"', // DTS Express
+      'audio/mp4; codecs="dtsx"', // DTS:X
       // WebM types
       'video/webm; codecs="vp8"',
       'video/webm; codecs="vp9"',

--- a/lib/util/manifest_parser_utils.js
+++ b/lib/util/manifest_parser_utils.js
@@ -185,8 +185,7 @@ shaka.util.ManifestParserUtils.AUDIO_CODEC_REGEXPS_ = [
   /^mp4a/,
   /^[ae]c-3$/,
   /^ac-4$/,
-  /^dts[cx]$/, // DTS Surround Sound
-  /^[du]dts$/, // DTS Surround Sound
+  /^dts[cex]$/, // DTS Digital Surround (dtsc), DTS Express (dtse), DTS:X (dtsx)
 ];
 
 


### PR DESCRIPTION
The SampleEntry box in the SampleDescription (stsd) box will have the codingname 'dtse' for DTS Express audio tracks.
This is defined in Table E-1 of ETSI TS 102 114 V1.6.1 (2019-08) DTS Coherent Acoustics; Core and Extensions with Additional Profiles.
The 'dtse' codingname has been added to the AUDIO_CODEC_REGEXPS_ list, which enables support for playback of DTS Express in HLS fMP4 streams.

The 'ddts' and 'udts' entries have been removed from the AUDIO_CODEC_REGEXPS_ list, as these are not audio codec identifiers, but FourCC values for the DTSSpecificBox and DTSUHDSpecificBox, which can be found within the SampleDescription box for DTS audio tracks.
The DTSSpecificBox (ddts) is defined in Section E.2.2.3.1 of ETSI TS 102 114 V1.6.1 (2019-08) DTS Coherent Acoustics; Core and Extensions with Additional Profiles.
The DTSUHDSpecificBox (udts) is defined in Table B-2 of ETSI TS 103 491 V1.2.1 (2019-05) DTS-UHD Audio Format; Delivery of Channels, Objects and Ambisonic Sound Fields.

The Mime Types for the DTS formats supported by Shaka Player have been added to the probeSupport function.

Fixes https://github.com/shaka-project/shaka-player/issues/5112