### PR TITLE
fix: Don't retry MSE errors on startup

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -121,7 +121,7 @@ shaka.media.StreamingEngine = class {
     this.destroyer_ = new shaka.util.Destroyer(() => this.doDestroy_());
 
     /** @private {number} */
-    this.lastMediaSourceReset_ = 0;
+    this.lastMediaSourceReset_ = Date.now() / 1000;
   }
 
   /** @override */


### PR DESCRIPTION
Do not retry MSE errors on startup to avoid masking errors when the stream loads