### PR TITLE
fix: Fix bug with live start time

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -1901,7 +1901,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.config_.playRangeStart,
         this.config_.playRangeEnd);
 
-    this.playhead_ = this.createPlayhead(this.startTime_ || 0);
+    this.playhead_ = this.createPlayhead(this.startTime_);
     this.playheadObservers_ =
         this.createPlayheadObserversForMSE_(startTimeOfLoad);
 


### PR DESCRIPTION
This fixes a bug introduced by the removal of the state graph that caused live content to start out at time=0, instead of at the live edge.