### PR TITLE
fix: Fix DRM workaround for Tizen and Xbox with ac-4 boxes

### DIFF
--- a/lib/media/content_workarounds.js
+++ b/lib/media/content_workarounds.js
@@ -105,6 +105,12 @@ shaka.media.ContentWorkarounds = class {
             newType: ContentWorkarounds.BOX_TYPE_ENCA_,
           });
         })
+        .fullBox('ac-4', (box) => {
+          boxesToModify.push({
+            box,
+            newType: ContentWorkarounds.BOX_TYPE_ENCA_,
+          });
+        })
         .fullBox('mp4a', (box) => {
           boxesToModify.push({
             box,

--- a/test/media/content_workarounds_unit.js
+++ b/test/media/content_workarounds_unit.js
@@ -7,7 +7,7 @@
 describe('ContentWorkarounds', () => {
   const encryptionBoxes = {
     'encv': ['hev1', 'hvc1', 'avc1', 'avc3'],
-    'enca': ['ac-3', 'ec-3', 'mp4a'],
+    'enca': ['ac-3', 'ec-3', 'ac-4', 'mp4a'],
   };
   for (const encryptionBox of Object.keys(encryptionBoxes)) {
     for (const box of encryptionBoxes[encryptionBox]) {


### PR DESCRIPTION
`content_workarounds.js` was introduced for Tizen and Xbox platforms. We found that that meant a regression where certain streams were unable to be played.

This PR adds ac-4 into the content workarounds in the same was as ec-4 to ensure these streams can be played once more.