### PR TITLE
fix: Fix compiled-mode error formatting

### DIFF
--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -63,8 +63,11 @@ shaka.util.Error = class {
      */
     this.handled = false;
 
-    // This improves the formatting of Errors in failure messages in the tests.
+    // A basic message for compiled mode.
+    let formattedMessage = 'Shaka Error ' + this.code;
     if (goog.DEBUG) {
+      // This improves the formatting of Errors in failure messages in the
+      // tests in debug mode.
       let categoryName = 'UNKNOWN';
       let codeName = 'UNKNOWN';
 
@@ -79,16 +82,19 @@ shaka.util.Error = class {
         }
       }
 
-      /**
-       * A human-readable version of the category and code.
-       * <i>(Only available in uncompiled mode.)</i>
-       *
-       * @const {string}
-       * @exportDoc
-       */
-      this.message = 'Shaka Error ' + categoryName + '.' + codeName +
-                     ' (' + this.data.toString() + ')';
+      formattedMessage = 'Shaka Error ' + categoryName + '.' + codeName +
+                         ' (' + this.data.toString() + ')';
     }
+
+    /**
+     * In compiled mode, contains a basic message string with the error code.
+     * In uncompiled and debug modes, contains a human-readable version of the
+     * category and code as enums.
+     *
+     * @const {string}
+     * @exportDoc
+     */
+    this.message = formattedMessage;
 
     if (shaka.util.Error.createStack) {
       try {


### PR DESCRIPTION
We declare shaka.util.Error to extend the native Error, but only supplied a message field in uncompiled and debug modes.  This broke the Jasmine test framework when it tried to extract error message information from a compiled-mode shaka.util.Error object.

Now we always supply a message object, and merely skip the fancy enum formatting in compiled mode.