### PR TITLE
feat: [DRAFT] enable detached player initialization/load

### DIFF
--- a/externs/shaka/text.js
+++ b/externs/shaka/text.js
@@ -487,6 +487,24 @@ shaka.extern.TextParserPlugin;
  */
 shaka.extern.TextDisplayer = class {
   /**
+   * Sets the video container the text displayer should use.
+   * @param {HTMLElement} videoContainer
+   *
+   * @exportDoc
+   */
+  setVideoContainer(videoContainer) {}
+
+  /**
+   * Attach the text displayer to a media element.
+   *
+   * @param {HTMLMediaElement} mediaElement
+   *
+   * @exportDoc
+   */
+  attach(mediaElement) {}
+
+
+  /**
    * @override
    * @exportDoc
    */

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -45,8 +45,6 @@ goog.require('shaka.lcevc.Dil');
  */
 shaka.media.MediaSourceEngine = class {
   /**
-   * @param {HTMLMediaElement} video The video element, whose source is tied to
-   *   MediaSource during the lifetime of the MediaSourceEngine.
    * @param {!shaka.extern.TextDisplayer} textDisplayer
    *    The text displayer that will be used with the text engine.
    *    MediaSourceEngine takes ownership of the displayer. When
@@ -56,9 +54,9 @@ shaka.media.MediaSourceEngine = class {
    * @param {?shaka.lcevc.Dil} [lcevcDil] Optional -  LCEVC Dil Object
    *
    */
-  constructor(video, textDisplayer, onMetadata, lcevcDil) {
+  constructor(textDisplayer, onMetadata, lcevcDil) {
     /** @private {HTMLMediaElement} */
-    this.video_ = video;
+    this.video_ = null;
 
     /** @private {?shaka.extern.MediaSourceConfiguration} */
     this.config_ = null;
@@ -112,9 +110,6 @@ shaka.media.MediaSourceEngine = class {
     /** @private {!shaka.util.PublicPromise} */
     this.mediaSourceOpen_ = new shaka.util.PublicPromise();
 
-    /** @private {string} */
-    this.url_ = '';
-
     /** @private {MediaSource} */
     this.mediaSource_ = this.createMediaSource(this.mediaSourceOpen_);
 
@@ -138,6 +133,31 @@ shaka.media.MediaSourceEngine = class {
   }
 
   /**
+   * @param {HTMLMediaElement} mediaElement The video element, whose source is
+   *     tied to MediaSource during the lifetime of the MediaSourceEngine.
+   */
+  async attach(mediaElement) {
+    this.video_ = mediaElement;
+
+    this.textDisplayer_.attach(mediaElement);
+
+    const url =
+        shaka.media.MediaSourceEngine.createObjectURL(this.mediaSource_);
+    this.video_.src = url;
+
+    await this.mediaSourceOpen_;
+
+    // Release the object URL that was previously created, to prevent memory
+    // leak.
+    // createObjectURL creates a strong reference to the MediaSource object
+    // inside the browser.  Setting the src of the video then creates another
+    // reference within the video element.  revokeObjectURL will remove the
+    // strong reference to the MediaSource object, and allow it to be
+    // garbage-collected later.
+    URL.revokeObjectURL(url);
+  }
+
+  /**
    * Create a MediaSource object, attach it to the video element, and return it.
    * Resolves the given promise when the MediaSource is ready.
    *
@@ -151,32 +171,9 @@ shaka.media.MediaSourceEngine = class {
 
     // Set up MediaSource on the video element.
     this.eventManager_.listenOnce(
-        mediaSource, 'sourceopen', () => this.onSourceOpen_(p));
-
-    // Store the object URL for releasing it later.
-    this.url_ = shaka.media.MediaSourceEngine.createObjectURL(mediaSource);
-
-    this.video_.src = this.url_;
+        mediaSource, 'sourceopen', () => p.resolve());
 
     return mediaSource;
-  }
-
-  /**
-   * @param {!shaka.util.PublicPromise} p
-   * @private
-   */
-  onSourceOpen_(p) {
-    goog.asserts.assert(this.url_, 'Must have object URL');
-
-    // Release the object URL that was previously created, to prevent memory
-    // leak.
-    // createObjectURL creates a strong reference to the MediaSource object
-    // inside the browser.  Setting the src of the video then creates another
-    // reference within the video element.  revokeObjectURL will remove the
-    // strong reference to the MediaSource object, and allow it to be
-    // garbage-collected later.
-    URL.revokeObjectURL(this.url_);
-    p.resolve();
   }
 
   /**

--- a/lib/player.js
+++ b/lib/player.js
@@ -1711,13 +1711,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.lastTextFactory_ = textDisplayerFactory;
 
     const mediaSourceEngine = this.createMediaSourceEngine(
-        has.mediaElement,
         textDisplayer,
         (metadata, offset, endTime) => {
           this.processTimedMetadataMediaSrc_(metadata, offset, endTime);
         },
         this.lcevcDil_);
     mediaSourceEngine.configure(this.config_.mediaSource);
+    await mediaSourceEngine.attach(has.mediaElement);
     const {segmentRelativeVttTiming} = this.config_.manifest;
     mediaSourceEngine.setSegmentRelativeVttTiming(segmentRelativeVttTiming);
 
@@ -3078,7 +3078,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Create a new media source engine. This will ONLY be replaced by tests as a
    * way to inject fake media source engine instances.
    *
-   * @param {!HTMLMediaElement} mediaElement
    * @param {!shaka.extern.TextDisplayer} textDisplayer
    * @param {!function(!Array.<shaka.extern.ID3Metadata>, number, ?number)}
    *  onMetadata
@@ -3086,9 +3085,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * @return {!shaka.media.MediaSourceEngine}
    */
-  createMediaSourceEngine(mediaElement, textDisplayer, onMetadata, lcevcDil) {
+  createMediaSourceEngine(textDisplayer, onMetadata, lcevcDil) {
     return new shaka.media.MediaSourceEngine(
-        mediaElement,
         textDisplayer,
         onMetadata,
         lcevcDil);
@@ -5346,10 +5344,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // TextDisplay factory must capture a reference to "this".
     config.textDisplayFactory = () => {
       if (this.videoContainer_) {
-        return new shaka.text.UITextDisplayer(
-            this.video_, this.videoContainer_);
+        const uiTextDisplayer = new shaka.text.UITextDisplayer();
+        uiTextDisplayer.setVideoContainer(this.videoContainer_);
+        uiTextDisplayer.attach(this.video_);
+        return uiTextDisplayer;
       } else {
-        return new shaka.text.SimpleTextDisplayer(this.video_);
+        const textDisplayer = new shaka.text.SimpleTextDisplayer();
+        textDisplayer.attach(this.video_);
+        return textDisplayer;
       }
     };
     return config;
@@ -6217,21 +6219,18 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   restoreDisabledVariants_(updateAbrManager=true) {
-    if (this.loadMode_ != shaka.Player.LoadMode.MEDIA_SOURCE) {
-      return;
-    }
-    goog.asserts.assert(this.manifest_, 'Should have manifest!');
+    if (this.manifest_) {
+      shaka.log.v2('Restoring all disabled streams...');
 
-    shaka.log.v2('Restoring all disabled streams...');
+      this.checkVariantsTimer_.stop();
 
-    this.checkVariantsTimer_.stop();
+      for (const variant of this.manifest_.variants) {
+        variant.disabledUntilTime = 0;
+      }
 
-    for (const variant of this.manifest_.variants) {
-      variant.disabledUntilTime = 0;
-    }
-
-    if (updateAbrManager) {
-      this.updateAbrManagerVariants_();
+      if (updateAbrManager) {
+        this.updateAbrManagerVariants_();
+      }
     }
   }
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -629,6 +629,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.adManager_ = shaka.Player.adManagerFactory_();
     }
 
+    /** @private {Promise} */
+    this.attachPromise_ = Promise.resolve();
+
+    /** @private {shaka.routing.Payload} */
+    this.currentLoadPayload_ = shaka.Player.createEmptyPayload_();
+
     // If the browser comes back online after being offline, then try to play
     // again.
     this.globalEventManager_.listen(window, 'online', () => {
@@ -741,10 +747,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       },
     };
 
+    if (mediaElement) {
+      this.currentLoadPayload_.mediaElement = mediaElement;
+    }
+
     /** @private {shaka.routing.Walker} */
     this.walker_ = new shaka.routing.Walker(
         this.detachNode_,
-        shaka.Player.createEmptyPayload_(),
+        this.currentLoadPayload_,
         walkerImplementation);
 
     /** @private {shaka.util.Timer} */
@@ -848,6 +858,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // internal state any more. This will stop calls to |attach|, |detach|, etc.
     // from interrupting our final move to the detached state.
     this.loadMode_ = shaka.Player.LoadMode.DESTROYED;
+
+    this.currentLoadPayload_ = shaka.Player.createEmptyPayload_();
 
     // Because we have set |loadMode_| to |DESTROYED| we can't call |detach|. We
     // must talk to |this.walker_| directly.
@@ -1057,8 +1069,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return Promise.reject(this.createAbortLoadError_());
     }
 
-    const payload = shaka.Player.createEmptyPayload_();
-    payload.mediaElement = mediaElement;
+    if (this.video_ && this.video_ !== mediaElement) {
+      // TODO(zangue)
+      // Reject? Detach -> ... -> Attach?
+    }
 
     // If the platform does not support media source, we will never want to
     // initialize media source.
@@ -1066,23 +1080,44 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       initializeMediaSource = false;
     }
 
-    const destination = initializeMediaSource ?
-                        this.mediaSourceNode_ :
-                        this.attachNode_;
+    this.video_ = mediaElement;
 
-    // Do not allow this route to be interrupted because calls after this attach
-    // call will depend on the media element being attached.
-    const events = this.walker_.startNewRoute((currentPayload) => {
-      return {
-        node: destination,
-        payload: payload,
-        interruptible: false,
-      };
-    });
+    this.currentLoadPayload_.mediaElement = mediaElement;
 
-    // List to the events that can occur with our request.
-    events.onStart = () => shaka.log.info('Starting attach...');
-    return this.wrapWalkerListenersWithPromise_(events);
+    let destination = null;
+
+    // Already initialized - waiting for media element
+    if (this.walker_.getCurrentNode() == this.drmNode_ &&
+        this.walker_.getCurrentDestination() == null &&
+        !this.currentLoadPayload_.useSrcEquals) {
+      destination = this.loadNode_;
+    }
+
+    if (this.walker_.getCurrentNode() == this.detachNode_) {
+      // Using src=
+      if (this.currentLoadPayload_.useSrcEquals) {
+        destination = this.srcEqualsNode_;
+      } else if (initializeMediaSource) {
+        destination = this.mediaSourceNode_;
+      }
+    }
+
+    if (destination) {
+      const events = this.walker_.startNewRoute((currentPayload) => {
+        return {
+          node: destination,
+          payload: this.currentLoadPayload_,
+          interruptible: false,
+        };
+      });
+
+      // List to the events that can occur with our request.
+      events.onStart = () => shaka.log.info('Starting attach...');
+      this.attachPromise_ = this.wrapWalkerListenersWithPromise_(events);
+    }
+
+    this.attachPromise_ = Promise.resolve();
+    return this.attachPromise_;
   }
 
 
@@ -1255,7 +1290,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @return {!Promise}
    * @export
    */
-  load(assetUri, startTime, mimeType) {
+  async load(assetUri, startTime, mimeType) {
     this.updatedStartTime_ = null;
 
     this.fullyLoaded_ = false;
@@ -1265,6 +1300,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return Promise.reject(this.createAbortLoadError_());
     }
 
+    // When a media element is passed as argument to the constructor, we start
+    // an attach() operation which is async. Make sure we wait for any
+    // ongoing attach operation to terminate first.
+    await this.attachPromise_;
+
+    // TODO(zangue) - Probably move to attach node.
     // We dispatch the loading event when someone calls |load| because we want
     // to surface the user intent.
     this.dispatchEvent(this.makeEvent_(shaka.util.FakeEvent.EventName.Loading));
@@ -1288,15 +1329,20 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // TODO: Refactor to determine whether it's a manifest or not, and whether
     // or not we can play it.  Then we could return a better error than
     // UNABLE_TO_GUESS_MANIFEST_TYPE for WebM in Safari.
-    const useSrcEquals = this.shouldUseSrcEquals_(payload);
-    const destination = useSrcEquals ? this.srcEqualsNode_ : this.loadNode_;
+    payload.useSrcEquals = this.shouldUseSrcEquals_(payload);
+    let destination =
+        payload.useSrcEquals ? this.srcEqualsNode_ : this.loadNode_;
+
+    // cache current/active load context
+    this.currentLoadPayload_ = payload;
 
     // Allow this request to be interrupted, this will allow other requests to
     // cancel a load and quickly start a new load.
     const events = this.walker_.startNewRoute((currentPayload) => {
+      // Perform "detached" load if we don't have a media element yet.
       if (currentPayload.mediaElement == null) {
-        // Because we return null, this "new route" will not be used.
-        return null;
+        // Because that's the furthest we can go without media element.
+        destination = payload.useSrcEquals ? this.detachNode_ : this.drmNode_;
       }
 
       // Keep using whatever media element we have right now.
@@ -1442,29 +1488,31 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @return {!Promise}
    * @private
    */
-  onAttach_(has, wants) {
-    // If we don't have a media element yet, it means we are entering
-    // "attach" from another node.
-    //
-    // If we have a media element, it should match |wants.mediaElement|
-    // because it means we are going from "attach" to "attach".
-    //
-    // These constraints should be maintained and guaranteed by the routing
-    // logic in |getNextStep_|.
-    goog.asserts.assert(
-        has.mediaElement == null || has.mediaElement == wants.mediaElement,
-        'The routing logic failed. MediaElement requirement failed.');
-
+  async onAttach_(has, wants) {
     if (has.mediaElement == null) {
       has.mediaElement = wants.mediaElement;
+
+      // If we don't have a video element it means that we are on a route that
+      // passed through 'detach'
+      // TODO(zangue) - handle this differently?
+      if (this.video_ == null) {
+        this.video_ = has.mediaElement;
+      }
 
       const onError = (error) => this.onVideoError_(error);
       this.attachEventManager_.listen(has.mediaElement, 'error', onError);
     }
 
-    this.video_ = has.mediaElement;
+    // Lock in load type
+    has.useSrcEquals = wants.useSrcEquals;
 
-    return Promise.resolve();
+    if (this.drmEngine_) {
+      await this.drmEngine_.attach(has.mediaElement);
+    }
+
+    if (this.mediaSourceEngine_) {
+      await this.mediaSourceEngine_.attach(has.mediaElement);
+    }
   }
 
   /**
@@ -1492,6 +1540,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.attachEventManager_.removeAll();
       has.mediaElement = null;
     }
+
+    // TODO(zangue) - release DRM and MSE?
 
     if (this.adManager_) {
       // The ad manager is specific to the video, so detach it too.
@@ -1685,18 +1735,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @return {!Promise}
    * @private
    */
-  async onInitializeMediaSourceEngine_(has, wants) {
+  onInitializeMediaSourceEngine_(has, wants) {
     goog.asserts.assert(
         shaka.util.Platform.supportsMediaSource(),
         'We should not be initializing media source on a platform that does ' +
             'not support media source.');
-    goog.asserts.assert(
-        has.mediaElement,
-        'We should have a media element when initializing media source.');
-    goog.asserts.assert(
-        has.mediaElement == wants.mediaElement,
-        '|has| and |wants| should have the same media element when ' +
-            'initializing media source.');
 
     goog.asserts.assert(
         this.mediaSourceEngine_ == null,
@@ -1717,13 +1760,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         },
         this.lcevcDil_);
     mediaSourceEngine.configure(this.config_.mediaSource);
-    await mediaSourceEngine.attach(has.mediaElement);
     const {segmentRelativeVttTiming} = this.config_.manifest;
     mediaSourceEngine.setSegmentRelativeVttTiming(segmentRelativeVttTiming);
-
-    // Wait for media source engine to finish opening. This promise should
-    // NEVER be rejected as per the media source engine implementation.
-    await mediaSourceEngine.open();
 
     // Wait until it is ready to actually store the reference.
     this.mediaSourceEngine_ = mediaSourceEngine;
@@ -1742,13 +1780,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   async onInitializeParser_(has, wants) {
-    goog.asserts.assert(
-        has.mediaElement,
-        'We should have a media element when initializing the parser.');
-    goog.asserts.assert(
-        has.mediaElement == wants.mediaElement,
-        '|has| and |wants| should have the same media element when ' +
-            'initializing the parser.');
+    // goog.asserts.assert(
+    //     has.mediaElement,
+    //     'We should have a media element when initializing the parser.');
+    // goog.asserts.assert(
+    //     has.mediaElement == wants.mediaElement,
+    //     '|has| and |wants| should have the same media element when ' +
+    //         'initializing the parser.');
 
     goog.asserts.assert(
         this.networkingEngine_,
@@ -1785,10 +1823,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     const manifestConfig =
         shaka.util.ObjectUtils.cloneObject(this.config_.manifest);
+    // TODO(zangue) - Make sure this still works
     // Don't read video segments if the player is attached to an audio element
-    if (wants.mediaElement && wants.mediaElement.nodeName === 'AUDIO') {
-      manifestConfig.disableVideo = true;
-    }
+    // if (wants.mediaElement && wants.mediaElement.nodeName === 'AUDIO') {
+    //   manifestConfig.disableVideo = true;
+    // }
 
     this.parser_.configure(manifestConfig);
   }
@@ -1965,9 +2004,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     goog.asserts.assert(
         this.manifest_,
         '|this.manifest_| should have been set in an earlier step.');
-    goog.asserts.assert(
-        has.mediaElement,
-        'We should have a media element when initializing the DRM Engine.');
+
 
     const startTime = Date.now() / 1000;
     let firstEvent = true;
@@ -2009,8 +2046,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     await this.drmEngine_.initForPlayback(
         this.manifest_.variants,
         this.manifest_.offlineSessionIds);
-
-    await this.drmEngine_.attach(has.mediaElement);
 
     // Now that we have drm information, filter the manifest (again) so that we
     // can ensure we only use variants with the selected key system.
@@ -2066,6 +2101,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // know that they will still be non-null between calls to await.
     const mediaElement = has.mediaElement;
     const assetUri = has.uri;
+
+    // TODO(zangue) - we can attach the mse at the very last moment.
+    // if (this.mediaSourceEngine_) {
+    //   this.mediaSourceEngine_.attach(has.mediaElement);
+    // }
 
     // Save the uri so that it can be used outside of the load-graph.
     this.assetUri_ = assetUri;
@@ -2245,6 +2285,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
     }
 
+    // TODO(zangue): open in load node.
+    // Wait for media source engine to finish opening. This promise should
+    // NEVER be rejected as per the media source engine implementation.
+    await this.mediaSourceEngine_.open();
 
     // Start streaming content. This will start the flow of content down to
     // media source.
@@ -5346,11 +5390,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       if (this.videoContainer_) {
         const uiTextDisplayer = new shaka.text.UITextDisplayer();
         uiTextDisplayer.setVideoContainer(this.videoContainer_);
-        uiTextDisplayer.attach(this.video_);
         return uiTextDisplayer;
       } else {
         const textDisplayer = new shaka.text.SimpleTextDisplayer();
-        textDisplayer.attach(this.video_);
         return textDisplayer;
       }
     };
@@ -5478,8 +5520,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   async filterManifestWithStreamUtils_(manifest) {
+    // Return if |destroy| is called.
+    if (this.loadMode_ == shaka.Player.LoadMode.DESTROYED) {
+      return;
+    }
+
     goog.asserts.assert(manifest, 'Manifest should exist!');
-    goog.asserts.assert(this.video_, 'Must not be destroyed');
 
     /** @type {?shaka.extern.Variant} */
     const currentVariant = this.streamingEngine_ ?
@@ -6877,14 +6923,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Graph Topology
    * ----------------------
    *
-   *        [SRC]-----+
+   *       [SRC]------+
    *         ^        |
-   *         |        v
-   * [D]<-->[A]<-----[U]
-   *         |        ^
-   *         v        |
-   *        [MS]------+
    *         |        |
+   *  +---->[A]-------+
+   *  |               |
+   *  |               v
+   * [D]--->[MS]---->[U]--->[D]
+   *         |        ^
    *         v        |
    *        [P]-------+
    *         |        |
@@ -6893,6 +6939,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *         |        |
    *         v        |
    *        [DRM]-----+
+   *         |        |
+   *         v        |
+   *        [A]-------+
    *         |        |
    *         v        |
    *        [L]-------+
@@ -6907,13 +6956,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   getNextStep_(currentlyAt, currentlyWith, wantsToBeAt, wantsToHave) {
     let next = null;
 
-    // Detach is very simple, either stay in detach (because |detach| was called
-    // while in detached) or go somewhere that requires us to attach to an
-    // element.
     if (currentlyAt == this.detachNode_) {
-      next = wantsToBeAt == this.detachNode_ ?
-             this.detachNode_ :
-             this.attachNode_;
+      next = this.getNextAfterDetach_(wantsToBeAt, currentlyWith, wantsToHave);
     }
 
     if (currentlyAt == this.attachNode_) {
@@ -6926,36 +6970,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     if (currentlyAt == this.parserNode_) {
-      next = this.getNextMatchingAllDependencies_(
-          /* destination= */ this.loadNode_,
-          /* next= */ this.manifestNode_,
-          /* reset= */ this.unloadNode_,
-          /* goingTo= */ wantsToBeAt,
-          /* has= */ currentlyWith,
-          /* wants= */ wantsToHave);
+      next = this.getNextAfterParser_(wantsToBeAt, currentlyWith, wantsToHave);
     }
 
     if (currentlyAt == this.manifestNode_) {
-      next = this.getNextMatchingAllDependencies_(
-          /* destination= */ this.loadNode_,
-          /* next= */ this.drmNode_,
-          /* reset= */ this.unloadNode_,
-          /* goingTo= */ wantsToBeAt,
-          /* has= */ currentlyWith,
-          /* wants= */ wantsToHave);
+      next = this.getNextAfterManifest_(
+          wantsToBeAt, currentlyWith, wantsToHave);
     }
 
-    // For DRM, we have two options "load" or "unload". If all our constraints
-    // are met, we can go to "load". If anything is off, we must go back to
-    // "unload" to reset.
     if (currentlyAt == this.drmNode_) {
-      next = this.getNextMatchingAllDependencies_(
-          /* destination= */ this.loadNode_,
-          /* next= */ this.loadNode_,
-          /* reset= */ this.unloadNode_,
-          /* goingTo= */ wantsToBeAt,
-          /* has= */ currentlyWith,
-          /* wants= */ wantsToHave);
+      next = this.getNextAfterDrm_(wantsToBeAt, currentlyWith, wantsToHave);
     }
 
     // For DRM w/ src= playback, we only care about destination and media
@@ -6976,7 +7000,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     if (currentlyAt == this.unloadNode_) {
-      next = this.getNextAfterUnload_(wantsToBeAt, currentlyWith, wantsToHave);
+      next = this.detachNode_;
     }
 
     goog.asserts.assert(next, 'Missing next step!');
@@ -6990,18 +7014,92 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @return {?shaka.routing.Node}
    * @private
    */
+  getNextAfterDrm_(goingTo, has, wants) {
+    if (goingTo == this.loadNode_ &&
+        has.uri == wants.uri &&
+        has.mimeType == wants.mimeType) {
+      return this.attachNode_;
+    }
+
+    return this.unloadNode_;
+  }
+
+  /**
+   * @param {!shaka.routing.Node} goingTo
+   * @param {shaka.routing.Payload} has
+   * @param {shaka.routing.Payload} wants
+   * @return {?shaka.routing.Node}
+   * @private
+   */
+  getNextAfterDetach_(goingTo, has, wants) {
+    if (goingTo == this.detachNode_) {
+      return this.detachNode_;
+    }
+
+    if (wants.useSrcEquals) {
+      return this.attachNode_;
+    }
+
+    return this.mediaSourceNode_;
+  }
+
+  /**
+   * @param {!shaka.routing.Node} goingTo
+   * @param {shaka.routing.Payload} has
+   * @param {shaka.routing.Payload} wants
+   * @return {?shaka.routing.Node}
+   * @private
+   */
+  getNextAfterParser_(goingTo, has, wants) {
+    if ((goingTo == this.drmNode_ || goingTo == this.loadNode_) &&
+        has.uri == wants.uri &&
+        has.mimeType == wants.mimeType) {
+      return this.manifestNode_;
+    }
+
+    return this.unloadNode_;
+  }
+
+  /**
+   * @param {!shaka.routing.Node} goingTo
+   * @param {shaka.routing.Payload} has
+   * @param {shaka.routing.Payload} wants
+   * @return {?shaka.routing.Node}
+   * @private
+   */
+  getNextAfterManifest_(goingTo, has, wants) {
+    if ((goingTo == this.drmNode_ || goingTo == this.loadNode_) &&
+        has.uri == wants.uri &&
+        has.mimeType == wants.mimeType) {
+      return this.drmNode_;
+    }
+
+    return this.unloadNode_;
+  }
+
+  /**
+   * @param {!shaka.routing.Node} goingTo
+   * @param {shaka.routing.Payload} has
+   * @param {shaka.routing.Payload} wants
+   * @return {?shaka.routing.Node}
+   * @private
+   */
   getNextAfterAttach_(goingTo, has, wants) {
     // Attach and detach are the only two nodes that we can directly go
     // back-and-forth between.
-    if (goingTo == this.detachNode_) {
+    if (wants.useSrcEquals && goingTo == this.detachNode_) {
       return this.detachNode_;
     }
 
     // If we are going anywhere other than detach, then we need the media
     // element to match, if they don't match, we need to go through detach
-    // first.
+    // first for src=. For media source playback we need to go through unload
+    // first to reach detach.
     if (has.mediaElement != wants.mediaElement) {
-      return this.detachNode_;
+      if (wants.useSrcEquals) {
+        return this.detachNode_;
+      }
+      return this.unloadNode_;
     }
 
     // If we are already in attached, and someone calls |attach| again (to the
@@ -7011,14 +7109,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return this.attachNode_;
     }
 
-    // The next step from attached to loaded is through media source.
-    if (goingTo == this.mediaSourceNode_ || goingTo == this.loadNode_) {
-      return this.mediaSourceNode_;
+    // Attach the last step before load for media source playback.
+    if (goingTo == this.loadNode_) {
+      return this.loadNode_;
     }
 
     // If we are going to src=, then we should set up DRM first.  This will
     // support cases like FairPlay HLS on Safari.
-    if (goingTo == this.srcEqualsNode_) {
+    if (wants.useSrcEquals && goingTo == this.srcEqualsNode_) {
       return this.srcEqualsDrmNode_;
     }
 
@@ -7035,10 +7133,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   getNextAfterMediaSource_(goingTo, has, wants) {
-    // We can only go to parse manifest or unload. If we want to go to load and
-    // we have the right media element, we can go to parse manifest. If we
-    // don't, no matter where we want to go, we must go through unload.
-    if (goingTo == this.loadNode_ && has.mediaElement == wants.mediaElement) {
+    if (goingTo == this.drmNode_ || goingTo == this.loadNode_) {
       return this.parserNode_;
     }
 
@@ -7054,63 +7149,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   }
 
   /**
-   * After unload there are only two options, attached or detached. This choice
-   * is based on whether or not we have a media element. If we have a media
-   * element, then we go to attach. If we don't have a media element, we go to
-   * detach.
-   *
-   * @param {!shaka.routing.Node} goingTo
-   * @param {shaka.routing.Payload} has
-   * @param {shaka.routing.Payload} wants
-   * @return {?shaka.routing.Node}
-   * @private
-   */
-  getNextAfterUnload_(goingTo, has, wants) {
-    // If we don't want a media element, detach.
-    // If we have the wrong media element, detach.
-    // Otherwise it means we want to attach to a media element and it is safe to
-    // do so.
-    return !wants.mediaElement || has.mediaElement != wants.mediaElement ?
-           this.detachNode_ :
-           this.attachNode_;
-  }
-
-  /**
-   * A general method used to handle routing when we can either than one step
-   * toward our destination (while all our dependencies match) or go to a node
-   * that will reset us so we can try again.
-   *
-   * @param {!shaka.routing.Node} destinationNode
-   *   What |goingTo| must be for us to step toward |nextNode|. Otherwise we
-   *   will go to |resetNode|.
-   * @param {!shaka.routing.Node} nextNode
-   *   The node we will go to next if |goingTo == destinationNode| and all
-   *   dependencies match.
-   * @param {!shaka.routing.Node} resetNode
-   *   The node we will go to next if |goingTo != destinationNode| or any
-   *   dependency does not match.
-   * @param {!shaka.routing.Node} goingTo
-   *   The node that the walker is trying to go to.
-   * @param {shaka.routing.Payload} has
-   *   The payload that the walker currently has.
-   * @param {shaka.routing.Payload} wants
-   *   The payload that the walker wants to have when iy gets to |goingTo|.
-   * @return {shaka.routing.Node}
-   * @private
-   */
-  getNextMatchingAllDependencies_(destinationNode, nextNode, resetNode, goingTo,
-      has, wants) {
-    if (goingTo == destinationNode &&
-        has.mediaElement == wants.mediaElement &&
-        has.uri == wants.uri &&
-        has.mimeType == wants.mimeType) {
-      return nextNode;
-    }
-
-    return resetNode;
-  }
-
-  /**
    * @return {shaka.routing.Payload}
    * @private
    */
@@ -7120,6 +7158,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       mimeType: null,
       startTime: null,
       startTimeOfLoad: NaN,
+      useSrcEquals: false,
       uri: null,
     };
   }

--- a/lib/player.js
+++ b/lib/player.js
@@ -1069,10 +1069,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return Promise.reject(this.createAbortLoadError_());
     }
 
-    if (this.video_ && this.video_ !== mediaElement) {
-      // TODO(zangue)
-      // Reject? Detach -> ... -> Attach?
-    }
+    // TODO(zangue)
+    // Reject? Detach -> ... -> Attach?
+    // if (this.video_ && this.video_ !== mediaElement) {
+    // }
 
     // If the platform does not support media source, we will never want to
     // initialize media source.
@@ -1765,6 +1765,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // Wait until it is ready to actually store the reference.
     this.mediaSourceEngine_ = mediaSourceEngine;
+
+    return Promise.resolve();
   }
 
   /**

--- a/lib/routing/payload.js
+++ b/lib/routing/payload.js
@@ -13,6 +13,7 @@ goog.provide('shaka.routing.Payload');
  *   mimeType: ?string,
  *   startTime: ?number,
  *   startTimeOfLoad: number,
+ *   useSrcEquals: boolean,
  *   uri: ?string
  * }}
  *
@@ -30,6 +31,9 @@ goog.provide('shaka.routing.Payload');
  * @property {?number} startTime
  *   The time (in seconds) where playback should start. When |null| we will
  *   use the content's default start time (0 for VOD and live edge for LIVE).
+ *
+ * @property {boolean} useSrcEquals
+ *   Set to true when loading with scr= and false when loading with media source
  *
  * @property {number} startTimeOfLoad
  *    The time (in seconds) of when a load request is created. This is used to

--- a/lib/routing/walker.js
+++ b/lib/routing/walker.js
@@ -116,6 +116,28 @@ shaka.routing.Walker = class {
     return this.currentlyWith_;
   }
 
+  /**
+   * Get the current routing node.
+   *
+   * @return {shaka.routing.Node}
+   */
+  getCurrentNode() {
+    return this.currentlyAt_;
+  }
+
+  /**
+   * Get the destination of the current route
+   *
+   * @return {?shaka.routing.Node}
+   */
+  getCurrentDestination() {
+    if (this.currentRoute_) {
+      return this.currentRoute_.node;
+    }
+
+    return null;
+  }
+
   /** @override */
   destroy() {
     return this.destroyer_.destroy();

--- a/lib/text/simple_text_displayer.js
+++ b/lib/text/simple_text_displayer.js
@@ -24,11 +24,23 @@ goog.require('shaka.text.Utils');
  * @export
  */
 shaka.text.SimpleTextDisplayer = class {
-  /** @param {HTMLMediaElement} video */
-  constructor(video) {
+  /** */
+  constructor() {
     /** @private {TextTrack} */
     this.textTrack_ = null;
+  }
 
+  /**
+   * @override
+   * @export
+   */
+  setVideoContainer(_) {}
+
+  /**
+   * @override
+   * @export
+   */
+  attach(video) {
     // TODO: Test that in all cases, the built-in CC controls in the video
     // element are toggling our TextTrack.
 

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -26,12 +26,8 @@ goog.require('shaka.util.Timer');
 shaka.text.UITextDisplayer = class {
   /**
    * Constructor.
-   * @param {HTMLMediaElement} video
-   * @param {HTMLElement} videoContainer
    */
-  constructor(video, videoContainer) {
-    goog.asserts.assert(videoContainer, 'videoContainer should be valid.');
-
+  constructor() {
     /** @private {boolean} */
     this.isTextVisible_ = false;
 
@@ -39,10 +35,10 @@ shaka.text.UITextDisplayer = class {
     this.cues_ = [];
 
     /** @private {HTMLMediaElement} */
-    this.video_ = video;
+    this.video_ = null;
 
     /** @private {HTMLElement} */
-    this.videoContainer_ = videoContainer;
+    this.videoContainer_ = null;
 
     /** @type {HTMLElement} */
     this.textContainer_ = shaka.util.Dom.createHTMLElement('div');
@@ -59,18 +55,10 @@ shaka.text.UITextDisplayer = class {
     // Set the captions at the bottom by default.
     this.textContainer_.style.justifyContent = 'flex-end';
 
-    this.videoContainer_.appendChild(this.textContainer_);
-
-    /**
-     * The captions' update period in seconds.
-     * @private {number}
-     */
-    const updatePeriod = 0.25;
-
     /** @private {shaka.util.Timer} */
     this.captionsTimer_ = new shaka.util.Timer(() => {
       this.updateCaptions_();
-    }).tickEvery(updatePeriod);
+    });
 
     /**
      * Maps cues to cue elements. Specifically points out the wrapper element of
@@ -103,6 +91,31 @@ shaka.text.UITextDisplayer = class {
     this.regionElements_ = new Map();
   }
 
+  /**
+   * @override
+   * @export
+   */
+  setVideoContainer(videoContainer) {
+    goog.asserts.assert(videoContainer, 'videoContainer should be valid.');
+
+    this.videoContainer_.appendChild(this.textContainer_);
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  attach(video) {
+    goog.asserts.assert(this.videoContainer_, 'Must have a video conatainer');
+    /**
+     * The captions' update period in seconds.
+     * @private {number}
+     */
+    const updatePeriod = 0.25;
+
+    this.video_ = video;
+    this.captionsTimer_.tickEvery(updatePeriod);
+  }
 
   /**
    * @override
@@ -327,7 +340,9 @@ shaka.text.UITextDisplayer = class {
    * @private
    */
   updateCaptions_(forceUpdate = false) {
-    if (!this.textContainer_) {
+    goog.asserts.assert(this.video_, 'Should have media element by now...');
+
+    if (!this.textContainer_ || !this.video_) {
       return;
     }
 

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -98,6 +98,7 @@ shaka.text.UITextDisplayer = class {
   setVideoContainer(videoContainer) {
     goog.asserts.assert(videoContainer, 'videoContainer should be valid.');
 
+    this.videoContainer_ = videoContainer;
     this.videoContainer_.appendChild(this.textContainer_);
   }
 

--- a/test/cast/cast_utils_unit.js
+++ b/test/cast/cast_utils_unit.js
@@ -210,11 +210,11 @@ describe('CastUtils', () => {
         }
 
         mediaSourceEngine = new shaka.media.MediaSourceEngine(
-            video,
             new shaka.test.FakeTextDisplayer());
         const config =
             shaka.util.PlayerConfiguration.createDefault().mediaSource;
         mediaSourceEngine.configure(config);
+        mediaSourceEngine.attach(video);
 
         const ContentType = shaka.util.ManifestParserUtils.ContentType;
         const initObject = new Map();

--- a/test/media/drm_engine_integration.js
+++ b/test/media/drm_engine_integration.js
@@ -115,11 +115,11 @@ describe('DrmEngine', () => {
     eventManager = new shaka.util.EventManager();
 
     mediaSourceEngine = new shaka.media.MediaSourceEngine(
-        video,
         new shaka.test.FakeTextDisplayer());
     const mediaSourceConfig =
         shaka.util.PlayerConfiguration.createDefault().mediaSource;
     mediaSourceEngine.configure(mediaSourceConfig);
+    mediaSourceEngine.attach(video);
 
     const expectedObject = new Map();
     expectedObject.set(ContentType.AUDIO, audioStream);

--- a/test/media/media_source_engine_integration.js
+++ b/test/media/media_source_engine_integration.js
@@ -168,11 +168,11 @@ describe('MediaSourceEngine', () => {
     onMetadata = jasmine.createSpy('onMetadata');
 
     mediaSourceEngine = new shaka.media.MediaSourceEngine(
-        video,
         textDisplayer,
         shaka.test.Util.spyFunc(onMetadata));
     const config = shaka.util.PlayerConfiguration.createDefault().mediaSource;
     mediaSourceEngine.configure(config);
+    mediaSourceEngine.attach(video);
 
     mediaSource = /** @type {?} */(mediaSourceEngine)['mediaSource_'];
     expect(video.src).toBeTruthy();

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -166,13 +166,13 @@ describe('MediaSourceEngine', () => {
     mockClosedCaptionParser = new shaka.test.FakeClosedCaptionParser();
     mockTextDisplayer = new shaka.test.FakeTextDisplayer();
     mediaSourceEngine = new shaka.media.MediaSourceEngine(
-        video,
         mockTextDisplayer);
     mediaSourceEngine.getCaptionParser = () => {
       return mockClosedCaptionParser;
     };
     const config = shaka.util.PlayerConfiguration.createDefault().mediaSource;
     mediaSourceEngine.configure(config);
+    mediaSourceEngine.attach(video);
   });
 
   afterEach(() => {
@@ -231,8 +231,8 @@ describe('MediaSourceEngine', () => {
 
     it('creates a MediaSource object and sets video.src', () => {
       mediaSourceEngine = new shaka.media.MediaSourceEngine(
-          video,
           new shaka.test.FakeTextDisplayer());
+      mediaSourceEngine.attach(video);
 
       expect(createMediaSourceSpy).toHaveBeenCalled();
       expect(createObjectURLSpy).toHaveBeenCalled();
@@ -249,8 +249,8 @@ describe('MediaSourceEngine', () => {
       });
 
       mediaSourceEngine = new shaka.media.MediaSourceEngine(
-          video,
           new shaka.test.FakeTextDisplayer());
+      mediaSourceEngine.attach(video);
 
       expect(mockMediaSource.addEventListener).toHaveBeenCalledTimes(1);
       expect(mockMediaSource.addEventListener.calls.mostRecent().args[0])

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -65,11 +65,11 @@ describe('StreamingEngine', () => {
     waiter = new shaka.test.Waiter(eventManager);
 
     mediaSourceEngine = new shaka.media.MediaSourceEngine(
-        video,
         new shaka.test.FakeTextDisplayer());
     const mediaSourceConfig =
         shaka.util.PlayerConfiguration.createDefault().mediaSource;
     mediaSourceEngine.configure(mediaSourceConfig);
+    mediaSourceEngine.attach(video);
     waiter.setMediaSourceEngine(mediaSourceEngine);
   });
 

--- a/test/routing/walker_unit.js
+++ b/test/routing/walker_unit.js
@@ -16,6 +16,7 @@ describe('Walker', () => {
     startTime: null,
     startTimeOfLoad: NaN,
     uri: null,
+    useSrcEquals: false,
   };
 
   // The graph topology that we will be using for our tests.

--- a/test/test/util/fake_text_displayer.js
+++ b/test/test/util/fake_text_displayer.js
@@ -15,6 +15,10 @@ shaka.test.FakeTextDisplayer = class {
     /** @type {!jasmine.Spy} */
     this.destroySpy = jasmine.createSpy('destroy');
     /** @type {!jasmine.Spy} */
+    this.attachSpy = jasmine.createSpy('attach');
+    /** @type {!jasmine.Spy} */
+    this.setVideoContainerSpy = jasmine.createSpy('setVideoContainer');
+    /** @type {!jasmine.Spy} */
     this.appendSpy = jasmine.createSpy('append');
     /** @type {!jasmine.Spy} */
     this.removeSpy = jasmine.createSpy('remove');
@@ -32,6 +36,18 @@ shaka.test.FakeTextDisplayer = class {
   destroy() {
     const func = shaka.test.Util.spyFunc(this.destroySpy);
     return func();
+  }
+
+  /** @override */
+  attach(mediaElement) {
+    const func = shaka.test.Util.spyFunc(this.attachSpy);
+    return func(mediaElement);
+  }
+
+  /** @override */
+  setVideoContainer(videoContainer) {
+    const func = shaka.test.Util.spyFunc(this.setVideoContainerSpy);
+    return func(videoContainer);
   }
 
   /** @override */

--- a/test/test/util/layout_tests.js
+++ b/test/test/util/layout_tests.js
@@ -289,9 +289,9 @@ shaka.test.DomTextLayoutTests = class extends shaka.test.TextLayoutTests {
 
   /** @override */
   recreateTextDisplayer() {
-    this.textDisplayer = new shaka.text.UITextDisplayer(
-        /** @type {!HTMLMediaElement} */(this.mockVideo),
-        this.videoContainer);
+    this.textDisplayer = new shaka.text.UITextDisplayer();
+    this.textDisplayer.attach(/** @type {!HTMLMediaElement} */(this.mockVideo));
+    this.textDisplayer.setVideoContainer(this.videoContainer);
     this.textDisplayer.setTextVisibility(true);
   }
 
@@ -377,7 +377,8 @@ shaka.test.NativeTextLayoutTests = class extends shaka.test.TextLayoutTests {
 
   /** @override */
   recreateTextDisplayer() {
-    this.textDisplayer = new shaka.text.SimpleTextDisplayer(this.video);
+    this.textDisplayer = new shaka.text.SimpleTextDisplayer();
+    this.textDisplayer.attach(this.video);
     this.textDisplayer.setTextVisibility(true);
   }
 

--- a/test/text/simple_text_displayer_unit.js
+++ b/test/text/simple_text_displayer_unit.js
@@ -18,7 +18,8 @@ describe('SimpleTextDisplayer', () => {
 
   beforeEach(() => {
     video = new shaka.test.FakeVideo();
-    displayer = new SimpleTextDisplayer(video);
+    displayer = new SimpleTextDisplayer();
+    displayer.attach(video);
 
     expect(video.textTracks.length).toBe(1);
     mockTrack = /** @type {!shaka.test.FakeTextTrack} */ (video.textTracks[0]);

--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -51,7 +51,9 @@ describe('UITextDisplayer', () => {
 
   beforeEach(() => {
     video.currentTime = 0;
-    textDisplayer = new shaka.text.UITextDisplayer(video, videoContainer);
+    textDisplayer = new shaka.text.UITextDisplayer();
+    textDisplayer.attach(video);
+    textDisplayer.setVideoContainer(videoContainer);
   });
 
   afterEach(async () => {


### PR DESCRIPTION
This is draft PR following up my [proposal](https://github.com/shaka-project/shaka-player/issues/880#issuecomment-1540708568) about providing a preload API (#880)

It contains a proof-of-concept implementation of the first step described in the [proposal](https://github.com/shaka-project/shaka-player/issues/880#issuecomment-1540708568) i.e. enabling detached initialization/load of the player so that the following is now possible:
```js
const player = new shaka.Player();
await player.load(assetUri);
await player.attach(mediaElement);
```
The proposed changes are backwards compatible.

I opened this draft PR with the intent support the feasibility of my proposal and to get feedback from the community. I'd appreciate if you can find some time to review it (and the [proposal](https://github.com/shaka-project/shaka-player/issues/880#issuecomment-1540708568) too).

Note:
If you want to checkout the code and test, I suggest you run the player in uncompiled mode as the current changes break the tests compilation.