### PR TITLE
test: Fix PlayReady server URL syntax

### DIFF
--- a/test/media/drm_engine_integration.js
+++ b/test/media/drm_engine_integration.js
@@ -91,7 +91,7 @@ describe('DrmEngine', () => {
     config.servers['com.widevine.alpha'] =
         'https://cwip-shaka-proxy.appspot.com/specific_key?blodJidXR9eARuql0dNLWg=GX8m9XLIZNIzizrl0RTqnA';
     config.servers['com.microsoft.playready'] =
-        'https://test.playready.microsoft.com/service/rightsmanager.asmx?cfg=(kid:6e5a1d26-2757-47d7-8046-eaa5d1d34b5a,contentkey:GX8m9XLIZNIzizrl0RTqnA,sl:150)';
+        'https://test.playready.microsoft.com/service/rightsmanager.asmx?cfg=(kid:6e5a1d26-2757-47d7-8046-eaa5d1d34b5a,contentkey:GX8m9XLIZNIzizrl0RTqnA==,sl:150)';
     drmEngine.configure(config);
 
     manifest = shaka.test.ManifestGenerator.generate((manifest) => {

--- a/test/test/util/test_scheme.js
+++ b/test/test/util/test_scheme.js
@@ -493,7 +493,7 @@ const axinomDrmServers = {
   'com.widevine.alpha':
       'https://cwip-shaka-proxy.appspot.com/specific_key?blodJidXR9eARuql0dNLWg=GX8m9XLIZNIzizrl0RTqnA',
   'com.microsoft.playready':
-      'https://test.playready.microsoft.com/service/rightsmanager.asmx?cfg=(kid:6e5a1d26-2757-47d7-8046-eaa5d1d34b5a,contentkey:GX8m9XLIZNIzizrl0RTqnA,sl:150)',
+      'https://test.playready.microsoft.com/service/rightsmanager.asmx?cfg=(kid:6e5a1d26-2757-47d7-8046-eaa5d1d34b5a,contentkey:GX8m9XLIZNIzizrl0RTqnA==,sl:150)',
 };
 
 /** @type {TextMetadataType} */


### PR DESCRIPTION
The padding on the base64-encoded content key was missing from the URL.  This did not show up until I tested on Tizen.