### PR TITLE
test: Fix Mac slowdowns and disconnections for Chrome and Edge testing

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -347,6 +347,20 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Return true if the platform is a Mac, regardless of the browser.
+   *
+   * @return {boolean}
+   */
+  static isMac() {
+    // Try the newer standard first.
+    if (navigator.userAgentData && navigator.userAgentData.platform) {
+      return navigator.userAgentData.platform.toLowerCase() == 'macos';
+    }
+    // Fall back to the old API, with less strict matching.
+    return navigator.platform.toLowerCase().includes('mac');
+  }
+
+  /**
    * Check if the user agent contains a key. This is the best way we know of
    * right now to detect platforms. If there is a better way, please send a
    * PR.

--- a/test/test/util/ui_utils.js
+++ b/test/test/util/ui_utils.js
@@ -162,12 +162,16 @@ shaka.test.UiUtils = class {
     const video = /** @type {!HTMLVideoElement} */(document.createElement(
         'video'));
 
-    // Instead of muting the video, set it to a very low volume.  This works
-    // around bizarre slowdowns and disconnection issues seen only on Mac, only
-    // with Edge and Chrome, and only while WebDriver is controlling the
-    // browser.
-    video.muted = false;
-    video.volume = 0.01;
+    if (shaka.util.Platform.isMac()) {
+      // Instead of muting the video, set it to a very low volume.  This works
+      // around bizarre slowdowns and disconnection issues seen only on Mac,
+      // only with Edge and Chrome, and only while WebDriver is controlling the
+      // browser.
+      video.muted = false;
+      video.volume = 0.01;
+    } else {
+      video.muted = true;
+    }
 
     video.width = 600;
     video.height = 400;

--- a/test/test/util/ui_utils.js
+++ b/test/test/util/ui_utils.js
@@ -162,7 +162,13 @@ shaka.test.UiUtils = class {
     const video = /** @type {!HTMLVideoElement} */(document.createElement(
         'video'));
 
-    video.muted = true;
+    // Instead of muting the video, set it to a very low volume.  This works
+    // around bizarre slowdowns and disconnection issues seen only on Mac, only
+    // with Edge and Chrome, and only while WebDriver is controlling the
+    // browser.
+    video.muted = false;
+    video.volume = 0.01;
+
     video.width = 600;
     video.height = 400;
 


### PR DESCRIPTION
This particular workaround was also discovered by accident while debugging tests on our lab Mac.  Playback tests were moving visually much slower than they should, I discovered that unmuting the video element caused them to run at a normal pace.  This also correlates with disconnections and other issues while running tests.  I don't have any explanation for why any of this would be so.  It only seems to happen while WebDriver is controlling the page, and only for Chrome and Edge, and only on Mac.