### PR TITLE
docs: fix use of encodeURIComponent() in fairplay tutorial

### DIFF
--- a/docs/tutorials/fairplay.md
+++ b/docs/tutorials/fairplay.md
@@ -98,9 +98,9 @@ player.getNetworkingEngine().registerRequestFilter((type, request, context) => {
   const originalPayload = new Uint8Array(request.body);
   const base64Payload =
       shaka.util.Uint8ArrayUtils.toStandardBase64(originalPayload);
-  const params = 'spc=' + base64Payload;
+  const params = 'spc=' + encodeURIComponent(base64Payload);
   request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
-  request.body = shaka.util.StringUtils.toUTF8(encodeURIComponent(params));
+  request.body = shaka.util.StringUtils.toUTF8(params);
 });
 
 player.getNetworkingEngine().registerResponseFilter((type, response, context) => {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST states
> `application/x-www-form-urlencoded`: the keys and values are encoded in key-value tuples separated by '&', with a '=' between the key and the value. Non-alphanumeric characters in both keys and values are [URL encoded](https://en.wikipedia.org/wiki/URL_encoding): [...]

however, the current documentation also encodes `=`, like so:

`encodeURIComponent('spc=foobar') === 'spc%3Dfoobar'`

instead, the values (and strictly also keys, but they don't contain anything special, so no need) should be encoded separately.

this pr fixes this.

maybe there is some drm quirks why it was like that, otherwise this should be a bug.
let me know if I'm missing something!