### PR TITLE
fix: Gap jump at start when first jump lands in a new gap

### DIFF
--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -243,6 +243,13 @@ shaka.media.GapJumpingController = class {
     }
 
     this.video_.currentTime = jumpTo;
+    // This accounts for the possibility that we jump a gap at the start
+    // position but we jump _into_ another gap. By setting the start
+    // position to the new jumpTo we ensure that the check above will
+    // pass even though the video is still paused.
+    if (currentTime == this.startTime_) {
+      this.startTime_ = jumpTo;
+    }
     this.gapsJumped_++;
     this.onEvent_(
         new shaka.util.FakeEvent(shaka.util.FakeEvent.EventName.GapJumped));


### PR DESCRIPTION
This change accounts for a gap jump at the start of an asset that lands the user user inside of another gap. The video element is still `paused` at this point, but we've moved past the `startTime` because we jumped a gap. Thus the gap jumper gets stuck, and playback will never start.

This seems like it should be a wild edge case, but we have some assets that reproduce it!