### PR TITLE
feat: SegmentIndex minimal interface

### DIFF
--- a/externs/shaka/manifest.js
+++ b/externs/shaka/manifest.js
@@ -363,6 +363,51 @@ shaka.extern.FetchCryptoKeysFunction;
 
 
 /**
+ * SegmentIndex minimal API.
+ * @interface
+ * @exportDoc
+ */
+shaka.extern.SegmentIndex = class {
+  /**
+   * Get number of references.
+   * @return {number}
+   * @exportDoc
+   */
+  getNumReferences() {}
+
+  /**
+   * Finds the position of the segment for the given time, in seconds, relative
+   * to the start of the presentation.  Returns the position of the segment
+   * with the largest end time if more than one segment is known for the given
+   * time.
+   *
+   * @param {number} time
+   * @return {?number} The position of the segment, or null if the position of
+   *   the segment could not be determined.
+   * @exportDoc
+   */
+  find(time) {}
+
+  /**
+   * Gets the SegmentReference for the segment at the given position.
+   *
+   * @param {number} position The position of the segment as returned by find().
+   * @return {shaka.media.SegmentReference} The SegmentReference, or null if
+   *   no such SegmentReference exists.
+   * @exportDoc
+   */
+  get(position) {}
+
+  /**
+   * Gets number of already evicted segments.
+   * @return {number}
+   * @exportDoc
+   */
+  getNumEvicted() {}
+};
+
+
+/**
  * @typedef {{
  *   id: number,
  *   originalId: ?string,

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -18,6 +18,7 @@ goog.require('shaka.util.Timer');
 /**
  * SegmentIndex.
  *
+ * @implements {shaka.extern.SegmentIndex}
  * @implements {shaka.util.IReleasable}
  * @implements {Iterable.<!shaka.media.SegmentReference>}
  * @export
@@ -61,12 +62,19 @@ shaka.media.SegmentIndex = class {
   }
 
   /**
-   * Get number of references
-   * @protected
-   * @return {number}
+   * @override
+   * @export
    */
   getNumReferences() {
     return this.references.length;
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  getNumEvicted() {
+    return this.numEvicted_;
   }
 
   /**
@@ -132,14 +140,7 @@ shaka.media.SegmentIndex = class {
 
 
   /**
-   * Finds the position of the segment for the given time, in seconds, relative
-   * to the start of the presentation.  Returns the position of the segment
-   * with the largest end time if more than one segment is known for the given
-   * time.
-   *
-   * @param {number} time
-   * @return {?number} The position of the segment, or null if the position of
-   *   the segment could not be determined.
+   * @override
    * @export
    */
   find(time) {
@@ -170,11 +171,7 @@ shaka.media.SegmentIndex = class {
 
 
   /**
-   * Gets the SegmentReference for the segment at the given position.
-   *
-   * @param {number} position The position of the segment as returned by find().
-   * @return {shaka.media.SegmentReference} The SegmentReference, or null if
-   *   no such SegmentReference exists.
+   * @override
    * @export
    */
   get(position) {
@@ -663,7 +660,7 @@ shaka.media.MetaSegmentIndex = class extends shaka.media.SegmentIndex {
    */
   appendSegmentIndex(segmentIndex) {
     goog.asserts.assert(
-        this.indexes_.length == 0 || segmentIndex.numEvicted_ == 0,
+        this.indexes_.length == 0 || segmentIndex.getNumEvicted() == 0,
         'Should not append a new segment index with already-evicted segments');
     this.indexes_.push(segmentIndex);
   }
@@ -707,7 +704,7 @@ shaka.media.MetaSegmentIndex = class extends shaka.media.SegmentIndex {
         return position + numPassedInEarlierIndexes;
       }
 
-      numPassedInEarlierIndexes += index.numEvicted_ +
+      numPassedInEarlierIndexes += index.getNumEvicted() +
         index.getNumReferences();
     }
 
@@ -724,7 +721,7 @@ shaka.media.MetaSegmentIndex = class extends shaka.media.SegmentIndex {
 
     for (const index of this.indexes_) {
       goog.asserts.assert(
-          !sawSegments || index.numEvicted_ == 0,
+          !sawSegments || index.getNumEvicted() == 0,
           'Should not see evicted segments after available segments');
       const reference = index.get(position - numPassedInEarlierIndexes);
 
@@ -733,7 +730,7 @@ shaka.media.MetaSegmentIndex = class extends shaka.media.SegmentIndex {
       }
 
       const num = index.getNumReferences();
-      numPassedInEarlierIndexes += index.numEvicted_ + num;
+      numPassedInEarlierIndexes += index.getNumEvicted() + num;
       sawSegments = sawSegments || num != 0;
     }
 


### PR DESCRIPTION
Motivation: we (Sky/Peacock) were working on custom manifest parser and we wanted to use similar approach to `shaka.dash.TimelineSegmentIndex` but adjusted to our needs and data structure.

So similar to that, we extended base `SegmentIndex` class with our implementation, but `MetaSegmentIndex` didn't work correctly with this implementation due to 2 issues:
1. `MetaSegmentIndex` uses protected `numEvicted_` field that we cannot modify externally in any way.
2. Even adding exported `getNumEvicted()` method wasn't enough, because Closure Compiler optimization was aliasing internal call to this method in `MetaSegmentIndex` for some reason.

By moving crucial APIs to extern we can overcome this issue. Still, preferred way of using own SegmentIndex implementation is by extending base class, as it offers SegmentIterator out of the box.