### PR TITLE
perf(HLS): do not filter all tags to get the first tag

### DIFF
--- a/lib/hls/hls_utils.js
+++ b/lib/hls/hls_utils.js
@@ -47,12 +47,12 @@ shaka.hls.Utils = class {
    * @return {?shaka.hls.Tag}
    */
   static getFirstTagWithName(tags, name) {
-    const tagsWithName = shaka.hls.Utils.filterTagsByName(tags, name);
-    if (!tagsWithName.length) {
-      return null;
+    for (const tag of tags) {
+      if (tag.name === name) {
+        return tag;
+      }
     }
-
-    return tagsWithName[0];
+    return null;
   }
 
   /**


### PR DESCRIPTION
Filtering all the tags to get the first one that's required is not needed