### PR TITLE
ci: Do not use a fork for release actions

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,8 +23,6 @@ jobs:
           default-branch: ${{ github.ref_name }}
           # Use a special shaka-bot access token for releases.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          # Create the PR from the bot account's fork.
-          fork: true
 
       # If we didn't create a release, we may have created or updated a PR.
       # Check out the code, then update the Player version in the PR.


### PR DESCRIPTION
Stop using a fork to run release actions.  Either it is missing a feature or I misunderstood what that flag is for.  See https://github.com/google-github-actions/release-please-action/issues/819