### PR TITLE
feat(UI): Remove copyStyleSheets

### DIFF
--- a/externs/pictureinpicture.js
+++ b/externs/pictureinpicture.js
@@ -55,7 +55,6 @@ HTMLMediaElement.prototype.webkitPresentationMode;
  * @typedef {{
  *   width: (number|undefined),
  *   height: (number|undefined),
- *   copyStyleSheets: (boolean|undefined),
  * }}
  */
 var DocumentPictureInPictureOptions;


### PR DESCRIPTION
Document Picture-in-Picture API owners are [removing `copyStyleSheets` option](https://github.com/WICG/document-picture-in-picture/pull/79) as it can be done in JavaScript. This PR removes this option and copy all style sheets internally to the PiP window.

Please review.