### PR TITLE
feat(DRM): use preferredKeySystems to reduce requestMediaKeySystemAccess() calls

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -390,7 +390,8 @@ shaka.media.DrmEngine = class {
     // We should get the decodingInfo results for the variants after we filling
     // in the drm infos, and before queryMediaKeys_().
     await shaka.util.StreamUtils.getDecodingInfosForVariants(variants,
-        this.usePersistentLicenses_, this.srcEquals_);
+        this.usePersistentLicenses_, this.srcEquals_,
+        this.config_.preferredKeySystems);
 
     const hasDrmInfo = hadDrmInfo || Object.keys(this.config_.servers).length;
     // An unencrypted content is initialized.

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -622,7 +622,13 @@ shaka.util.StreamUtils = class {
     for (const variant of variants) {
       /** @type {!Array.<!MediaDecodingConfiguration>} */
       const decodingConfigs = shaka.util.StreamUtils.getDecodingConfigs_(
-          variant, usePersistentLicenses, srcEquals);
+          variant, usePersistentLicenses, srcEquals)
+          .filter((config) => {
+            const keySystem = config.keySystemConfiguration &&
+              config.keySystemConfiguration.keySystem;
+            // Avoid checking preferred systems twice.
+            return !keySystem || !preferredKeySystems.includes(keySystem);
+          });
 
       // The reason we are performing this await in a loop rather than
       // batching into a `promise.all` is performance related.

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -428,7 +428,8 @@ shaka.util.StreamUtils = class {
         'MediaCapabilities should be valid.');
 
     await shaka.util.StreamUtils.getDecodingInfosForVariants(
-        manifest.variants, usePersistentLicenses, /* srcEquals= */ false);
+        manifest.variants, usePersistentLicenses, /* srcEquals= */ false,
+        /** preferredKeySystems= */ []);
     manifest.variants = manifest.variants.filter((variant) => {
       // See: https://github.com/shaka-project/shaka-player/issues/3860
       const video = variant.video;
@@ -575,16 +576,48 @@ shaka.util.StreamUtils = class {
    * @param {!Array.<shaka.extern.Variant>} variants
    * @param {boolean} usePersistentLicenses
    * @param {boolean} srcEquals
+   * @param {!Array<string>} preferredKeySystems
    * @exportDoc
    */
   static async getDecodingInfosForVariants(variants, usePersistentLicenses,
-      srcEquals) {
+      srcEquals, preferredKeySystems) {
     const gotDecodingInfo = variants.some((variant) =>
       variant.decodingInfos.length);
     if (gotDecodingInfo) {
       shaka.log.debug('Already got the variants\' decodingInfo.');
       return;
     }
+
+    // Try to get preferred key systems first to avoid unneeded calls to CDM.
+    for (const preferredKeySystem of preferredKeySystems) {
+      let keySystemSatisfied = false;
+      for (const variant of variants) {
+        /** @type {!Array.<!MediaDecodingConfiguration>} */
+        const decodingConfigs = shaka.util.StreamUtils.getDecodingConfigs_(
+            variant, usePersistentLicenses, srcEquals)
+            .filter((config) => {
+              const keySystem = config.keySystemConfiguration &&
+                config.keySystemConfiguration.keySystem;
+              return keySystem === preferredKeySystem;
+            });
+
+        // The reason we are performing this await in a loop rather than
+        // batching into a `promise.all` is performance related.
+        // https://github.com/shaka-project/shaka-player/pull/4708#discussion_r1022581178
+        for (const config of decodingConfigs) {
+          // eslint-disable-next-line no-await-in-loop
+          await shaka.util.StreamUtils.getDecodingInfosForVariant_(
+              variant, config);
+        }
+        if (variant.decodingInfos.length) {
+          keySystemSatisfied = true;
+        }
+      } // for (const variant of variants)
+      if (keySystemSatisfied) {
+        // Return if any preferred key system is already satisfied.
+        return;
+      }
+    } // for (const preferredKeySystem of preferredKeySystems)
 
     for (const variant of variants) {
       /** @type {!Array.<!MediaDecodingConfiguration>} */

--- a/test/media/drm_engine_unit.js
+++ b/test/media/drm_engine_unit.js
@@ -214,7 +214,9 @@ describe('DrmEngine', () => {
       const variants = manifest.variants;
       await drmEngine.initForPlayback(variants, manifest.offlineSessionIds);
 
-      expect(variants[0].decodingInfos.length).toBe(2);
+      // should be only one variant, as preferredKeySystems is propagated
+      // to getDecodingInfos
+      expect(variants[0].decodingInfos.length).toBe(1);
       expect(shaka.media.DrmEngine.keySystem(drmEngine.getDrmInfo()))
           .toBe('drm.def');
     });


### PR DESCRIPTION
Propagate `preferredKeySystems` config to `getDecodingInfosForVariants()` method.
By doing that, shaka can only ask for `MediaKeySystemAccess` objects that will be used during playback.

If any preferred key system is available, player will stop requesting for MKSA.
If none of preferred key systems is available, player will try to get MKSA for any existing configuration, as usual.