### PR TITLE
perf(HLS): Improve detection of all partial segments

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -2943,6 +2943,9 @@ shaka.hls.HlsParser = class {
       return uris || [];
     };
 
+    const allPartialSegments = partialSegmentRefs.length > 0 &&
+        !!hlsSegment.verbatimSegmentUri;
+
     const reference = new shaka.media.SegmentReference(
         startTime,
         endTime,
@@ -2959,6 +2962,7 @@ shaka.hls.HlsParser = class {
         syncTime,
         status,
         aes128Key,
+        allPartialSegments
     );
 
     if (segmentWithByteRangeOptimization) {

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -582,7 +582,7 @@ shaka.media.SegmentIterator = class {
     // new references in merge(), the pointers may not make sense any more.
     // This adjusts the invalid pointer values to point to the next newly added
     // segment or partial segment.
-    if (ref && ref.hasPartialSegments() && ref.getUris().length &&
+    if (ref && ref.hasPartialSegments() && ref.hasAllPartialSegments() &&
         this.currentPartialPosition_ >= ref.partialReferences.length) {
       this.currentPosition_++;
       this.currentPartialPosition_ = 0;
@@ -609,12 +609,12 @@ shaka.media.SegmentIterator = class {
       // If the regular segment contains partial segments, move to the next
       // partial SegmentReference.
       this.currentPartialPosition_++;
-      // If the current regular segment has been published completely (has a
-      // valid Uri), and we've reached the end of its partial segments list,
-      // move to the next regular segment.
+      // If the current regular segment has been published completely, and
+      // we've reached the end of its partial segments list, move to the next
+      // regular segment.
       // If the Partial Segments list is still on the fly, do not move to
       // the next regular segment.
-      if (ref.getUris().length &&
+      if (ref.hasAllPartialSegments() &&
           this.currentPartialPosition_ == ref.partialReferences.length) {
         this.currentPosition_++;
         this.currentPartialPosition_ = 0;

--- a/lib/media/segment_reference.js
+++ b/lib/media/segment_reference.js
@@ -198,13 +198,15 @@ shaka.media.SegmentReference = class {
    *  not available.
    * @param {?shaka.extern.aes128Key=} aes128Key
    *  The segment's AES-128-CBC full segment encryption key and iv.
+   * @param {boolean=} allPartialSegments
+   *  Indicate if the segment has all partial segments
    */
   constructor(
       startTime, endTime, uris, startByte, endByte, initSegmentReference,
       timestampOffset, appendWindowStart, appendWindowEnd,
       partialReferences = [], tilesLayout = '', tileDuration = null,
       syncTime = null, status = shaka.media.SegmentReference.Status.AVAILABLE,
-      aes128Key = null) {
+      aes128Key = null, allPartialSegments = false) {
     // A preload hinted Partial Segment has the same startTime and endTime.
     goog.asserts.assert(startTime <= endTime,
         'startTime must be less than or equal to endTime');
@@ -284,6 +286,9 @@ shaka.media.SegmentReference = class {
 
     /** @type {number} */
     this.discontinuitySequence = 0;
+
+    /** @type {boolean} */
+    this.allPartialSegments = allPartialSegments;
   }
 
   /**
@@ -357,6 +362,14 @@ shaka.media.SegmentReference = class {
    */
   hasPartialSegments() {
     return this.partialReferences.length > 0;
+  }
+
+  /**
+   * Returns true if it contains all partial SegmentReferences.
+   * @return {boolean}
+   */
+  hasAllPartialSegments() {
+    return this.allPartialSegments;
   }
 
   /**


### PR DESCRIPTION
This reduces calls to getUris that use regular expressions which are slow on low-end devices.