### PR TITLE
fix(DRM): broken keySystemsMapping due to multiple references of drmInfo

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -372,17 +372,23 @@ shaka.media.DrmEngine = class {
       shaka.media.DrmEngine.replaceDrmInfo_(variants, servers);
     }
 
-    // Make sure all the drm infos are valid and filled in correctly.
+    /** @type {!Set<shaka.extern.DrmInfo>} */
+    const drmInfos = new Set();
     for (const variant of variants) {
-      const drmInfos = this.getVariantDrmInfos_(variant);
-      for (const info of drmInfos) {
-        shaka.media.DrmEngine.fillInDrmInfoDefaults_(
-            info,
-            shaka.util.MapUtils.asMap(this.config_.servers),
-            shaka.util.MapUtils.asMap(this.config_.advanced || {}),
-            this.config_.keySystemsMapping);
+      const variantDrmInfos = this.getVariantDrmInfos_(variant);
+      for (const info of variantDrmInfos) {
+        drmInfos.add(info);
       }
     }
+
+    for (const info of drmInfos) {
+      shaka.media.DrmEngine.fillInDrmInfoDefaults_(
+          info,
+          shaka.util.MapUtils.asMap(this.config_.servers),
+          shaka.util.MapUtils.asMap(this.config_.advanced || {}),
+          this.config_.keySystemsMapping);
+    }
+
 
     /** @type {!Map.<string, MediaKeySystemConfiguration>} */
     let configsByKeySystem;


### PR DESCRIPTION
Different streams may share `drmInfo` references, which makes problem when `keySystemsMapping` config is used. Assuming we have config:
```js
drm: {
  servers: {
    'a.b.c': '...',
  },
  keySystemsMapping: {
    'a.b.c': 'd.e.f',
  },
}
```
on the first access to the `drmInfo` object `DrmEngine` will set server for `a.b.c` key system and replace key system to `d.e.f`. On the 2nd access DrmEngine will not find server config for `d.e.f` and thus will remove any server set.
This issue can be easily mitigated by deduplicating `drmInfo` array.