### PR TITLE
fix: log prefetch miss for missing segments

### DIFF
--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -165,12 +165,12 @@ shaka.media.SegmentPrefetch = class {
       if (reference instanceof shaka.media.SegmentReference) {
         shaka.log.debug(
             logPrefix,
-            'reused prefetched segment at time:', reference.startTime,
+            'missed segment at time:', reference.startTime,
             'mapSize', this.segmentPrefetchMap_.size);
       } else {
         shaka.log.debug(
             logPrefix,
-            'reused prefetched init segment at time, mapSize',
+            'missed init segment at time, mapSize',
             this.segmentPrefetchMap_.size);
       }
       return null;


### PR DESCRIPTION
A recent change made it always log that segments were re-used, but in reality there were times when they were missed. Uses the language from the original PR