### PR TITLE
feat(DASH): Add support for service descriptions

### DIFF
--- a/externs/shaka/manifest.js
+++ b/externs/shaka/manifest.js
@@ -21,7 +21,7 @@
  *   sequenceMode: boolean,
  *   ignoreManifestTimestampsInSegmentsMode: boolean,
  *   type: string,
- *   serviceDescription: !shaka.extern.ServiceDescription
+ *   serviceDescription: ?shaka.extern.ServiceDescription
  * }}
  *
  * @description
@@ -90,8 +90,7 @@
  * @property {string} type
  *   Indicates the type of the manifest. It can be <code>'HLS'</code> or
  *   <code>'DASH'</code>.
- * @property {!shaka.extern.ServiceDescription} serviceDescription
- *   <i>Defaults to {}.</i> <br>
+ * @property {?shaka.extern.ServiceDescription} serviceDescription
  *   The service description for the manifest. Used to adapt playbackRate to
  *   decrease latency.
  *

--- a/externs/shaka/manifest.js
+++ b/externs/shaka/manifest.js
@@ -20,7 +20,8 @@
  *   minBufferTime: number,
  *   sequenceMode: boolean,
  *   ignoreManifestTimestampsInSegmentsMode: boolean,
- *   type: string
+ *   type: string,
+ *   serviceDescription: !shaka.extern.ServiceDescription
  * }}
  *
  * @description
@@ -89,6 +90,10 @@
  * @property {string} type
  *   Indicates the type of the manifest. It can be <code>'HLS'</code> or
  *   <code>'DASH'</code>.
+ * @property {!shaka.extern.ServiceDescription} serviceDescription
+ *   <i>Defaults to {}.</i> <br>
+ *   The service description for the manifest. Used to adapt playbackRate to
+ *   decrease latency.
  *
  * @exportDoc
  */
@@ -117,6 +122,26 @@ shaka.extern.Manifest;
  * @exportDoc
  */
 shaka.extern.InitDataOverride;
+
+/**
+ * @typedef {{
+ *   maxLatency: ?number,
+ *   maxPlaybackRate: ?number
+ * }}
+ *
+ * @description
+ * Maximum latency and playback rate for a manifest. When max latency is reached
+ * playbackrate is updated to maxPlaybackRate to decrease latency.
+ * More information {@link https://dashif.org/docs/CR-Low-Latency-Live-r8.pdf here}.
+ *
+ * @property {?number} maxLatency
+ *  Maximum latency in seconds.
+ * @property {?number} maxPlaybackRate
+ *  Maximum playback rate.
+ *
+ * @exportDoc
+ */
+shaka.extern.ServiceDescription;
 
 
 /**

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -497,6 +497,29 @@ shaka.dash.DashParser = class {
       this.updatePeriod_ = this.minTotalAvailabilityTimeOffset_;
     }
 
+    const serviceDescriptionNode = XmlUtils.findChild(mpd,
+        'ServiceDescription');
+    const serviceDescription = {};
+
+    const latencyNode = XmlUtils.findChild(serviceDescriptionNode, 'Latency');
+    if (latencyNode) {
+      serviceDescription.latency = {
+        target: parseInt(latencyNode.getAttribute('target'), 10) / 1000,
+        max: parseInt(latencyNode.getAttribute('max'), 10) / 1000,
+        min: parseInt(latencyNode.getAttribute('min'), 10) / 1000,
+        referenceId: parseInt(latencyNode.getAttribute('referenceId'), 10),
+      };
+    }
+
+    const playbackRateNode = XmlUtils.findChild(serviceDescriptionNode,
+        'PlaybackRate');
+    if (playbackRateNode) {
+      serviceDescription.playbackRate = {
+        max: parseFloat(playbackRateNode.getAttribute('max'), 10),
+        min: parseFloat(playbackRateNode.getAttribute('min'), 10),
+      };
+    }
+
     // These steps are not done on manifest update.
     if (!this.manifest_) {
       this.manifest_ = {
@@ -509,6 +532,7 @@ shaka.dash.DashParser = class {
         sequenceMode: this.config_.dash.sequenceMode,
         ignoreManifestTimestampsInSegmentsMode: false,
         type: shaka.media.ManifestParser.DASH,
+        serviceDescription: serviceDescription,
       };
 
       // We only need to do clock sync when we're using presentation start

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -549,33 +549,36 @@ shaka.dash.DashParser = class {
   }
 
   /**
-   * Reads and parses service description properties.
+   * Reads maxLatency and maxPlaybackRate properties from service
+   * description element.
    *
    * @param {!Element} mpd
-   * @return {!shaka.extern.ServiceDescription}
+   * @return {?shaka.extern.ServiceDescription}
    * @private
    */
   parseServiceDescription_(mpd) {
     const XmlUtils = shaka.util.XmlUtils;
-    const serviceDescription = {};
     const elem = XmlUtils.findChild(mpd, 'ServiceDescription');
 
-    if (elem) {
-      const latencyNode = XmlUtils.findChild(elem, 'Latency');
-      if (latencyNode) {
-        serviceDescription.maxLatency = parseInt(
-            latencyNode.getAttribute('max'), 10) / 1000;
-      }
-
-      const playbackRateNode = XmlUtils.findChild(elem,
-          'PlaybackRate');
-      if (playbackRateNode) {
-        serviceDescription.maxPlaybackRate = parseFloat(
-            playbackRateNode.getAttribute('max'));
-      }
+    if (!elem ) {
+      return null;
     }
 
-    return serviceDescription;
+    const latencyNode = XmlUtils.findChild(elem, 'Latency');
+    const playbackRateNode = XmlUtils.findChild(elem, 'PlaybackRate');
+
+    if ((latencyNode && latencyNode.getAttribute('max')) || playbackRateNode) {
+      const maxLatency = latencyNode && latencyNode.getAttribute('max') ?
+        parseInt(latencyNode.getAttribute('max'), 10) / 1000 :
+        null;
+      const maxPlaybackRate = playbackRateNode ?
+        parseFloat(playbackRateNode.getAttribute('max')) :
+        null;
+
+      return {maxLatency, maxPlaybackRate};
+    }
+
+    return null;
   }
 
   /**

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -497,29 +497,6 @@ shaka.dash.DashParser = class {
       this.updatePeriod_ = this.minTotalAvailabilityTimeOffset_;
     }
 
-    const serviceDescriptionNode = XmlUtils.findChild(mpd,
-        'ServiceDescription');
-    const serviceDescription = {};
-
-    const latencyNode = XmlUtils.findChild(serviceDescriptionNode, 'Latency');
-    if (latencyNode) {
-      serviceDescription.latency = {
-        target: parseInt(latencyNode.getAttribute('target'), 10) / 1000,
-        max: parseInt(latencyNode.getAttribute('max'), 10) / 1000,
-        min: parseInt(latencyNode.getAttribute('min'), 10) / 1000,
-        referenceId: parseInt(latencyNode.getAttribute('referenceId'), 10),
-      };
-    }
-
-    const playbackRateNode = XmlUtils.findChild(serviceDescriptionNode,
-        'PlaybackRate');
-    if (playbackRateNode) {
-      serviceDescription.playbackRate = {
-        max: parseFloat(playbackRateNode.getAttribute('max'), 10),
-        min: parseFloat(playbackRateNode.getAttribute('min'), 10),
-      };
-    }
-
     // These steps are not done on manifest update.
     if (!this.manifest_) {
       this.manifest_ = {
@@ -532,7 +509,7 @@ shaka.dash.DashParser = class {
         sequenceMode: this.config_.dash.sequenceMode,
         ignoreManifestTimestampsInSegmentsMode: false,
         type: shaka.media.ManifestParser.DASH,
-        serviceDescription: serviceDescription,
+        serviceDescription: this.parseServiceDescription_(mpd),
       };
 
       // We only need to do clock sync when we're using presentation start
@@ -569,6 +546,36 @@ shaka.dash.DashParser = class {
     // after period combining, while we still have a direct reference, so that
     // any new streams will appear in the period combiner.
     this.playerInterface_.makeTextStreamsForClosedCaptions(this.manifest_);
+  }
+
+  /**
+   * Reads and parses service description properties.
+   *
+   * @param {!Element} mpd
+   * @return {!shaka.extern.ServiceDescription}
+   * @private
+   */
+  parseServiceDescription_(mpd) {
+    const XmlUtils = shaka.util.XmlUtils;
+    const serviceDescription = {};
+    const elem = XmlUtils.findChild(mpd, 'ServiceDescription');
+
+    if (elem) {
+      const latencyNode = XmlUtils.findChild(elem, 'Latency');
+      if (latencyNode) {
+        serviceDescription.maxLatency = parseInt(
+            latencyNode.getAttribute('max'), 10) / 1000;
+      }
+
+      const playbackRateNode = XmlUtils.findChild(elem,
+          'PlaybackRate');
+      if (playbackRateNode) {
+        serviceDescription.maxPlaybackRate = parseFloat(
+            playbackRateNode.getAttribute('max'));
+      }
+    }
+
+    return serviceDescription;
   }
 
   /**

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -801,6 +801,10 @@ shaka.hls.HlsParser = class {
       ignoreManifestTimestampsInSegmentsMode:
         this.config_.hls.ignoreManifestTimestampsInSegmentsMode,
       type: shaka.media.ManifestParser.HLS,
+      serviceDescription: {
+        maxLatency: null,
+        maxPlaybackRate: null,
+      },
     };
     this.playerInterface_.makeTextStreamsForClosedCaptions(this.manifest_);
   }

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -801,10 +801,7 @@ shaka.hls.HlsParser = class {
       ignoreManifestTimestampsInSegmentsMode:
         this.config_.hls.ignoreManifestTimestampsInSegmentsMode,
       type: shaka.media.ManifestParser.HLS,
-      serviceDescription: {
-        maxLatency: null,
-        maxPlaybackRate: null,
-      },
+      serviceDescription: null,
     };
     this.playerInterface_.makeTextStreamsForClosedCaptions(this.manifest_);
   }

--- a/lib/mss/mss_parser.js
+++ b/lib/mss/mss_parser.js
@@ -376,10 +376,7 @@ shaka.mss.MssParser = class {
         sequenceMode: this.config_.mss.sequenceMode,
         ignoreManifestTimestampsInSegmentsMode: false,
         type: shaka.media.ManifestParser.MSS,
-        serviceDescription: {
-          maxLatency: null,
-          maxPlaybackRate: null,
-        },
+        serviceDescription: null,
       };
 
       // This is the first point where we have a meaningful presentation start

--- a/lib/mss/mss_parser.js
+++ b/lib/mss/mss_parser.js
@@ -376,6 +376,10 @@ shaka.mss.MssParser = class {
         sequenceMode: this.config_.mss.sequenceMode,
         ignoreManifestTimestampsInSegmentsMode: false,
         type: shaka.media.ManifestParser.MSS,
+        serviceDescription: {
+          maxLatency: null,
+          maxPlaybackRate: null,
+        },
       };
 
       // This is the first point where we have a meaningful presentation start

--- a/lib/offline/manifest_converter.js
+++ b/lib/offline/manifest_converter.js
@@ -91,10 +91,7 @@ shaka.offline.ManifestConverter = class {
       sequenceMode: manifestDB.sequenceMode || false,
       ignoreManifestTimestampsInSegmentsMode: false,
       type: manifestDB.type || shaka.media.ManifestParser.UNKNOWN,
-      serviceDescription: {
-        maxLatency: null,
-        maxPlaybackRate: null,
-      },
+      serviceDescription: null,
     };
   }
 

--- a/lib/offline/manifest_converter.js
+++ b/lib/offline/manifest_converter.js
@@ -91,6 +91,10 @@ shaka.offline.ManifestConverter = class {
       sequenceMode: manifestDB.sequenceMode || false,
       ignoreManifestTimestampsInSegmentsMode: false,
       type: manifestDB.type || shaka.media.ManifestParser.UNKNOWN,
+      serviceDescription: {
+        maxLatency: null,
+        maxPlaybackRate: null,
+      },
     };
   }
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -5731,12 +5731,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     // Should use serviceDescription if they exist.
-    const liveSyncMaxLatency = this.manifest_.serviceDescription.latency ?
-      this.manifest_.serviceDescription.latency.max :
-      this.config_.streaming.liveSyncMaxLatency;
+    const liveSyncMaxLatency =
+      this.manifest_ && this.manifest_.serviceDescription.maxLatency ?
+        this.manifest_.serviceDescription.maxLatency :
+        this.config_.streaming.liveSyncMaxLatency;
     const liveSyncPlaybackRate =
-      this.manifest_.serviceDescription.playbackRate ?
-        this.manifest_.serviceDescription.playbackRate.max :
+      this.manifest_ && this.manifest_.serviceDescription.maxPlaybackRate ?
+        this.manifest_.serviceDescription.maxPlaybackRate :
         this.config_.streaming.liveSyncPlaybackRate;
     const playbackRate = this.video_.playbackRate;
     const latency = seekRange.end - this.video_.currentTime;
@@ -5755,8 +5756,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     if ((latency - offset) > liveSyncMaxLatency) {
       if (playbackRate != liveSyncPlaybackRate) {
-        shaka.log.debug('Latency (' + latency +
-          's) is greater than liveSyncMaxLatency. ' +
+        shaka.log.debug('Latency (' + latency + 's) ' +
+          'is greater than liveSyncMaxLatency (' + liveSyncMaxLatency + 's).' +
           'Updating playbackRate to ' + liveSyncPlaybackRate);
         this.trickPlay(liveSyncPlaybackRate);
       }

--- a/lib/player.js
+++ b/lib/player.js
@@ -5730,15 +5730,23 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return;
     }
 
-    // Should use serviceDescription if they exist.
-    const liveSyncMaxLatency =
-      this.manifest_ && this.manifest_.serviceDescription.maxLatency ?
-        this.manifest_.serviceDescription.maxLatency :
-        this.config_.streaming.liveSyncMaxLatency;
-    const liveSyncPlaybackRate =
-      this.manifest_ && this.manifest_.serviceDescription.maxPlaybackRate ?
-        this.manifest_.serviceDescription.maxPlaybackRate :
-        this.config_.streaming.liveSyncPlaybackRate;
+    let liveSyncMaxLatency;
+    let liveSyncPlaybackRate;
+    if (this.config_.streaming.liveSync) {
+      liveSyncMaxLatency = this.config_.streaming.liveSyncMaxLatency;
+      liveSyncPlaybackRate = this.config_.streaming.liveSyncPlaybackRate;
+    } else {
+      // serviceDescription must override if it is defined in the MPD and
+      // liveSync configuration is not set.
+      if (this.manifest_ && this.manifest_.serviceDescription) {
+        liveSyncMaxLatency = this.manifest_.serviceDescription.maxLatency ||
+          this.config_.streaming.liveSyncMaxLatency;
+        liveSyncPlaybackRate =
+          this.manifest_.serviceDescription.maxPlaybackRate ||
+          this.config_.streaming.liveSyncPlaybackRate;
+      }
+    }
+
     const playbackRate = this.video_.playbackRate;
     const latency = seekRange.end - this.video_.currentTime;
     let offset = 0;
@@ -5754,10 +5762,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
     }
 
-    if ((latency - offset) > liveSyncMaxLatency) {
+    if (liveSyncMaxLatency && liveSyncPlaybackRate &&
+        (latency - offset) > liveSyncMaxLatency) {
       if (playbackRate != liveSyncPlaybackRate) {
         shaka.log.debug('Latency (' + latency + 's) ' +
-          'is greater than liveSyncMaxLatency (' + liveSyncMaxLatency + 's).' +
+          'is greater than liveSyncMaxLatency (' + liveSyncMaxLatency + 's). ' +
           'Updating playbackRate to ' + liveSyncPlaybackRate);
         this.trickPlay(liveSyncPlaybackRate);
       }

--- a/lib/player.js
+++ b/lib/player.js
@@ -2278,7 +2278,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
                         'arbitrary language initially');
     }
 
-    if (this.isLive() && this.config_.streaming.liveSync) {
+    if (this.isLive() && (this.config_.streaming.liveSync ||
+        this.manifest_.serviceDescription)) {
       const onTimeUpdate = () => this.onTimeUpdate_();
       this.loadEventManager_.listen(mediaElement, 'timeupdate', onTimeUpdate);
     }
@@ -5728,8 +5729,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // Bad stream?
       return;
     }
-    const liveSyncMaxLatency = this.config_.streaming.liveSyncMaxLatency;
-    const liveSyncPlaybackRate = this.config_.streaming.liveSyncPlaybackRate;
+
+    // Should use serviceDescription if they exist.
+    const liveSyncMaxLatency = this.manifest_.serviceDescription.latency ?
+      this.manifest_.serviceDescription.latency.max :
+      this.config_.streaming.liveSyncMaxLatency;
+    const liveSyncPlaybackRate =
+      this.manifest_.serviceDescription.playbackRate ?
+        this.manifest_.serviceDescription.playbackRate.max :
+        this.config_.streaming.liveSyncPlaybackRate;
     const playbackRate = this.video_.playbackRate;
     const latency = seekRange.end - this.video_.currentTime;
     let offset = 0;
@@ -5747,6 +5755,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     if ((latency - offset) > liveSyncMaxLatency) {
       if (playbackRate != liveSyncPlaybackRate) {
+        shaka.log.debug('Latency (' + latency +
+          's) is greater than liveSyncMaxLatency. ' +
+          'Updating playbackRate to ' + liveSyncPlaybackRate);
         this.trickPlay(liveSyncPlaybackRate);
       }
     } else if (playbackRate !== 1 && playbackRate !== 0) {

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -2556,4 +2556,26 @@ describe('DashParser Manifest', () => {
     expect(segments[0][1].startTime).toBe(15);
     expect(segments[1][1].startTime).toBe(15);
   });
+
+  describe('Parses ServiceDescription', () => {
+    it('with PlaybackRate and Latency', async () => {
+      const source = [
+        '<MPD minBufferTime="PT75S" type="dynamic"',
+        '     availabilityStartTime="1970-01-01T00:00:00Z">',
+        '  <ServiceDescription id="0">',
+        '    <Latency max="2000" min="2000" referenceId="0" target="4000" />',
+        '    <PlaybackRate max="1.10" min="0.96" />',
+        '  </ServiceDescription>',
+        '</MPD>',
+      ].join('\n');
+
+      fakeNetEngine.setResponseText('dummy://foo', source);
+
+      /** @type {shaka.extern.Manifest} */
+      const manifest = await parser.start('dummy://foo', playerInterface);
+
+      expect(manifest.serviceDescription.maxLatency).toBe(2);
+      expect(manifest.serviceDescription.maxPlaybackRate).toBe(1.1);
+    });
+  });
 });

--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -136,10 +136,7 @@ describe('Playhead', () => {
       sequenceMode: false,
       ignoreManifestTimestampsInSegmentsMode: false,
       type: 'UNKNOWN',
-      serviceDescription: {
-        maxLatency: null,
-        maxPlaybackRate: null,
-      },
+      serviceDescription: null,
     };
 
     config = shaka.util.PlayerConfiguration.createDefault().streaming;

--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -136,6 +136,10 @@ describe('Playhead', () => {
       sequenceMode: false,
       ignoreManifestTimestampsInSegmentsMode: false,
       type: 'UNKNOWN',
+      serviceDescription: {
+        maxLatency: null,
+        maxPlaybackRate: null,
+      },
     };
 
     config = shaka.util.PlayerConfiguration.createDefault().streaming;

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -597,6 +597,10 @@ describe('StreamingEngine', () => {
         sequenceMode: false,
         ignoreManifestTimestampsInSegmentsMode: false,
         type: 'UNKNOWN',
+        serviceDescription: {
+          maxLatency: null,
+          maxPlaybackRate: null,
+        },
         variants: [{
           id: 1,
           video: {

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -597,10 +597,7 @@ describe('StreamingEngine', () => {
         sequenceMode: false,
         ignoreManifestTimestampsInSegmentsMode: false,
         type: 'UNKNOWN',
-        serviceDescription: {
-          maxLatency: null,
-          maxPlaybackRate: null,
-        },
+        serviceDescription: null,
         variants: [{
           id: 1,
           video: {

--- a/test/test/util/manifest_generator.js
+++ b/test/test/util/manifest_generator.js
@@ -101,6 +101,12 @@ shaka.test.ManifestGenerator.Manifest = class {
     this.ignoreManifestTimestampsInSegmentsMode = false;
     /** @type {string} */
     this.type = 'UNKNOWN';
+    /** @type {!shaka.extern.ServiceDescription} */
+    this.serviceDescription = {
+      maxLatency: null,
+      maxPlaybackRate: null,
+    };
+
 
     /** @type {shaka.extern.Manifest} */
     const foo = this;

--- a/test/test/util/manifest_generator.js
+++ b/test/test/util/manifest_generator.js
@@ -101,11 +101,8 @@ shaka.test.ManifestGenerator.Manifest = class {
     this.ignoreManifestTimestampsInSegmentsMode = false;
     /** @type {string} */
     this.type = 'UNKNOWN';
-    /** @type {!shaka.extern.ServiceDescription} */
-    this.serviceDescription = {
-      maxLatency: null,
-      maxPlaybackRate: null,
-    };
+    /** @type {?shaka.extern.ServiceDescription} */
+    this.serviceDescription = null;
 
 
     /** @type {shaka.extern.Manifest} */

--- a/test/test/util/streaming_engine_util.js
+++ b/test/test/util/streaming_engine_util.js
@@ -286,10 +286,7 @@ shaka.test.StreamingEngineUtil = class {
       sequenceMode: false,
       ignoreManifestTimestampsInSegmentsMode: false,
       type: 'UNKNOWN',
-      serviceDescription: {
-        maxLatency: null,
-        maxPlaybackRate: null,
-      },
+      serviceDescription: null,
     };
 
     /** @type {shaka.extern.Variant} */

--- a/test/test/util/streaming_engine_util.js
+++ b/test/test/util/streaming_engine_util.js
@@ -286,6 +286,10 @@ shaka.test.StreamingEngineUtil = class {
       sequenceMode: false,
       ignoreManifestTimestampsInSegmentsMode: false,
       type: 'UNKNOWN',
+      serviceDescription: {
+        maxLatency: null,
+        maxPlaybackRate: null,
+      },
     };
 
     /** @type {shaka.extern.Variant} */


### PR DESCRIPTION
# Changes

- Parse ServiceDescription from Manifest
- Use ServiceDescription for live syncrhonization

# Doubts

- I have added support for just one ServiceDescription. [Low Latency spec](https://dashif.org/docs/CR-Low-Latency-Live-r8.pdf) seems that it supports more than one. If this support is mandatory, how can I know which ServiceDescription should I use?
- I am executing onTimeUpdate when `this.manifest_.serviceDescription` OR `this.config_.streaming.liveSync`, should it be an AND?