### PR TITLE
fix: fix handling of multiple CC tracks

### DIFF
--- a/lib/cea/cea608_memory.js
+++ b/lib/cea/cea608_memory.js
@@ -79,7 +79,7 @@ shaka.cea.Cea608Memory = class {
    * @return {?shaka.extern.ICaptionDecoder.ClosedCaption}
    */
   forceEmit(startTime, endTime) {
-    const stream = `CC${(this.fieldNum_<< 1) | this.channelNum_ +1}`;
+    const stream = `CC${((this.fieldNum_<< 1) | this.channelNum_) + 1}`;
     const topLevelCue = new shaka.text.Cue(
         startTime, endTime, /* payload= */ '');
     topLevelCue.lineInterpretation =

--- a/lib/cea/cea_decoder.js
+++ b/lib/cea/cea_decoder.js
@@ -283,7 +283,7 @@ shaka.cea.CeaDecoder = class {
     // Get the correct stream for this caption packet (CC1, ..., CC4)
     const selectedChannel = fieldNum ?
         this.currentField2Channel_ : this.currentField1Channel_;
-    const selectedMode = `CC${(fieldNum << 1) | selectedChannel + 1}`;
+    const selectedMode = `CC${((fieldNum << 1) | selectedChannel) + 1}`;
     const selectedStream = this.cea608ModeToStream_.get(selectedMode);
 
     // Check for bad frames (bad pairs). This can be two 0xff, two 0x00, or any


### PR DESCRIPTION
Due to issue around channel calculation, shaka was never using CC4 track and data from there were landing in CC2 track.