### PR TITLE
fix(ads): Fix ads starting muted behavior

### DIFF
--- a/lib/ads/client_side_ad_manager.js
+++ b/lib/ads/client_side_ad_manager.js
@@ -457,7 +457,10 @@ shaka.ads.ClientSideAdManager = class {
     if (this.ad_.isLinear()) {
       this.adContainer_.setAttribute('ad-active', 'true');
       this.video_.pause();
-      this.ad_.setVolume(this.video_.muted ? 0 : this.video_.volume);
+      this.ad_.setVolume(this.video_.volume);
+      if (this.video_.muted) {
+        this.ad_.setMuted(true);
+      }
     }
   }
 


### PR DESCRIPTION
Previously, we would set the starting volume of an ad to 0 if the main video is muted.
This had the problem that, because of how our custom mute/unmute functionality on ads worked, that would lead to the "unmute" button setting the ad to the "last volume" of 0.
This changes the ads manager to, instead, set the volume of the ad to the volume of the video, and then call the mute function if the ad is muted. That way, the ad will remember the previous volume of the video, and will be able to unmute properly.

Closes #5125