### PR TITLE
fix(dash): fix race condition in segment template

### DIFF
--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -813,12 +813,12 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
     let ref = this.references[correctedPosition];
 
     if (!ref) {
+      const mediaTemplate = this.templateInfo_.mediaTemplate;
       const range = this.templateInfo_.timeline[correctedPosition];
       const segmentReplacement = position + this.templateInfo_.startNumber;
       const timeReplacement = this.templateInfo_
           .unscaledPresentationTimeOffset + range.unscaledStart;
 
-      const mediaTemplate = this.templateInfo_.mediaTemplate;
       const createUrisCb = () => {
         return shaka.dash.TimelineSegmentIndex
             .createUris_(

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -818,13 +818,11 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
       const timeReplacement = this.templateInfo_
           .unscaledPresentationTimeOffset + range.unscaledStart;
 
+      const mediaTemplate = this.templateInfo_.mediaTemplate;
       const createUrisCb = () => {
-        if (!this.templateInfo_) {
-          return [];
-        }
         return shaka.dash.TimelineSegmentIndex
             .createUris_(
-                this.templateInfo_.mediaTemplate,
+                mediaTemplate,
                 this.representationId_,
                 segmentReplacement,
                 this.bandwidth_,


### PR DESCRIPTION
This was introduced in #5061.

If `.release()` is called between the time `createUrisCb()` is created and when it's called, then `this.templateInfo_` is set to null, causing #5614 and #5760. The fix in #5619 may have been enough to fix or silence #5614, but it wasn't enough to fix #5760, which is the issue I'm having (at least I'm getting the same error).

Maybe @nrcrast can confirm this is the correct `this.templateInfo_.mediaTemplate` to pass to `createUris_()`? I don't fully understand the segment template (I have git bisected my way to find the issue). The initial PR draft for #5061 didn't actually have the race condition. It was introduced when [addressing](https://github.com/shaka-project/shaka-player/pull/5061/commits/e7971c16e258fe1aa96f6d80d57e9ab2bf6f8ef8#diff-c5ae94ade4937cab5320a06ed21898f31cc818f6a5d2a8017fe034650dad445fR868) feedback about using `.bind()` for createUrisCb: https://github.com/shaka-project/shaka-player/pull/5061#discussion_r1171827475. So to me it seems like that change was unintentional.