### PR TITLE
fix: media source object URL revocation

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -112,14 +112,14 @@ shaka.media.MediaSourceEngine = class {
     /** @private {!shaka.util.PublicPromise} */
     this.mediaSourceOpen_ = new shaka.util.PublicPromise();
 
+    /** @private {string} */
+    this.url_ = '';
+
     /** @private {MediaSource} */
     this.mediaSource_ = this.createMediaSource(this.mediaSourceOpen_);
 
     /** @type {!shaka.util.Destroyer} */
     this.destroyer_ = new shaka.util.Destroyer(() => this.doDestroy_());
-
-    /** @private {string} */
-    this.url_ = '';
 
     /** @private {boolean} */
     this.sequenceMode_ = false;
@@ -163,6 +163,8 @@ shaka.media.MediaSourceEngine = class {
    * @private
    */
   onSourceOpen_(p) {
+    goog.asserts.assert(this.url_, 'Must have object URL');
+
     // Release the object URL that was previously created, to prevent memory
     // leak.
     // createObjectURL creates a strong reference to the MediaSource object


### PR DESCRIPTION
`createMediaSource()` sets `this.url_` for later revocation when the media source opens. However, `createMediaSource()` is called before the `url_` property is declared and initialised in the constructor. As result, `this.url_` actually get declared an initialised with the object URL in `createMediaSource()` and is later overwritten with an empty string in the constructor. This compromises the revocation logic as we end up always passing an empty string to `URL.revokeObjectURL()`.

To fix this, we make sure `this.url_` is declared and assigned default value in the constructor before any other class methods are called.