### PR TITLE
perf(mp4generator): stop nesting concat in methods

### DIFF
--- a/lib/util/mp4_generator.js
+++ b/lib/util/mp4_generator.js
@@ -47,10 +47,11 @@ shaka.util.Mp4Generator = class {
     goog.asserts.assert(this.streamInfos_.length > 0,
         'StreamInfos must have elements');
     const Mp4Generator = shaka.util.Mp4Generator;
-    let traks = new Uint8Array([]);
+    const trakArrays = [];
     for (const streamInfo of this.streamInfos_) {
-      traks = shaka.util.Uint8ArrayUtils.concat(traks, this.trak_(streamInfo));
+      trakArrays.push(this.trak_(streamInfo));
     }
+    const traks = shaka.util.Uint8ArrayUtils.concat(...trakArrays);
     const firstStreamInfo = this.streamInfos_[0];
     return Mp4Generator.box('moov',
         this.mvhd_(firstStreamInfo),
@@ -693,10 +694,11 @@ shaka.util.Mp4Generator = class {
    */
   mvex_() {
     const Mp4Generator = shaka.util.Mp4Generator;
-    let trexs = new Uint8Array([]);
+    const trexArrays = [];
     for (const streamInfo of this.streamInfos_) {
-      trexs = shaka.util.Uint8ArrayUtils.concat(trexs, this.trex_(streamInfo));
+      trexArrays.push(this.trex_(streamInfo));
     }
+    const trexs = shaka.util.Uint8ArrayUtils.concat(...trexArrays);
     return Mp4Generator.box('mvex', trexs);
   }
 
@@ -730,9 +732,9 @@ shaka.util.Mp4Generator = class {
    * @private
    */
   pssh_(streamInfo) {
-    let boxes = new Uint8Array([]);
+    const initDatas = [];
     if (!streamInfo.encrypted) {
-      return boxes;
+      return new Uint8Array([]);
     }
 
     for (const drmInfo of streamInfo.stream.drmInfos) {
@@ -740,9 +742,10 @@ shaka.util.Mp4Generator = class {
         continue;
       }
       for (const initData of drmInfo.initData) {
-        boxes = shaka.util.Uint8ArrayUtils.concat(boxes, initData.initData);
+        initDatas.push(initData.initData);
       }
     }
+    const boxes = shaka.util.Uint8ArrayUtils.concat(...initDatas);
     return boxes;
   }
 
@@ -845,11 +848,12 @@ shaka.util.Mp4Generator = class {
    * @return {!Uint8Array}
    */
   segmentData() {
-    let result = new Uint8Array([]);
+    const segmentDataArray = [];
     for (const streamInfo of this.streamInfos_) {
-      result = shaka.util.Uint8ArrayUtils.concat(result,
-          this.moof_(streamInfo), this.mdat_(streamInfo));
+      segmentDataArray.push(
+          ...[this.moof_(streamInfo), this.mdat_(streamInfo)]);
     }
+    const result = shaka.util.Uint8ArrayUtils.concat(...segmentDataArray);
     return result;
   }
 


### PR DESCRIPTION
This change removes `concat` util function from mp4 generator iterations and runs it later, as well as stops creating new Uint8 arrays, as `concat` does this within itself.