### PR TITLE
ci: Fix version update in release workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -29,8 +29,6 @@ jobs:
       - uses: actions/checkout@v3
         if: steps.release.outputs.release_created == false
         with:
-          # Checkout the fork, where the PR is generated from.
-          repository: shaka-bot/${{ github.event.repository.name }}
           # Use a special shaka-bot access token for releases.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
       - name: Custom update Player version
@@ -63,8 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # Check out the origin repo, not the fork, and do it at main, not the
-          # PR branch.
+          # Check out the origin repo, and do it at main, not the PR branch.
           ref: main
           # Use a special shaka-bot access token for releases.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
In #5588 we switched off one part of using a fork for release PRs, but not every part.  That caused player.js not to be updated in release PRs, which broke NPM releases.

This fixes the issue by removing other references to the shaka-bot fork.

Closes #5599