### PR TITLE
feat(HLS): Allow delivery directives in Live streams

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -345,29 +345,27 @@ shaka.hls.HlsParser = class {
   async updateStream_(streamInfo) {
     const manifestUri = streamInfo.absoluteMediaPlaylistUri;
     const uriObj = new goog.Uri(manifestUri);
-    if (this.lowLatencyMode_) {
-      const queryData = new goog.Uri.QueryData();
-      if (streamInfo.canSkipSegments) {
-        // Enable delta updates. This will replace older segments with
-        // 'EXT-X-SKIP' tag in the media playlist.
-        queryData.add('_HLS_skip', 'YES');
+    const queryData = new goog.Uri.QueryData();
+    if (streamInfo.canSkipSegments) {
+      // Enable delta updates. This will replace older segments with
+      // 'EXT-X-SKIP' tag in the media playlist.
+      queryData.add('_HLS_skip', 'YES');
+    }
+    if (streamInfo.canBlockReload) {
+      if (streamInfo.nextMediaSequence >= 0) {
+        // Indicates that the server must hold the request until a Playlist
+        // contains a Media Segment with Media Sequence
+        queryData.add('_HLS_msn', String(streamInfo.nextMediaSequence));
       }
-      if (streamInfo.canBlockReload) {
-        if (streamInfo.nextMediaSequence >= 0) {
-          // Indicates that the server must hold the request until a Playlist
-          // contains a Media Segment with Media Sequence
-          queryData.add('_HLS_msn', String(streamInfo.nextMediaSequence));
-        }
-        if (streamInfo.nextPart >= 0) {
-          // Indicates, in combination with _HLS_msn, that the server must hold
-          // the request until a Playlist contains Partial Segment N of Media
-          // Sequence Number M or later.
-          queryData.add('_HLS_part', String(streamInfo.nextPart));
-        }
+      if (streamInfo.nextPart >= 0) {
+        // Indicates, in combination with _HLS_msn, that the server must hold
+        // the request until a Playlist contains Partial Segment N of Media
+        // Sequence Number M or later.
+        queryData.add('_HLS_part', String(streamInfo.nextPart));
       }
-      if (queryData.getCount()) {
-        uriObj.setQueryData(queryData);
-      }
+    }
+    if (queryData.getCount()) {
+      uriObj.setQueryData(queryData);
     }
     const response =
         await this.requestManifest_(uriObj.toString(), /* isPlaylist= */ true);


### PR DESCRIPTION
According to https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-6.2.5 delivery directives are allowed for all live content
