### PR TITLE
fix: Avoid unnecessary timestampOffset updates when using HLS segments mode

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -691,7 +691,7 @@ shaka.media.MediaSourceEngine = class {
                 Math.round(metadataTimestamp.data) / 1000;
             const timestampOffsetDifference =
                 Math.abs(timestampOffset - calculatedTimestampOffset);
-            if (timestampOffsetDifference >= 0.01 || seeked || adaptation) {
+            if (timestampOffsetDifference >= 0.1 || seeked || adaptation) {
               timestampOffset = calculatedTimestampOffset;
               this.enqueueOperation_(contentType, () =>
                 this.abort_(contentType));
@@ -741,7 +741,7 @@ shaka.media.MediaSourceEngine = class {
           const calculatedTimestampOffset = reference.startTime - startTime;
           const timestampOffsetDifference =
               Math.abs(timestampOffset - calculatedTimestampOffset);
-          if (timestampOffsetDifference >= 0.01 || seeked || adaptation) {
+          if (timestampOffsetDifference >= 0.1 || seeked || adaptation) {
             timestampOffset = calculatedTimestampOffset;
             this.enqueueOperation_(contentType, () => this.abort_(contentType));
             this.enqueueOperation_(
@@ -757,7 +757,7 @@ shaka.media.MediaSourceEngine = class {
         const calculatedTimestampOffset = reference.startTime - startTime;
         const timestampOffsetDifference =
             Math.abs(timestampOffset - calculatedTimestampOffset);
-        if (timestampOffsetDifference >= 0.01 || seeked || adaptation) {
+        if (timestampOffsetDifference >= 0.1 || seeked || adaptation) {
           timestampOffset = calculatedTimestampOffset;
           // The SourceBuffer timestampOffset may or may not be set yet,
           // so this is the timestamp offset that would eventually compute


### PR DESCRIPTION
With this change, we are changing the minimum timestampOffsetDifference to 0.1 to prevent unnecessary timestampOffset updates