### PR TITLE
fix: Only append to the buffer init segments when the segment is independent

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1792,7 +1792,7 @@ shaka.media.StreamingEngine = class {
         reference.initSegmentReference, mediaState.lastInitSegmentReference)) {
       mediaState.lastInitSegmentReference = reference.initSegmentReference;
 
-      if (reference.initSegmentReference) {
+      if (reference.isIndependent() && reference.initSegmentReference) {
         shaka.log.v1(logPrefix, 'fetching init segment');
 
         const fetchInit =


### PR DESCRIPTION
Note: this happens with LL only.