### PR TITLE
chore(Demo): Remove HLS tab and add extra tracks tab on custom assets

### DIFF
--- a/demo/common/asset.js
+++ b/demo/common/asset.js
@@ -83,8 +83,6 @@ const ShakaDemoAssetInfo = class {
     this.mediaTailorAdsParams = null;
     /** @type {?string} */
     this.mimeType = null;
-    /** @type {?string} */
-    this.mediaPlaylistFullMimeType = null;
 
 
     // Offline storage values.
@@ -172,15 +170,6 @@ const ShakaDemoAssetInfo = class {
   /** @return {boolean} */
   isAes128() {
     return this.drm.length == 1 && this.drm[0] == shakaAssets.KeySystem.AES128;
-  }
-
-  /**
-   * @param {string} mediaPlaylistFullMimeType
-   * @return {!ShakaDemoAssetInfo}
-   */
-  setMediaPlaylistFullMimeType(mediaPlaylistFullMimeType) {
-    this.mediaPlaylistFullMimeType = mediaPlaylistFullMimeType;
-    return this;
   }
 
   /**
@@ -434,11 +423,6 @@ const ShakaDemoAssetInfo = class {
       for (const key in this.extraConfig) {
         config[key] = this.extraConfig[key];
       }
-    }
-
-    if (this.mediaPlaylistFullMimeType) {
-      config.manifest.hls.mediaPlaylistFullMimeType =
-          this.mediaPlaylistFullMimeType;
     }
 
     if (this.licenseServers.size) {

--- a/demo/common/assets.js
+++ b/demo/common/assets.js
@@ -314,8 +314,7 @@ shakaAssets.testAssets = [
       /* source= */ shakaAssets.Source.SHAKA)
       .addFeature(shakaAssets.Feature.HLS)
       .addFeature(shakaAssets.Feature.MP4)
-      .addFeature(shakaAssets.Feature.OFFLINE)
-      .setMediaPlaylistFullMimeType('video/mp4; codecs="avc1.4d401f"'),
+      .addFeature(shakaAssets.Feature.OFFLINE),
   new ShakaDemoAssetInfo(
       /* name= */ 'Angel One (HLS, MP4, multilingual, Widevine)',
       /* iconUri= */ 'https://storage.googleapis.com/shaka-asset-icons/angel_one.png',

--- a/demo/custom.js
+++ b/demo/custom.js
@@ -241,40 +241,6 @@ shakaDemo.Custom = class {
    * @return {!Element} div
    * @private
    */
-  makeAssetDialogContentsHLS_(assetInProgress, inputsToCheck) {
-    const mediaPlaylistDiv = document.createElement('div');
-    const containerStyle = shakaDemo.InputContainer.Style.FLEX;
-    const container = new shakaDemo.InputContainer(
-        mediaPlaylistDiv, /* headerText= */ null, containerStyle,
-        /* docLink= */ null);
-    container.getClassList().add('wide-input');
-    container.setDefaultRowClass('wide-input');
-
-    const fullMimeTypeSetup = (input, container) => {
-      if (assetInProgress.mediaPlaylistFullMimeType) {
-        input.value = assetInProgress.mediaPlaylistFullMimeType;
-      }
-      const defaultConfig = shaka.util.PlayerConfiguration.createDefault();
-      input.placeholder = defaultConfig.manifest.hls.mediaPlaylistFullMimeType;
-    };
-    const fullMimeTypeOnChange = (input) => {
-      assetInProgress.setMediaPlaylistFullMimeType(input.value);
-    };
-    const fullMimeTypeName =
-        'Full Mime Type for Playing Media Playlists Directly';
-    this.makeField_(
-        container, fullMimeTypeName, fullMimeTypeSetup, fullMimeTypeOnChange);
-
-    return mediaPlaylistDiv;
-  }
-
-
-  /**
-   * @param {!ShakaDemoAssetInfo} assetInProgress
-   * @param {!Array.<!HTMLInputElement>} inputsToCheck
-   * @return {!Element} div
-   * @private
-   */
   makeAssetDialogContentsAds_(assetInProgress, inputsToCheck) {
     const adsDiv = document.createElement('div');
     const containerStyle = shakaDemo.InputContainer.Style.VERTICAL;
@@ -679,8 +645,6 @@ shakaDemo.Custom = class {
         assetInProgress, inputsToCheck);
     const adsDiv = this.makeAssetDialogContentsAds_(
         assetInProgress, inputsToCheck);
-    const hlsDiv = this.makeAssetDialogContentsHLS_(
-        assetInProgress, inputsToCheck);
     const extraConfigDiv = this.makeAssetDialogContentsExtra_(
         assetInProgress, inputsToCheck);
     const finishDiv = this.makeAssetDialogContentsFinish_(
@@ -715,7 +679,6 @@ shakaDemo.Custom = class {
     addTabButton('Drm', drmDiv, /* startOn= */ false);
     addTabButton('Headers', headersDiv, /* startOn= */ false);
     addTabButton('Ads', adsDiv, /* startOn= */ false);
-    addTabButton('HLS', hlsDiv, /* startOn= */ false);
     addTabButton('Extra Config', extraConfigDiv, /* startOn= */ false);
 
     // Append the divs in the desired order.
@@ -724,7 +687,6 @@ shakaDemo.Custom = class {
     this.dialog_.appendChild(drmDiv);
     this.dialog_.appendChild(headersDiv);
     this.dialog_.appendChild(adsDiv);
-    this.dialog_.appendChild(hlsDiv);
     this.dialog_.appendChild(extraConfigDiv);
     this.dialog_.appendChild(finishDiv);
     this.dialog_.appendChild(iconDiv);

--- a/demo/custom.js
+++ b/demo/custom.js
@@ -425,6 +425,37 @@ shakaDemo.Custom = class {
    * @return {!Element} div
    * @private
    */
+  makeAssetDialogContentsExtraTracks_(assetInProgress, inputsToCheck) {
+    const extraTracksDiv = document.createElement('div');
+    const containerStyle = shakaDemo.InputContainer.Style.FLEX;
+    const container = new shakaDemo.InputContainer(
+        extraTracksDiv, /* headerText= */ null, containerStyle,
+        /* docLink= */ null);
+    container.getClassList().add('wide-input');
+    container.setDefaultRowClass('wide-input');
+
+    const thumbnailsUrlSetup = (input, container) => {
+      if (assetInProgress.extraThumbnail.length) {
+        input.value = assetInProgress.extraThumbnail[0];
+      }
+    };
+    const thumbnailsUrlOnChange = (input) => {
+      assetInProgress.extraThumbnail = [];
+      assetInProgress.addExtraThumbnail(input.value);
+    };
+
+    this.makeField_(
+        container, 'Thumbnails URL', thumbnailsUrlSetup, thumbnailsUrlOnChange);
+
+    return extraTracksDiv;
+  }
+
+  /**
+   * @param {!ShakaDemoAssetInfo} assetInProgress
+   * @param {!Array.<!HTMLInputElement>} inputsToCheck
+   * @return {!Element} div
+   * @private
+   */
   makeAssetDialogContentsExtra_(assetInProgress, inputsToCheck) {
     const extraConfigDiv = document.createElement('div');
     const containerStyle = shakaDemo.InputContainer.Style.FLEX;
@@ -645,6 +676,8 @@ shakaDemo.Custom = class {
         assetInProgress, inputsToCheck);
     const adsDiv = this.makeAssetDialogContentsAds_(
         assetInProgress, inputsToCheck);
+    const extraTracksDiv = this.makeAssetDialogContentsExtraTracks_(
+        assetInProgress, inputsToCheck);
     const extraConfigDiv = this.makeAssetDialogContentsExtra_(
         assetInProgress, inputsToCheck);
     const finishDiv = this.makeAssetDialogContentsFinish_(
@@ -679,6 +712,7 @@ shakaDemo.Custom = class {
     addTabButton('Drm', drmDiv, /* startOn= */ false);
     addTabButton('Headers', headersDiv, /* startOn= */ false);
     addTabButton('Ads', adsDiv, /* startOn= */ false);
+    addTabButton('Extra Tracks', extraTracksDiv, /* startOn= */ false);
     addTabButton('Extra Config', extraConfigDiv, /* startOn= */ false);
 
     // Append the divs in the desired order.
@@ -687,6 +721,7 @@ shakaDemo.Custom = class {
     this.dialog_.appendChild(drmDiv);
     this.dialog_.appendChild(headersDiv);
     this.dialog_.appendChild(adsDiv);
+    this.dialog_.appendChild(extraTracksDiv);
     this.dialog_.appendChild(extraConfigDiv);
     this.dialog_.appendChild(finishDiv);
     this.dialog_.appendChild(iconDiv);


### PR DESCRIPTION
The removed functionality is no longer necessary since the HLS parser detect the correct codecs if a media playlist is used.