### PR TITLE
perf(DASH): reduce looping and remove chaining awaits in period

### DIFF
--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -104,6 +104,37 @@ shaka.util.PeriodCombiner = class {
   }
 
   /**
+    * Returns an object that contains arrays of streams by type
+    * @param {!Array.<shaka.extern.Period>} periods
+    * @return {{
+    *  audioStreamsPerPeriod: !Array.<!Array.<shaka.extern.Stream>>,
+    *  videoStreamsPerPeriod: !Array.<!Array.<shaka.extern.Stream>>,
+    *  textStreamsPerPeriod: !Array.<!Array.<shaka.extern.Stream>>,
+    *  imageStreamsPerPeriod: !Array.<!Array.<shaka.extern.Stream>>
+    * }}
+   * @private
+  */
+  getStreamsPerPeriod_(periods) {
+    const audioStreamsPerPeriod = [];
+    const videoStreamsPerPeriod = [];
+    const textStreamsPerPeriod = [];
+    const imageStreamsPerPeriod = [];
+
+    for (const period of periods) {
+      audioStreamsPerPeriod.push(period.audioStreams);
+      videoStreamsPerPeriod.push(period.videoStreams);
+      textStreamsPerPeriod.push(period.textStreams);
+      imageStreamsPerPeriod.push(period.imageStreams);
+    }
+    return {
+      audioStreamsPerPeriod,
+      videoStreamsPerPeriod,
+      textStreamsPerPeriod,
+      imageStreamsPerPeriod,
+    };
+  }
+
+  /**
    * @param {!Array.<shaka.extern.Period>} periods
    * @param {boolean} isDynamic
    * @return {!Promise}
@@ -151,14 +182,12 @@ shaka.util.PeriodCombiner = class {
         return;
       }
 
-      const audioStreamsPerPeriod = periods.map(
-          (period) => period.audioStreams);
-      const videoStreamsPerPeriod = periods.map(
-          (period) => period.videoStreams);
-      const textStreamsPerPeriod = periods.map(
-          (period) => period.textStreams);
-      const imageStreamsPerPeriod = periods.map(
-          (period) => period.imageStreams);
+      const {
+        audioStreamsPerPeriod,
+        videoStreamsPerPeriod,
+        textStreamsPerPeriod,
+        imageStreamsPerPeriod,
+      } = this.getStreamsPerPeriod_(periods);
 
       // It's okay to have a period with no text or images, but our algorithm
       // fails on any period without matching streams.  So we add dummy streams
@@ -174,33 +203,32 @@ shaka.util.PeriodCombiner = class {
             ContentType.IMAGE));
       }
 
-      await shaka.util.PeriodCombiner.combine_(
-          this.audioStreams_,
-          audioStreamsPerPeriod,
-          firstNewPeriodIndex,
-          shaka.util.PeriodCombiner.cloneStream_,
-          shaka.util.PeriodCombiner.concatenateStreams_);
-
-      await shaka.util.PeriodCombiner.combine_(
-          this.videoStreams_,
-          videoStreamsPerPeriod,
-          firstNewPeriodIndex,
-          shaka.util.PeriodCombiner.cloneStream_,
-          shaka.util.PeriodCombiner.concatenateStreams_);
-
-      await shaka.util.PeriodCombiner.combine_(
-          this.textStreams_,
-          textStreamsPerPeriod,
-          firstNewPeriodIndex,
-          shaka.util.PeriodCombiner.cloneStream_,
-          shaka.util.PeriodCombiner.concatenateStreams_);
-
-      await shaka.util.PeriodCombiner.combine_(
-          this.imageStreams_,
-          imageStreamsPerPeriod,
-          firstNewPeriodIndex,
-          shaka.util.PeriodCombiner.cloneStream_,
-          shaka.util.PeriodCombiner.concatenateStreams_);
+      await Promise.all([
+        shaka.util.PeriodCombiner.combine_(
+            this.audioStreams_,
+            audioStreamsPerPeriod,
+            firstNewPeriodIndex,
+            shaka.util.PeriodCombiner.cloneStream_,
+            shaka.util.PeriodCombiner.concatenateStreams_),
+        shaka.util.PeriodCombiner.combine_(
+            this.videoStreams_,
+            videoStreamsPerPeriod,
+            firstNewPeriodIndex,
+            shaka.util.PeriodCombiner.cloneStream_,
+            shaka.util.PeriodCombiner.concatenateStreams_),
+        shaka.util.PeriodCombiner.combine_(
+            this.textStreams_,
+            textStreamsPerPeriod,
+            firstNewPeriodIndex,
+            shaka.util.PeriodCombiner.cloneStream_,
+            shaka.util.PeriodCombiner.concatenateStreams_),
+        shaka.util.PeriodCombiner.combine_(
+            this.imageStreams_,
+            imageStreamsPerPeriod,
+            firstNewPeriodIndex,
+            shaka.util.PeriodCombiner.cloneStream_,
+            shaka.util.PeriodCombiner.concatenateStreams_),
+      ]);
     }
 
     // Create variants for all audio/video combinations.


### PR DESCRIPTION
This change removes chaining awaits in period combiner when combining variants and parses streams in one loop instead of 4