### PR TITLE
fix: CEA decoder should return early if packet is not large enough

### DIFF
--- a/lib/cea/cea_decoder.js
+++ b/lib/cea/cea_decoder.js
@@ -137,6 +137,9 @@ shaka.cea.CeaDecoder = class {
     const reader = new shaka.util.DataViewReader(
         userDataSeiMessage, shaka.util.DataViewReader.Endianness.BIG_ENDIAN);
 
+    if (reader.getLength() < shaka.cea.CeaDecoder.MIN_LENGTH) {
+      return;
+    }
     if (reader.readUint8() !== shaka.cea.CeaDecoder.USA_COUNTRY_CODE) {
       return;
     }
@@ -434,6 +437,13 @@ shaka.cea.CeaDecoder.NTSC_CC_FIELD_2 = 1;
  * @private @const {number}
  */
 shaka.cea.CeaDecoder.USA_COUNTRY_CODE = 0xb5;
+
+/**
+ * Caption packet min length
+ * Country Code + ATSC_PROVIDER_CODE + ATSC_1_USER_IDENTIFIER + USER_DATA_TYPE
+ * @private @const {number}
+ */
+shaka.cea.CeaDecoder.MIN_LENGTH = 8;
 
 shaka.media.ClosedCaptionParser.registerDecoder(
     () => new shaka.cea.CeaDecoder());

--- a/test/cea/cea_decoder_unit.js
+++ b/test/cea/cea_decoder_unit.js
@@ -519,6 +519,13 @@ describe('CeaDecoder', () => {
 
       expect(decoder.reset).toHaveBeenCalledTimes(1);
     });
+
+    it('does not attempt to extract SEI packet that is too short', () => {
+      const badData = new Uint8Array([0xb5]);
+      decoder.extract(badData, 0);
+      const captions = decoder.decode();
+      expect(captions.length).toBe(0);
+    });
   });
 
   describe('decodes CEA-708', () => {


### PR DESCRIPTION
Fixes #5891 

In production, we are seeing the occasional SEI packet [`0x5b`], which is causing the parser to error. Using Mux.JS, this packet is ignored because it's not long enough to be a valid captions packet, so for feature parity it would make sense for the built in Shaka parser to also ignore. 