### PR TITLE
test: Drop Axinom DRM servers from tests

### DIFF
--- a/test/media/drm_engine_integration.js
+++ b/test/media/drm_engine_integration.js
@@ -74,19 +74,6 @@ describe('DrmEngine', () => {
     onEventSpy = jasmine.createSpy('onEvent');
 
     networkingEngine = new shaka.net.NetworkingEngine();
-    networkingEngine.registerRequestFilter((type, request) => {
-      if (type != shaka.net.NetworkingEngine.RequestType.LICENSE) {
-        return;
-      }
-
-      request.headers['X-AxDRM-Message'] = [
-        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lk',
-        'IjoiNjllNTQwODgtZTllMC00NTMwLThjMWEtMWViNmRjZDBkMTRlIiwibWVzc2FnZSI6e',
-        'yJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImtleXMiOlt7ImlkIjoiNmU1YTFkMj',
-        'YtMjc1Ny00N2Q3LTgwNDYtZWFhNWQxZDM0YjVhIn1dfX0.yF7PflOPv9qHnu3ZWJNZ12j',
-        'gkqTabmwXbDWk_47tLNE',
-      ].join('');
-    });
 
     const playerInterface = {
       netEngine: networkingEngine,
@@ -99,22 +86,22 @@ describe('DrmEngine', () => {
     drmEngine = new shaka.media.DrmEngine(playerInterface);
     const config = shaka.util.PlayerConfiguration.createDefault().drm;
     config.servers['com.widevine.alpha'] =
-        'https://drm-widevine-licensing.axtest.net/AcquireLicense';
+        'https://cwip-shaka-proxy.appspot.com/specific_key?blodJidXR9eARuql0dNLWg=GX8m9XLIZNIzizrl0RTqnA';
     config.servers['com.microsoft.playready'] =
-        'https://drm-playready-licensing.axtest.net/AcquireLicense';
+        'https://test.playready.microsoft.com/service/rightsmanager.asmx?cfg=(kid:6e5a1d26-2757-47d7-8046-eaa5d1d34b5a,contentkey:GX8m9XLIZNIzizrl0RTqnA,sl:150)';
     drmEngine.configure(config);
 
     manifest = shaka.test.ManifestGenerator.generate((manifest) => {
       manifest.addVariant(0, (variant) => {
         variant.addVideo(1, (stream) => {
           stream.encrypted = true;
-          stream.addDrmInfo('com.widevine.alpha');
           stream.addDrmInfo('com.microsoft.playready');
+          stream.addDrmInfo('com.widevine.alpha');
         });
         variant.addAudio(2, (stream) => {
           stream.encrypted = true;
-          stream.addDrmInfo('com.widevine.alpha');
           stream.addDrmInfo('com.microsoft.playready');
+          stream.addDrmInfo('com.widevine.alpha');
         });
       });
     });

--- a/test/test/util/test_scheme.js
+++ b/test/test/util/test_scheme.js
@@ -455,6 +455,7 @@ const widevineDrmServers = {
 
 /** @type {AVMetadataType} */
 const axinomMultiDrmVideoSegment = {
+  // Taken from Axinom's v6 test vector.
   initSegmentUri: '/base/test/test/assets/multidrm-video-init.mp4',
   mdhdOffset: 0x1d1,
   segmentUri: '/base/test/test/assets/multidrm-video-segment.mp4',
@@ -469,6 +470,7 @@ const axinomMultiDrmVideoSegment = {
 
 /** @type {AVMetadataType} */
 const axinomMultiDrmAudioSegment = {
+  // Taken from Axinom's v6 test vector.
   initSegmentUri: '/base/test/test/assets/multidrm-audio-init.mp4',
   mdhdOffset: 0x192,
   segmentUri: '/base/test/test/assets/multidrm-audio-segment.mp4',
@@ -483,20 +485,15 @@ const axinomMultiDrmAudioSegment = {
 
 /** @type {!Object.<string, string>} */
 const axinomDrmServers = {
+  // NOTE: These are not Axinom's actual servers.  These are test servers for
+  // Widevine and PlayReady that let us specify the known key IDs and keys for
+  // Axinom's v6 test vectors.  Axinom's own servers started returning 403
+  // errors for these older test vectors, and we were forced to switch to
+  // something stable and independent.
   'com.widevine.alpha':
-      'https://drm-widevine-licensing.axtest.net/AcquireLicense',
+      'https://cwip-shaka-proxy.appspot.com/specific_key?blodJidXR9eARuql0dNLWg=GX8m9XLIZNIzizrl0RTqnA',
   'com.microsoft.playready':
-      'https://drm-playready-licensing.axtest.net/AcquireLicense',
-};
-
-/** @type {!Object.<string, string>} */
-const axinomDrmHeaders = {
-  'X-AxDRM-Message':
-      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5' +
-      'X2lkIjoiNjllNTQwODgtZTllMC00NTMwLThjMWEtMWViNmRjZDBkMTRlIiwibWVzc' +
-      '2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImtleXMiOlt7ImlkIj' +
-      'oiNmU1YTFkMjYtMjc1Ny00N2Q3LTgwNDYtZWFhNWQxZDM0YjVhIn1dfX0.yF7PflO' +
-      'Pv9qHnu3ZWJNZ12jgkqTabmwXbDWk_47tLNE',
+      'https://test.playready.microsoft.com/service/rightsmanager.asmx?cfg=(kid:6e5a1d26-2757-47d7-8046-eaa5d1d34b5a,contentkey:GX8m9XLIZNIzizrl0RTqnA,sl:150)',
 };
 
 /** @type {TextMetadataType} */
@@ -614,7 +611,6 @@ shaka.test.TestScheme.DATA = {
     audio: axinomMultiDrmAudioSegment,
     text: vttSegment,
     licenseServers: axinomDrmServers,
-    licenseRequestHeaders: axinomDrmHeaders,
     duration: 30,
   },
 
@@ -626,7 +622,6 @@ shaka.test.TestScheme.DATA = {
       initData: undefined,
     }),
     licenseServers: axinomDrmServers,
-    licenseRequestHeaders: axinomDrmHeaders,
     duration: 30,
   },
 


### PR DESCRIPTION
Axinom's DRM servers started returning 403 errors for the Axinom v6 test vectors we use in our tests, and we were forced to switch to more stable and independent DRM servers for testing.