### PR TITLE
fix: Fix unreleased stack overflow on statechanged

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5737,11 +5737,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     } else if (this.video_.ended) {
       updateState = 'ended';
     }
-    history.update(updateState);
+    const stateChanged = history.update(updateState);
 
-    const eventName = shaka.util.FakeEvent.EventName.StateChanged;
-    const data = (new Map()).set('newstate', updateState);
-    this.dispatchEvent(this.makeEvent_(eventName, data));
+    if (stateChanged) {
+      const eventName = shaka.util.FakeEvent.EventName.StateChanged;
+      const data = (new Map()).set('newstate', updateState);
+      this.dispatchEvent(this.makeEvent_(eventName, data));
+    }
   }
 
   /**

--- a/lib/util/state_history.js
+++ b/lib/util/state_history.js
@@ -40,13 +40,15 @@ shaka.util.StateHistory = class {
 
   /**
    * @param {string} state
+   * @return {boolean} True if this changed the state
    */
   update(state) {
     // |open_| will only be |null| when we first call |update|.
     if (this.open_ == null) {
       this.start_(state);
+      return true;
     } else {
-      this.update_(state);
+      return this.update_(state);
     }
   }
 
@@ -116,6 +118,7 @@ shaka.util.StateHistory = class {
 
   /**
    * @param {string} state
+   * @return {boolean} True if this changed the state
    * @private
    */
   update_(state) {
@@ -131,7 +134,7 @@ shaka.util.StateHistory = class {
 
     // If the state has not changed, there is no need to add a new entry.
     if (this.open_.state == state) {
-      return;
+      return false;
     }
 
     // We have changed states, so "close" the open state.
@@ -142,6 +145,7 @@ shaka.util.StateHistory = class {
       state: state,
       duration: 0,
     };
+    return true;
   }
 
   /**

--- a/test/cast/cast_receiver_integration.js
+++ b/test/cast/cast_receiver_integration.js
@@ -157,17 +157,18 @@ filterDescribe('CastReceiver', castReceiverIntegrationSupport, () => {
       // *pass*.  So we need to fail fast.  The best way I have found is to
       // catch the very first recursion of pollAttributes_, long before we
       // overflow, fail, then return early to avoid the actual recursion.
-      const original = receiver.pollAttributes_;
+      const original = /** @type {?} */(receiver).pollAttributes_;
       let numRecursions = 0;
-      receiver.pollAttributes_ = function() {
+      // eslint-disable-next-line no-restricted-syntax
+      /** @type {?} */(receiver).pollAttributes_ = function() {
         try {
           if (numRecursions > 0) {
             fail('Found recursion in pollAttributes_!');
-            return;
+            return undefined;
           }
 
           numRecursions++;
-          return original.apply(this, arguments);
+          return original.apply(receiver, arguments);
         } finally {
           numRecursions--;
         }


### PR DESCRIPTION
Do not dispatch statechanged events unless there is an actual change. This fixes a stack overflow in the Cast proxy code triggered by statechanged events.