### PR TITLE
feat: Improve liveSync when using src=

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5734,7 +5734,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const buffered = this.video_.buffered;
       if (buffered.length > 0) {
         const bufferedEnd = buffered.end(buffered.length - 1);
-        offset = Math.max(liveSyncPlaybackRate, bufferedEnd - seekRange.end);
+        if (bufferedEnd > seekRange.end) {
+          offset = Math.max(liveSyncPlaybackRate, bufferedEnd - seekRange.end);
+        }
       }
     }
 


### PR DESCRIPTION
There are two cases:

1) When the bufferedEnd is less than seekRange.end
```
-------|---------------|-------------|--------------|------
seekRange.start   currentTime   bufferedEnd   seekRange.end
```
In this case the offset is not necessary because we aren't near to live edge


2) When the bufferedEnd is greater than seekRange.end
```
-------|---------------|-------------|--------------|------
seekRange.start   currentTime  seekRange.end   bufferedEnd   
```
After the update (tested in Safari), `bufferedEnd - seekRange.end` is constant

Examples:
Values for the examples
```
liveSync = true
liveSyncPlaybackRate = 1.1
liveSyncMaxLatency = 3
```

**Example 1:**
```
currentTime = 10
seekRange.end = 18
bufferedEnd = 15
```
Latency = 5 , offset 0 --> Need live sync

After some time
```
currentTime = 20
seekRange.end = 25
bufferedEnd = 22
```
Latency = 2 , offset 0 --> No need live sync

**Example 2:**

```
currentTime = 10
seekRange.end = 15
bufferedEnd = 18
```
Latency = 5 , offset 3 --> No need live sync

After some time
```
currentTime = 20
seekRange.end = 22
bufferedEnd = 25
```
Latency = 2 , offset 3 --> No need live sync

After some time
```
currentTime = 30
seekRange.end = 37
bufferedEnd = 40
```
Latency = 7 , offset 3 --> Need live sync

The maximum latency that we have is liveSyncMaxLatency + offset