### PR TITLE
fix: Handle empty media segments for Mp4VttParser

### DIFF
--- a/lib/text/mp4_vtt_parser.js
+++ b/lib/text/mp4_vtt_parser.js
@@ -97,6 +97,10 @@ shaka.text.Mp4VttParser = class {
    * @export
    */
   parseMedia(data, time) {
+    if (!data.length) {
+      return [];
+    }
+
     if (!this.timescale_) {
       // Missing timescale for VTT content. We should have seen the init
       // segment.

--- a/test/text/mp4_vtt_parser_unit.js
+++ b/test/text/mp4_vtt_parser_unit.js
@@ -171,6 +171,14 @@ describe('Mp4VttParser', () => {
     verifyHelper(cues, result);
   });
 
+  it('handles empty media segments', () => {
+    const parser = new shaka.text.Mp4VttParser();
+    parser.parseInit(vttInitSegment);
+    const time = {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0};
+    const result = parser.parseMedia(new Uint8Array(0), time);
+    verifyHelper([], result);
+  });
+
   it('rejects init segment with no vtt', () => {
     const error = shaka.test.Util.jasmineError(new shaka.util.Error(
         shaka.util.Error.Severity.CRITICAL,


### PR DESCRIPTION
Handles https://github.com/shaka-project/shaka-player/issues/4429

