### PR TITLE
docs: Link to Shaka Player React UI Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ The Shaka team doesn't have the bandwidth and experience to provide guidance and
 support for integrating Shaka Player with specific frameworks, but some of our
 users have successfully done so and created tutorials to help other beginners.
 
+Shaka + ReactJS Library
+- https://github.com/winoffrg/limeplay
+
 Shaka + ReactJS integrations:
 - https://github.com/matvp91/shaka-player-react
 - https://github.com/amit08255/shaka-player-react-with-ui-config


### PR DESCRIPTION
Not sure how I should propose this, But want to mention that https://github.com/shaka-project/shaka-player/blob/main/README.md#framework-integrations all mention here are wrappers. Which allows us to use it with specific framework or library. Whereas, https://limeplay.me is a React Library where everything has been made from scratch specifically for React. 

Should we rename and put others under the category of **Wrappers** and this under **Library**? 