### PR TITLE
test: Fix prefetch test pollution

### DIFF
--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -3936,19 +3936,24 @@ describe('StreamingEngine', () => {
   describe('prefetch segments', () => {
     const segmentType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
 
+    let OriginalSegmentPrefetch;
+
     beforeEach(() => {
-      shaka.media.SegmentPrefetch = Util.spyFunc(
-          jasmine.createSpy('SegmentPrefetch')
-              .and.callFake((config, stream) =>
-                new shaka.test.FakeSegmentPrefetch(stream, segmentData),
-              ),
-      );
+      OriginalSegmentPrefetch = shaka.media.SegmentPrefetch;
+      shaka.media.SegmentPrefetch = function(config, stream) {
+        return new shaka.test.FakeSegmentPrefetch(stream, segmentData);
+      };
+
       setupVod();
       mediaSourceEngine = new shaka.test.FakeMediaSourceEngine(segmentData);
       createStreamingEngine();
       const config = shaka.util.PlayerConfiguration.createDefault().streaming;
       config.segmentPrefetchLimit = 3;
       streamingEngine.configure(config);
+    });
+
+    afterEach(() => {
+      shaka.media.SegmentPrefetch = OriginalSegmentPrefetch;
     });
 
     it('should use prefetched segment without fetching again', async () => {


### PR DESCRIPTION
The prefetch tests overwrite SegmentPrefetch with a fake version, but never restored it.  This left the API polluted with a fake.  This fixes that by backing up the original and restoring it after testing.

They also used createSpy in a way that caused runtime failures when babel was disabled (test.py --disable-babel), since the constructor spy can't be invoked with "new".  Babel translation masked this by rewriting ES6 classes.  Since no expectations were ever set on the spy, we can do away with it and simply replace the constructor with a function that can be invoked with "new" in all cases.