### PR TITLE
fix: Allow PID change in TsParser

### DIFF
--- a/lib/util/ts_parser.js
+++ b/lib/util/ts_parser.js
@@ -129,15 +129,15 @@ shaka.util.TsParser = class {
             // for example
             // NOTE this is only the PID of the track as found in TS,
             // but we are not using this for MP4 track IDs.
-            if (this.videoPid_ == null) {
+            if (parsedPIDs.video != -1) {
               this.videoPid_ = parsedPIDs.video;
               this.videoCodec_ = parsedPIDs.videoCodec;
             }
-            if (this.audioPid_ == null) {
+            if (parsedPIDs.audio != -1) {
               this.audioPid_ = parsedPIDs.audio;
               this.audioCodec_ = parsedPIDs.audioCodec;
             }
-            if (this.id3Pid_ == null) {
+            if (parsedPIDs.id3 != -1) {
               this.id3Pid_ = parsedPIDs.id3;
             }
 

--- a/test/util/ts_parser_unit.js
+++ b/test/util/ts_parser_unit.js
@@ -72,6 +72,6 @@ describe('TsParser', () => {
     const codecs = new shaka.util.TsParser().parse(tsSegment)
         .getCodecs();
     expect(codecs.audio).toBe('aac');
-    expect(codecs.video).toBe('');
+    expect(codecs.video).toBe(null);
   });
 });


### PR DESCRIPTION
This is necessary because some Live streams change audio or video PID when there are ads.