### PR TITLE
chore: Switch to new issues email

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -44,7 +44,7 @@ assignees: ''
 
 **What are the manifest and license server URIs?**
 <!-- NOTE:
-  You can send the URIs to <shaka-player-issues@google.com> instead,
+  You can send the URIs to <shaka-player-maintainers@googlegroups.com> instead,
   but please use GitHub and the template for the rest.
   A copy of the manifest text or an attached manifest will **not** be
   enough to reproduce your issue, and we **will** ask you to send a

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -69,7 +69,7 @@ dispute. If you are unable to resolve the matter for any reason, or if the
 behavior is threatening or harassing, report it. We are dedicated to providing
 an environment where participants feel welcome and safe.
 
-Reports should be directed to *shaka-player-issues@google.com*, the
+Reports should be directed to *shaka-player-maintainers@googlegroups.com*, the
 Project Steward(s) for *Shaka Player*. It is the Project Steward’s duty to
 receive and address reported violations of the code of conduct. They will then
 work with a committee consisting of representatives from the Open Source


### PR DESCRIPTION
The new email (shaka-player-maintainers@googlegroups.com) will direct issue reproduction information to a google group that includes core maintainers who are not part of Google proper, as opposed to the old email (shaka-player-issues@google.com) which was Google employees only.