### PR TITLE
perf(utils): use WeakSet to track object references

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Gil Gonen <gil.gonen@gmail.com>
 Giorgio Gamberoni <giorgio.gamberoni@gmail.com>
 Giuseppe Samela <giuseppe.samela@gmail.com>
 Google Inc. <*@google.com>
+Ivan Kohut <i.kohut@yahoo.com>
 Itay Kinnrot <Itay.Kinnrot@Kaltura.com>
 Jaeseok Lee <devsunb@gmail.com>
 Jason Palmer <jason@jason-palmer.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -60,6 +60,7 @@ Gil Gonen <gil.gonen@gmail.com>
 Giorgio Gamberoni <giorgio.gamberoni@gmail.com>
 Giuseppe Samela <giuseppe.samela@gmail.com>
 Hichem Taoufik <hichem@code-it.fr>
+Ivan Kohut <i.kohut@yahoo.com>
 Itay Kinnrot <itay.kinnrot@kaltura.com>
 Isaac Ramirez <isaac.ramirez.herrera@gmail.com>
 Jacob Trimble <modmaker@google.com>

--- a/lib/util/object_utils.js
+++ b/lib/util/object_utils.js
@@ -19,7 +19,7 @@ shaka.util.ObjectUtils = class {
    * @return {T}
    */
   static cloneObject(arg) {
-    const seenObjects = new Set();
+    const seenObjects = new WeakSet();
     // This recursively clones the value |val|, using the captured variable
     // |seenObjects| to track the objects we have already cloned.
     /** @suppress {strictMissingProperties} */


### PR DESCRIPTION
This change removes `Set` in favour of `WeakSet` to track seen objects while cloning for performance reasons

From MDN:
`
The number of objects or their traversal order is immaterial, so a WeakSet is more suitable (and performant) than a Set for tracking object references, especially if a very large number of objects is involved.
`