### PR TITLE
fix(docs): fix player configuration code in drm config tutorial

### DIFF
--- a/docs/tutorials/drm-config.md
+++ b/docs/tutorials/drm-config.md
@@ -59,15 +59,18 @@ If this is the only `<ContentProtection>` element in the manifest, Shaka will
 try all key systems it knows. (Based on keySystemsByURI in
 {@linksource shaka.extern.DashManifestConfiguration}.)
 
-Through `player.configure()`, you can change the dash key systems mapping by
+Through `player.configure()`, you can update the dash key systems mapping by
 scheme URI:
+
 ```js
 player.configure({
-  dash: {
-    keySystemsByURI: {
-      'urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95': 'com.microsoft.playready.recommendation',
-      'urn:uuid:79f0049a-4098-8642-ab92-e65be0885f95': 'com.microsoft.playready.recommendation',
-    }
+  manifest: {
+    dash: {
+      keySystemsByURI: {
+        'urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95': 'com.microsoft.playready.recommendation',
+        'urn:uuid:79f0049a-4098-8642-ab92-e65be0885f95': 'com.microsoft.playready.recommendation',
+      }
+  }
   }
 });
 ```


### PR DESCRIPTION
This PR updates the DRM configuration tutorial.

The configuration code example is incorrect,  and also it suggests you can change the mapping, which is not true, you are only able to overwrite parts of it.