### PR TITLE
fix: Ship to NPM without node version restrictions

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@
 .gitattributes
 .gitignore
 .release-please*
+*.backup
 *.pyc
 app-engine/
 build/

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "awesomplete": "^1.1.5",
         "babel-plugin-istanbul": "^6.1.1",
         "cajon": "^0.4.4",
+        "clean-package": "^2.2.0",
         "code-prettify": "^0.1.0",
         "codem-isoboxer": "^0.3.7",
         "color-themes-for-google-code-prettify": "^2.0.4",
@@ -3078,6 +3079,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/clean-package": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-package/-/clean-package-2.2.0.tgz",
+      "integrity": "sha512-vLv8kRqvh4smPDpqAYFPLEijTppAd/cfCz4yBcUGoVl/JKu6ZWKhlo+G/cAmwlSa29RudfBeuyiNEzas8bTwEQ==",
+      "dev": true,
+      "dependencies": {
+        "dot-prop": "^6.0.1"
+      },
+      "bin": {
+        "clean-package": "bin/main.js"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -3583,6 +3596,21 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
       "dev": true
+    },
+    "node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -5085,6 +5113,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -10867,6 +10904,15 @@
         }
       }
     },
+    "clean-package": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-package/-/clean-package-2.2.0.tgz",
+      "integrity": "sha512-vLv8kRqvh4smPDpqAYFPLEijTppAd/cfCz4yBcUGoVl/JKu6ZWKhlo+G/cAmwlSa29RudfBeuyiNEzas8bTwEQ==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^6.0.1"
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -11279,6 +11325,15 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
       "dev": true
+    },
+    "dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^2.0.0"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -12421,6 +12476,12 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true
     },
     "is-plain-obj": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "awesomplete": "^1.1.5",
     "babel-plugin-istanbul": "^6.1.1",
     "cajon": "^0.4.4",
+    "clean-package": "^2.2.0",
     "code-prettify": "^0.1.0",
     "codem-isoboxer": "^0.3.7",
     "color-themes-for-google-code-prettify": "^2.0.4",
@@ -95,6 +96,8 @@
   },
   "license": "Apache-2.0",
   "scripts": {
+    "prepack": "clean-package",
+    "postpack": "clean-package restore",
     "prepublishOnly": "python build/checkversion.py && python build/all.py --force"
   },
   "dependencies": {
@@ -102,5 +105,10 @@
   },
   "engines": {
     "node": ">=14"
+  },
+  "clean-package": {
+    "remove": [
+      "engines"
+    ]
   }
 }


### PR DESCRIPTION
Before packaging for NPM, remove the "engines" section of package.json to avoid unnecessary restrictions on node versions for projects that simply depend on Shaka Player, but don't need to rebuild it.  This is accomplished with the clean-package tool: https://github.com/roydukkey/clean-package

The "engines" section and its restrictions still make sense for Shaka Player development, so it will not be removed from package.json in the repo.

Closes #5243