### PR TITLE
perf: Optimization to resolve uris

### DIFF
--- a/lib/util/manifest_parser_utils.js
+++ b/lib/util/manifest_parser_utils.js
@@ -41,10 +41,10 @@ shaka.util.ManifestParserUtils = class {
     const relativeAsGoog = relativeUris.map((uri) => new goog.Uri(uri));
     // Resolve each URI relative to each base URI, creating an Array of Arrays.
     // Then flatten the Arrays into a single Array.
-    return baseUris.map((uri) => new goog.Uri(uri))
-        .map((base) => relativeAsGoog.map((i) => base.resolve(i)))
-        .reduce(Functional.collapseArrays, [])
-        .map((uri) => uri.toString());
+    return baseUris.map((uri) => {
+      const base = new goog.Uri(uri);
+      return relativeAsGoog.map((i) => base.resolve(i).toString());
+    }).reduce(Functional.collapseArrays, []);
   }
 
 

--- a/lib/util/manifest_parser_utils.js
+++ b/lib/util/manifest_parser_utils.js
@@ -32,6 +32,12 @@ shaka.util.ManifestParserUtils = class {
       return baseUris;
     }
 
+    if (baseUris.length == 1 && relativeUris.length == 1) {
+      const baseUri = new goog.Uri(baseUris[0]);
+      const relativeUri = new goog.Uri(relativeUris[0]);
+      return [baseUri.resolve(relativeUri).toString()];
+    }
+
     const relativeAsGoog = relativeUris.map((uri) => new goog.Uri(uri));
     // Resolve each URI relative to each base URI, creating an Array of Arrays.
     // Then flatten the Arrays into a single Array.


### PR DESCRIPTION
Chained use of maps and reduce on legacy devices reduces performance. So if there is only one url to generate we can optimize performance.