### PR TITLE
fix: APL set-top box wrongly identifies as an Apple device.

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -234,6 +234,7 @@ shaka.util.Platform = class {
     return !!navigator.vendor && navigator.vendor.includes('Apple') &&
         !shaka.util.Platform.isTizen() &&
         !shaka.util.Platform.isEOS() &&
+        !shaka.util.Platform.isAPL() &&
         !shaka.util.Platform.isVirginMedia() &&
         !shaka.util.Platform.isOrange() &&
         !shaka.util.Platform.isPS4() &&
@@ -348,6 +349,15 @@ shaka.util.Platform = class {
     return shaka.util.Platform.userAgentContains_('PC=EOS');
   }
 
+  /**
+   * Check if the current platform is an APL set-top box.
+   *
+   * @return {boolean}
+   */
+  static isAPL() {
+    return shaka.util.Platform.userAgentContains_('PC=APL');
+  }
+  
   /**
    * Guesses if the platform is a mobile one (iOS or Android).
    *

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -357,7 +357,7 @@ shaka.util.Platform = class {
   static isAPL() {
     return shaka.util.Platform.userAgentContains_('PC=APL');
   }
-  
+
   /**
    * Guesses if the platform is a mobile one (iOS or Android).
    *


### PR DESCRIPTION
A simillar to this PR raised last year - https://github.com/shaka-project/shaka-player/pull/4310. 
The APL devices also belong to Liberty Global and are Webkit-based. We noticed that these devices are being detected incorrectly as Apple - `Platform.isApple()`, and as such, the source equals `shouldUseSrcEquals_` is selected instead of MSE. The native playback is not working as expected, and MSE is preferred on these devices 