### PR TITLE
fix(hisense): set stallSkip to 0 for HiSense devices

### DIFF
--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -218,13 +218,15 @@ shaka.util.PlayerConfiguration = class {
       liveSyncPlaybackRate: 1.1,
     };
 
-    // WebOS, Tizen, and Chromecast have long hardware pipelines that respond
-    // slowly to seeking.  Therefore we should not seek when we detect a stall
+    // WebOS, Tizen, Chromecast and Hisense have long hardware pipelines
+    // that respond slowly to seeking.
+    // Therefore we should not seek when we detect a stall
     // on one of these platforms.  Instead, default stallSkip to 0 to force the
     // stall detector to pause and play instead.
     if (shaka.util.Platform.isWebOS() ||
         shaka.util.Platform.isTizen() ||
-        shaka.util.Platform.isChromecast()) {
+        shaka.util.Platform.isChromecast() ||
+        shaka.util.Platform.isHisense()) {
       streaming.stallSkip = 0;
     }
 


### PR DESCRIPTION
This change fixes an issue on HiSense devices, where playback is sometimes repeated because current time is updated by skip on devices which don't support precise seeking