### PR TITLE
test: Fix playback test timeouts on Safari

### DIFF
--- a/test/test/util/waiter.js
+++ b/test/test/util/waiter.js
@@ -394,7 +394,7 @@ shaka.test.Waiter = class {
    * @private
    */
   macPlaybackWorkaround_(mediaElement) {
-    if (shaka.util.Platform.isMac()) {
+    if (shaka.util.Platform.isMac() && !shaka.util.Platform.safariVersion()) {
       // Work around bizarre playback slowdowns that only seem to occur with
       // WebDriver and only on Mac.  Increasing the playback rate allows tests
       // to complete without timing out.


### PR DESCRIPTION
Related to https://github.com/shaka-project/shaka-player/pull/5504

This PR reduce the number of errors in transmuxer integration tests.