### PR TITLE
feat(DASH): Allow PeriodCombiner for using streams once

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -236,6 +236,8 @@ shakaDemo.Config = class {
             /* canBeUnset= */ true)
         .addBoolInput_('Enable DASH sequence mode',
             'manifest.dash.sequenceMode')
+        .addBoolInput_('Use stream once in period flattening',
+            'manifest.dash.useStreamOnceInPeriodFlattening')
         .addBoolInput_('Disable Audio', 'manifest.disableAudio')
         .addBoolInput_('Disable Video', 'manifest.disableVideo')
         .addBoolInput_('Disable Text', 'manifest.disableText')

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -856,7 +856,8 @@ shaka.extern.InitDataTransform;
  *   manifestPreprocessor: function(!Element),
  *   sequenceMode: boolean,
  *   enableAudioGroups: boolean,
- *   multiTypeVariantsAllowed: boolean
+ *   multiTypeVariantsAllowed: boolean,
+ *   useStreamOnceInPeriodFlattening: boolean
  * }}
  *
  * @property {string} clockSyncUri
@@ -928,6 +929,12 @@ shaka.extern.InitDataTransform;
  *   Might result in undesirable behavior if mediaSource.codecSwitchingStrategy
  *   is not set to SMOOTH.
  *   Defaults to true if SMOOTH codec switching is supported, RELOAD overwise.
+ * @property {boolean} useStreamOnceInPeriodFlattening
+ *   If period combiner is used, this option ensures every stream is used
+ *   only once in period flattening. It speeds up underlying algorithm
+ *   but may raise issues if manifest does not have stream consistency
+ *   between periods.
+ *   Defaults to <code>false</code>.
  * @exportDoc
  */
 shaka.extern.DashManifestConfiguration;
@@ -1095,7 +1102,6 @@ shaka.extern.MssManifestConfiguration;
  * @property {boolean} raiseFatalErrorOnManifestUpdateRequestFailure
  *   If true, manifest update request failures will cause a fatal error.
  *   Defaults to <code>false</code> if not provided.
- *
  * @exportDoc
  */
 shaka.extern.ManifestConfiguration;

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1102,6 +1102,7 @@ shaka.extern.MssManifestConfiguration;
  * @property {boolean} raiseFatalErrorOnManifestUpdateRequestFailure
  *   If true, manifest update request failures will cause a fatal error.
  *   Defaults to <code>false</code> if not provided.
+ *
  * @exportDoc
  */
 shaka.extern.ManifestConfiguration;

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -140,6 +140,8 @@ shaka.dash.DashParser = class {
       this.periodCombiner_.setAllowMultiTypeVariants(
           this.config_.dash.multiTypeVariantsAllowed &&
           shaka.media.Capabilities.isChangeTypeSupported());
+      this.periodCombiner_.setUseStreamOnce(
+          this.config_.dash.useStreamOnceInPeriodFlattening);
     }
   }
 

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -1043,7 +1043,7 @@ shaka.util.PeriodCombiner = class {
     // Remove just found stream if configured to, so possible future linear
     // searches can be faster.
     if (this.useStreamOnce_ && !shaka.util.PeriodCombiner.isDummy_(best)) {
-      streams.delete(best);
+      streams.delete(getKey(best));
     }
 
     return best;
@@ -1080,6 +1080,7 @@ shaka.util.PeriodCombiner = class {
   /**
    * @param {boolean} allowed If set to true, multi-mimeType or multi-codec
    *   variants will be allowed.
+   * @export
    */
   setAllowMultiTypeVariants(allowed) {
     this.multiTypeVariantsAllowed_ = allowed;
@@ -1088,6 +1089,7 @@ shaka.util.PeriodCombiner = class {
   /**
    * @param {boolean} useOnce if true, stream will be used only once in period
    *   flattening algoritnm.
+   * @export
    */
   setUseStreamOnce(useOnce) {
     this.useStreamOnce_ = useOnce;

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -45,6 +45,9 @@ shaka.util.PeriodCombiner = class {
     /** @private {boolean} */
     this.multiTypeVariantsAllowed_ = false;
 
+    /** @private {boolean} */
+    this.useStreamOnce_ = false;
+
     /**
      * The IDs of the periods we have already used to generate streams.
      * This helps us identify the periods which have been added when a live
@@ -1037,6 +1040,12 @@ shaka.util.PeriodCombiner = class {
       }
     }
 
+    // Remove just found stream if configured to, so possible future linear
+    // searches can be faster.
+    if (this.useStreamOnce_ && !shaka.util.PeriodCombiner.isDummy_(best)) {
+      streams.delete(best);
+    }
+
     return best;
   }
 
@@ -1074,6 +1083,14 @@ shaka.util.PeriodCombiner = class {
    */
   setAllowMultiTypeVariants(allowed) {
     this.multiTypeVariantsAllowed_ = allowed;
+  }
+
+  /**
+   * @param {boolean} useOnce if true, stream will be used only once in period
+   *   flattening algoritnm.
+   */
+  setUseStreamOnce(useOnce) {
+    this.useStreamOnce_ = useOnce;
   }
 
   /**

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -144,6 +144,7 @@ shaka.util.PlayerConfiguration = class {
         sequenceMode: false,
         enableAudioGroups: false,
         multiTypeVariantsAllowed,
+        useStreamOnceInPeriodFlattening: false,
       },
       hls: {
         ignoreTextStreamFailures: false,


### PR DESCRIPTION
In our streams we have guarantee that every track will have a single match in every period. This change allows `PeriodCombiner` to take benefit of this knowledge.

I was testing `PeriodCombiner.combinePeriods()` performance of mentioned changes on Tizen 2021 on 2 streams and I've got following results:

| content | upstream | proposed changes |
| - | -: | -: |
| stream 1 | 17 ms | 12 ms |
| stream 2 | 191 ms | 98 ms |

Both streams are VOD.
Stream 1 has 18 periods with 6 video & audio tracks in each.
Stream 2 has 18 periods with 6 video tracks & 36 audio tracks in each. 
