### PR TITLE
ci: Make version index aware of deployments

### DIFF
--- a/.github/workflows/demo-version-index.yaml
+++ b/.github/workflows/demo-version-index.yaml
@@ -27,12 +27,12 @@ jobs:
           # We need a list of all tags for this, so fetch the entire history.
           fetch-depth: 0
 
-      - name: Generate static content
-        run: python3 app-engine/demo-version-index/generate.py
-
       - uses: google-github-actions/auth@v0
         with:
           credentials_json: '${{ secrets.APPENGINE_DEPLOY_KEY }}'
+
+      - name: Generate static content
+        run: python3 app-engine/demo-version-index/generate.py
 
       - uses: google-github-actions/deploy-appengine@v0
         with:

--- a/app-engine/demo-version-index/templates/index.html
+++ b/app-engine/demo-version-index/templates/index.html
@@ -80,8 +80,16 @@ table.all tr:nth-child(2n) {
       <tr class="old">
       {% endif %}
         <th>{{ v.version }}</th>
-        <td><a href="{{ v.demo }}">demo</a></td>
-        <td><a href="{{ v.lib }}">non-UI library</a></td>
+        <td>
+          {% if v.demo %}
+          <a href="{{ v.demo }}">demo</a>
+          {% endif %}
+        </td>
+        <td>
+          {% if v.lib %}
+          <a href="{{ v.lib }}">non-UI library</a>
+          {% endif %}
+        </td>
         <td>
           {% if v.ui_lib %}
           <a href="{{ v.ui_lib }}">UI-enabled library</a>


### PR DESCRIPTION
Due to limits in the number of versions you can have deployed at once on App Engine, we can no longer keep every version of the Shaka Player Demo deployed.  So the version index needs to be aware of which versions are deployed, and only link to versions that are still available.

This makes the index generator aware of App Engine deployments.