### PR TITLE
chore: Fix core build without dash

### DIFF
--- a/externs/shaka/manifest.js
+++ b/externs/shaka/manifest.js
@@ -326,7 +326,7 @@ shaka.extern.FetchCryptoKeysFunction;
  *   trickModeVideo: ?shaka.extern.Stream,
  *   emsgSchemeIdUris: ?Array.<string>,
  *   roles: !Array.<string>,
- *   accessibilityPurpose: ?shaka.dash.DashParser.AccessibilityPurpose,
+ *   accessibilityPurpose: ?shaka.media.ManifestParser.AccessibilityPurpose,
  *   forced: boolean,
  *   channelsCount: ?number,
  *   audioSamplingRate: ?number,
@@ -425,7 +425,8 @@ shaka.extern.FetchCryptoKeysFunction;
  * @property {!Array.<string>} roles
  *   The roles of the stream as they appear on the manifest,
  *   e.g. 'main', 'caption', or 'commentary'.
- * @property {?shaka.dash.DashParser.AccessibilityPurpose} accessibilityPurpose
+ * @property {?shaka.media.ManifestParser.AccessibilityPurpose}
+ *     accessibilityPurpose
  *   The DASH accessibility descriptor, if one was provided for this stream.
  * @property {boolean} forced
  *   <i>Defaults to false.</i> <br>

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -225,7 +225,7 @@ shaka.extern.BufferedInfo;
  *   primary: boolean,
  *   roles: !Array.<string>,
  *   audioRoles: Array.<string>,
- *   accessibilityPurpose: ?shaka.dash.DashParser.AccessibilityPurpose,
+ *   accessibilityPurpose: ?shaka.media.ManifestParser.AccessibilityPurpose,
  *   forced: boolean,
  *   videoId: ?number,
  *   audioId: ?number,
@@ -302,7 +302,8 @@ shaka.extern.BufferedInfo;
  *   The roles of the audio in the track, e.g. <code>'main'</code> or
  *   <code>'commentary'</code>. Will be null for text tracks or variant tracks
  *   without audio.
- * @property {?shaka.dash.DashParser.AccessibilityPurpose} accessibilityPurpose
+ * @property {?shaka.media.ManifestParser.AccessibilityPurpose}
+ *     accessibilityPurpose
  *   The DASH accessibility descriptor, if one was provided for this track.
  *   For text tracks, this describes the text; otherwise, this is for the audio.
  * @property {boolean} forced

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -939,7 +939,7 @@ shaka.dash.DashParser = class {
     const accessibilities = XmlUtils.findChildren(elem, 'Accessibility');
     const LanguageUtils = shaka.util.LanguageUtils;
     const closedCaptions = new Map();
-    /** @type {?shaka.dash.DashParser.AccessibilityPurpose} */
+    /** @type {?shaka.media.ManifestParser.AccessibilityPurpose} */
     let accessibilityPurpose;
     for (const prop of accessibilities) {
       const schemeId = prop.getAttribute('schemeIdUri');
@@ -1027,10 +1027,10 @@ shaka.dash.DashParser = class {
         // See DASH DVB Document A168 Rev.6 Table 5.
         if (value == '1') {
           accessibilityPurpose =
-              shaka.dash.DashParser.AccessibilityPurpose.VISUALLY_IMPAIRED;
+              shaka.media.ManifestParser.AccessibilityPurpose.VISUALLY_IMPAIRED;
         } else if (value == '2') {
           accessibilityPurpose =
-              shaka.dash.DashParser.AccessibilityPurpose.HARD_OF_HEARING;
+              shaka.media.ManifestParser.AccessibilityPurpose.HARD_OF_HEARING;
         }
       }
     }
@@ -1150,7 +1150,8 @@ shaka.dash.DashParser = class {
    * @param {!Array.<string>} roles
    * @param {Map.<string, string>} closedCaptions
    * @param {!Element} node
-   * @param {?shaka.dash.DashParser.AccessibilityPurpose} accessibilityPurpose
+   * @param {?shaka.media.ManifestParser.AccessibilityPurpose}
+   *   accessibilityPurpose
    *
    * @return {?shaka.extern.Stream} The Stream, or null when there is a
    *   non-critical parsing error.
@@ -2079,16 +2080,6 @@ shaka.dash.DashParser.AdaptationInfo;
  * An async function which generates and returns a SegmentIndex.
  */
 shaka.dash.DashParser.GenerateSegmentIndexFunction;
-
-
-/**
- * @enum {string}
- * @export
- */
-shaka.dash.DashParser.AccessibilityPurpose = {
-  VISUALLY_IMPAIRED: 'visually impaired',
-  HARD_OF_HEARING: 'hard of hearing',
-};
 
 
 /**

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -15,6 +15,7 @@ goog.require('shaka.util.Functional');
 goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.XmlUtils');
 goog.requireType('shaka.dash.DashParser');
+goog.requireType('shaka.media.PresentationTimeline');
 
 
 /**
@@ -121,7 +122,7 @@ shaka.dash.MpdUtils = class {
    * @param {number} unscaledPresentationTimeOffset
    * @param {number} periodDuration The Period's duration in seconds.
    *   Infinity indicates that the Period continues indefinitely.
-   * @return {!Array.<shaka.dash.MpdUtils.TimeRange>}
+   * @return {!Array.<shaka.media.PresentationTimeline.TimeRange>}
    */
   static createTimeline(
       segmentTimeline, timescale, unscaledPresentationTimeOffset,
@@ -137,7 +138,7 @@ shaka.dash.MpdUtils = class {
 
     const timePoints = XmlUtils.findChildren(segmentTimeline, 'S');
 
-    /** @type {!Array.<shaka.dash.MpdUtils.TimeRange>} */
+    /** @type {!Array.<shaka.media.PresentationTimeline.TimeRange>} */
     const timeline = [];
     let lastEndTime = -unscaledPresentationTimeOffset;
 
@@ -289,7 +290,7 @@ shaka.dash.MpdUtils = class {
 
     const timelineNode =
         MpdUtils.inheritChild(context, callback, 'SegmentTimeline');
-    /** @type {Array.<shaka.dash.MpdUtils.TimeRange>} */
+    /** @type {Array.<shaka.media.PresentationTimeline.TimeRange>} */
     let timeline = null;
     if (timelineNode) {
       timeline = MpdUtils.createTimeline(
@@ -540,34 +541,12 @@ shaka.dash.MpdUtils = class {
 
 /**
  * @typedef {{
- *   start: number,
- *   unscaledStart: number,
- *   end: number
- * }}
- *
- * @description
- * Defines a time range of a media segment.  Times are in seconds.
- *
- * @property {number} start
- *   The start time of the range.
- * @property {number} unscaledStart
- *   The start time of the range in representation timescale units.
- * @property {number} end
- *   The end time (exclusive) of the range.
- *
- * @export
- */
-shaka.dash.MpdUtils.TimeRange;
-
-
-/**
- * @typedef {{
  *   timescale: number,
  *   segmentDuration: ?number,
  *   startNumber: number,
  *   scaledPresentationTimeOffset: number,
  *   unscaledPresentationTimeOffset: number,
- *   timeline: Array.<shaka.dash.MpdUtils.TimeRange>
+ *   timeline: Array.<shaka.media.PresentationTimeline.TimeRange>
  * }}
  *
  * @description
@@ -583,7 +562,7 @@ shaka.dash.MpdUtils.TimeRange;
  *   The presentation time offset of the representation, in seconds.
  * @property {number} unscaledPresentationTimeOffset
  *   The presentation time offset of the representation, in timescale units.
- * @property {Array.<shaka.dash.MpdUtils.TimeRange>} timeline
+ * @property {Array.<shaka.media.PresentationTimeline.TimeRange>} timeline
  *   The timeline of the representation, if given.  Times in seconds.
  */
 shaka.dash.MpdUtils.SegmentInfo;

--- a/lib/dash/segment_list.js
+++ b/lib/dash/segment_list.js
@@ -18,6 +18,7 @@ goog.require('shaka.util.Functional');
 goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.XmlUtils');
 goog.requireType('shaka.dash.DashParser');
+goog.requireType('shaka.media.PresentationTimeline');
 
 
 /**
@@ -326,7 +327,7 @@ shaka.dash.SegmentList.MediaSegment;
  *   startTime: number,
  *   startNumber: number,
  *   scaledPresentationTimeOffset: number,
- *   timeline: Array.<shaka.dash.MpdUtils.TimeRange>,
+ *   timeline: Array.<shaka.media.PresentationTimeline.TimeRange>,
  *   mediaSegments: !Array.<shaka.dash.SegmentList.MediaSegment>
  * }}
  * @private
@@ -342,7 +343,7 @@ shaka.dash.SegmentList.MediaSegment;
  *   The start number of the segments; 1 or greater.
  * @property {number} scaledPresentationTimeOffset
  *   The scaledPresentationTimeOffset of the representation, in seconds.
- * @property {Array.<shaka.dash.MpdUtils.TimeRange>} timeline
+ * @property {Array.<shaka.media.PresentationTimeline.TimeRange>} timeline
  *   The timeline of the representation, if given.  Times in seconds.
  * @property {!Array.<shaka.dash.SegmentList.MediaSegment>} mediaSegments
  *   The URI and byte-ranges of the media segments.

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -18,6 +18,7 @@ goog.require('shaka.util.IReleasable');
 goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.ObjectUtils');
 goog.requireType('shaka.dash.DashParser');
+goog.requireType('shaka.media.PresentationTimeline');
 
 
 /**
@@ -923,7 +924,7 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
  *   startNumber: number,
  *   scaledPresentationTimeOffset: number,
  *   unscaledPresentationTimeOffset: number,
- *   timeline: Array.<shaka.dash.MpdUtils.TimeRange>,
+ *   timeline: Array.<shaka.media.PresentationTimeline.TimeRange>,
  *   mediaTemplate: ?string,
  *   indexTemplate: ?string
  * }}
@@ -941,7 +942,7 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
  *   The presentation time offset of the representation, in seconds.
  * @property {number} unscaledPresentationTimeOffset
  *   The presentation time offset of the representation, in timescale units.
- * @property {Array.<shaka.dash.MpdUtils.TimeRange>} timeline
+ * @property {Array.<shaka.media.PresentationTimeline.TimeRange>} timeline
  *   The timeline of the representation, if given.  Times in seconds.
  * @property {?string} mediaTemplate
  *   The media URI template, if given.

--- a/lib/media/manifest_parser.js
+++ b/lib/media/manifest_parser.js
@@ -275,6 +275,16 @@ shaka.media.ManifestParser.UNKNOWN = 'UNKNOWN';
 
 
 /**
+ * @enum {string}
+ * @export
+ */
+shaka.media.ManifestParser.AccessibilityPurpose = {
+  VISUALLY_IMPAIRED: 'visually impaired',
+  HARD_OF_HEARING: 'hard of hearing',
+};
+
+
+/**
  * Contains the parser factory functions indexed by MIME type.
  *
  * @type {!Object.<string, shaka.extern.ManifestParser.Factory>}

--- a/lib/media/presentation_timeline.js
+++ b/lib/media/presentation_timeline.js
@@ -7,7 +7,6 @@
 goog.provide('shaka.media.PresentationTimeline');
 
 goog.require('goog.asserts');
-goog.require('shaka.dash.MpdUtils');
 goog.require('shaka.log');
 goog.require('shaka.media.SegmentReference');
 
@@ -225,7 +224,7 @@ shaka.media.PresentationTimeline = class {
    * the segment availability window, and account for missing segment
    * information.
    *
-   * @param {!Array.<shaka.dash.MpdUtils.TimeRange>} timeline
+   * @param {!Array.<shaka.media.PresentationTimeline.TimeRange>} timeline
    * @param {number} startOffset
    * @export
    */
@@ -615,3 +614,24 @@ shaka.media.PresentationTimeline = class {
   }
 };
 
+
+/**
+ * @typedef {{
+ *   start: number,
+ *   unscaledStart: number,
+ *   end: number
+ * }}
+ *
+ * @description
+ * Defines a time range of a media segment.  Times are in seconds.
+ *
+ * @property {number} start
+ *   The start time of the range.
+ * @property {number} unscaledStart
+ *   The start time of the range in representation timescale units.
+ * @property {number} end
+ *   The end time (exclusive) of the range.
+ *
+ * @export
+ */
+shaka.media.PresentationTimeline.TimeRange;

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -1899,12 +1899,12 @@ describe('DashParser Manifest', () => {
     /** @type {shaka.extern.Manifest} */
     const manifest = await parser.start('dummy://foo', playerInterface);
     const textStream = manifest.textStreams[0];
-    expect(textStream.accessibilityPurpose)
-        .toBe(shaka.dash.DashParser.AccessibilityPurpose.HARD_OF_HEARING);
+    expect(textStream.accessibilityPurpose).toBe(
+        shaka.media.ManifestParser.AccessibilityPurpose.HARD_OF_HEARING);
     const variant = manifest.variants[0];
     expect(variant.video.accessibilityPurpose).toBeUndefined();
-    expect(variant.audio.accessibilityPurpose)
-        .toBe(shaka.dash.DashParser.AccessibilityPurpose.VISUALLY_IMPAIRED);
+    expect(variant.audio.accessibilityPurpose).toBe(
+        shaka.media.ManifestParser.AccessibilityPurpose.VISUALLY_IMPAIRED);
   });
 
   it('converts Accessibility element to "kind"', async () => {

--- a/test/dash/dash_parser_segment_template_unit.js
+++ b/test/dash/dash_parser_segment_template_unit.js
@@ -822,7 +822,7 @@ function makeInitSegmentReference() {
  * @param {number} start
  * @param {number} duration
  * @param {number} num
- * @return {Array<shaka.dash.MpdUtils.TimeRange>}
+ * @return {Array<shaka.media.PresentationTimeline.TimeRange>}
  */
 function makeRanges(start, duration, num) {
   const ranges = [];
@@ -844,7 +844,7 @@ function makeRanges(start, duration, num) {
  * expect().  You can't expect jasmine.any(Number) to equal
  * jasmine.any(Number).  :-(
  *
- * @param {Array<shaka.dash.MpdUtils.TimeRange>} timeline
+ * @param {Array<shaka.media.PresentationTimeline.TimeRange>} timeline
  * @return {shaka.dash.SegmentTemplate.SegmentTemplateInfo}
  */
 function makeTemplateInfo(timeline) {

--- a/test/test/util/manifest_generator.js
+++ b/test/test/util/manifest_generator.js
@@ -548,7 +548,7 @@ shaka.test.ManifestGenerator.Stream = class {
       this.hdr = undefined;
       /** @type {(string|undefined)} */
       this.tilesLayout = undefined;
-      /** @type {?shaka.dash.DashParser.AccessibilityPurpose} */
+      /** @type {?shaka.media.ManifestParser.AccessibilityPurpose} */
       this.accessibilityPurpose;
     }
 


### PR DESCRIPTION
 - Move TimeRange from shaka.dash.MpdUtils to shaka.media.PresentationTimeline
 - Move AccessibilityPurpose from shaka.dash.DashParser to shaka.media.ManifestParser

With these changes, core Shaka Player can be built without the dash module.