### PR TITLE
fix: Typing of PeriodCombiner.Period was incorrect

### DIFF
--- a/externs/shaka/manifest.js
+++ b/externs/shaka/manifest.js
@@ -101,6 +101,33 @@ shaka.extern.Manifest;
 
 /**
  * @typedef {{
+*   id: string,
+*   audioStreams: !Array.<shaka.extern.Stream>,
+*   videoStreams: !Array.<shaka.extern.Stream>,
+*   textStreams: !Array.<shaka.extern.Stream>,
+*   imageStreams: !Array.<shaka.extern.Stream>
+* }}
+*
+* @description Contains the streams from one DASH period.
+* For use in {@link shaka.util.PeriodCombiner}.
+*
+* @property {string} id
+*   The Period ID.
+* @property {!Array.<shaka.extern.Stream>} audioStreams
+*   The audio streams from one Period.
+* @property {!Array.<shaka.extern.Stream>} videoStreams
+*   The video streams from one Period.
+* @property {!Array.<shaka.extern.Stream>} textStreams
+*   The text streams from one Period.
+* @property {!Array.<shaka.extern.Stream>} imageStreams
+*   The image streams from one Period.
+*
+* @exportDoc
+*/
+shaka.extern.Period;
+
+/**
+ * @typedef {{
  *   initData: !Uint8Array,
  *   initDataType: string,
  *   keyId: ?string

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -590,7 +590,7 @@ shaka.dash.DashParser = class {
    * @param {!Array.<string>} baseUris
    * @param {!Element} mpd
    * @return {{
-   *   periods: !Array.<shaka.util.PeriodCombiner.Period>,
+   *   periods: !Array.<shaka.extern.Period>,
    *   duration: ?number,
    *   durationDerivedFromPeriods: boolean
    * }}
@@ -742,7 +742,7 @@ shaka.dash.DashParser = class {
    * @param {shaka.dash.DashParser.Context} context
    * @param {!Array.<string>} baseUris
    * @param {shaka.dash.DashParser.PeriodInfo} periodInfo
-   * @return {shaka.util.PeriodCombiner.Period}
+   * @return {shaka.extern.Period}
    * @private
    */
   parsePeriod_(context, baseUris, periodInfo) {

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -104,7 +104,7 @@ shaka.util.PeriodCombiner = class {
   }
 
   /**
-   * @param {!Array.<shaka.util.PeriodCombiner.Period>} periods
+   * @param {!Array.<shaka.extern.Period>} periods
    * @param {boolean} isDynamic
    * @return {!Promise}
    *
@@ -262,7 +262,7 @@ shaka.util.PeriodCombiner = class {
   }
 
   /**
-   * @param {!Array.<shaka.util.PeriodCombiner.Period>} periods
+   * @param {!Array.<shaka.extern.Period>} periods
    * @private
    */
   static filterOutAudioStreamDuplicates_(periods) {
@@ -299,7 +299,7 @@ shaka.util.PeriodCombiner = class {
   }
 
   /**
-   * @param {!Array.<shaka.util.PeriodCombiner.Period>} periods
+   * @param {!Array.<shaka.extern.Period>} periods
    * @private
    */
   static filterOutTextStreamDuplicates_(periods) {
@@ -333,7 +333,7 @@ shaka.util.PeriodCombiner = class {
   }
 
   /**
-   * @param {!Array.<shaka.util.PeriodCombiner.Period>} periods
+   * @param {!Array.<shaka.extern.Period>} periods
    * @private
    */
   static filterOutVideoStreamDuplicates_(periods) {
@@ -370,7 +370,7 @@ shaka.util.PeriodCombiner = class {
   }
 
   /**
-   * @param {!Array.<shaka.util.PeriodCombiner.Period>} periods
+   * @param {!Array.<shaka.extern.Period>} periods
    * @private
    */
   static filterOutImageStreamDuplicates_(periods) {
@@ -1638,32 +1638,6 @@ shaka.util.PeriodCombiner = class {
     return EQUAL;
   }
 };
-
-/**
- * @typedef {{
- *   id: string,
- *   audioStreams: !Array.<shaka.extern.Stream>,
- *   videoStreams: !Array.<shaka.extern.Stream>,
- *   textStreams: !Array.<shaka.extern.Stream>,
- *   imageStreams: !Array.<shaka.extern.Stream>
- * }}
- *
- * @description Contains the streams from one DASH period.
- *
- * @property {string} id
- *   The Period ID.
- * @property {!Array.<shaka.extern.Stream>} audioStreams
- *   The audio streams from one Period.
- * @property {!Array.<shaka.extern.Stream>} videoStreams
- *   The video streams from one Period.
- * @property {!Array.<shaka.extern.Stream>} textStreams
- *   The text streams from one Period.
- * @property {!Array.<shaka.extern.Stream>} imageStreams
- *   The image streams from one Period.
- *
- * @export
- */
-shaka.util.PeriodCombiner.Period;
 
 /**
  * @enum {number}

--- a/test/util/periods_unit.js
+++ b/test/util/periods_unit.js
@@ -29,7 +29,7 @@ describe('PeriodCombiner', () => {
   });
 
   it('Ad insertion - join during main content', async () => {
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: 'main',
@@ -112,7 +112,7 @@ describe('PeriodCombiner', () => {
   });
 
   it('Ad insertion - join during ad', async () => {
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: 'ad',
@@ -190,7 +190,7 @@ describe('PeriodCombiner', () => {
   });
 
   it('Ad insertion - smaller ad, res not found in main content', async () => {
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -240,7 +240,7 @@ describe('PeriodCombiner', () => {
   });
 
   it('Ad insertion - larger ad, res not found in main content', async () => {
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -288,7 +288,7 @@ describe('PeriodCombiner', () => {
   });
 
   it('Language changes during and after an ad', async () => {
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: 'show1',
@@ -368,7 +368,7 @@ describe('PeriodCombiner', () => {
   });
 
   it('VOD playlist of completely unrelated periods', async () => {
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: 'show1',
@@ -421,7 +421,7 @@ describe('PeriodCombiner', () => {
     /** @type {shaka.extern.Stream} */
     const video2 = makeVideoStream(480);
     video2.bandwidth = 2;
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -538,7 +538,7 @@ describe('PeriodCombiner', () => {
     const i3 = makeImageStream(240);
     i3.originalId = 'i3';
 
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -606,7 +606,7 @@ describe('PeriodCombiner', () => {
   // Regression test for #3383, where we failed on multi-period content with
   // multiple image streams per period.
   it('Can handle multiple image streams', async () => {
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -647,7 +647,7 @@ describe('PeriodCombiner', () => {
   });
 
   it('handles text track gaps', async () => {
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -714,7 +714,7 @@ describe('PeriodCombiner', () => {
   });
 
   it('handles image track gaps', async () => {
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -778,7 +778,7 @@ describe('PeriodCombiner', () => {
   });
 
   it('Disjoint audio channels', async () => {
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -826,7 +826,7 @@ describe('PeriodCombiner', () => {
       return stream;
     };
 
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -874,7 +874,7 @@ describe('PeriodCombiner', () => {
       return stream;
     };
 
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -918,7 +918,7 @@ describe('PeriodCombiner', () => {
     const newCodec = makeVideoStream(720);
     newCodec.codecs = 'foo.abcd';
 
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -970,7 +970,7 @@ describe('PeriodCombiner', () => {
     stream4.codecs = 'mp4a.40.2';
     stream4.roles = ['description'];
 
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '0',
@@ -1052,7 +1052,7 @@ describe('PeriodCombiner', () => {
     stream8.bandwidth = 120000;
     stream8.codecs = 'vp09.01.20.08.01';
 
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '0',
@@ -1110,7 +1110,7 @@ describe('PeriodCombiner', () => {
     const stream4 = makeAudioStreamWithRoles(['role1']);
     stream4.originalId = 'stream4';
 
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -1152,7 +1152,7 @@ describe('PeriodCombiner', () => {
   });
 
   it('Matches streams with roles in common', async () => {
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',
@@ -1204,7 +1204,7 @@ describe('PeriodCombiner', () => {
   });
 
   it('Matches streams with mismatched roles', async () => {
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '0',
@@ -1381,7 +1381,7 @@ describe('PeriodCombiner', () => {
     v20.frameRate = 24000/1001;
     v20.bandwidth = 570005990000;
 
-    /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
+    /** @type {!Array.<shaka.extern.Period>} */
     const periods = [
       {
         id: '1',


### PR DESCRIPTION
When we exported `PeriodCombiner` in https://github.com/shaka-project/shaka-player/pull/5324 we added an `@export` to `PeriodCombiner.Period`, and since then we've been testing in our dogfood builds using shaka-player.compiled.debug, because we like to get logs from dogfood. Everything was working great.

When we went to switch over to the production build, we realized that `@export` on a `typedef` doesn't really work because the type gets minified internally!!

This PR moves `Period` over to `extern` so that it does not get minified and can be used externally.