### PR TITLE
fix: prevent memory leak in SimpleAbrManager while destroying

### DIFF
--- a/externs/network_information.js
+++ b/externs/network_information.js
@@ -21,3 +21,10 @@ NetworkInformation.prototype.saveData;
  */
 NetworkInformation.prototype.addEventListener =
     function(type, listener) {};
+
+/**
+ * @param {string} type
+ * @param {Function} listener
+ */
+NetworkInformation.prototype.removeEventListener =
+function(type, listener) {};

--- a/externs/network_information.js
+++ b/externs/network_information.js
@@ -19,12 +19,10 @@ NetworkInformation.prototype.saveData;
  * @param {string} type
  * @param {Function} listener
  */
-NetworkInformation.prototype.addEventListener =
-    function(type, listener) {};
+NetworkInformation.prototype.addEventListener = function(type, listener) {};
 
 /**
  * @param {string} type
  * @param {Function} listener
  */
-NetworkInformation.prototype.removeEventListener =
-function(type, listener) {};
+NetworkInformation.prototype.removeEventListener = function(type, listener) {};

--- a/externs/shaka/abr_manager.js
+++ b/externs/shaka/abr_manager.js
@@ -45,6 +45,16 @@ shaka.extern.AbrManager = class {
   stop() {}
 
   /**
+   * Request that this object be destroyed, releasing all resources and shutting
+   * down all operations. Returns a Promise which is resolved when destruction
+   * is complete. This Promise should never be rejected.
+   *
+   * @return {!Promise}
+   * @exportDoc
+   */
+  destroy() {}
+
+  /**
    * Updates manager's variants collection.
    *
    * @param {!Array.<!shaka.extern.Variant>} variants

--- a/externs/shaka/abr_manager.js
+++ b/externs/shaka/abr_manager.js
@@ -45,14 +45,10 @@ shaka.extern.AbrManager = class {
   stop() {}
 
   /**
-   * Request that this object be destroyed, releasing all resources and shutting
-   * down all operations. Returns a Promise which is resolved when destruction
-   * is complete. This Promise should never be rejected.
-   *
-   * @return {!Promise}
+   * Request that this object release all internal references.
    * @exportDoc
    */
-  destroy() {}
+  release() {}
 
   /**
    * Updates manager's variants collection.

--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -6,7 +6,7 @@
 
 goog.provide('shaka.abr.SimpleAbrManager');
 
-goog.require('shaka.util.IDestroyable');
+goog.require('shaka.util.IReleasable');
 goog.require('goog.asserts');
 goog.require('shaka.abr.EwmaBandwidthEstimator');
 goog.require('shaka.log');
@@ -33,7 +33,7 @@ goog.require('shaka.util.Timer');
  * </p>
  *
  * @implements {shaka.extern.AbrManager}
- * @implements {shaka.util.IDestroyable}
+ * @implements {shaka.util.IReleasable}
  * @export
  */
 shaka.abr.SimpleAbrManager = class {
@@ -140,7 +140,7 @@ shaka.abr.SimpleAbrManager = class {
    * @override
    * @export
    */
-  destroy() {
+  release() {
     // stop() should already have been called for unload
 
     if (navigator.connection) {
@@ -150,8 +150,6 @@ shaka.abr.SimpleAbrManager = class {
     }
 
     this.resizeObserverTimer_ = null;
-
-    return Promise.resolve();
   }
 
 

--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -67,7 +67,7 @@ shaka.abr.SimpleAbrManager = class {
       };
 
       navigator.connection.addEventListener(
-          'change', () => this.onNetworkInformationChange_);
+          'change', this.onNetworkInformationChange_);
     }
 
     /**
@@ -145,7 +145,7 @@ shaka.abr.SimpleAbrManager = class {
 
     if (navigator.connection) {
       navigator.connection.removeEventListener(
-          'change', () => this.onNetworkInformationChange_);
+          'change', this.onNetworkInformationChange_);
       this.onNetworkInformationChange_ = null;
     }
 

--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -6,6 +6,7 @@
 
 goog.provide('shaka.abr.SimpleAbrManager');
 
+goog.require('shaka.util.IDestroyable');
 goog.require('goog.asserts');
 goog.require('shaka.abr.EwmaBandwidthEstimator');
 goog.require('shaka.log');
@@ -32,6 +33,7 @@ goog.require('shaka.util.Timer');
  * </p>
  *
  * @implements {shaka.extern.AbrManager}
+ * @implements {shaka.util.IDestroyable}
  * @export
  */
 shaka.abr.SimpleAbrManager = class {
@@ -51,7 +53,7 @@ shaka.abr.SimpleAbrManager = class {
     // to the change event to be able to make quick changes in case the type
     // of connectivity changes.
     if (navigator.connection) {
-      navigator.connection.addEventListener('change', () => {
+      this.onNetworkInformationChange_ = () => {
         if (this.config_.useNetworkInformation && this.enabled_) {
           this.bandwidthEstimator_ = new shaka.abr.EwmaBandwidthEstimator();
           if (this.config_) {
@@ -62,7 +64,10 @@ shaka.abr.SimpleAbrManager = class {
             this.switch_(chosenVariant);
           }
         }
-      });
+      };
+
+      navigator.connection.addEventListener(
+          'change', () => this.onNetworkInformationChange_);
     }
 
     /**
@@ -92,6 +97,9 @@ shaka.abr.SimpleAbrManager = class {
 
     /** @private {ResizeObserver} */
     this.resizeObserver_ = null;
+
+    /** @private {?function():void} */
+    this.onNetworkInformationChange_ = null;
 
     /** @private {shaka.util.Timer} */
     this.resizeObserverTimer_ = new shaka.util.Timer(() => {
@@ -126,6 +134,24 @@ shaka.abr.SimpleAbrManager = class {
 
     // Don't reset |startupComplete_|: if we've left the startup interval, we
     // can start using bandwidth estimates right away after init() is called.
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  destroy() {
+    // stop() should already have been called for unload
+
+    if (navigator.connection) {
+      navigator.connection.removeEventListener(
+          'change', () => this.onNetworkInformationChange_);
+      this.onNetworkInformationChange_ = null;
+    }
+
+    this.resizeObserverTimer_ = null;
+
+    return Promise.resolve();
   }
 
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -901,7 +901,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     this.abrManagerFactory_ = null;
-    this.abrManager_ = null;
     this.config_ = null;
     this.stats_ = null;
     this.videoContainer_ = null;
@@ -910,6 +909,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (this.networkingEngine_) {
       await this.networkingEngine_.destroy();
       this.networkingEngine_ = null;
+    }
+
+    if (this.abrManager_) {
+      await this.abrManager_.destroy();
+      this.abrManager_ = null;
     }
 
     // FakeEventTarget implements IReleasable

--- a/lib/player.js
+++ b/lib/player.js
@@ -912,7 +912,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     if (this.abrManager_) {
-      await this.abrManager_.destroy();
+      this.abrManager_.release();
       this.abrManager_ = null;
     }
 

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -208,6 +208,7 @@ describe('Player', () => {
       await player.destroy();
 
       expect(abrManager.stop).toHaveBeenCalled();
+      expect(abrManager.destroy).toHaveBeenCalled();
       expect(networkingEngine.destroy).toHaveBeenCalled();
       expect(drmEngine.destroy).toHaveBeenCalled();
       expect(playhead.release).toHaveBeenCalled();
@@ -246,6 +247,7 @@ describe('Player', () => {
       parser.start.and.returnValue(p);
       parser.stop.and.callFake(() => {
         expect(abrManager.stop).not.toHaveBeenCalled();
+        expect(abrManager.destroy).not.toHaveBeenCalled();
         expect(networkingEngine.destroy).not.toHaveBeenCalled();
       });
       shaka.media.ManifestParser.registerParserByMime(
@@ -255,6 +257,7 @@ describe('Player', () => {
       await shaka.test.Util.shortDelay();
       await player.destroy();
       expect(abrManager.stop).toHaveBeenCalled();
+      expect(abrManager.destroy).toHaveBeenCalled();
       expect(networkingEngine.destroy).toHaveBeenCalled();
       expect(parser.stop).toHaveBeenCalled();
       await expectAsync(load).toBeRejected();

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -208,7 +208,7 @@ describe('Player', () => {
       await player.destroy();
 
       expect(abrManager.stop).toHaveBeenCalled();
-      expect(abrManager.destroy).toHaveBeenCalled();
+      expect(abrManager.release).toHaveBeenCalled();
       expect(networkingEngine.destroy).toHaveBeenCalled();
       expect(drmEngine.destroy).toHaveBeenCalled();
       expect(playhead.release).toHaveBeenCalled();
@@ -247,7 +247,7 @@ describe('Player', () => {
       parser.start.and.returnValue(p);
       parser.stop.and.callFake(() => {
         expect(abrManager.stop).not.toHaveBeenCalled();
-        expect(abrManager.destroy).not.toHaveBeenCalled();
+        expect(abrManager.release).not.toHaveBeenCalled();
         expect(networkingEngine.destroy).not.toHaveBeenCalled();
       });
       shaka.media.ManifestParser.registerParserByMime(
@@ -257,7 +257,7 @@ describe('Player', () => {
       await shaka.test.Util.shortDelay();
       await player.destroy();
       expect(abrManager.stop).toHaveBeenCalled();
-      expect(abrManager.destroy).toHaveBeenCalled();
+      expect(abrManager.release).toHaveBeenCalled();
       expect(networkingEngine.destroy).toHaveBeenCalled();
       expect(parser.stop).toHaveBeenCalled();
       await expectAsync(load).toBeRejected();

--- a/test/test/util/simple_fakes.js
+++ b/test/test/util/simple_fakes.js
@@ -36,7 +36,7 @@ shaka.test.FakeAbrManager = class {
     this.stop = jasmine.createSpy('stop');
 
     /** @type {!jasmine.Spy} */
-    this.destroy = jasmine.createSpy('destroy');
+    this.release = jasmine.createSpy('release');
 
     /** @type {!jasmine.Spy} */
     this.enable = jasmine.createSpy('enable');

--- a/test/test/util/simple_fakes.js
+++ b/test/test/util/simple_fakes.js
@@ -36,6 +36,9 @@ shaka.test.FakeAbrManager = class {
     this.stop = jasmine.createSpy('stop');
 
     /** @type {!jasmine.Spy} */
+    this.destroy = jasmine.createSpy('destroy');
+
+    /** @type {!jasmine.Spy} */
     this.enable = jasmine.createSpy('enable');
 
     /** @type {!jasmine.Spy} */


### PR DESCRIPTION
SimpleAbrManager was not properly destroyed after a call to player.destroy, leading to SimpleAbrManager instances being kept in memory.

This PR aims to resolve it :) 