### PR TITLE
fix: Allow parseXmlString when createNodeIterator is not available

### DIFF
--- a/lib/util/xml_utils.js
+++ b/lib/util/xml_utils.js
@@ -397,6 +397,11 @@ shaka.util.XmlUtils = class {
       return null;
     }
 
+    // Cobalt browser doesn't support document.createNodeIterator.
+    if (!('createNodeIterator' in document)) {
+      return rootElem;
+    }
+
     // SECURITY: Verify that the document does not contain elements from the
     // HTML or SVG namespaces, which could trigger script execution and XSS.
     const iterator = document.createNodeIterator(


### PR DESCRIPTION
Related to https://github.com/shaka-project/shaka-player/issues/5804