### PR TITLE
test: Deflake UI test teardown

### DIFF
--- a/test/test/util/ui_utils.js
+++ b/test/test/util/ui_utils.js
@@ -115,11 +115,18 @@ shaka.test.UiUtils = class {
       // Destroying the UI destroys the controls and player inside.
       destroys.push(ui.destroy());
     }
-    await Promise.all(destroys);
+
+    const allDestroyed = Promise.all(destroys);
+    // 10 seconds should be more than enough to tear down the UI.
+    // Adding this silent timeout fixes several tests that inconsistently hang
+    // during teardown and cause failures in afterEach() clauses.
+    await Promise.race([allDestroyed, shaka.test.Util.delay(10)]);
 
     // Now remove all the containers from the DOM.
     for (const container of containers) {
-      container.parentElement.removeChild(container);
+      if (container.parentElement) {
+        container.parentElement.removeChild(container);
+      }
     }
   }
 


### PR DESCRIPTION
Some UI tests would fail with a timeout during teardown.  This may indicate some condition in which player.destroy() could hang, though I have been unable to replicate that hypothetical condition in an explicit unit test.

Since that issue has nothing to do with the UI tests, set a 10-second timeout for UI teardown, after which we move on without a failure.

This also adds a check for container.parentElement before removing child elements, since at least once I saw an exception during test teardown from an element that was already removed from its parent by that point.