### PR TITLE
test: Deflake slow SegmentIndex test

### DIFF
--- a/test/media/segment_index_unit.js
+++ b/test/media/segment_index_unit.js
@@ -1026,9 +1026,9 @@ describe('SegmentIndex', /** @suppress {accessControls} */ () => {
           return [newRefs.shift()];
         });
       });
-      // Wait long enough for all three new refs to be appended.
-      // Or for all of the new refs to be passed out.
-      await Promise.race([shaka.test.Util.delay(1), done]);
+
+      // Wait for the new refs to be appended.
+      await done;
 
       expect(Array.from(metaIndex)).toEqual(oldRefs.concat(inputRefs2));
     });


### PR DESCRIPTION
We used to have a timeout of 1s, for a test that could theoretically complete in 0.3s.  However, on heavily-loaded test devices, this was failing on occasion.

Now, we just wait for completion with no timeout.  The default timeout of 120s per test will trigger if the test truly fails.