### PR TITLE
fix(Demo): Allow play MP4 and TS in legacy iOS devices

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -738,9 +738,19 @@ shakaDemo.Main = class {
     if (asset.features.includes(shakaAssets.Feature.DOLBY_VISION_3D)) {
       mimeTypes.push('video/mp4; codecs="dvh1.20.01"');
     }
-    const hasSupportedMimeType = mimeTypes.some((type) => {
+    let hasSupportedMimeType = mimeTypes.some((type) => {
       return this.support_.media[type];
     });
+    if (!hasSupportedMimeType &&
+        !(window.ManagedMediaSource || window.MediaSource) &&
+        !!navigator.vendor && navigator.vendor.includes('Apple')) {
+      if (mimeTypes.includes('video/mp4')) {
+        hasSupportedMimeType = true;
+      }
+      if (mimeTypes.includes('video/mp2t')) {
+        hasSupportedMimeType = true;
+      }
+    }
     if (!hasSupportedMimeType) {
       return 'Your browser does not support the required video format.';
     }


### PR DESCRIPTION
This occurs on a 6th generation iPod touch with iOS 12.