### PR TITLE
perf(Xbox): drop incompatible variants for XBOX early

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -358,14 +358,15 @@ shaka.util.StreamUtils = class {
     manifest.variants = manifest.variants.filter((variant) => {
       // See: https://github.com/shaka-project/shaka-player/issues/3860
       const video = variant.video;
+      const videoWidth = video.width || 0;
+      const videoHeight = video.height || 0;
 
       // See: https://github.com/shaka-project/shaka-player/issues/3380
       // Note: it makes sense to drop early
       if (isXboxOne && video &&
-        ((video.width && video.width > 1920) ||
-        (video.height && video.height > 1080)) &&
-        (video.codecs.includes('avc1.') ||
-        video.codecs.includes('avc3.'))) {
+        (videoWidth > 1920 || videoHeight > 1080) &&
+        (video.codecs.includes('avc1.') || video.codecs.includes('avc3.'))
+      ) {
         shaka.log.debug('Dropping variant - not compatible with platform',
             StreamUtils.getVariantSummaryString_(variant));
         return false;

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -358,8 +358,8 @@ shaka.util.StreamUtils = class {
     manifest.variants = manifest.variants.filter((variant) => {
       // See: https://github.com/shaka-project/shaka-player/issues/3860
       const video = variant.video;
-      const videoWidth = video.width || 0;
-      const videoHeight = video.height || 0;
+      const videoWidth = (video && video.width) || 0;
+      const videoHeight = (video && video.height) || 0;
 
       // See: https://github.com/shaka-project/shaka-player/issues/3380
       // Note: it makes sense to drop early

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -347,19 +347,32 @@ shaka.util.StreamUtils = class {
     await shaka.util.StreamUtils.getDecodingInfosForVariants(
         manifest.variants, usePersistentLicenses, /* srcEquals= */ false,
         /** preferredKeySystems= */ []);
+
+    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const Capabilities = shaka.media.Capabilities;
+    const ManifestParserUtils = shaka.util.ManifestParserUtils;
+    const MimeUtils = shaka.util.MimeUtils;
+    const StreamUtils = shaka.util.StreamUtils;
+    const isXboxOne = shaka.util.Platform.isXboxOne();
+
     manifest.variants = manifest.variants.filter((variant) => {
       // See: https://github.com/shaka-project/shaka-player/issues/3860
       const video = variant.video;
 
-      const ContentType = shaka.util.ManifestParserUtils.ContentType;
-      const Capabilities = shaka.media.Capabilities;
-      const ManifestParserUtils = shaka.util.ManifestParserUtils;
-      const MimeUtils = shaka.util.MimeUtils;
-      const StreamUtils = shaka.util.StreamUtils;
+      // See: https://github.com/shaka-project/shaka-player/issues/3380
+      // Note: it makes sense to drop early
+      if (isXboxOne && video &&
+        ((video.width && video.width > 1920) ||
+        (video.height && video.height > 1080)) &&
+        (video.codecs.includes('avc1.') ||
+        video.codecs.includes('avc3.'))) {
+        shaka.log.debug('Dropping variant - not compatible with platform',
+            StreamUtils.getVariantSummaryString_(variant));
+        return false;
+      }
 
       if (video) {
         let videoCodecs = StreamUtils.getCorrectVideoCodecs_(video.codecs);
-
         // For multiplexed streams. Here we must check the audio of the
         // stream to see if it is compatible.
         if (video.codecs.includes(',')) {
@@ -368,7 +381,6 @@ shaka.util.StreamUtils = class {
           videoCodecs = ManifestParserUtils.guessCodecs(
               ContentType.VIDEO, allCodecs);
           videoCodecs = StreamUtils.getCorrectVideoCodecs_(videoCodecs);
-
           let audioCodecs = ManifestParserUtils.guessCodecs(
               ContentType.AUDIO, allCodecs);
           audioCodecs = StreamUtils.getCorrectAudioCodecs_(audioCodecs);
@@ -408,17 +420,6 @@ shaka.util.StreamUtils = class {
 
         // Update the codec string with the (possibly) converted codecs.
         audio.codecs = codecs;
-      }
-
-      // See: https://github.com/shaka-project/shaka-player/issues/3380
-      if (shaka.util.Platform.isXboxOne() && video &&
-          ((video.width && video.width > 1920) ||
-          (video.height && video.height > 1080)) &&
-          (video.codecs.includes('avc1.') ||
-          video.codecs.includes('avc3.'))) {
-        shaka.log.debug('Dropping variant - not compatible with platform',
-            StreamUtils.getVariantSummaryString_(variant));
-        return false;
       }
 
       const supported = variant.decodingInfos.some((decodingInfo) => {


### PR DESCRIPTION
This change:

- drops incompatible variants for XBOX before parsing codes and checking them against media capabilities API
- avoids redeclaring variables each time in the loop