### PR TITLE
fix(UI): Use pagehide instead of unload for PiP

### DIFF
--- a/demo/close_button.js
+++ b/demo/close_button.js
@@ -36,7 +36,7 @@ shakaDemo.CloseButton = class extends shaka.ui.Element {
           window.documentPictureInPicture, 'enter', () => {
             this.button_.style.display = 'none';
             const pipWindow = window.documentPictureInPicture.window;
-            this.eventManager.listen(pipWindow, 'unload', () => {
+            this.eventManager.listen(pipWindow, 'pagehide', () => {
               this.button_.style.display = 'block';
             });
           });

--- a/ui/pip_button.js
+++ b/ui/pip_button.js
@@ -187,7 +187,7 @@ shaka.ui.PipButton = class extends shaka.ui.Element {
     this.onEnterPictureInPicture_();
 
     // Listen for the PiP closing event to move the player back.
-    this.eventManager.listenOnce(pipWindow, 'unload', () => {
+    this.eventManager.listenOnce(pipWindow, 'pagehide', () => {
       placeholder.replaceWith(/** @type {!Node} */(pipPlayer));
     });
   }


### PR DESCRIPTION
As noted in https://groups.google.com/a/chromium.org/g/blink-dev/c/JTPl7fM64Lc, we should use "pagehide" not "unload" JS event to monitor when PiP window gets closed.

