### PR TITLE
fix: Fix DASH rejection of streams with ColourPrimaries and MatrixCoefficients

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -934,12 +934,13 @@ shaka.dash.DashParser = class {
       const schemeId = prop.getAttribute('schemeIdUri');
       if (schemeId == 'http://dashif.org/guidelines/trickmode') {
         trickModeFor = prop.getAttribute('value');
-      } else if (schemeId == transferCharacteristicsScheme ||
-          schemeId == colourPrimariesScheme ||
-          schemeId == matrixCoefficientsScheme) {
+      } else if (schemeId == transferCharacteristicsScheme) {
         videoRange = getVideoRangeFromTransferCharacteristicCICP(
             parseInt(prop.getAttribute('value'), 10),
         );
+      } else if (schemeId == colourPrimariesScheme ||
+                 schemeId == matrixCoefficientsScheme) {
+        continue;
       } else {
         unrecognizedEssentialProperty = true;
       }

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -896,7 +896,15 @@ shaka.dash.DashParser = class {
 
     // Parallel for HLS VIDEO-RANGE as defined in DASH-IF IOP v4.3 6.2.5.1.
     let videoRange;
-    const videoRangeScheme = 'urn:mpeg:mpegB:cicp:TransferCharacteristics';
+
+    // If signaled, a Supplemental or Essential Property descriptor shall be used, with the 
+    // @schemeIdUri set to urn:mpeg:mpegB:cicp:<Parameter> as defined in 
+    // ISO/IEC 23001-8 [49] and <Parameter> one of the following: ColourPrimaries, 
+    // TransferCharacteristics, or MatrixCoefficients. Ref. https://dashif.org/docs/DASH-IF-IOP-v4.3.pdf
+    const videoRangeTransferCharacteristicsScheme = 'urn:mpeg:mpegB:cicp:TransferCharacteristics';
+    const videoRangeColourPrimariesScheme = 'urn:mpeg:mpegB:cicp:ColourPrimaries';
+    const videoRangeMatrixCoefficientsScheme = 'urn:mpeg:mpegB:cicp:MatrixCoefficients';
+
     const getVideoRangeFromTransferCharacteristicCICP = (cicp) => {
       switch (cicp) {
         case 1:
@@ -922,7 +930,9 @@ shaka.dash.DashParser = class {
       const schemeId = prop.getAttribute('schemeIdUri');
       if (schemeId == 'http://dashif.org/guidelines/trickmode') {
         trickModeFor = prop.getAttribute('value');
-      } else if (schemeId == videoRangeScheme) {
+      } else if (schemeId == videoRangeTransferCharacteristicsScheme ||
+          schemeId == videoRangeColourPrimariesScheme ||
+          schemeId == videoRangeMatrixCoefficientsScheme) {
         videoRange = getVideoRangeFromTransferCharacteristicCICP(
             parseInt(prop.getAttribute('value'), 10),
         );
@@ -935,7 +945,9 @@ shaka.dash.DashParser = class {
         XmlUtils.findChildren(elem, 'SupplementalProperty');
     for (const prop of supplementalProperties) {
       const schemeId = prop.getAttribute('schemeIdUri');
-      if (schemeId == videoRangeScheme) {
+      if (schemeId == videoRangeTransferCharacteristicsScheme ||
+          schemeId == videoRangeColourPrimariesScheme ||
+          schemeId == videoRangeMatrixCoefficientsScheme) {
         videoRange = getVideoRangeFromTransferCharacteristicCICP(
             parseInt(prop.getAttribute('value'), 10),
         );

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -950,9 +950,7 @@ shaka.dash.DashParser = class {
         XmlUtils.findChildren(elem, 'SupplementalProperty');
     for (const prop of supplementalProperties) {
       const schemeId = prop.getAttribute('schemeIdUri');
-      if (schemeId == transferCharacteristicsScheme ||
-          schemeId == colourPrimariesScheme ||
-          schemeId == matrixCoefficientsScheme) {
+      if (schemeId == transferCharacteristicsScheme) {
         videoRange = getVideoRangeFromTransferCharacteristicCICP(
             parseInt(prop.getAttribute('value'), 10),
         );

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -897,13 +897,17 @@ shaka.dash.DashParser = class {
     // Parallel for HLS VIDEO-RANGE as defined in DASH-IF IOP v4.3 6.2.5.1.
     let videoRange;
 
-    // If signaled, a Supplemental or Essential Property descriptor shall be used, with the 
-    // @schemeIdUri set to urn:mpeg:mpegB:cicp:<Parameter> as defined in 
-    // ISO/IEC 23001-8 [49] and <Parameter> one of the following: ColourPrimaries, 
-    // TransferCharacteristics, or MatrixCoefficients. Ref. https://dashif.org/docs/DASH-IF-IOP-v4.3.pdf
-    const videoRangeTransferCharacteristicsScheme = 'urn:mpeg:mpegB:cicp:TransferCharacteristics';
-    const videoRangeColourPrimariesScheme = 'urn:mpeg:mpegB:cicp:ColourPrimaries';
-    const videoRangeMatrixCoefficientsScheme = 'urn:mpeg:mpegB:cicp:MatrixCoefficients';
+    // Ref. https://dashif.org/docs/DASH-IF-IOP-v4.3.pdf
+    // If signaled, a Supplemental or Essential Property descriptor
+    // shall be used, with the schemeIdUri set to
+    // urn:mpeg:mpegB:cicp:<Parameter> as defined in
+    // ISO/IEC 23001-8 [49] and <Parameter> one of the
+    // following: ColourPrimaries, TransferCharacteristics,
+    // or MatrixCoefficients.
+    const scheme = 'urn:mpeg:mpegB:cicp';
+    const transferCharacteristicsScheme = `${scheme}:TransferCharacteristics`;
+    const colourPrimariesScheme = `${scheme}:ColourPrimaries`;
+    const matrixCoefficientsScheme = `${scheme}:MatrixCoefficients`;
 
     const getVideoRangeFromTransferCharacteristicCICP = (cicp) => {
       switch (cicp) {
@@ -930,9 +934,9 @@ shaka.dash.DashParser = class {
       const schemeId = prop.getAttribute('schemeIdUri');
       if (schemeId == 'http://dashif.org/guidelines/trickmode') {
         trickModeFor = prop.getAttribute('value');
-      } else if (schemeId == videoRangeTransferCharacteristicsScheme ||
-          schemeId == videoRangeColourPrimariesScheme ||
-          schemeId == videoRangeMatrixCoefficientsScheme) {
+      } else if (schemeId == transferCharacteristicsScheme ||
+          schemeId == colourPrimariesScheme ||
+          schemeId == matrixCoefficientsScheme) {
         videoRange = getVideoRangeFromTransferCharacteristicCICP(
             parseInt(prop.getAttribute('value'), 10),
         );
@@ -945,9 +949,9 @@ shaka.dash.DashParser = class {
         XmlUtils.findChildren(elem, 'SupplementalProperty');
     for (const prop of supplementalProperties) {
       const schemeId = prop.getAttribute('schemeIdUri');
-      if (schemeId == videoRangeTransferCharacteristicsScheme ||
-          schemeId == videoRangeColourPrimariesScheme ||
-          schemeId == videoRangeMatrixCoefficientsScheme) {
+      if (schemeId == transferCharacteristicsScheme ||
+          schemeId == colourPrimariesScheme ||
+          schemeId == matrixCoefficientsScheme) {
         videoRange = getVideoRangeFromTransferCharacteristicCICP(
             parseInt(prop.getAttribute('value'), 10),
         );

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -2071,12 +2071,11 @@ describe('DashParser Manifest', () => {
   it('supports SupplementalProperty MatrixCoefficients', async () => {
     // (DASH-IF IOP v4.3 6.2.5.1.)
     const scheme = cicpScheme('MatrixCoefficients');
-    const hlg = 18;
     const manifestText = [
       '<MPD minBufferTime="PT75S">',
       '  <Period id="1" duration="PT30S">',
       '    <AdaptationSet id="2" mimeType="video/mp4">',
-      `      <SupplementalProperty schemeIdUri="${scheme}" value="${hlg}" />`,
+      `      <SupplementalProperty schemeIdUri="${scheme}" value="9" />`,
       '      <Representation codecs="hvc1.2.4.L153.B0">',
       '        <BaseURL>v-sd.mp4</BaseURL>',
       '        <SegmentBase indexRange="100-200" />',
@@ -2097,19 +2096,16 @@ describe('DashParser Manifest', () => {
     /** @type {shaka.extern.Manifest} */
     const manifest = await parser.start('dummy://foo', playerInterface);
     expect(manifest.variants.length).toBe(1);
-    const stream = manifest.variants[0].video;
-    expect(stream.hdr).toBe('HLG');
   });
 
   it('supports SupplementalProperty ColourPrimaries', async () => {
     // (DASH-IF IOP v4.3 6.2.5.1.)
     const scheme = cicpScheme('ColourPrimaries');
-    const hlg = 18;
     const manifestText = [
       '<MPD minBufferTime="PT75S">',
       '  <Period id="1" duration="PT30S">',
       '    <AdaptationSet id="2" mimeType="video/mp4">',
-      `      <SupplementalProperty schemeIdUri="${scheme}" value="${hlg}" />`,
+      `      <SupplementalProperty schemeIdUri="${scheme}" value="9" />`,
       '      <Representation codecs="hvc1.2.4.L153.B0">',
       '        <BaseURL>v-sd.mp4</BaseURL>',
       '        <SegmentBase indexRange="100-200" />',
@@ -2130,8 +2126,6 @@ describe('DashParser Manifest', () => {
     /** @type {shaka.extern.Manifest} */
     const manifest = await parser.start('dummy://foo', playerInterface);
     expect(manifest.variants.length).toBe(1);
-    const stream = manifest.variants[0].video;
-    expect(stream.hdr).toBe('HLG');
   });
 
   it('supports HDR signaling via EssentialProperty', async () => {
@@ -2170,12 +2164,11 @@ describe('DashParser Manifest', () => {
   it('supports EssentialProperty MatrixCoefficients', async () => {
     // (DASH-IF IOP v4.3 6.2.5.1.)
     const hdrScheme = cicpScheme('MatrixCoefficients');
-    const hlg = 18;
     const manifestText = [
       '<MPD minBufferTime="PT75S">',
       '  <Period id="1" duration="PT30S">',
       '    <AdaptationSet id="2" mimeType="video/mp4">',
-      `      <EssentialProperty schemeIdUri="${hdrScheme}" value="${hlg}" />`,
+      `      <EssentialProperty schemeIdUri="${hdrScheme}" value="9" />`,
       '      <Representation codecs="hvc1.2.4.L153.B0">',
       '        <BaseURL>v-sd.mp4</BaseURL>',
       '        <SegmentBase indexRange="100-200" />',
@@ -2196,19 +2189,16 @@ describe('DashParser Manifest', () => {
     /** @type {shaka.extern.Manifest} */
     const manifest = await parser.start('dummy://foo', playerInterface);
     expect(manifest.variants.length).toBe(1);
-    const stream = manifest.variants[0].video;
-    expect(stream.hdr).toBe('HLG');
   });
 
   it('supports EssentialProperty ColourPrimaries', async () => {
     // (DASH-IF IOP v4.3 6.2.5.1.)
     const hdrScheme = cicpScheme('ColourPrimaries');
-    const hlg = 18;
     const manifestText = [
       '<MPD minBufferTime="PT75S">',
       '  <Period id="1" duration="PT30S">',
       '    <AdaptationSet id="2" mimeType="video/mp4">',
-      `      <EssentialProperty schemeIdUri="${hdrScheme}" value="${hlg}" />`,
+      `      <EssentialProperty schemeIdUri="${hdrScheme}" value="9" />`,
       '      <Representation codecs="hvc1.2.4.L153.B0">',
       '        <BaseURL>v-sd.mp4</BaseURL>',
       '        <SegmentBase indexRange="100-200" />',
@@ -2229,8 +2219,6 @@ describe('DashParser Manifest', () => {
     /** @type {shaka.extern.Manifest} */
     const manifest = await parser.start('dummy://foo', playerInterface);
     expect(manifest.variants.length).toBe(1);
-    const stream = manifest.variants[0].video;
-    expect(stream.hdr).toBe('HLG');
   });
 
   it('supports SDR signalling via EssentialProperty', async () => {

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -2068,9 +2068,141 @@ describe('DashParser Manifest', () => {
     expect(stream.hdr).toBe('PQ');
   });
 
+  it('supports SupplementalProperty MatrixCoefficients', async () => {
+    // (DASH-IF IOP v4.3 6.2.5.1.)
+    const scheme = cicpScheme('MatrixCoefficients');
+    const hlg = 18;
+    const manifestText = [
+      '<MPD minBufferTime="PT75S">',
+      '  <Period id="1" duration="PT30S">',
+      '    <AdaptationSet id="2" mimeType="video/mp4">',
+      `      <SupplementalProperty schemeIdUri="${scheme}" value="${hlg}" />`,
+      '      <Representation codecs="hvc1.2.4.L153.B0">',
+      '        <BaseURL>v-sd.mp4</BaseURL>',
+      '        <SegmentBase indexRange="100-200" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '    <AdaptationSet id="3" mimeType="audio/mp4">',
+      '      <Representation id="audio-en">',
+      '        <BaseURL>a-en.mp4</BaseURL>',
+      '        <SegmentBase indexRange="100-200" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '  </Period>',
+      '</MPD>',
+    ].join('\n');
+
+    fakeNetEngine.setResponseText('dummy://foo', manifestText);
+
+    /** @type {shaka.extern.Manifest} */
+    const manifest = await parser.start('dummy://foo', playerInterface);
+    expect(manifest.variants.length).toBe(1);
+    const stream = manifest.variants[0].video;
+    expect(stream.hdr).toBe('HLG');
+  });
+
+  it('supports SupplementalProperty ColourPrimaries', async () => {
+    // (DASH-IF IOP v4.3 6.2.5.1.)
+    const scheme = cicpScheme('ColourPrimaries');
+    const hlg = 18;
+    const manifestText = [
+      '<MPD minBufferTime="PT75S">',
+      '  <Period id="1" duration="PT30S">',
+      '    <AdaptationSet id="2" mimeType="video/mp4">',
+      `      <SupplementalProperty schemeIdUri="${scheme}" value="${hlg}" />`,
+      '      <Representation codecs="hvc1.2.4.L153.B0">',
+      '        <BaseURL>v-sd.mp4</BaseURL>',
+      '        <SegmentBase indexRange="100-200" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '    <AdaptationSet id="3" mimeType="audio/mp4">',
+      '      <Representation id="audio-en">',
+      '        <BaseURL>a-en.mp4</BaseURL>',
+      '        <SegmentBase indexRange="100-200" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '  </Period>',
+      '</MPD>',
+    ].join('\n');
+
+    fakeNetEngine.setResponseText('dummy://foo', manifestText);
+
+    /** @type {shaka.extern.Manifest} */
+    const manifest = await parser.start('dummy://foo', playerInterface);
+    expect(manifest.variants.length).toBe(1);
+    const stream = manifest.variants[0].video;
+    expect(stream.hdr).toBe('HLG');
+  });
+
   it('supports HDR signaling via EssentialProperty', async () => {
     // (DASH-IF IOP v4.3 6.2.5.1.)
     const hdrScheme = cicpScheme('TransferCharacteristics');
+    const hlg = 18;
+    const manifestText = [
+      '<MPD minBufferTime="PT75S">',
+      '  <Period id="1" duration="PT30S">',
+      '    <AdaptationSet id="2" mimeType="video/mp4">',
+      `      <EssentialProperty schemeIdUri="${hdrScheme}" value="${hlg}" />`,
+      '      <Representation codecs="hvc1.2.4.L153.B0">',
+      '        <BaseURL>v-sd.mp4</BaseURL>',
+      '        <SegmentBase indexRange="100-200" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '    <AdaptationSet id="3" mimeType="audio/mp4">',
+      '      <Representation id="audio-en">',
+      '        <BaseURL>a-en.mp4</BaseURL>',
+      '        <SegmentBase indexRange="100-200" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '  </Period>',
+      '</MPD>',
+    ].join('\n');
+
+    fakeNetEngine.setResponseText('dummy://foo', manifestText);
+
+    /** @type {shaka.extern.Manifest} */
+    const manifest = await parser.start('dummy://foo', playerInterface);
+    expect(manifest.variants.length).toBe(1);
+    const stream = manifest.variants[0].video;
+    expect(stream.hdr).toBe('HLG');
+  });
+
+  it('supports EssentialProperty MatrixCoefficients', async () => {
+    // (DASH-IF IOP v4.3 6.2.5.1.)
+    const hdrScheme = cicpScheme('MatrixCoefficients');
+    const hlg = 18;
+    const manifestText = [
+      '<MPD minBufferTime="PT75S">',
+      '  <Period id="1" duration="PT30S">',
+      '    <AdaptationSet id="2" mimeType="video/mp4">',
+      `      <EssentialProperty schemeIdUri="${hdrScheme}" value="${hlg}" />`,
+      '      <Representation codecs="hvc1.2.4.L153.B0">',
+      '        <BaseURL>v-sd.mp4</BaseURL>',
+      '        <SegmentBase indexRange="100-200" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '    <AdaptationSet id="3" mimeType="audio/mp4">',
+      '      <Representation id="audio-en">',
+      '        <BaseURL>a-en.mp4</BaseURL>',
+      '        <SegmentBase indexRange="100-200" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '  </Period>',
+      '</MPD>',
+    ].join('\n');
+
+    fakeNetEngine.setResponseText('dummy://foo', manifestText);
+
+    /** @type {shaka.extern.Manifest} */
+    const manifest = await parser.start('dummy://foo', playerInterface);
+    expect(manifest.variants.length).toBe(1);
+    const stream = manifest.variants[0].video;
+    expect(stream.hdr).toBe('HLG');
+  });
+
+  it('supports EssentialProperty ColourPrimaries', async () => {
+    // (DASH-IF IOP v4.3 6.2.5.1.)
+    const hdrScheme = cicpScheme('ColourPrimaries');
     const hlg = 18;
     const manifestText = [
       '<MPD minBufferTime="PT75S">',


### PR DESCRIPTION
Add ColourPrimaries and MatrixCoefficients schemes as specified by https://dashif.org/docs/DASH-IF-IOP-v4.3.pdf.

In particular, `ColourPrimaries` and `MatrixCoefficients` schemes are currently considered "unrecognizedEssentialProperty", causing some streams with valid manifests to discard the video track.

<img width="648" alt="image" src="https://github.com/shaka-project/shaka-player/assets/99928/339d9364-0ca7-4a54-aaf8-95357fbad3d8">
