### PR TITLE
ci: run tests in Docker

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -214,9 +214,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - name: Build Docker image
-        run: docker build -t shaka-player-build build/docker
-      - name: Build in Docker
-        run: docker run -v $(pwd):/usr/src --user $(id -u):$(id -g) shaka-player-build
-      - name: Test in Docker
-        run: docker run -v $(pwd):/usr/src --user $(id -u):$(id -g) shaka-player-build python3 build/test.py --quick --browsers ChromeHeadless
+
+      - name: Docker
+        run: |
+          docker build -t shaka-player-build build/docker
+          docker run -v $(pwd):/usr/src --user $(id -u):$(id -g) shaka-player-build

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -214,25 +214,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref || github.ref }}
-
+      - name: Build Docker image
+        run: docker build -t shaka-player-build build/docker
       - name: Build in Docker
-        run: |
-          docker build -t shaka-player-build build/docker
-          docker run -v $(pwd):/usr/src --user $(id -u):$(id -g) shaka-player-build
-
-  test_in_docker:
-    # Don't waste time doing a full matrix of test runs when there was an
-    # obvious linter error.
-    needs: lint
-    name: Docker
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
+        run: docker run -v $(pwd):/usr/src --user $(id -u):$(id -g) shaka-player-build
       - name: Test in Docker
-        run: |
-          docker build -t shaka-player-build build/docker
-          docker run -v $(pwd):/usr/src --user $(id -u):$(id -g) shaka-player-build python3 build/test.py --quick --browsers ChromeHeadless
+        run: docker run -v $(pwd):/usr/src --user $(id -u):$(id -g) shaka-player-build python3 build/test.py --quick --browsers ChromeHeadless

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -215,7 +215,24 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Docker
+      - name: Build in Docker
         run: |
           docker build -t shaka-player-build build/docker
           docker run -v $(pwd):/usr/src --user $(id -u):$(id -g) shaka-player-build
+
+  test_in_docker:
+    # Don't waste time doing a full matrix of test runs when there was an
+    # obvious linter error.
+    needs: lint
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Test in Docker
+        run: |
+          docker build -t shaka-player-build build/docker
+          docker run -v $(pwd):/usr/src --user $(id -u):$(id -g) shaka-player-build python3 build/test.py --quick --browsers ChromeHeadless

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -2,14 +2,17 @@
 #   docker build -t shaka-player-build /path/to/shaka-player/build/docker
 # Run with:
 #   docker run -v /path/to/shaka-player:/usr/src --user $(id -u):$(id -g) shaka-player-build
+# Run tests with:
+#   docker run -v /path/to/shaka-player:/usr/src --user $(id -u):$(id -g) shaka-player-build python3 build/test.py --quick --browsers ChromeHeadless
 
-FROM alpine:3.14
+FROM alpine:3.18
 
 # Install dependencies
 RUN apk add --update --no-cache \
-  bash git nodejs npm openjdk11-jre-headless python3
+  bash chromium chromium-chromedriver git nodejs npm openjdk11-jre-headless python3
 
 WORKDIR /usr/src
 ENV HOME /tmp
+ENV CHROMEDRIVER_PATH /usr/bin/chromedriver
 
 CMD ["python3", "build/all.py"]


### PR DESCRIPTION
This PR adds Chromium with webdriver to the Docker image, so it's now possible to run at least some subset of tests using Docker env.
Additionally, Alpine version has been bumped up, so recent version of Chromium can be used.