### PR TITLE
fix: Fix init segment comparison

### DIFF
--- a/lib/media/segment_reference.js
+++ b/lib/media/segment_reference.js
@@ -128,7 +128,8 @@ shaka.media.InitSegmentReference = class {
     } else {
       return reference1.getStartByte() == reference2.getStartByte() &&
           reference1.getEndByte() == reference2.getEndByte() &&
-          ArrayUtils.equal(reference1.getUris(), reference2.getUris()) &&
+          ArrayUtils.equal(
+              reference1.getUris().sort(), reference2.getUris().sort()) &&
           BufferUtils.equal(reference1.getSegmentData(),
               reference2.getSegmentData());
     }


### PR DESCRIPTION
With the introduction of Content Steering the URLs may change order, but the segment is the same