### PR TITLE
fix: Default language to 'und' for native tracks

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1385,13 +1385,15 @@ shaka.util.StreamUtils = class {
    * @private
    */
   static html5TrackToGenericShakaTrack_(html5Track) {
+    const language = html5Track.language;
+
     /** @type {shaka.extern.Track} */
     const track = {
       id: shaka.util.StreamUtils.html5TrackId(html5Track),
       active: false,
       type: '',
       bandwidth: 0,
-      language: shaka.util.LanguageUtils.normalize(html5Track.language),
+      language: shaka.util.LanguageUtils.normalize(language || 'und'),
       label: html5Track.label,
       kind: html5Track.kind,
       width: null,
@@ -1422,7 +1424,7 @@ shaka.util.StreamUtils = class {
       originalTextId: null,
       originalImageId: null,
       accessibilityPurpose: null,
-      originalLanguage: html5Track.language,
+      originalLanguage: language,
     };
 
     return track;


### PR DESCRIPTION
Set default language to `und` for native audio/text tracks if missing.