### PR TITLE
ci: Use shaka-bot for releases

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -21,10 +21,20 @@ jobs:
           release-type: node
           # Make sure we create the PR against the correct branch.
           default-branch: ${{ github.ref_name }}
+          # Use a special shaka-bot access token for releases.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # Create the PR from the bot account's fork.
+          fork: true
 
       # If we didn't create a release, we may have created or updated a PR.
+      # Check out the code, then update the Player version in the PR.
       - uses: actions/checkout@v3
         if: steps.release.outputs.release_created == false
+        with:
+          # Checkout the fork, where the PR is generated from.
+          repository: shaka-bot/${{ github.event.repository.name }}
+          # Use a special shaka-bot access token for releases.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
       - name: Custom update Player version
         if: steps.release.outputs.release_created == false
         run: |
@@ -38,9 +48,9 @@ jobs:
           sed -e "s/^\\(shaka.Player.version =\\).*/\\1 '$VERSION';/" \
               -i lib/player.js
           git add lib/player.js
-          # Emulate the actions bot.
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Set missing git config for the commit.
+          git config user.name "shaka-bot"
+          git config user.email "shaka-bot@users.noreply.github.com"
           # Update the PR.
           git commit --amend --no-edit
           git push -f
@@ -55,12 +65,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          # Check out the origin repo, not the fork, and do it at main, not the
+          # PR branch.
           ref: main
+          # Use a special shaka-bot access token for releases.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
       - name: Tag the main branch
         run: |
-          # Emulate the actions bot.
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Set missing git config for the tag.
+          git config user.name "shaka-bot"
+          git config user.email "shaka-bot@users.noreply.github.com"
+          # Tag the main branch.
           VERSION=${{ needs.release.outputs.tag_name }}
           git tag -m "$VERSION-main" "$VERSION-main"
           git push origin "$VERSION-main"
@@ -155,6 +170,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          # Use a special shaka-bot access token for releases.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Create release branch
         run: |


### PR DESCRIPTION
This enables workflows to be triggered automatically on release PRs, instead of requiring maintainers to edit the PR description on every release to trigger required PR workflows.

This uses a separate token from the other shaka-bot token, because it requires additional permissions to make releases.