### PR TITLE
feat(Ads): Disable custom playback on iOS 10+ browsers for CC

### DIFF
--- a/externs/ima.js
+++ b/externs/ima.js
@@ -230,6 +230,11 @@ google.ima.ImaSdkSettings = class {
    * @param {google.ima.ImaSdkSettings.VpaidMode} vpaidMode
    */
   setVpaidMode(vpaidMode) {}
+
+  /**
+   * @param {boolean} disable
+   */
+  setDisableCustomPlaybackForIOS10Plus(disable) {}
 };
 
 /**

--- a/lib/ads/client_side_ad_manager.js
+++ b/lib/ads/client_side_ad_manager.js
@@ -53,6 +53,8 @@ shaka.ads.ClientSideAdManager = class {
 
     google.ima.settings.setLocale(locale);
 
+    google.ima.settings.setDisableCustomPlaybackForIOS10Plus(true);
+
     const adDisplayContainer = new google.ima.AdDisplayContainer(
         this.adContainer_,
         this.video_);

--- a/test/ads/ad_manager_unit.js
+++ b/test/ads/ad_manager_unit.js
@@ -204,6 +204,8 @@ describe('Ad manager', () => {
     window['google'].ima.dai.api.StreamRequest = class {};
     window['google'].ima.settings = {};
     window['google'].ima.settings.setLocale = (locale) => {};
+    // eslint-disable-next-line max-len
+    window['google'].ima.settings.setDisableCustomPlaybackForIOS10Plus = (disable) => {};
     window['google'].ima.AdsManagerLoadedEvent = {};
     window['google'].ima.AdsManagerLoadedEvent.Type = {
       ADS_MANAGER_LOADED: 'ADS_MANAGER_LOADED',


### PR DESCRIPTION
More info: https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/js/google.ima.ImaSdkSettings#setDisableCustomPlaybackForIOS10Plus