### PR TITLE
chore(DASH): move repetitive code to method, avoid full iteration if possible

### DIFF
--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -315,6 +315,26 @@ shaka.dash.MpdUtils = class {
   }
 
   /**
+   * Parses common attributes for Representation, AdaptationSet, and Period.
+   * @param {shaka.dash.DashParser.Context} context
+   * @param {function(?shaka.dash.DashParser.InheritanceFrame):Element} callback
+   * @return {!Array.<!Element>}
+    */
+  static getNodes(context, callback) {
+    const Functional = shaka.util.Functional;
+    goog.asserts.assert(
+        callback(context.representation),
+        'There must be at least one element of the given type',
+    );
+
+    return [
+      callback(context.representation),
+      callback(context.adaptationSet),
+      callback(context.period),
+    ].filter(Functional.isNotNull);
+  }
+
+  /**
    * Searches the inheritance for a Segment* with the given attribute.
    *
    * @param {shaka.dash.DashParser.Context} context
@@ -324,21 +344,17 @@ shaka.dash.MpdUtils = class {
    * @return {?string}
    */
   static inheritAttribute(context, callback, attribute) {
-    const Functional = shaka.util.Functional;
-    goog.asserts.assert(
-        callback(context.representation),
-        'There must be at least one element of the given type');
+    const MpdUtils = shaka.dash.MpdUtils;
+    const nodes = MpdUtils.getNodes(context, callback);
 
-    /** @type {!Array.<!Element>} */
-    const nodes = [
-      callback(context.representation),
-      callback(context.adaptationSet),
-      callback(context.period),
-    ].filter(Functional.isNotNull);
-
-    return nodes
-        .map((s) => { return s.getAttribute(attribute); })
-        .reduce((all, part) => { return all || part; });
+    let result = null;
+    for (const node of nodes) {
+      result = node.getAttribute(attribute);
+      if (result) {
+        break;
+      }
+    }
+    return result;
   }
 
   /**
@@ -351,22 +367,18 @@ shaka.dash.MpdUtils = class {
    * @return {Element}
    */
   static inheritChild(context, callback, child) {
-    const Functional = shaka.util.Functional;
-    goog.asserts.assert(
-        callback(context.representation),
-        'There must be at least one element of the given type');
-
-    /** @type {!Array.<!Element>} */
-    const nodes = [
-      callback(context.representation),
-      callback(context.adaptationSet),
-      callback(context.period),
-    ].filter(Functional.isNotNull);
+    const MpdUtils = shaka.dash.MpdUtils;
+    const nodes = MpdUtils.getNodes(context, callback);
 
     const XmlUtils = shaka.util.XmlUtils;
-    return nodes
-        .map((s) => { return XmlUtils.findChild(s, child); })
-        .reduce((all, part) => { return all || part; });
+    let result = null;
+    for (const node of nodes) {
+      result = XmlUtils.findChild(node, child);
+      if (result) {
+        break;
+      }
+    }
+    return result;
   }
 
   /**


### PR DESCRIPTION
This change creates a separate method to get context nodes, and breaks from loops early if it finds the desired result