### PR TITLE
fix: Fix transmuxing of muxed content

### DIFF
--- a/lib/transmuxer/ts_transmuxer.js
+++ b/lib/transmuxer/ts_transmuxer.js
@@ -22,6 +22,8 @@ goog.require('shaka.util.Mp4Generator');
 goog.require('shaka.util.TsParser');
 goog.require('shaka.util.Uint8ArrayUtils');
 
+goog.requireType('shaka.media.SegmentReference');
+
 
 /**
  * @implements {shaka.extern.Transmuxer}
@@ -175,11 +177,11 @@ shaka.transmuxer.TsTransmuxer = class {
         switch (codecs.video) {
           case 'avc':
             streamInfo =
-              this.getAvcStreamInfo_(tsParser, stream, duration);
+              this.getAvcStreamInfo_(tsParser, stream, duration, reference);
             break;
           case 'hvc':
             streamInfo =
-              this.getHvcStreamInfo_(tsParser, stream, duration);
+              this.getHvcStreamInfo_(tsParser, stream, duration, reference);
             break;
         }
         if (streamInfo) {
@@ -191,7 +193,7 @@ shaka.transmuxer.TsTransmuxer = class {
         switch (codecs.audio) {
           case 'aac':
             streamInfo =
-              this.getAacStreamInfo_(tsParser, stream, duration);
+              this.getAacStreamInfo_(tsParser, stream, duration, reference);
             break;
           case 'ac3':
             streamInfo =
@@ -242,10 +244,11 @@ shaka.transmuxer.TsTransmuxer = class {
    * @param {shaka.util.TsParser} tsParser
    * @param {shaka.extern.Stream} stream
    * @param {number} duration
+   * @param {?shaka.media.SegmentReference} reference
    * @return {shaka.util.Mp4Generator.StreamInfo}
    * @private
    */
-  getAacStreamInfo_(tsParser, stream, duration) {
+  getAacStreamInfo_(tsParser, stream, duration, reference) {
     const ADTS = shaka.transmuxer.ADTS;
     const timescale = shaka.util.TsParser.Timescale;
 
@@ -306,10 +309,58 @@ shaka.transmuxer.TsTransmuxer = class {
     }
 
     if (!info || firstPts == null) {
-      throw new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.MEDIA,
-          shaka.util.Error.Code.TRANSMUXING_FAILED);
+      if (!tsParser.getVideoData().length) {
+        throw new shaka.util.Error(
+            shaka.util.Error.Severity.CRITICAL,
+            shaka.util.Error.Category.MEDIA,
+            shaka.util.Error.Code.TRANSMUXING_FAILED);
+      }
+
+      firstPts = reference.startTime * timescale;
+
+      const allCodecs = shaka.util.MimeUtils.splitCodecs(stream.codecs);
+      const audioCodec = shaka.util.ManifestParserUtils.guessCodecsSafe(
+          shaka.util.ManifestParserUtils.ContentType.AUDIO, allCodecs);
+      if (!audioCodec || !stream.channelsCount || !stream.audioSamplingRate) {
+        throw new shaka.util.Error(
+            shaka.util.Error.Severity.CRITICAL,
+            shaka.util.Error.Category.MEDIA,
+            shaka.util.Error.Code.TRANSMUXING_FAILED);
+      }
+      info = {
+        sampleRate: stream.audioSamplingRate,
+        channelCount: stream.channelsCount,
+        codec: audioCodec,
+      };
+      const silenceFrame =
+          ADTS.getSilentFrame(audioCodec, stream.channelsCount);
+      if (!silenceFrame) {
+        throw new shaka.util.Error(
+            shaka.util.Error.Severity.CRITICAL,
+            shaka.util.Error.Category.MEDIA,
+            shaka.util.Error.Code.TRANSMUXING_FAILED);
+      }
+      const segmentDuration =
+          (reference.endTime - reference.startTime) * timescale;
+      const finalPTs = firstPts + segmentDuration;
+      let currentPts = firstPts;
+      while (currentPts < finalPTs) {
+        samples.push({
+          data: silenceFrame,
+          size: silenceFrame.byteLength,
+          duration: ADTS.AAC_SAMPLES_PER_FRAME,
+          cts: 0,
+          flags: {
+            isLeading: 0,
+            isDependedOn: 0,
+            hasRedundancy: 0,
+            degradPrio: 0,
+            dependsOn: 2,
+            isNonSync: 0,
+          },
+        });
+        currentPts += ADTS.AAC_SAMPLES_PER_FRAME / info.sampleRate * timescale;
+      }
     }
 
     /** @type {number} */
@@ -609,10 +660,11 @@ shaka.transmuxer.TsTransmuxer = class {
    * @param {shaka.util.TsParser} tsParser
    * @param {shaka.extern.Stream} stream
    * @param {number} duration
+   * @param {?shaka.media.SegmentReference} reference
    * @return {shaka.util.Mp4Generator.StreamInfo}
    * @private
    */
-  getAvcStreamInfo_(tsParser, stream, duration) {
+  getAvcStreamInfo_(tsParser, stream, duration, reference) {
     const H264 = shaka.transmuxer.H264;
     const timescale = shaka.util.TsParser.Timescale;
 
@@ -642,8 +694,10 @@ shaka.transmuxer.TsTransmuxer = class {
       let duration;
       if (i + 1 < videoData.length) {
         duration = (videoData[i + 1].dts || 0) - (pes.dts || 0);
-      } else {
+      } else if (videoData.length > 1) {
         duration = (pes.dts || 0) - (videoData[i - 1].dts || 0);
+      } else {
+        duration = (reference.endTime - reference.startTime) * timescale;
       }
       samples.push({
         data: frame.data,
@@ -696,10 +750,11 @@ shaka.transmuxer.TsTransmuxer = class {
    * @param {shaka.util.TsParser} tsParser
    * @param {shaka.extern.Stream} stream
    * @param {number} duration
+   * @param {?shaka.media.SegmentReference} reference
    * @return {shaka.util.Mp4Generator.StreamInfo}
    * @private
    */
-  getHvcStreamInfo_(tsParser, stream, duration) {
+  getHvcStreamInfo_(tsParser, stream, duration, reference) {
     const H265 = shaka.transmuxer.H265;
     const timescale = shaka.util.TsParser.Timescale;
 
@@ -729,8 +784,10 @@ shaka.transmuxer.TsTransmuxer = class {
       let duration;
       if (i + 1 < videoData.length) {
         duration = (videoData[i + 1].dts || 0) - (pes.dts || 0);
-      } else {
+      } else if (videoData.length > 1) {
         duration = (pes.dts || 0) - (videoData[i - 1].dts || 0);
+      } else {
+        duration = (reference.endTime - reference.startTime) * timescale;
       }
       samples.push({
         data: frame.data,


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/5684

This PR fixes two issues:
- Fixes the duration of a video sample when there is only one pes packet.
- When there is muxed content, in some TS segments there is not audio but the audio is declared in the PMT, so we have to add silence frames