### PR TITLE
ci: Work around msedgedriver 115+ bug

### DIFF
--- a/build/shaka-lab.yaml
+++ b/build/shaka-lab.yaml
@@ -62,6 +62,12 @@ vars:
       excludeSwitches:
         - "disable-component-update"
 
+  # Work around https://github.com/MicrosoftEdge/EdgeWebDriver/issues/102#issuecomment-1710724173
+  # by specifying the binary path on Linux.
+  edge_linux_config: &edge_linux_config
+    ms:edgeOptions:
+      binary: /usr/bin/microsoft-edge
+
   android_chrome_config: &android_chrome_config
     goog:chromeOptions:
       args:
@@ -180,6 +186,7 @@ EdgeLinux:
   os: Linux
   extra_configs:
     - *basic_edge_config
+    - *edge_linux_config
 
 
 ### Misc ###

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "karma-coverage": "^2.2.0",
         "karma-jasmine": "^4.0.1",
         "karma-jasmine-ajax": "^0.1.13",
-        "karma-local-wd-launcher": "^1.6.4",
+        "karma-local-wd-launcher": "^1.6.6",
         "karma-opera-launcher": "^1.0.0",
         "karma-sourcemap-loader": "^0.3.8",
         "karma-spec-reporter": "^0.0.34",
@@ -5608,17 +5608,42 @@
       "dev": true
     },
     "node_modules/karma-local-wd-launcher": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/karma-local-wd-launcher/-/karma-local-wd-launcher-1.6.4.tgz",
-      "integrity": "sha512-+vb7LGbkkyG2s/aZvH6ksmHw1kiiWbcM64AMkgE8/pcCZwhHXumfK4Bo4gWGrtnl/rKy/5PNPHUp7q0PrtQSGA==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/karma-local-wd-launcher/-/karma-local-wd-launcher-1.6.6.tgz",
+      "integrity": "sha512-8An620Xk5o6o0qVq0ATSgI2xY3+QAzEgrYvwoy4N0eDPzPrCOy99RYPCEOit8XL2AKeOCJ3Q7Puc+mjtBiVwpg==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.21",
         "wd": "^1.14.0",
-        "webdriver-installer": "^1.1.8"
+        "webdriver-installer": "^1.1.9",
+        "which": "^4.0.0"
       },
       "peerDependencies": {
         "karma": "^6.2.0"
+      }
+    },
+    "node_modules/karma-local-wd-launcher/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/karma-local-wd-launcher/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/karma-opera-launcher": {
@@ -8483,9 +8508,9 @@
       }
     },
     "node_modules/webdriver-installer": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/webdriver-installer/-/webdriver-installer-1.1.8.tgz",
-      "integrity": "sha512-Ptgz8VdhdzMPNDqVl7Z24n7vMIC+4wPM7C3HgU2Ikc70IXKqIUx6z+kooVs+ZKaUUvEhAhtxbs0kwqR5IERPvA==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/webdriver-installer/-/webdriver-installer-1.1.9.tgz",
+      "integrity": "sha512-lWoCiOC9LvmGOgsTGCvu4opZxPBA76cPPbp93peSrO3djSLg5C6yDiyeWy+jN4uj3LHISZ5GTfjVOJmCE04OUQ==",
       "dev": true,
       "dependencies": {
         "node-fetch": "^2.6.7",
@@ -12976,14 +13001,32 @@
       }
     },
     "karma-local-wd-launcher": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/karma-local-wd-launcher/-/karma-local-wd-launcher-1.6.4.tgz",
-      "integrity": "sha512-+vb7LGbkkyG2s/aZvH6ksmHw1kiiWbcM64AMkgE8/pcCZwhHXumfK4Bo4gWGrtnl/rKy/5PNPHUp7q0PrtQSGA==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/karma-local-wd-launcher/-/karma-local-wd-launcher-1.6.6.tgz",
+      "integrity": "sha512-8An620Xk5o6o0qVq0ATSgI2xY3+QAzEgrYvwoy4N0eDPzPrCOy99RYPCEOit8XL2AKeOCJ3Q7Puc+mjtBiVwpg==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.21",
         "wd": "^1.14.0",
-        "webdriver-installer": "^1.1.8"
+        "webdriver-installer": "^1.1.9",
+        "which": "^4.0.0"
+      },
+      "dependencies": {
+        "isexe": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+          "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+          "dev": true
+        },
+        "which": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+          "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+          "dev": true,
+          "requires": {
+            "isexe": "^3.1.1"
+          }
+        }
       }
     },
     "karma-opera-launcher": {
@@ -15180,9 +15223,9 @@
       }
     },
     "webdriver-installer": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/webdriver-installer/-/webdriver-installer-1.1.8.tgz",
-      "integrity": "sha512-Ptgz8VdhdzMPNDqVl7Z24n7vMIC+4wPM7C3HgU2Ikc70IXKqIUx6z+kooVs+ZKaUUvEhAhtxbs0kwqR5IERPvA==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/webdriver-installer/-/webdriver-installer-1.1.9.tgz",
+      "integrity": "sha512-lWoCiOC9LvmGOgsTGCvu4opZxPBA76cPPbp93peSrO3djSLg5C6yDiyeWy+jN4uj3LHISZ5GTfjVOJmCE04OUQ==",
       "dev": true,
       "requires": {
         "node-fetch": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "karma-coverage": "^2.2.0",
     "karma-jasmine": "^4.0.1",
     "karma-jasmine-ajax": "^0.1.13",
-    "karma-local-wd-launcher": "^1.6.4",
+    "karma-local-wd-launcher": "^1.6.6",
     "karma-opera-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma-spec-reporter": "^0.0.34",


### PR DESCRIPTION
Specify the explicit path to microsoft-edge on Linux if found, to work around https://github.com/MicrosoftEdge/EdgeWebDriver/issues/102#issuecomment-1710724173

This also incorporates
https://github.com/shaka-project/webdriver-installer/pull/35, https://github.com/shaka-project/karma-local-wd-launcher/pull/60, and https://github.com/shaka-project/karma-local-wd-launcher/pull/62 to revert earlier workarounds and apply new ones for local test runs.