### PR TITLE
ci: Publish NPM tags explicitly

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -90,10 +90,52 @@ jobs:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Compute NPM tags
+        run: |
+          # NPM publish always sets a tag.  If you don't provide an explicit
+          # tag, you get the "latest" tag by default, but we want "latest" to
+          # always point to the highest version number.  So we set an explicit
+          # tag on every "publish" command, then follow up with a command to
+          # set "latest" only if this release was the highest version yet.
+
+          # The explicit tag is based on the branch.  If the git tag is v4.4.1,
+          # the branch was v4.4.x, and the explicit NPM tag should be
+          # v4.4-latest.
+          GIT_TAG_NAME=${{ needs.release.outputs.tag_name }}
+          NPM_TAG=$(echo "$GIT_TAG_NAME" | cut -f 1-2 -d .)-latest
+          echo "NPM_TAG=$NPM_TAG" >> $GITHUB_ENV
+
+          # We only tag the NPM package as "latest" if this release is the
+          # highest version to date.
+          RELEASE_TAGS=$(git tag | grep ^v[0-9] | grep -Ev -- '-(master|main)')
+          LATEST_RELEASE=$(echo "$RELEASE_TAGS" | sort --version-sort | tail -1)
+
+          if [[ "$GIT_TAG_NAME" == "$LATEST_RELEASE" ]]; then
+            NPM_LATEST=true
+          else
+            NPM_LATEST=false
+          fi
+          echo NPM_LATEST=$NPM_LATEST >> $GITHUB_ENV
+
+          # Debug the decisions made here.
+          echo "Latest release: $LATEST_RELEASE"
+          echo "This release: $GIT_TAG_NAME"
+          echo "NPM tag: $NPM_TAG"
+          echo "NPM latest: $NPM_LATEST"
+
       - run: npm ci
-      - run: npm publish
+      - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: |
+          # Publish with an explicit tag.
+          npm publish --tag "$NPM_TAG"
+
+          # Add the "latest" tag if needed.
+          if [[ "$NPM_LATEST" == "true" ]]; then
+            NPM_VERSION=$(npm version --json | jq -r '."shaka-player"')
+            npm dist-tag add "shaka-player@$NPM_VERSION" latest
+          fi
 
       - run: npm pack
       - uses: svenstaro/upload-release-action@483c1e56f95e88835747b1c7c60581215016cbf2
@@ -134,10 +176,11 @@ jobs:
           TAG_NAME=${{ needs.release.outputs.tag_name }}
 
           if [[ "$TAG_NAME" == "$LATEST_RELEASE" ]]; then
-            echo APPSPOT_PROMOTE=true >> $GITHUB_ENV
+            APPSPOT_PROMOTE=true
           else
-            echo APPSPOT_PROMOTE=false >> $GITHUB_ENV
+            APPSPOT_PROMOTE=false
           fi
+          APPSPOT_PROMOTE=$APPSPOT_PROMOTE >> $GITHUB_ENV
 
           # Debug the decisions made here.
           echo "Subdomain: $APPSPOT_SUBDOMAIN"


### PR DESCRIPTION
This avoids the implied "latest" tag being added to each and every release by adding explicit, branch-derived tags to each release, then setting "latest" explicitly based on the highest release number so far.

See https://github.com/shaka-project/shaka-player/issues/5599#issuecomment-1707047101