### PR TITLE
fix: Fix chooseCodecsAndFilterManifest for similar frameRate

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -128,7 +128,7 @@ shaka.util.StreamUtils = class {
     const validVideoIds = [];
     const validVideoStreamsMap = new Map();
     const getVideoGroupId = (stream) => {
-      return (stream.frameRate || 0) + (stream.hdr || '');
+      return Math.round(stream.frameRate || 0) + (stream.hdr || '');
     };
     for (const stream of videoStreams) {
       const groupId = getVideoGroupId(stream);


### PR DESCRIPTION
Fixes https://storage.googleapis.com/shaka-demo-assets/sintel/dash.mpd
mp4 --> 12288/512 --> 24
webm --> 1000000/42000 --> 23.80952380952381