### PR TITLE
fix: Fix exiting fullscreen on Safari

### DIFF
--- a/lib/polyfill/orientation.js
+++ b/lib/polyfill/orientation.js
@@ -6,6 +6,7 @@
 
 goog.provide('shaka.polyfill.Orientation');
 
+goog.require('shaka.log');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.FakeEventTarget');
 goog.require('shaka.polyfill');
@@ -23,18 +24,44 @@ shaka.polyfill.Orientation = class {
    * @export
    */
   static install() {
-    if (screen.orientation) {
+    if (screen.orientation && screen.orientation.unlock) {
       // Not needed.
+      shaka.log.info('Using native screen.orientation');
       return;
     }
 
-    // There is no way to check to see if the 'orientationchange' event exists
-    // on window, which could theoretically lead to this making a
-    // screen.orientation object that doesn't actually work.
-    // However, it looks like all platforms that support the deprecated
-    // window.orientation feature also support that event.
-    if (window.orientation != undefined) {
+    if (screen.orientation != undefined) {
+      // There are some platforms where screen.orientation is defined but
+      // incomplete (e.g. Safari).
+      // Install a very simple polyfill in that case.
+      shaka.polyfill.Orientation.installBasedOnScreenMethods_();
+    } else if (window.orientation != undefined) {
+      // There is no way to check to see if the 'orientationchange' event exists
+      // on window, which could theoretically lead to this making a
+      // screen.orientation object that doesn't actually work.
+      // However, it looks like all platforms that support the deprecated
+      // window.orientation feature also support that event.
       shaka.polyfill.Orientation.installBasedOnWindowMethods_();
+    }
+  }
+
+  /**
+   * Modifies screen.orientation to add no-ops for missing methods.
+   * Meant for cases where screen.orientation is defined, but has missing
+   * methods that cannot be properly polyfilled.
+   * @private
+   */
+  static installBasedOnScreenMethods_() {
+    if (screen.orientation.lock === undefined) {
+      screen.orientation.lock = (orientation) => {
+        shaka.log.info('screen.orientation.lock is a no-op');
+        return Promise.resolve();
+      };
+    }
+    if (screen.orientation.unlock === undefined) {
+      screen.orientation.unlock = () => {
+        shaka.log.info('screen.orientation.unlock is a no-op');
+      };
     }
   }
 

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -622,9 +622,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
   /** @private */
   async exitFullScreen_() {
     if (document.fullscreenEnabled) {
-      // There are some platforms (e.g. Safari) where screen.orientation does
-      // not have the "unlock" method.
-      if (screen.orientation && screen.orientation.unlock !== undefined) {
+      if (screen.orientation) {
         screen.orientation.unlock();
       }
       await document.exitFullscreen();

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -622,7 +622,9 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
   /** @private */
   async exitFullScreen_() {
     if (document.fullscreenEnabled) {
-      if (screen.orientation) {
+      // There are some platforms (e.g. Safari) where screen.orientation does
+      // not have the "unlock" method.
+      if (screen.orientation && screen.orientation.unlock !== undefined) {
         screen.orientation.unlock();
       }
       await document.exitFullscreen();


### PR DESCRIPTION
`screen.orientation.unlock` is not defined on Safari, even though `screen.orientation` is.
This changes our orientation polyfill to add that method to `screen.orientation`.

Fixes #5437