### PR TITLE
fix: Properly size region anchor from LINE units

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -55,6 +55,7 @@ Esteban Dosztal <edosztal@gmail.com>
 Fadomire <fadomire@gmail.com>
 Fernando Neira <slocomber@gmail.com>
 François Beaufort <fbeaufort@google.com>
+Gary Katsevman <git@gkatsev.com>
 Gerardo Meola <meola.gerardo@gmail.com>
 Gil Gonen <gil.gonen@gmail.com>
 Giorgio Gamberoni <giorgio.gamberoni@gmail.com>

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -417,11 +417,18 @@ shaka.text.UITextDisplayer = class {
     regionElement.id = 'shaka-text-region---' + regionId;
     regionElement.classList.add('shaka-text-region');
 
-    regionElement.style.height = region.height + heightUnit;
-    regionElement.style.width = region.width + widthUnit;
     regionElement.style.position = 'absolute';
-    regionElement.style.top = region.viewportAnchorY + viewportAnchorUnit;
-    regionElement.style.left = region.viewportAnchorX + viewportAnchorUnit;
+
+    const linesUnit = shaka.text.CueRegion.units.LINES;
+    if (region.heightUnits !== linesUnit && region.widthUnits !== linesUnit) {
+      regionElement.style.height = region.height + heightUnit;
+      regionElement.style.width = region.width + widthUnit;
+    }
+
+    if (region.viewportAnchorUnits !== linesUnit) {
+      regionElement.style.top = region.viewportAnchorY + viewportAnchorUnit;
+      regionElement.style.left = region.viewportAnchorX + viewportAnchorUnit;
+    }
 
     regionElement.style.display = 'flex';
     regionElement.style.flexDirection = 'column';

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -420,6 +420,10 @@ shaka.text.UITextDisplayer = class {
    */
   getRegionElement_(cue) {
     const region = cue.region;
+    // from https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html#caption-window-size
+    // if aspect ratio is 4/3, use that value, otherwise, use the 16:9 value
+    const lineWidthMultiple = this.aspectRatio_ === 4/3 ? 2.5 : 1.9;
+    const lineHeightMultiple = 5.33;
 
     const regionId = this.generateRegionId_(region);
     if (this.regionElements_.has(regionId)) {
@@ -441,9 +445,8 @@ shaka.text.UITextDisplayer = class {
 
     const linesUnit = shaka.text.CueRegion.units.LINES;
     if (region.heightUnits === linesUnit && region.widthUnits === linesUnit) {
-      // from https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html#caption-window-size
-      regionElement.style.height = region.height * 5.33 + '%';
-      regionElement.style.width = region.width * 1.9 + '%';
+      regionElement.style.height = region.height * lineHeightMultiple + '%';
+      regionElement.style.width = region.width * lineWidthMultiple + '%';
     } else {
       regionElement.style.height = region.height + heightUnit;
       regionElement.style.width = region.width + widthUnit;
@@ -452,10 +455,11 @@ shaka.text.UITextDisplayer = class {
     if (region.viewportAnchorUnits === linesUnit) {
       // from https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html#positioning-in-cea-708
       let top = region.viewportAnchorY / 75 * 100;
-      let left = region.viewportAnchorX / 210 * 100;
+      const windowWidth = this.aspectRatio_ === 4/3 ? 160 : 210;
+      let left = region.viewportAnchorX / windowWidth * 100;
       // adjust top and left values based on the region anchor and window size
-      top -= region.regionAnchorY * region.height * 5.33 / 100;
-      left -= region.regionAnchorX * region.width * 1.9 / 100;
+      top -= region.regionAnchorY * region.height * lineHeightMultiple / 100;
+      left -= region.regionAnchorX * region.width * lineWidthMultiple / 100;
       regionElement.style.top = top + '%';
       regionElement.style.left = left + '%';
     } else {

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -431,8 +431,13 @@ shaka.text.UITextDisplayer = class {
 
     if (region.viewportAnchorUnits === linesUnit) {
       // from https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html#positioning-in-cea-708
-      regionElement.style.top = region.viewportAnchorY / 75 * 100 + '%';
-      regionElement.style.left = region.viewportAnchorX / 210 * 100 + '%';
+      let top = region.viewportAnchorY / 75 * 100;
+      let left = region.viewportAnchorX / 210 * 100;
+      // adjust top and left values based on the region anchor and window size
+      top -= region.regionAnchorY * region.height * 5.33 / 100;
+      left -= region.regionAnchorX * region.width * 1.9 / 100;
+      regionElement.style.top = top + '%';
+      regionElement.style.left = left + '%';
     } else {
       regionElement.style.top = region.viewportAnchorY + viewportAnchorUnit;
       regionElement.style.left = region.viewportAnchorX + viewportAnchorUnit;

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -44,6 +44,9 @@ shaka.text.UITextDisplayer = class {
     /** @private {HTMLElement} */
     this.videoContainer_ = videoContainer;
 
+    /** @private {?number} */
+    this.aspectRatio_ = null;
+
     /** @type {HTMLElement} */
     this.textContainer_ = shaka.util.Dom.createHTMLElement('div');
     this.textContainer_.classList.add('shaka-text-container');
@@ -88,6 +91,23 @@ shaka.text.UITextDisplayer = class {
 
     this.eventManager_.listen(document, 'fullscreenchange', () => {
       this.updateCaptions_(/* forceUpdate= */ true);
+    });
+
+    // From: https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth
+    // Whenever the natural width or natural height of the video changes
+    // (including, for example, because the selected video track was changed),
+    // if the element's readyState attribute is not HAVE_NOTHING, the user
+    // agent must queue a media element task given the media element to fire an
+    // event named resize at the media element.
+    this.eventManager_.listen(this.video_, 'resize', () => {
+      const element = /** @type {!HTMLVideoElement} */ (this.video_);
+      const width = element.videoWidth;
+      const height = element.videoHeight;
+      if (width && height) {
+        this.aspectRatio_ = width / height;
+      } else {
+        this.aspectRatio_ = null;
+      }
     });
 
     /** @private {ResizeObserver} */

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -420,12 +420,20 @@ shaka.text.UITextDisplayer = class {
     regionElement.style.position = 'absolute';
 
     const linesUnit = shaka.text.CueRegion.units.LINES;
-    if (region.heightUnits !== linesUnit && region.widthUnits !== linesUnit) {
+    if (region.heightUnits === linesUnit && region.widthUnits === linesUnit) {
+      // from https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html#caption-window-size
+      regionElement.style.height = region.height * 5.33 + '%';
+      regionElement.style.width = region.width * 1.9 + '%';
+    } else {
       regionElement.style.height = region.height + heightUnit;
       regionElement.style.width = region.width + widthUnit;
     }
 
-    if (region.viewportAnchorUnits !== linesUnit) {
+    if (region.viewportAnchorUnits === linesUnit) {
+      // from https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html#positioning-in-cea-708
+      regionElement.style.top = region.viewportAnchorY / 75 * 100 + '%';
+      regionElement.style.left = region.viewportAnchorX / 210 * 100 + '%';
+    } else {
       regionElement.style.top = region.viewportAnchorY + viewportAnchorUnit;
       regionElement.style.left = region.viewportAnchorX + viewportAnchorUnit;
     }

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -439,8 +439,10 @@ shaka.text.UITextDisplayer = class {
       regionElement.style.top = top + '%';
       regionElement.style.left = left + '%';
     } else {
-      regionElement.style.top = region.viewportAnchorY + viewportAnchorUnit;
-      regionElement.style.left = region.viewportAnchorX + viewportAnchorUnit;
+      regionElement.style.top = region.viewportAnchorY -
+        region.regionAnchorY * region.height / 100 + viewportAnchorUnit;
+      regionElement.style.left = region.viewportAnchorX -
+        region.regionAnchorX * region.width / 100 + viewportAnchorUnit;
     }
 
     regionElement.style.display = 'flex';


### PR DESCRIPTION
CEA708 captions may set windows in LINE units, this needs to be converted to percentages to be properly displayed. In addition, adjust by the region anchor.