### PR TITLE
fix: CEA 608 captions not work with H.265 video streams #5251

### DIFF
--- a/lib/cea/mp4_cea_parser.js
+++ b/lib/cea/mp4_cea_parser.js
@@ -277,6 +277,7 @@ shaka.cea.Mp4CeaParser = class {
       const naluHeader = reader.readUint8();
       let naluType = null;
       let isSeiMessage = false;
+      let naluHeaderSize = 1;
 
       goog.asserts.assert(this.bitstreamFormat_ != BitstreamFormat.UNKNOWN,
           'Bitstream format should have been checked before now!');
@@ -287,6 +288,8 @@ shaka.cea.Mp4CeaParser = class {
           break;
 
         case BitstreamFormat.H265:
+          naluHeaderSize = 2;
+          reader.skip(1);
           naluType = (naluHeader >> 1) & 0x3f;
           isSeiMessage =
               naluType == CeaUtils.H265_PREFIX_NALU_TYPE_SEI ||
@@ -306,7 +309,7 @@ shaka.cea.Mp4CeaParser = class {
 
         const pts = (time + timeOffset)/timescale;
         for (const packet of this.seiProcessor_
-            .process(reader.readBytes(naluSize - 1))) {
+            .process(reader.readBytes(naluSize - naluHeaderSize))) {
           captionPackets.push({
             packet,
             pts,
@@ -314,7 +317,7 @@ shaka.cea.Mp4CeaParser = class {
         }
       } else {
         try {
-          reader.skip(naluSize - 1);
+          reader.skip(naluSize - naluHeaderSize);
         } catch (e) {
           // It is necessary to ignore this error because it can break the start
           // of playback even if the user does not want to see the subtitles.


### PR DESCRIPTION
Fix parsing of CEA 608 captions in H.265 video streams by handling 2 byte nal unit header.

Fixes #5251 