### PR TITLE
test: Drop --lets-encrypt-folder from test.py

### DIFF
--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -251,7 +251,8 @@ jobs:
           python3 build/test.py \
               --no-build \
               --reporters spec --spec-hide-passed \
-              --lets-encrypt-folder /etc/shakalab.rocks \
+              --tls-key /etc/letsencrypt/live/karma.shakalab.rocks/privkey.pem \
+              --tls-cert /etc/letsencrypt/live/karma.shakalab.rocks/fullchain.pem \
               --hostname karma.shakalab.rocks \
               --port $KARMA_PORT \
               --grid-config build/shaka-lab.yaml \

--- a/build/test.py
+++ b/build/test.py
@@ -358,11 +358,6 @@ class Launcher:
     networking_commands.add_argument(
         '--tls-cert',
         help='Specify a TLS cert to serve tests over HTTPs.')
-    networking_commands.add_argument(
-        '--lets-encrypt-folder',
-        help="Specify a Let's Encrypt folder to search for the latest key and "
-             "cert, to serve tests over HTTPs.  This overrides --tls-key and "
-             "--tls-cert.")
 
 
     pre_launch_commands.add_argument(
@@ -440,26 +435,6 @@ class Launcher:
         self.karma_config['capture_timeout'] = SELENIUM_CAPTURE_TIMEOUT
       else:
         self.karma_config['capture_timeout'] = LOCAL_CAPTURE_TIMEOUT
-
-    self._HandleLetsEncryptConfig()
-
-  def _HandleLetsEncryptConfig(self):
-    folder = self.parsed_args.lets_encrypt_folder
-    if not folder:
-      return
-
-    max_serial_number = 0
-    # Go through the contents of the folder to find the latest key & cert.
-    for file_name in os.listdir(folder):
-      matches = re.match(r'(?:privkey|fullchain)(\d+).pem', file_name)
-      if matches:
-        serial_number = int(matches.group(1))
-        max_serial_number = max(max_serial_number, serial_number)
-
-    self.karma_config['tls_key'] = os.path.join(
-        folder, 'privkey{}.pem'.format(max_serial_number))
-    self.karma_config['tls_cert'] = os.path.join(
-        folder, 'fullchain{}.pem'.format(max_serial_number))
 
   def ResolveBrowsers(self, default_browsers):
     """Decide what browsers we should use.


### PR DESCRIPTION
When we first deployed certificates from letsencrypt, we did not know about the "live" folder, which contains helpful symlinks to the latest certificate.  Instead, we were copying the entire "archive" folder, which contains even old certs, then searching that folder for the latest version.  We should be using the "live" folder instead, letting certbot maintain the symlinks.  This means there is no need for --lets-encrypt-folder in test.py.