### PR TITLE
perf(manifest): avoid unnecessary looping in uri resolver

### DIFF
--- a/lib/util/manifest_parser_utils.js
+++ b/lib/util/manifest_parser_utils.js
@@ -8,7 +8,6 @@ goog.provide('shaka.util.ManifestParserUtils');
 
 goog.require('goog.Uri');
 goog.require('shaka.util.Error');
-goog.require('shaka.util.Functional');
 
 
 /**
@@ -27,7 +26,6 @@ shaka.util.ManifestParserUtils = class {
    * @return {!Array.<string>}
    */
   static resolveUris(baseUris, relativeUris) {
-    const Functional = shaka.util.Functional;
     if (relativeUris.length == 0) {
       return baseUris;
     }
@@ -39,12 +37,18 @@ shaka.util.ManifestParserUtils = class {
     }
 
     const relativeAsGoog = relativeUris.map((uri) => new goog.Uri(uri));
-    // Resolve each URI relative to each base URI, creating an Array of Arrays.
-    // Then flatten the Arrays into a single Array.
-    return baseUris.map((uri) => {
-      const base = new goog.Uri(uri);
-      return relativeAsGoog.map((i) => base.resolve(i).toString());
-    }).reduce(Functional.collapseArrays, []);
+
+    // For each base URI, this code resolves it with every relative URI.
+    // The result is a single array containing all the resolved URIs.
+    const resolvedUris = [];
+    for (const baseStr of baseUris) {
+      const base = new goog.Uri(baseStr);
+      for (const relative of relativeAsGoog) {
+        resolvedUris.push(base.resolve(relative).toString());
+      }
+    }
+
+    return resolvedUris;
   }
 
 


### PR DESCRIPTION
This removes creating an array of arrays in manifest URI resolver and uses a nested loop to update an empty array instead