### PR TITLE
fix(HLS): Avoid "Possible encoding problem detected!" when is a preload reference

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -916,7 +916,7 @@ shaka.media.MediaSourceEngine = class {
       this.append_(contentType, data);
     });
 
-    if (goog.DEBUG && reference) {
+    if (goog.DEBUG && reference && !reference.isPreload()) {
       const bufferedAfter = this.getBuffered_(contentType);
       const newBuffered = shaka.media.TimeRangesUtils.computeAddedRange(
           bufferedBefore, bufferedAfter);


### PR DESCRIPTION
Preload segments do not have a defined duration, so this log may be wrong.