### PR TITLE
fix: Prevent codecs override in the transmuxer

### DIFF
--- a/lib/mss/mss_parser.js
+++ b/lib/mss/mss_parser.js
@@ -635,6 +635,7 @@ shaka.mss.MssParser = class {
         const streamInfo = {
           id: stream.id,
           type: stream.type,
+          codecs: stream.codecs,
           encrypted: stream.encrypted,
           timescale: stream.mssPrivateData.timescale,
           duration: stream.mssPrivateData.duration,

--- a/lib/transmuxer/aac_transmuxer.js
+++ b/lib/transmuxer/aac_transmuxer.js
@@ -145,7 +145,6 @@ shaka.transmuxer.AacTransmuxer = class {
     }
     stream.audioSamplingRate = info.sampleRate;
     stream.channelsCount = info.channelCount;
-    stream.codecs = info.codec;
 
     /** @type {!Array.<shaka.util.Mp4Generator.Mp4Sample>} */
     const samples = [];
@@ -189,6 +188,7 @@ shaka.transmuxer.AacTransmuxer = class {
     const streamInfo = {
       id: stream.id,
       type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      codecs: info.codec,
       encrypted: stream.encrypted && stream.drmInfos.length > 0,
       timescale: sampleRate,
       duration: duration,

--- a/lib/transmuxer/ac3_transmuxer.js
+++ b/lib/transmuxer/ac3_transmuxer.js
@@ -177,6 +177,7 @@ shaka.transmuxer.Ac3Transmuxer = class {
     const streamInfo = {
       id: stream.id,
       type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      codecs: 'ac-3',
       encrypted: stream.encrypted && stream.drmInfos.length > 0,
       timescale: sampleRate,
       duration: duration,

--- a/lib/transmuxer/ec3_transmuxer.js
+++ b/lib/transmuxer/ec3_transmuxer.js
@@ -177,6 +177,7 @@ shaka.transmuxer.Ec3Transmuxer = class {
     const streamInfo = {
       id: stream.id,
       type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      codecs: 'ec-3',
       encrypted: stream.encrypted && stream.drmInfos.length > 0,
       timescale: sampleRate,
       duration: duration,

--- a/lib/transmuxer/mp3_transmuxer.js
+++ b/lib/transmuxer/mp3_transmuxer.js
@@ -169,6 +169,7 @@ shaka.transmuxer.Mp3Transmuxer = class {
     const streamInfo = {
       id: stream.id,
       type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      codecs: 'mp3',
       encrypted: stream.encrypted && stream.drmInfos.length > 0,
       timescale: sampleRate,
       duration: duration,

--- a/lib/transmuxer/ts_transmuxer.js
+++ b/lib/transmuxer/ts_transmuxer.js
@@ -280,7 +280,6 @@ shaka.transmuxer.TsTransmuxer = class {
       }
       stream.audioSamplingRate = info.sampleRate;
       stream.channelsCount = info.channelCount;
-      stream.codecs = info.codec;
 
       while (offset < data.length) {
         const header = ADTS.parseHeader(data, offset);
@@ -332,6 +331,7 @@ shaka.transmuxer.TsTransmuxer = class {
     return {
       id: id,
       type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      codecs: info.codec,
       encrypted: stream.encrypted && stream.drmInfos.length > 0,
       timescale: sampleRate,
       duration: duration,
@@ -422,6 +422,7 @@ shaka.transmuxer.TsTransmuxer = class {
     return {
       id: id,
       type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      codecs: 'ac-3',
       encrypted: stream.encrypted && stream.drmInfos.length > 0,
       timescale: sampleRate,
       duration: duration,
@@ -512,6 +513,7 @@ shaka.transmuxer.TsTransmuxer = class {
     return {
       id: id,
       type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      codecs: 'ec-3',
       encrypted: stream.encrypted && stream.drmInfos.length > 0,
       timescale: sampleRate,
       duration: duration,
@@ -597,6 +599,7 @@ shaka.transmuxer.TsTransmuxer = class {
     return {
       id: id,
       type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      codecs: 'mp3',
       encrypted: stream.encrypted && stream.drmInfos.length > 0,
       timescale: sampleRate,
       duration: duration,
@@ -686,6 +689,7 @@ shaka.transmuxer.TsTransmuxer = class {
     return {
       id: stream.id,
       type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      codecs: 'avc1',
       encrypted: stream.encrypted && stream.drmInfos.length > 0,
       timescale: timescale,
       duration: duration,

--- a/lib/util/mp4_generator.js
+++ b/lib/util/mp4_generator.js
@@ -300,24 +300,18 @@ shaka.util.Mp4Generator = class {
     let bytes = new Uint8Array([]);
     switch (streamInfo.type) {
       case ContentType.VIDEO:
-        if (streamInfo.stream.codecs.includes('avc1.') ||
-            streamInfo.stream.codecs.includes('avc3.')) {
+        if (streamInfo.codecs.includes('avc1')) {
           bytes = this.avc1_(streamInfo);
-        } else if (streamInfo.stream.codecs.includes('hev1.') ||
-            streamInfo.stream.codecs.includes('hvc1.')) {
+        } else if (streamInfo.codecs.includes('hvc1')) {
           bytes = this.hvc1_(streamInfo);
         }
         break;
       case ContentType.AUDIO:
-        if (streamInfo.stream.mimeType === 'audio/mpeg' ||
-            streamInfo.stream.codecs.includes('mp3') ||
-            streamInfo.stream.codecs.includes('mp4a.40.34')) {
+        if (streamInfo.codecs.includes('mp3')) {
           bytes = this.mp3_(streamInfo);
-        } else if (streamInfo.stream.mimeType === 'audio/ac3' ||
-            streamInfo.stream.codecs.includes('ac-3')) {
+        } else if (streamInfo.codecs.includes('ac-3')) {
           bytes = this.ac3_(streamInfo);
-        } else if (streamInfo.stream.mimeType === 'audio/ec3' ||
-            streamInfo.stream.codecs.includes('ec-3')) {
+        } else if (streamInfo.codecs.includes('ec-3')) {
           bytes = this.ec3_(streamInfo);
         } else {
           bytes = this.mp4a_(streamInfo);
@@ -635,7 +629,7 @@ shaka.util.Mp4Generator = class {
     const audioSamplingRate = streamInfo.stream.audioSamplingRate || 44100;
 
     const audioCodec = shaka.util.ManifestParserUtils.guessCodecs(
-        ContentType.AUDIO, streamInfo.stream.codecs.split(','));
+        ContentType.AUDIO, streamInfo.codecs.split(','));
 
     const samplingFrequencyIndex = {
       96000: 0x0,
@@ -773,8 +767,8 @@ shaka.util.Mp4Generator = class {
    * @private
    */
   frma_(streamInfo) {
-    const codec = streamInfo.stream.codecs.substring(
-        0, streamInfo.stream.codecs.indexOf('.'));
+    const codec = streamInfo.codecs.substring(
+        0, streamInfo.codecs.indexOf('.'));
     const Mp4Generator = shaka.util.Mp4Generator;
     const codecNumber = this.stringToCharCode_(codec);
     const bytes = new Uint8Array([
@@ -1298,6 +1292,7 @@ shaka.util.Mp4Generator.DINF_ = new Uint8Array([]);
  * @typedef {{
  *    id: number,
  *    type: string,
+ *    codecs: string,
  *    encrypted: boolean,
  *    timescale: number,
  *    duration: number,
@@ -1312,6 +1307,10 @@ shaka.util.Mp4Generator.DINF_ = new Uint8Array([]);
  *   A unique ID
  * @property {string} type
  *   Indicate the content type: 'video' or 'audio'.
+ * @property {string} codecs
+ *   <i>Defaults to '' (i.e., unknown / not needed).</i> <br>
+ *   The Stream's codecs, e.g., 'avc1.4d4015' or 'vp9'<br>
+ *   See {@link https://tools.ietf.org/html/rfc6381}
  * @property {boolean} encrypted
  *   Indicate if the stream is encrypted.
  * @property {number} timescale


### PR DESCRIPTION
This prevent errors when the codec specified is not the same that in the stream, and also fixes the override when there are multiples codecs (eg: muxed content)