### PR TITLE
fix(HLS): Fix audio and video out of sync

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -2882,15 +2882,13 @@ shaka.hls.HlsParser = class {
    * @param {string} absoluteMediaPlaylistUri
    * @param {string} type
    * @param {string} mimeType
-   * @param {number} timestampOffset
    * @param {shaka.extern.aes128Key=} aes128Key
    * @return {shaka.media.SegmentReference}
    * @private
    */
   createSegmentReference_(
       initSegmentReference, previousReference, hlsSegment, startTime,
-      variables, absoluteMediaPlaylistUri, type, mimeType, timestampOffset,
-      aes128Key) {
+      variables, absoluteMediaPlaylistUri, type, mimeType, aes128Key) {
     const tags = hlsSegment.tags;
     const extinfTag =
         shaka.hls.Utils.getFirstTagWithName(tags, 'EXTINF');
@@ -3027,7 +3025,7 @@ shaka.hls.HlsParser = class {
             pStartByte,
             pEndByte,
             initSegmentReference,
-            /* timestampOffset= */ 0, // This value is ignored in sequence mode.
+            /* timestampOffset= */ 0,
             /* appendWindowStart= */ 0,
             /* appendWindowEnd= */ Infinity,
             /* partialReferences= */ [],
@@ -3136,7 +3134,7 @@ shaka.hls.HlsParser = class {
         startByte,
         endByte,
         initSegmentReference,
-        timestampOffset, // This value is ignored in sequence mode.
+        /* timestampOffset= */ 0,
         /* appendWindowStart= */ 0,
         /* appendWindowEnd= */ Infinity,
         partialSegmentRefs,
@@ -3235,7 +3233,6 @@ shaka.hls.HlsParser = class {
     const references = [];
 
     let previousReference = null;
-    let lastDiscontinuityStartTime = firstStartTime;
 
     /** @type {!Array.<{bitrate: number, duration: number}>} */
     const bitrates = [];
@@ -3250,7 +3247,6 @@ shaka.hls.HlsParser = class {
           item.tags, 'EXT-X-DISCONTINUITY');
       if (discontinuityTag) {
         discontinuitySequence++;
-        lastDiscontinuityStartTime = startTime;
       }
 
       // Apply new AES-128 tags as you see them, keeping a running total.
@@ -3290,7 +3286,6 @@ shaka.hls.HlsParser = class {
           playlist.absoluteUri,
           type,
           mimeType,
-          lastDiscontinuityStartTime,
           aes128Key);
 
       if (reference) {

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1818,10 +1818,10 @@ shaka.media.StreamingEngine = class {
       }
     }
 
-    const lastDiscontinuitySequence =
-        mediaState.lastSegmentReference ?
-            mediaState.lastSegmentReference.discontinuitySequence : null;
     if (this.manifest_.sequenceMode) {
+      const lastDiscontinuitySequence =
+          mediaState.lastSegmentReference ?
+              mediaState.lastSegmentReference.discontinuitySequence : null;
       // Across discontinuity bounds, we should resync timestamps for
       // sequence mode playbacks.  The next segment appended should
       // land at its theoretical timestamp from the segment index.
@@ -1830,18 +1830,6 @@ shaka.media.StreamingEngine = class {
         mediaState.needsResync = false;
         operations.push(this.playerInterface_.mediaSourceEngine.resync(
             mediaState.type, reference.startTime));
-      }
-    } else if (this.manifest_.ignoreManifestTimestampsInSegmentsMode) {
-      // In segments mode, we need to resync to set the timestampOffset
-      // to the start of the current discontinuity sequence. This is
-      // because individual discontinuity sequences may have internal
-      // timestamps that overlap, so we adjust the timestampOffset to avoid
-      // having the SourceBuffer get overwritten.
-      if (reference.discontinuitySequence != lastDiscontinuitySequence) {
-        operations.push(
-            this.playerInterface_.mediaSourceEngine.resync(
-                mediaState.type,
-                reference.timestampOffset));
       }
     }
 

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -1137,63 +1137,6 @@ describe('HlsParser', () => {
     expect(references[6].discontinuitySequence).toBe(3);
   });
 
-  it('sets reference timetampOffset based on discontinuity start time',
-      async () => {
-        const master = [
-          '#EXTM3U\n',
-          '#EXT-X-STREAM-INF:BANDWIDTH=2000000,CODECS="avc1"\n',
-          'video\n',
-        ].join('');
-
-        const media = [
-          '#EXTM3U\n',
-          '#EXT-X-VERSION:3\n',
-          '#EXT-X-TARGETDURATION:5\n',
-          '#EXT-X-MEDIA-SEQUENCE:0\n',
-          '#EXTINF:3,\n',
-          'clip0-video-0.ts\n',
-          '#EXTINF:1,\n',
-          'clip0-video-1.ts\n',
-          '#EXT-X-DISCONTINUITY\n',
-          '#EXTINF:2,\n',
-          'clip1-video-1.ts\n',
-          '#EXTINF:3,\n',
-          'clip1-video-2.ts\n',
-          '#EXT-X-DISCONTINUITY\n',
-          '#EXTINF:1,\n',
-          'media-clip2-video-0.ts\n',
-          '#EXTINF:1,\n',
-          'media-clip2-video-1.ts\n',
-          '#EXT-X-DISCONTINUITY\n',
-          '#EXTINF:4,\n',
-          'media-clip3-video-1.ts\n',
-          '#EXT-X-ENDLIST\n',
-        ].join('');
-
-        fakeNetEngine
-            .setResponseText('test:/master', master)
-            .setResponseText('test:/video', media);
-
-        const manifest = await parser.start('test:/master', playerInterface);
-        await manifest.variants[0].video.createSegmentIndex();
-
-        const segmentIndex = manifest.variants[0].video.segmentIndex;
-        const references = [];
-
-        for (let i = 0; i < 7; i++) {
-          references.push(segmentIndex.get(i));
-        }
-
-        expect(references[0].timestampOffset).toBe(0);
-        expect(references[1].timestampOffset).toBe(0);
-        expect(references[2].timestampOffset).toBe(4);
-        expect(references[3].timestampOffset).toBe(4);
-        expect(references[4].timestampOffset).toBe(9);
-        expect(references[5].timestampOffset).toBe(9);
-        expect(references[6].timestampOffset).toBe(11);
-      },
-  );
-
   it('parses characteristics from audio tags', async () => {
     const master = [
       '#EXTM3U\n',


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/5584
Fixes https://github.com/shaka-project/shaka-player/issues/5013
Fixes https://github.com/shaka-project/shaka-player/issues/5397

timestampOffset calculation is no longer necessary in the HLS parser because we introduce recently some change in MediaSourceEngine to calculate the timestampOffset