### PR TITLE
fix: avoid uiTextDisplayer.destroy crashing if called more than once

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ Alugha GmbH <*@alugha.com>
 Alvaro Velad Galvan <ladvan91@hotmail.com>
 Amila Sampath <lucksy@gmail.com>
 Anthony Stansbridge <github@anthonystansbridge.co.uk>
+Antonio Diaz Correa <hello@antoniodiaz.me>
 Armand Zangue <armand.zangue@gmail.com>
 Benjamin Wallberg <me@bwallberg.com>
 Bonnier Broadcasting <*@bonnierbroadcasting.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,6 +32,7 @@ Alvaro Velad Galvan <ladvan91@hotmail.com>
 Amila Sampath <lucksy@gmail.com>
 Andy Hochhaus <ahochhaus@samegoal.com>
 Anthony Stansbridge <github@anthonystansbridge.co.uk>
+Antonio Diaz Correa <hello@antoniodiaz.me>
 Armand Zangue <armand.zangue@gmail.com>
 Ashutosh Kumar Mukhiya <ashukm4@gmail.com>
 Benjamin Wallberg <benjamin.wallberg@bonnierbroadcasting.com>

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -154,6 +154,11 @@ shaka.text.UITextDisplayer = class {
    * @export
    */
   destroy() {
+    // Return resolved promise if destroy() has been called.
+    if (!this.textContainer_) {
+      return Promise.resolve();
+    }
+
     // Remove the text container element from the UI.
     this.videoContainer_.removeChild(this.textContainer_);
     this.textContainer_ = null;
@@ -176,6 +181,8 @@ shaka.text.UITextDisplayer = class {
       this.resizeObserver_.disconnect();
       this.resizeObserver_ = null;
     }
+
+    return Promise.resolve();
   }
 
 

--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -605,4 +605,13 @@ describe('UITextDisplayer', () => {
         (e) => e.nodeType == Node.ELEMENT_NODE);
     expect(childrenOfTwo.length).toBe(3);
   });
+
+  it('textDisplayer does not crash if destroy is called more than once', () => {
+    expect(videoContainer.childNodes.length).toBe(1);
+
+    textDisplayer.destroy();
+    textDisplayer.destroy();
+
+    expect(videoContainer.childNodes.length).toBe(0);
+  });
 });


### PR DESCRIPTION
Currently an instance of `uiTextDisplayer` is not idempotent, crashing if `uiTextDisplayer.destroy()` is called more than once:

```javascript
const uiTextDisplayer = new shaka.text.UITextDisplayer(
  videoElement,
  subtitlesElement
);

uiTextDisplayer.destroy();
uiTextDisplayer.destroy();
```

This is due to `videoContainer.removeChild` being called with `null` parameter on the second interation, as `textContainer` was already deleted on the first one.
Source: https://github.com/shaka-project/shaka-player/blob/9f5e46190ca00b1df36d5210852962bb52aac0c4/lib/text/ui_text_displayer.js#L158

An early return will prevent this crash, maintaining consistency with other methods.

Already created an issue for this bug at: https://github.com/shaka-project/shaka-player/issues/6023