### PR TITLE
fix: Document Picture-in-Picture: Use width/height instead of initialAspectRatio

### DIFF
--- a/externs/pictureinpicture.js
+++ b/externs/pictureinpicture.js
@@ -53,7 +53,6 @@ HTMLMediaElement.prototype.webkitPresentationMode;
 
 /**
  * @typedef {{
- *   initialAspectRatio: (number|undefined),
  *   width: (number|undefined),
  *   height: (number|undefined),
  *   copyStyleSheets: (boolean|undefined),

--- a/ui/pip_button.js
+++ b/ui/pip_button.js
@@ -162,7 +162,8 @@ shaka.ui.PipButton = class extends shaka.ui.Element {
     const pipPlayer = this.videoContainer_;
     const rectPipPlayer = pipPlayer.getBoundingClientRect();
     const pipWindow = await window.documentPictureInPicture.requestWindow({
-      initialAspectRatio: rectPipPlayer.width / rectPipPlayer.height,
+      width: rectPipPlayer.width,
+      height: rectPipPlayer.height,
       copyStyleSheets: true,
     });
 


### PR DESCRIPTION
The `initialAspectRatio` option was removed from the Document Picture-in-Picture spec in favour of `width` and `height`, so we should use them. See https://github.com/WICG/document-picture-in-picture/pull/36