### PR TITLE
test: Deflake tests on Tizen

### DIFF
--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -575,7 +575,10 @@ describe('Player', () => {
       await waiter.timeoutAfter(20).waitUntilPlayheadReaches(video, 5);
 
       // Seek the video, and see if it can continue playing from that point.
-      video.currentTime = 20;
+      // If this is a multiple of 10, it tends to flake on Tizen with stall
+      // detection disabled.  So use 25.
+      video.currentTime = 25;
+
       // Expect that we can then reach the end of the video.
       await waiter.timeoutAfter(40).waitForEnd(video);
     });

--- a/test/transmuxer/transmuxer_integration.js
+++ b/test/transmuxer/transmuxer_integration.js
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// TODO(joeyparrish): Rewrite these with StreamGenerator, to avoid flake.
+// With external resources, we can't guarantee that they are delivered on time.
+// The extra-long timeouts below (90s) are to compensate for this.
 describe('Transmuxer Player', () => {
   const Util = shaka.test.Util;
 
@@ -80,9 +83,9 @@ describe('Transmuxer Player', () => {
     // seconds, fail the test.
     await waiter.waitForMovementOrFailOnTimeout(video, 10);
 
-    // Play for 10 seconds, but stop early if the video ends.  If it takes
-    // longer than 30 seconds, fail the test.
-    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 10, 30);
+    // Play for 15 seconds, but stop early if the video ends.  If it takes
+    // longer than 90 seconds, fail the test.
+    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 15, 90);
 
     await player.unload();
   });
@@ -104,8 +107,8 @@ describe('Transmuxer Player', () => {
     await waiter.waitForMovementOrFailOnTimeout(video, 10);
 
     // Play for 15 seconds, but stop early if the video ends.  If it takes
-    // longer than 45 seconds, fail the test.
-    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 15, 45);
+    // longer than 90 seconds, fail the test.
+    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 15, 90);
 
     await player.unload();
   });
@@ -142,8 +145,8 @@ describe('Transmuxer Player', () => {
     await waiter.waitForMovementOrFailOnTimeout(video, 10);
 
     // Play for 15 seconds, but stop early if the video ends.  If it takes
-    // longer than 45 seconds, fail the test.
-    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 15, 45);
+    // longer than 90 seconds, fail the test.
+    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 15, 90);
 
     await player.unload();
   });
@@ -176,8 +179,8 @@ describe('Transmuxer Player', () => {
     await waiter.waitForMovementOrFailOnTimeout(video, 10);
 
     // Play for 15 seconds, but stop early if the video ends.  If it takes
-    // longer than 45 seconds, fail the test.
-    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 15, 45);
+    // longer than 90 seconds, fail the test.
+    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 15, 90);
 
     await player.unload();
   });
@@ -215,9 +218,9 @@ describe('Transmuxer Player', () => {
     // seconds, fail the test.
     await waiter.waitForMovementOrFailOnTimeout(video, 10);
 
-    // Play for 10 seconds, but stop early if the video ends.  If it takes
-    // longer than 30 seconds, fail the test.
-    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 10, 30);
+    // Play for 15 seconds, but stop early if the video ends.  If it takes
+    // longer than 90 seconds, fail the test.
+    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 15, 90);
 
     await player.unload();
   });
@@ -235,9 +238,9 @@ describe('Transmuxer Player', () => {
     // seconds, fail the test.
     await waiter.waitForMovementOrFailOnTimeout(video, 10);
 
-    // Play for 10 seconds, but stop early if the video ends.  If it takes
-    // longer than 30 seconds, fail the test.
-    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 10, 30);
+    // Play for 15 seconds, but stop early if the video ends.  If it takes
+    // longer than 90 seconds, fail the test.
+    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 15, 90);
 
     await player.unload();
   });


### PR DESCRIPTION
This reduces test failures on Tizen from 7/10 to 1/30 test runs.