### PR TITLE
fix: unnecessary parsing of in-band pssh when pssh is in the manifest

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -139,6 +139,9 @@ shaka.media.DrmEngine = class {
 
     /** @private {Promise} */
     this.mediaKeysAttached_ = null;
+
+    /** @private {?shaka.extern.InitDataOverride} */
+    this.manifestInitData_ = null;
   }
 
   /** @override */
@@ -498,10 +501,10 @@ shaka.media.DrmEngine = class {
           () => this.closeOpenSessions_());
     }
 
-    const manifestInitData = this.currentDrmInfo_ ?
-      this.currentDrmInfo_.initData.find(
+    this.manifestInitData_ = this.currentDrmInfo_ ?
+      (this.currentDrmInfo_.initData.find(
           (initDataOverride) => initDataOverride.initData.length > 0,
-      ) : null;
+      ) || null) : null;
 
     /**
      * We can attach media keys before the playback actually begins when:
@@ -509,7 +512,7 @@ shaka.media.DrmEngine = class {
      *  - Some initData already has been generated (through the manifest)
      *  - In case of an offline session
      */
-    if (manifestInitData ||
+    if (this.manifestInitData_ ||
         this.currentDrmInfo_.keySystem !== 'com.apple.fps' ||
         this.storedPersistentSessions_.size) {
       await this.attachMediaKeys_();
@@ -525,7 +528,7 @@ shaka.media.DrmEngine = class {
     // Also suppress 'encrypted' events when parsing in-band ppsh
     // from media segments because that serves the same purpose as the
     // 'encrypted' events.
-    if (!manifestInitData && !this.storedPersistentSessions_.size &&
+    if (!this.manifestInitData_ && !this.storedPersistentSessions_.size &&
         !this.config_.parseInbandPsshEnabled) {
       this.eventManager_.listen(
           this.video_, 'encrypted', (e) => this.onEncryptedEvent_(e));
@@ -2496,7 +2499,7 @@ shaka.media.DrmEngine = class {
    * @return {!Promise<void>}
    */
   parseInbandPssh(contentType, mediaSegment) {
-    if (!this.config_.parseInbandPsshEnabled) {
+    if (!this.config_.parseInbandPsshEnabled || this.manifestInitData_) {
       return Promise.resolve();
     }
 


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/5197

When pssh is provided in the manifest we do not need to parse in-band pssh even if the drm.parseInbandPssh setting is true.

Tested on an xbox one with some additional temporary logging the reported when in-band pssh is being parsed.
Tested with setting drm.parseInbandPssh=true (the default for XboxOne)
Verified that we DO NOT parse in-band pssh when pssh is present in the manifest
Verified that we DO parse in-band pssh when pssh is NOT present in the manifest
