### PR TITLE
chore: Update maintained branches

### DIFF
--- a/maintained-branches.md
+++ b/maintained-branches.md
@@ -2,10 +2,9 @@
 
 We are currently maintaining the following branches of Shaka Player:
 
- - v4.3 (latest)
+ - v4.3 (latest, also in use by the Cast Application Framework)
  - v4.2 (previous)
- - v3.3 (LTS until April 30, 2023)
- - v3.2 (in use by the Cast Application Framework)
+ - No active LTS branches at this time
 
 Other branches are no longer receiving bug fixes, and we recommend you upgrade
 to a maintained branch.  For details on upgrading, please see our


### PR DESCRIPTION
The Cast Application Framework is adopting v4.3, which allows us to drop v3.2, and v3.3 LTS support ends at the end of April.