### PR TITLE
fix: stay paused after codec switch

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1805,7 +1805,7 @@ shaka.media.MediaSourceEngine = class {
 
       this.destroyer_.ensureNotDestroyed();
 
-      this.eventManager_.listenOnce(this.video_, 'canplay', () => {
+      this.eventManager_.listenOnce(this.video_, 'canplaythrough', () => {
         this.destroyer_.ensureNotDestroyed();
 
         this.video_.autoplay = previousAutoPlayState;

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -1247,7 +1247,7 @@ describe('MediaSourceEngine', () => {
             const callback = addListenOnceSpy.calls.argsFor(0)[2];
             callback();
             expect(initSourceBufferSpy).toHaveBeenCalled();
-            expect(addListenOnceSpy.calls.argsFor(0)[1]).toBe('canplay');
+            expect(addListenOnceSpy.calls.argsFor(0)[1]).toBe('canplaythrough');
             expect(video.autoplay).toBe(true);
             expect(playSpy).not.toHaveBeenCalled();
           } finally {
@@ -1314,7 +1314,7 @@ describe('MediaSourceEngine', () => {
             const callback = addListenOnceSpy.calls.argsFor(0)[2];
             callback();
             expect(initSourceBufferSpy).toHaveBeenCalled();
-            expect(addListenOnceSpy.calls.argsFor(0)[1]).toBe('canplay');
+            expect(addListenOnceSpy.calls.argsFor(0)[1]).toBe('canplaythrough');
             expect(video.autoplay).toBe(false);
             expect(playSpy).toHaveBeenCalled();
           } finally {


### PR DESCRIPTION
When stream is paused and codec switch is done, stream resumes to play. Moving setting autoplay from `canplay` to `canplaythrough` fixes this issue.

Problem observed on Tizen 6 & 7.