### PR TITLE
fix(HLS): Fix live playlist update when using no LL in a LL stream

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -2637,14 +2637,19 @@ shaka.hls.HlsParser = class {
       let lastTargetDuration = Infinity;
       const segments = playlist.segments;
       if (segments.length) {
-        const lastSegment = segments[segments.length - 1];
-        const extinfTag =
-            shaka.hls.Utils.getFirstTagWithName(lastSegment.tags, 'EXTINF');
-        if (extinfTag) {
-          // The EXTINF tag format is '#EXTINF:<duration>,[<title>]'.
-          // We're interested in the duration part.
-          const extinfValues = extinfTag.value.split(',');
-          lastTargetDuration = Number(extinfValues[0]);
+        let segmentIndex = segments.length - 1;
+        while (segmentIndex >= 0) {
+          const segment = segments[segmentIndex];
+          const extinfTag =
+              shaka.hls.Utils.getFirstTagWithName(segment.tags, 'EXTINF');
+          if (extinfTag) {
+            // The EXTINF tag format is '#EXTINF:<duration>,[<title>]'.
+            // We're interested in the duration part.
+            const extinfValues = extinfTag.value.split(',');
+            lastTargetDuration = Number(extinfValues[0]);
+            break;
+          }
+          segmentIndex--;
         }
       }
       this.lastTargetDuration_ = Math.min(


### PR DESCRIPTION
This happens because the last segment in an LL stream may not be complete and may not have EXTINF