### PR TITLE
fix(DASH): fix bufferBehind broken by thumbnails with TimelineSegmentIndex

### DIFF
--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -143,7 +143,7 @@ shaka.dash.SegmentTemplate = class {
         tsi.evict(availabilityStart);
       }
 
-      if (info.timeline) {
+      if (info.timeline && context.adaptationSet.contentType !== 'image') {
         const timeline = info.timeline;
         context.presentationTimeline.notifyTimeRange(
             timeline,


### PR DESCRIPTION
Similar to https://github.com/shaka-project/shaka-player/issues/4717 the same problem with broken `bufferBehind` occurs with the latest addition of `TimelineSegmentIndex`.