### PR TITLE
ci: Update environment variable name for runner port

### DIFF
--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -221,9 +221,9 @@ jobs:
 
       # Run tests on the Selenium grid in our lab.  This uses a private
       # hostname and TLS cert to get EME tests working on all platforms
-      # (since EME only works on https or localhost).  The variable KARMA_PORT
-      # must be defined by the self-hosted runner, and mapped from the host to
-      # the container.
+      # (since EME only works on https or localhost).  The variable
+      # ALLOCATED_PORT must be defined by the self-hosted runner, and mapped
+      # from the host to the container.
       - name: Test Player
         run: |
           # Use of an array keeps elements intact, and allows an element to
@@ -254,7 +254,7 @@ jobs:
               --tls-key /etc/letsencrypt/live/karma.shakalab.rocks/privkey.pem \
               --tls-cert /etc/letsencrypt/live/karma.shakalab.rocks/fullchain.pem \
               --hostname karma.shakalab.rocks \
-              --port $KARMA_PORT \
+              --port $ALLOCATED_PORT \
               --grid-config build/shaka-lab.yaml \
               --grid-address selenium-grid.lab.shaka:4444 \
               --browsers ${{ matrix.browser }} \


### PR DESCRIPTION
As I was building packages for shaka-lab services in the shaka-project/shaka-lab repo, it occurred to me that this KARMA_PORT variable was too specific to the shaka-player project.  Instead, the new shaka-lab package for self-hosted runners will have a more generic ALLOCATED_PORT variable.  This updates the CI workflow to use that new name.