### PR TITLE
fix: Add Orange platform to requiresEncryptionInfoInAllInitSegments

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -464,7 +464,7 @@ shaka.util.Platform = class {
    */
   static requiresEncryptionInfoInAllInitSegments() {
     const Platform = shaka.util.Platform;
-    return Platform.isTizen() || Platform.isXboxOne();
+    return Platform.isTizen() || Platform.isXboxOne() || Platform.isOrange();
   }
 
   /**


### PR DESCRIPTION
In testing Shaka on Orange S.A devices, we discovered these devices require encryption info in all init segments when content includes unencrypted and encrypted periods. 

This PR adds the Orange platform to `requiresEncryptionInfoInAllInitSegments`, so the the fake encryption workaround can be applied. Resolves: https://github.com/shaka-project/shaka-player/issues/5894.