### PR TITLE
fix:  PERIOD_FLATTENING_FAILED error with shaka 4.3.4 that did not occur with shaka 3.1.2 #5183 

### DIFF
--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -730,7 +730,7 @@ shaka.util.PeriodCombiner = class {
       // in advance.  concat() will add them to the output's MetaSegmentIndex.
     }
 
-    if (!outputStream.matchedStreams) {
+    if (!outputStream.matchedStreams || !outputStream.matchedStreams.length) {
       // This is not a stream we can build output from, but it may become part
       // of another output based on another period's stream.
       return null;


### PR DESCRIPTION
Fixed handling of manifest with new codecs in later periods by adding check for empty matchedStreams array in createNewOutputStrems()

Fixes #5183 

