### PR TITLE
fix: prevent access to null config_ in SimpleAbrManager

### DIFF
--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -54,7 +54,7 @@ shaka.abr.SimpleAbrManager = class {
     // of connectivity changes.
     if (navigator.connection && navigator.connection.addEventListener) {
       this.onNetworkInformationChange_ = () => {
-        if (this.config_.useNetworkInformation && this.enabled_) {
+        if (this.enabled_ && this.config_.useNetworkInformation) {
           this.bandwidthEstimator_ = new shaka.abr.EwmaBandwidthEstimator();
           if (this.config_) {
             this.bandwidthEstimator_.configure(this.config_.advanced);


### PR DESCRIPTION
Well sometimes network information change could be triggered even if this.config_ is null, resulting in an exception thrown in the browser. Doesn't affect playback, but affects the number of errors detected by our tools 😅 