### PR TITLE
fix(Demo): Allow enable LL only with Low Latency Mode config

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -1227,9 +1227,8 @@ shakaDemo.Main = class {
       // Remove all not-player-applied configurations, by resetting the
       // configuration then re-applying the desired configuration.
       this.player_.resetConfiguration();
-      this.player_.configure(this.desiredConfig_);
+      this.readHash_();
       this.player_.configure(assetConfig);
-      // This uses Player.configure so as to not change |this.desiredConfig_|.
     }
 
     const config = storage ?


### PR DESCRIPTION
Previously all config is passed to the player but some config parameters are untouched, we need only pass the config params that are different, to allow enable LL with only one change.