### PR TITLE
test: Disable power-saving features on both Chrome and Edge

### DIFF
--- a/build/shaka-lab.yaml
+++ b/build/shaka-lab.yaml
@@ -32,10 +32,33 @@ vars:
         # Normally, Chrome disallows autoplaying videos in many cases.  Enable
         # it for testing.
         - "--autoplay-policy=no-user-gesture-required"
+        # Disable browser features that try to save power by suspending media,
+        # throttling timers, etc.
+        - "--disable-background-media-suspend"
+        - "--disable-background-timer-throttling"
+        - "--disable-backgrounding-occluded-windows"
 
-      # Instruct chromedriver not to disable component updater. The
-      # component updater must run in order for the Widevine CDM to be
-      # available when using a new user-data-dir.
+      # Instruct chromedriver not to disable component updater. The component
+      # updater must run in order for the Widevine CDM to be available when
+      # using a new user-data-dir.
+      excludeSwitches:
+        - "disable-component-update"
+
+  basic_edge_config: &basic_edge_config
+    ms:edgeOptions:
+      args:
+        # Normally, Edge disallows autoplaying videos in many cases.  Enable it
+        # for testing.
+        - "--autoplay-policy=no-user-gesture-required"
+        # Disable browser features that try to save power by suspending media,
+        # throttling timers, etc.
+        - "--disable-background-media-suspend"
+        - "--disable-background-timer-throttling"
+        - "--disable-backgrounding-occluded-windows"
+
+      # Instruct edgedriver not to disable component updater. The component
+      # updater must run in order for the Widevine CDM to be available when
+      # using a new user-data-dir.
       excludeSwitches:
         - "disable-component-update"
 
@@ -73,6 +96,11 @@ vars:
       # Allow remote attestation even though the device may be in dev mode.  This
       # is critical for testing involving L1 content licenses.
       - "--allow-ra-in-dev-mode"
+      # Disable browser features that try to save power by suspending media,
+      # throttling timers, etc.
+      - "--disable-background-media-suspend"
+      - "--disable-background-timer-throttling"
+      - "--disable-backgrounding-occluded-windows"
 
   safari_tp_config: &safari_tp_config
     safari.options:
@@ -96,6 +124,8 @@ FirefoxMac:
 EdgeMac:
   browser: msedge
   os: Mac
+  extra_configs:
+    - *basic_edge_config
 
 Safari:
   browser: safari
@@ -127,6 +157,8 @@ FirefoxWindows:
 Edge:
   browser: msedge
   os: Windows
+  extra_configs:
+    - *basic_edge_config
 
 
 ### Linux ###
@@ -146,6 +178,8 @@ FirefoxLinux:
 EdgeLinux:
   browser: msedge
   os: Linux
+  extra_configs:
+    - *basic_edge_config
 
 
 ### Misc ###

--- a/test/media/drm_engine_integration.js
+++ b/test/media/drm_engine_integration.js
@@ -247,7 +247,7 @@ describe('DrmEngine', () => {
           /* hasClosedCaptions= */ false);
 
       expect(video.buffered.end(0)).toBeGreaterThan(0);
-      video.play();
+      await video.play();
 
       const waiter = new shaka.test.Waiter(eventManager).timeoutAfter(15);
       waiter.setMediaSourceEngine(mediaSourceEngine);
@@ -330,7 +330,7 @@ describe('DrmEngine', () => {
           /* hasClosedCaptions= */ false);
 
       expect(video.buffered.end(0)).toBeGreaterThan(0);
-      video.play();
+      await video.play();
 
       const waiter = new shaka.test.Waiter(eventManager).timeoutAfter(15);
       waiter.setMediaSourceEngine(mediaSourceEngine);

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -57,6 +57,9 @@ describe('StreamingEngine', () => {
   beforeEach(() => {
     config = shaka.util.PlayerConfiguration.createDefault().streaming;
 
+    // Disable stall detection, which can interfere with playback tests.
+    config.stallEnabled = false;
+
     onError = jasmine.createSpy('onError');
     onError.and.callFake(fail);
     onEvent = jasmine.createSpy('onEvent');
@@ -279,7 +282,7 @@ describe('StreamingEngine', () => {
       // Let's go!
       streamingEngine.switchVariant(variant);
       await streamingEngine.start();
-      video.play();
+      await video.play();
       // The overall test timeout is 120 seconds, and the content is 40
       // seconds.  It should be possible to complete this test in 100 seconds,
       // and if not, we want the error thrown to be within the overall test's
@@ -299,7 +302,7 @@ describe('StreamingEngine', () => {
       // Let's go!
       streamingEngine.switchVariant(variant);
       await streamingEngine.start();
-      video.play();
+      await video.play();
 
       // Wait for playback to begin before increasing the playback rate.  This
       // improves test reliability on slow platforms like Chromecast.
@@ -313,7 +316,7 @@ describe('StreamingEngine', () => {
       // Let's go!
       streamingEngine.switchVariant(variant);
       await streamingEngine.start();
-      video.play();
+      await video.play();
 
       // After 35 seconds seek back 10 seconds into the first Period.
       await waiter.timeoutAfter(80).waitUntilPlayheadReaches(video, 35);
@@ -325,7 +328,7 @@ describe('StreamingEngine', () => {
       // Let's go!
       streamingEngine.switchVariant(variant);
       await streamingEngine.start();
-      video.play();
+      await video.play();
       await waiter.timeoutAfter(60).waitUntilPlayheadReaches(video, 20);
       video.currentTime = 40;
       await waiter.timeoutAfter(60).waitForEnd(video);
@@ -353,7 +356,7 @@ describe('StreamingEngine', () => {
       streamingEngine.switchVariant(variant);
       await streamingEngine.start();
 
-      video.play();
+      await video.play();
       await waiter.timeoutAfter(60).waitUntilPlayheadReaches(video, 305);
 
       const segmentType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
@@ -376,7 +379,7 @@ describe('StreamingEngine', () => {
       // Seek outside the availability window right away. The playhead
       // should adjust the video's current time.
       video.currentTime = segmentAvailability.end + 120;
-      video.play();
+      await video.play();
 
       // Wait until the repositioning is complete so we don't
       // immediately hit this case.
@@ -401,7 +404,7 @@ describe('StreamingEngine', () => {
       video.currentTime = segmentAvailability.start - 120;
       expect(video.currentTime).toBeGreaterThan(0);
 
-      video.play();
+      await video.play();
       await waiter.timeoutAfter(60).waitUntilPlayheadReaches(video, 305);
 
       // We are playing close to the beginning of the availability window.
@@ -429,7 +432,7 @@ describe('StreamingEngine', () => {
       // Let's go!
       streamingEngine.switchVariant(variant);
       await streamingEngine.start();
-      video.play();
+      await video.play();
 
       await waiter.timeoutAfter(5).waitUntilPlayheadReaches(video, 0.01);
       expect(video.buffered.length).toBeGreaterThan(0);
@@ -444,7 +447,7 @@ describe('StreamingEngine', () => {
       // Let's go!
       streamingEngine.switchVariant(variant);
       await streamingEngine.start();
-      video.play();
+      await video.play();
 
       await waiter.timeoutAfter(5).waitUntilPlayheadReaches(video, 0.01);
       expect(video.buffered.length).toBeGreaterThan(0);
@@ -463,7 +466,7 @@ describe('StreamingEngine', () => {
       await waiter.timeoutAfter(5).waitForEvent(video, 'loadeddata');
 
       video.currentTime = 8;
-      video.play();
+      await video.play();
 
       await waiter.timeoutAfter(60).waitUntilPlayheadReaches(video, 23);
       // Should be close enough to still have the gap buffered.
@@ -480,7 +483,7 @@ describe('StreamingEngine', () => {
       await waiter.timeoutAfter(5).waitForEvent(video, 'loadeddata');
 
       video.currentTime = 8;
-      video.play();
+      await video.play();
 
       await waiter.timeoutAfter(60).waitUntilPlayheadReaches(video, 23);
       // Should be close enough to still have the gap buffered.

--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -33,6 +33,9 @@ filterDescribe('Offline', supportsStorage, () => {
     player = new shaka.Player(video);
     player.addEventListener('error', fail);
 
+    // Disable stall detection, which can interfere with playback tests.
+    player.configure('streaming.stallEnabled', false);
+
     eventManager = new shaka.util.EventManager();
     waiter = new shaka.test.Waiter(eventManager);
     waiter.setPlayer(player);
@@ -67,7 +70,7 @@ filterDescribe('Offline', supportsStorage, () => {
 
     await player.load(contentUri);
 
-    video.play();
+    await video.play();
     await playTo(/* end= */ 3, /* timeout= */ 20);
     await player.unload();
     await storage.remove(contentUri);
@@ -103,7 +106,7 @@ filterDescribe('Offline', supportsStorage, () => {
 
         await player.load(contentUri);
 
-        video.play();
+        await video.play();
         await playTo(/* end= */ 3, /* timeout= */ 20);
         await player.unload();
         await storage.remove(contentUri);
@@ -146,7 +149,7 @@ filterDescribe('Offline', supportsStorage, () => {
 
         await player.load(contentUri);
 
-        video.play();
+        await video.play();
         await playTo(/* end= */ 3, /* timeout= */ 20);
         await player.unload();
         await storage.remove(contentUri);

--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -34,6 +34,9 @@ describe('Player', () => {
     await shaka.test.TestScheme.createManifests(compiledShaka, '_compiled');
     player = new compiledShaka.Player(video);
 
+    // Disable stall detection, which can interfere with playback tests.
+    player.configure('streaming.stallEnabled', false);
+
     // Grab event manager from the uncompiled library:
     eventManager = new shaka.util.EventManager();
     waiter = new shaka.test.Waiter(eventManager);
@@ -81,11 +84,15 @@ describe('Player', () => {
       // Unlike the other tests in this file, this uses an uncompiled build of
       // Shaka, so that we don't need to expose shaka.util.Timer.activeTimers.
       player = new shaka.Player(video);
+
+      // Disable stall detection, which can interfere with playback tests.
+      player.configure('streaming.stallEnabled', false);
+
       waiter.setPlayer(player);
 
       // Play the video for a little while.
       await player.load('test:sintel');
-      video.play();
+      await video.play();
       await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 1, 10);
 
       // Destroy the player.
@@ -127,7 +134,7 @@ describe('Player', () => {
             }
           });
       await player.load('test:sintel_compiled');
-      video.play();
+      await video.play();
       await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 25, 30);
       expect(results).toEqual(expected);
     });
@@ -139,7 +146,7 @@ describe('Player', () => {
       // This is tested more in player_unit.js.  This is here to test the public
       // API and to check for renaming.
       await player.load('test:sintel_compiled');
-      video.play();
+      await video.play();
       await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 1, 10);
 
       const stats = player.getStats();
@@ -210,7 +217,7 @@ describe('Player', () => {
 
     it('does not cause cues to be null', async () => {
       await player.load('test:sintel_compiled');
-      video.play();
+      await video.play();
       await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 1, 10);
 
       // This TextTrack was created as part of load() when we set up the
@@ -249,7 +256,7 @@ describe('Player', () => {
       await player.load('test:sintel_realistic_compiled');
 
       // Play until a time at which the external cues would be on screen.
-      video.play();
+      await video.play();
       await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 4, 20);
 
       expect(player.isTextTrackVisible()).toBe(true);
@@ -281,7 +288,7 @@ describe('Player', () => {
       await waiter.waitForEvent(player, 'texttrackvisibility');
 
       // Play until a time at which the external cues would be on screen.
-      video.play();
+      await video.play();
       await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 4, 20);
 
       expect(player.isTextTrackVisible()).toBe(true);
@@ -352,7 +359,7 @@ describe('Player', () => {
       player.setTextTrackVisibility(true);
       player.selectTextLanguage('fr');
       video.currentTime = 5;
-      video.play();
+      await video.play();
       await waiter.waitForMovementOrFailOnTimeout(video, 10);
 
       expect(video.textTracks[0].activeCues.length).toBe(1);
@@ -544,7 +551,7 @@ describe('Player', () => {
 
     it('at higher playback rates', async () => {
       await player.load('test:sintel_compiled');
-      video.play();
+      await video.play();
       await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 1, 10);
 
       // Enabling trick play should change our playback rate to the same rate.
@@ -560,13 +567,11 @@ describe('Player', () => {
     });
 
     it('in sequence mode', async () => {
-      const testSchemeMimeType = 'application/x-test-manifest';
-      player = new compiledShaka.Player(video);
-      await player.load('test:sintel_sequence_compiled', 0, testSchemeMimeType);
+      await player.load('test:sintel_sequence_compiled');
       expect(player.getManifest().sequenceMode).toBe(true);
 
       // Ensure the video plays.
-      video.play();
+      await video.play();
       await waiter.timeoutAfter(20).waitUntilPlayheadReaches(video, 5);
 
       // Seek the video, and see if it can continue playing from that point.
@@ -586,9 +591,8 @@ describe('Player', () => {
     // even if one is not specified in load().
     it('immediately after construction with MIME type', async () => {
       const testSchemeMimeType = 'application/x-test-manifest';
-      player = new compiledShaka.Player(video);
       await player.load('test:sintel_compiled', 0, testSchemeMimeType);
-      video.play();
+      await video.play();
       await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 1, 10);
     });
 
@@ -627,7 +631,7 @@ describe('Player', () => {
     // Regression test for https://github.com/shaka-project/shaka-player/issues/1187
     it('does not throw on destroy', async () => {
       await player.load('test:sintel_compiled');
-      video.play();
+      await video.play();
       await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 1, 10);
       await player.unload();
       // Before we fixed #1187, the call to destroy() on textDisplayer was
@@ -873,7 +877,7 @@ describe('Player', () => {
       player.configure('streaming.observeQualityChanges', true);
 
       await player.load('test:sintel_compiled');
-      video.play();
+      await video.play();
 
       // Wait for the video to start playback.  If it takes longer than 10
       // seconds, fail the test.
@@ -887,7 +891,7 @@ describe('Player', () => {
       player.configure('streaming.observeQualityChanges', false);
 
       await player.load('test:sintel_compiled');
-      video.play();
+      await video.play();
 
       // Wait for the video to start playback.  If it takes longer than 10
       // seconds, fail the test.
@@ -916,7 +920,7 @@ describe('Player', () => {
 
       // Play the stream.
       await player.load('/base/test/test/assets/3675/dash_0.mpd');
-      video.play();
+      await video.play();
 
       // Wait for the stream to be over.
       eventManager.listen(player, 'error', Util.spyFunc(onErrorSpy));

--- a/test/player_src_equals_integration.js
+++ b/test/player_src_equals_integration.js
@@ -27,6 +27,10 @@ describe('Player Src Equals', () => {
   beforeEach(() => {
     player = new shaka.Player();
     player.addEventListener('error', fail);
+
+    // Disable stall detection, which can interfere with playback tests.
+    player.configure('streaming.stallEnabled', false);
+
     eventManager = new shaka.util.EventManager();
     waiter = new shaka.test.Waiter(eventManager);
   });
@@ -101,7 +105,7 @@ describe('Player Src Equals', () => {
     expect(video.duration).not.toBeCloseTo(0);
 
     // Start playback and wait for the playhead to move.
-    video.play();
+    await video.play();
     await waiter.waitForMovementOrFailOnTimeout(video, /* timeout= */10);
 
     // Make sure the playhead is roughly where we expect it to be before
@@ -138,7 +142,7 @@ describe('Player Src Equals', () => {
     await loadWithSrcEquals(SMALL_MP4_CONTENT_URI, /* startTime= */ null);
 
     // For playback to begin so that we have some content buffered.
-    video.play();
+    await video.play();
     await waiter.waitForMovementOrFailOnTimeout(video, /* timeout= */10);
 
     const buffered = player.getBufferedInfo();
@@ -162,7 +166,7 @@ describe('Player Src Equals', () => {
     await loadWithSrcEquals(SMALL_MP4_CONTENT_URI, /* startTime= */ null);
 
     // Let playback run for a little.
-    video.play();
+    await video.play();
     await waiter.waitForMovementOrFailOnTimeout(video, /* timeout= */10);
 
     let videoRateChange = false;
@@ -279,7 +283,7 @@ describe('Player Src Equals', () => {
     expect(video.currentTime).toBeCloseTo(0);
 
     // Start playback and wait. We should see the playhead move.
-    video.play();
+    await video.play();
     await waiter.waitForMovementOrFailOnTimeout(video, /* timeout= */10);
     await shaka.test.Util.delay(1.5);
 
@@ -296,7 +300,7 @@ describe('Player Src Equals', () => {
 
     // Wait some time for playback to start so that we will have a load latency
     // value.
-    video.play();
+    await video.play();
     await waiter.waitForMovementOrFailOnTimeout(video, /* timeout= */10);
 
     // Get the stats and check that some stats have been filled in.

--- a/test/test/util/layout_tests.js
+++ b/test/test/util/layout_tests.js
@@ -395,7 +395,7 @@ shaka.test.NativeTextLayoutTests = class extends shaka.test.TextLayoutTests {
     // The this.video must be played a little now, after the cues were appended,
     // but before the screenshot.
     this.video.playbackRate = 1;
-    this.video.play();
+    await this.video.play();
     await this.waiter.failOnTimeout(false).timeoutAfter(5)
         .waitForMovement(this.video);
     this.video.pause();
@@ -404,7 +404,7 @@ shaka.test.NativeTextLayoutTests = class extends shaka.test.TextLayoutTests {
     this.video.currentTime = time;
     // Get into a playing state, but without movement.
     this.video.playbackRate = 0;
-    this.video.play();
+    await this.video.play();
 
     // Add a short delay to ensure that the system has caught up and that
     // native text displayers have been updated by the browser.

--- a/test/transmuxer/transmuxer_integration.js
+++ b/test/transmuxer/transmuxer_integration.js
@@ -45,6 +45,9 @@ describe('Transmuxer Player', () => {
     player.configure('mediaSource.forceTransmux', true);
     player.configure('streaming.useNativeHlsOnSafari', false);
 
+    // Disable stall detection, which can interfere with playback tests.
+    player.configure('streaming.stallEnabled', false);
+
     // Grab event manager from the uncompiled library:
     eventManager = new shaka.util.EventManager();
     waiter = new shaka.test.Waiter(eventManager);
@@ -70,7 +73,7 @@ describe('Transmuxer Player', () => {
 
     await player.load(url, /* startTime= */ null,
         /* mimeType= */ undefined);
-    video.play();
+    await video.play();
     expect(player.isLive()).toBe(false);
 
     // Wait for the video to start playback.  If it takes longer than 10
@@ -93,7 +96,7 @@ describe('Transmuxer Player', () => {
 
     await player.load(url, /* startTime= */ null,
         /* mimeType= */ undefined);
-    video.play();
+    await video.play();
     expect(player.isLive()).toBe(false);
 
     // Wait for the video to start playback.  If it takes longer than 10
@@ -131,7 +134,7 @@ describe('Transmuxer Player', () => {
 
     await player.load(url, /* startTime= */ null,
         /* mimeType= */ undefined);
-    video.play();
+    await video.play();
     expect(player.isLive()).toBe(false);
 
     // Wait for the video to start playback.  If it takes longer than 10
@@ -165,7 +168,7 @@ describe('Transmuxer Player', () => {
 
     await player.load(url, /* startTime= */ null,
         /* mimeType= */ undefined);
-    video.play();
+    await video.play();
     expect(player.isLive()).toBe(false);
 
     // Wait for the video to start playback.  If it takes longer than 10
@@ -185,7 +188,7 @@ describe('Transmuxer Player', () => {
 
     await player.load(url, /* startTime= */ null,
         /* mimeType= */ undefined);
-    video.play();
+    await video.play();
     expect(player.isLive()).toBe(false);
 
     // Wait for the video to start playback.  If it takes longer than 10
@@ -205,7 +208,7 @@ describe('Transmuxer Player', () => {
 
     await player.load(url, /* startTime= */ null,
         /* mimeType= */ undefined);
-    video.play();
+    await video.play();
     expect(player.isLive()).toBe(false);
 
     // Wait for the video to start playback.  If it takes longer than 10
@@ -225,7 +228,7 @@ describe('Transmuxer Player', () => {
 
     await player.load(url, /* startTime= */ null,
         /* mimeType= */ undefined);
-    video.play();
+    await video.play();
     expect(player.isLive()).toBe(false);
 
     // Wait for the video to start playback.  If it takes longer than 10


### PR DESCRIPTION
Power-saving features on Chrome and Edge were subtly interfering with playback tests.  Timers could be throttled, and both video-only media and media in occluded windows could be paused by the browser.

This was discovered only after awaiting play() Promises in all tests. These Promises were being rejected with useful error messages that led to these discoveries.

Awaiting play() requires us to disable stall detection during playback tests.  This is because on some platforms, stalls get resolved by calling pause() and then play(), which would cause the original awaited play() Promise to be rejected.

Finally, some Player tests created additional Player instances that were unnecessary.  Removing those allowed me to centralize most of the configuration to disable stall detection.