### PR TITLE
ci: Simplify release version updates

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,33 +23,8 @@ jobs:
           default-branch: ${{ github.ref_name }}
           # Use a special shaka-bot access token for releases.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-
-      # If we didn't create a release, we may have created or updated a PR.
-      # Check out the code, then update the Player version in the PR.
-      - uses: actions/checkout@v3
-        if: steps.release.outputs.release_created == false
-        with:
-          # Use a special shaka-bot access token for releases.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-      - name: Custom update Player version
-        if: steps.release.outputs.release_created == false
-        run: |
-          # Check out the branch that release-please created.
-          # If it does not exist, FAIL!
-          git fetch
-          git checkout release-please--branches--${{ github.ref_name }}--components--shaka-player || exit 1
-          # If it does exist, update lib/player.js in the PR branch, so that the
-          # -uncompiled tag remains in the player version in that context.
-          VERSION="v$(jq -r .version package.json)-uncompiled"
-          sed -e "s/^\\(shaka.Player.version =\\).*/\\1 '$VERSION';/" \
-              -i lib/player.js
-          git add lib/player.js
-          # Set missing git config for the commit.
-          git config user.name "shaka-bot"
-          git config user.email "shaka-bot@users.noreply.github.com"
-          # Update the PR.
-          git commit --amend --no-edit
-          git push -f
+          # Update these additional files containing version numbers.
+          extra-files: lib/player.js
 
   # The jobs below are all conditional on a release having been created by
   # someone merging the release PR.  They all run in parallel.

--- a/build/generateExterns.js
+++ b/build/generateExterns.js
@@ -626,6 +626,11 @@ function createExternAssignment(name, node, alwaysIncludeConstructor) {
       // Example extern: /** @const {string} */ foo.version;
       return '';
 
+    case 'BinaryExpression':
+      // Example code: /** @const {string} @export */ foo.version = 'a' + 'b';
+      // Example extern: /** @const {string} */ foo.version;
+      return '';
+
     default:
       assert.fail('Unexpected export type: ' + node.type);
       return '';  // Shouldn't be hit, but linter wants a return statement.

--- a/lib/player.js
+++ b/lib/player.js
@@ -7244,6 +7244,7 @@ shaka.Player.TYPICAL_BUFFERING_THRESHOLD_ = 0.5;
  * @define {string} A version number taken from git at compile time.
  * @export
  */
+// eslint-disable-next-line no-useless-concat
 shaka.Player.version = 'v4.4.0' + '-uncompiled';  // x-release-please-version
 
 // Initialize the deprecation system using the version string we just set

--- a/lib/player.js
+++ b/lib/player.js
@@ -7244,7 +7244,7 @@ shaka.Player.TYPICAL_BUFFERING_THRESHOLD_ = 0.5;
  * @define {string} A version number taken from git at compile time.
  * @export
  */
-shaka.Player.version = 'v4.4.0-uncompiled';
+shaka.Player.version = 'v4.4.0' + '-uncompiled';  // x-release-please-version
 
 // Initialize the deprecation system using the version string we just set
 // on the player.


### PR DESCRIPTION
lib/player.js was being updated separately because:

1. Originally, we didn't have support for updating arbitrary files with release-please.
2. When we did get that support in release-please, it would trash the "-uncompiled" tag we have in uncompiled mode.

By separating the uncompiled version string into two parts and using the extra-files feature of release-please, we can get the updater to preserve the "-uncompiled" tag and simplify the release workflow to only update the PR once per change instead of twice.