### PR TITLE
test: Deflake demo tests

### DIFF
--- a/test/test/util/fake_demo_main.js
+++ b/test/test/util/fake_demo_main.js
@@ -12,9 +12,13 @@
  */
 shaka.test.FakeDemoMain = class {
   constructor() {
-    this.video = /** @type {!HTMLVideoElement} */ (
-      document.createElement('video'));
-    this.player = new shaka.Player(this.video);
+    // Using the player's constructor argument to attach a video element seems
+    // to cause flaky timeouts on teardown.  If a video element is needed in
+    // the future, please explicitly call attach(video) and await the result
+    // during the test setup.
+    /** @type {!shaka.Player} */
+    this.player = new shaka.Player();
+
     this.config_ = this.player.getConfiguration();
     this.selectedAsset = null;
 


### PR DESCRIPTION
The demo tests occasionally timeout, in spite of being synchronous test cases.  This is because of an async teardown process between tests, which can sometimes hang.

This may indicate some condition in which player.destroy() could hang, though I have been unable to replicate that hypothetical condition in an explicit unit test.

The hang goes away if we don't attach to the video element.  Since the tests don't use the video element directly or attempt to load any content, we can just skip the video element attachment.

Another thing that appears to resolve the hang is to await attach(), so a comment has been left to warn anyone modifying the code in the future not to use the constructor argument to attach a video element.