### PR TITLE
perf: simplify and improve performance of parsing initData when deduping

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -2045,15 +2045,17 @@ shaka.media.DrmEngine = class {
         // audio adaptations, so we shouldn't have to worry about checking
         // robustness.
         if (drm1.keySystem == drm2.keySystem) {
-          /** @type {Array<shaka.extern.InitDataOverride>} */
-          let initData = [];
-          initData = initData.concat(drm1.initData || []);
-          initData = initData.concat(drm2.initData || []);
-          initData = initData.filter((d, i) => {
-            return d.keyId === undefined || i === initData.findIndex((d2) => {
-              return d2.keyId === d.keyId;
-            });
-          });
+          const initDataMap = new Map();
+          const bothInitDatas = (drm1.initData || [])
+              .concat(drm2.initData || []);
+          for (const d of bothInitDatas) {
+            if (typeof d !== 'string' && !initDataMap.has(d.keyId)) {
+              initDataMap.set(d.keyId, d);
+            } else if (typeof d === 'string' && !initDataMap.has(d)) {
+              initDataMap.set(d, d);
+            }
+          }
+          const initData = Array.from(initDataMap.values());
 
           const keyIds = drm1.keyIds && drm2.keyIds ?
               new Set([...drm1.keyIds, ...drm2.keyIds]) :


### PR DESCRIPTION
This change simplifies code that parses initData in the `getCommonDrmInfos` method