### PR TITLE
revert: Install by default shaka.polyfill.PatchedMediaKeysApple when there is no unprefixed EME support

### DIFF
--- a/lib/polyfill/patchedmediakeys_apple.js
+++ b/lib/polyfill/patchedmediakeys_apple.js
@@ -791,9 +791,3 @@ shaka.polyfill.PatchedMediaKeysApple.MediaKeyStatusMap = class {
     goog.asserts.assert(false, 'Not used!  Provided only for the compiler.');
   }
 };
-
-if (!navigator.requestMediaKeySystemAccess ||
-    // eslint-disable-next-line no-restricted-syntax
-    !MediaKeySystemAccess.prototype.getConfiguration) {
-  shaka.polyfill.register(shaka.polyfill.PatchedMediaKeysApple.install);
-}


### PR DESCRIPTION
This reverts commit 5b5b2ce1746ea888e163dddb3d36125f03100102.

Due to: https://github.com/shaka-project/shaka-player/commit/b1e5063cb8f17747bad40836c3c612224e2811a5#commitcomment-136674454