### PR TITLE
fix: Fix exception on Tizen due to unsupported Array method

### DIFF
--- a/build/conformance.textproto
+++ b/build/conformance.textproto
@@ -358,7 +358,7 @@ requirement: {
 }
 
 requirement: {
-  type: BANNED_PROPERTY
+  type: BANNED_PROPERTY_CALL
   value: "String.prototype.replaceAll"
   error_message:
     "Using \"String.replaceAll\" is not allowed; "
@@ -377,3 +377,9 @@ requirement: {
   whitelist_regexp: "test/"
 }
 
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  value: "Array.prototype.flat"
+  error_message:
+    "Using \"Array.flat\" is not allowed because is not supported on Tizen 3."
+}

--- a/lib/cea/mp4_cea_parser.js
+++ b/lib/cea/mp4_cea_parser.js
@@ -270,7 +270,7 @@ shaka.cea.Mp4CeaParser = class {
     // Combine all sample data.  This assumes that the samples described across
     // multiple trun boxes are still continuous in the mdat box.
     const sampleDatas = parsedTRUNs.map((t) => t.sampleData);
-    const sampleData = sampleDatas.flat();
+    const sampleData = [].concat(...sampleDatas);
 
     if (sampleData.length) {
       sampleSize = sampleData[0].sampleSize || defaultSampleSize;


### PR DESCRIPTION
Tizen 3 does not support Array.flat().  This fixes a runtime exception on Tizen 3 by replacing flat() with concat() and the spread operator. This also bans the use of flat().

flat() was originally introduced in PR #5422