### PR TITLE
feat: Improve latency in LL DASH streams

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1381,6 +1381,10 @@ shaka.media.StreamingEngine = class {
             await this.append_(
                 mediaState, presentationTime, stream, reference, dataToAppend,
                 /* isChunkedData= */ true);
+
+            if (mediaState.segmentPrefetch && mediaState.segmentIterator) {
+              mediaState.segmentPrefetch.prefetchSegments(reference);
+            }
           }
         };
 
@@ -1410,6 +1414,10 @@ shaka.media.StreamingEngine = class {
 
           await this.append_(
               mediaState, presentationTime, stream, reference, result);
+        }
+
+        if (mediaState.segmentPrefetch && mediaState.segmentIterator) {
+          mediaState.segmentPrefetch.prefetchSegments(reference);
         }
       } else {
         if (this.config_.lowLatencyMode && !isReadableStreamSupported) {


### PR DESCRIPTION
This change causes the prefetch to be called much earlier, which improves latency in DASH streams in around 500ms.