### PR TITLE
fix: Allow get seekRange on manifestparsed event in some cases

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -3317,17 +3317,22 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
   /**
    * Get the range of time (in seconds) that seeking is allowed. If the player
-   * has not loaded content, this will return a range from 0 to 0.
+   * has not loaded content and the manifest is HLS, this will return a range
+   * from 0 to 0.
    *
    * @return {{start: number, end: number}}
    * @export
    */
   seekRange() {
-    if (!this.fullyLoaded_) {
-      return {'start': 0, 'end': 0};
-    }
-
     if (this.manifest_) {
+      // With HLS lazy-loading, there were some situations where the manifest
+      // had partially loaded, enough to move onto further load stages, but no
+      // segments had been loaded, so the timeline is still unknown.
+      // See: https://github.com/shaka-project/shaka-player/pull/4590
+      if (!this.fullyLoaded_ &&
+          this.manifest_.type == shaka.media.ManifestParser.HLS) {
+        return {'start': 0, 'end': 0};
+      }
       const timeline = this.manifest_.presentationTimeline;
 
       return {


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/5115