### PR TITLE
fix(UI): Fix broken language names on Google TV

### DIFF
--- a/ui/language_utils.js
+++ b/ui/language_utils.js
@@ -193,21 +193,6 @@ shaka.ui.LanguageUtils = class {
     // Extract the base language from the locale as a fallback step.
     const language = shaka.util.LanguageUtils.getBase(locale);
 
-    // If Intl.DisplayNames is supported we prefer it, because the list of
-    // languages is up to date.
-    if (window.Intl && 'DisplayNames' in Intl) {
-      try {
-        if (Intl.DisplayNames.supportedLocalesOf([locale]).length) {
-          const languageNames =
-              new Intl.DisplayNames([locale], {type: 'language'});
-          const language = languageNames.of(locale);
-          return language.charAt(0).toUpperCase() + language.slice(1);
-        }
-      } catch (e) {
-        // Ignore errors and try the fallback
-      }
-    }
-
     // First try to resolve the full language name.
     // If that fails, try the base.
     // Finally, report "unknown".


### PR DESCRIPTION
Reverts shaka-project/shaka-player#5365:  "feat(UI): Use Intl.DisplayNames to show the language name"

On the Google TV Chromecast just added to the lab, Intl.DisplayNames is returning the input as output again for some languages.  For example, instead of `en` => `English`, we get `en` => `en`.  Same for `fr`.  Oddly, it works for some others, such as `zh`.

We can follow up with a change that either avoids Google TV or that falls back to the internal map when Intl.DisplayNames returns its input as output.