### PR TITLE
fix(HLS): Consider skipped segments to calculate next media sequence

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -418,9 +418,13 @@ shaka.hls.HlsParser = class {
     if (segments.length) {
       const mediaSequenceNumber = shaka.hls.Utils.getFirstTagWithNameAsNumber(
           playlist.tags, 'EXT-X-MEDIA-SEQUENCE', 0);
+      const skipTag = shaka.hls.Utils.getFirstTagWithName(
+          playlist.tags, 'EXT-X-SKIP');
+      const skippedSegments =
+          skipTag ? Number(skipTag.getAttributeValue('SKIPPED-SEGMENTS')) : 0;
       const {nextMediaSequence, nextPart} =
           this.getNextMediaSequenceAndPart_(mediaSequenceNumber, segments);
-      streamInfo.nextMediaSequence = nextMediaSequence;
+      streamInfo.nextMediaSequence = nextMediaSequence + skippedSegments;
       streamInfo.nextPart = nextPart;
       const playlistStartTime = mediaSequenceToStartTime.get(
           mediaSequenceNumber);

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -349,11 +349,6 @@ shaka.hls.HlsParser = class {
     const manifestUri = streamInfo.absoluteMediaPlaylistUri;
     const uriObj = new goog.Uri(manifestUri);
     const queryData = new goog.Uri.QueryData();
-    if (streamInfo.canSkipSegments) {
-      // Enable delta updates. This will replace older segments with
-      // 'EXT-X-SKIP' tag in the media playlist.
-      queryData.add('_HLS_skip', 'YES');
-    }
     if (streamInfo.canBlockReload) {
       if (streamInfo.nextMediaSequence >= 0) {
         // Indicates that the server must hold the request until a Playlist
@@ -366,6 +361,11 @@ shaka.hls.HlsParser = class {
         // Sequence Number M or later.
         queryData.add('_HLS_part', String(streamInfo.nextPart));
       }
+    }
+    if (streamInfo.canSkipSegments) {
+      // Enable delta updates. This will replace older segments with
+      // 'EXT-X-SKIP' tag in the media playlist.
+      queryData.add('_HLS_skip', 'YES');
     }
     if (queryData.getCount()) {
       uriObj.setQueryData(queryData);

--- a/test/hls/hls_live_unit.js
+++ b/test/hls/hls_live_unit.js
@@ -1015,7 +1015,7 @@ describe('HlsParser live', () => {
         ].join('');
 
         fakeNetEngine.setResponseText(
-            'test:/video?_HLS_skip=YES&_HLS_msn=2', mediaWithSkippedSegments);
+            'test:/video?_HLS_msn=2&_HLS_skip=YES', mediaWithSkippedSegments);
 
         playerInterface.isLowLatencyMode = () => true;
 
@@ -1025,7 +1025,7 @@ describe('HlsParser live', () => {
         await delayForUpdatePeriod();
 
         fakeNetEngine.expectRequest(
-            'test:/video?_HLS_skip=YES&_HLS_msn=2',
+            'test:/video?_HLS_msn=2&_HLS_skip=YES',
             shaka.net.NetworkingEngine.RequestType.MANIFEST,
             {type:
               shaka.net.NetworkingEngine.AdvancedRequestType.MEDIA_PLAYLIST});


### PR DESCRIPTION
The `_HLS_msn` directive must be the next media sequence number to block playlist reload. The actual logic uses the `EXT-X-MEDIA-SEQUENCE` plus the number of segments. However, a playlist may skip segments, so it should also consider `EXT-X-SKIP:SKIPPED-SEGMENTS`.