### PR TITLE
feat: prefetch audio languages.

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -433,6 +433,8 @@ shakaDemo.Config = class {
               'streaming.prefetchAudioLanguages',
               input.value.split(',').filter(Boolean));
         })
+        .addBoolInput_('Disable Audio Prefetch',
+            'streaming.disableAudioPrefetch')
         .addBoolInput_('Disable Video Prefetch',
             'streaming.disableVideoPrefetch')
         .addBoolInput_('Live Sync', 'streaming.liveSync')

--- a/demo/config.js
+++ b/demo/config.js
@@ -424,7 +424,17 @@ shakaDemo.Config = class {
         .addBoolInput_('Parse PRFT box',
             'streaming.parsePrftBox')
         .addNumberInput_('Segment Prefetch Limit',
-            'streaming.segmentPrefetchLimit')
+            'streaming.segmentPrefetchLimit',
+            /* canBeDecimal= */ false,
+            /* canBeZero= */ true,
+            /* canBeUnset= */ true)
+        .addCustomTextInput_('Prefetch audio languages', (input) => {
+          shakaDemoMain.configure(
+              'streaming.prefetchAudioLanguages',
+              input.value.split(',').filter(Boolean));
+        })
+        .addBoolInput_('Disable Video Prefetch',
+            'streaming.disableVideoPrefetch')
         .addBoolInput_('Live Sync', 'streaming.liveSync')
         .addNumberInput_('Max latency for live sync',
             'streaming.liveSyncMaxLatency',
@@ -752,7 +762,9 @@ shakaDemo.Config = class {
   addNumberInput_(name, valueName, canBeDecimal = false, canBeZero = true,
       canBeUnset = false, tooltipMessage) {
     const onChange = (input) => {
-      shakaDemoMain.resetConfiguration(valueName);
+      if (valueName !== 'streaming.segmentPrefetchLimit') {
+        shakaDemoMain.resetConfiguration(valueName);
+      }
       shakaDemoMain.remakeHash();
       if (input.value == 'Infinity') {
         shakaDemoMain.configure(valueName, Infinity);

--- a/demo/config.js
+++ b/demo/config.js
@@ -762,29 +762,25 @@ shakaDemo.Config = class {
   addNumberInput_(name, valueName, canBeDecimal = false, canBeZero = true,
       canBeUnset = false, tooltipMessage) {
     const onChange = (input) => {
-      if (valueName !== 'streaming.segmentPrefetchLimit') {
-        shakaDemoMain.resetConfiguration(valueName);
-      }
-      shakaDemoMain.remakeHash();
       if (input.value == 'Infinity') {
         shakaDemoMain.configure(valueName, Infinity);
-        shakaDemoMain.remakeHash();
-        return;
-      }
-      if (input.value == '' && canBeUnset) {
-        return;
-      }
-      const valueAsNumber = Number(input.value);
-      if (valueAsNumber == 0 && !canBeZero) {
-        return;
-      }
-      if (!isNaN(valueAsNumber)) {
-        if (Math.floor(valueAsNumber) != valueAsNumber && !canBeDecimal) {
-          return;
+      } else if (input.value == '' && canBeUnset) {
+        shakaDemoMain.resetConfiguration(valueName);
+      } else {
+        const valueAsNumber = Number(input.value);
+        if (valueAsNumber == 0 && !canBeZero) {
+          shakaDemoMain.resetConfiguration(valueName);
+        } else if (isNaN(valueAsNumber)) {
+          shakaDemoMain.resetConfiguration(valueName);
+        } else {
+          if (Math.floor(valueAsNumber) != valueAsNumber && !canBeDecimal) {
+            shakaDemoMain.resetConfiguration(valueName);
+          } else {
+            shakaDemoMain.configure(valueName, valueAsNumber);
+          }
         }
-        shakaDemoMain.configure(valueName, valueAsNumber);
-        shakaDemoMain.remakeHash();
       }
+      shakaDemoMain.remakeHash();
     };
     this.createRow_(name, tooltipMessage);
     this.latestInput_ = new shakaDemo.NumberInput(

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1138,6 +1138,7 @@ shaka.extern.ManifestConfiguration;
  *   parsePrftBox: boolean,
  *   segmentPrefetchLimit: number,
  *   prefetchAudioLanguages: !Array<string>,
+ *   disableAudioPrefetch: boolean,
  *   disableVideoPrefetch: boolean,
  *   liveSync: boolean,
  *   liveSyncMaxLatency: number,
@@ -1265,6 +1266,10 @@ shaka.extern.ManifestConfiguration;
  * @property {!Array<string>} prefetchAudioLanguages
  *   The audio languages to prefetch.
  *   Defaults to an empty array.
+ * @property {boolean} disableAudioPrefetch
+ *   If set and prefetch limit is defined, it will prevent from prefetching data
+ *   for audio.
+ *   Defaults to <code>false</code>.
  * @property {boolean} disableVideoPrefetch
  *   If set and prefetch limit is defined, it will prevent from prefetching data
  *   for video.

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1137,6 +1137,8 @@ shaka.extern.ManifestConfiguration;
  *   maxDisabledTime: number,
  *   parsePrftBox: boolean,
  *   segmentPrefetchLimit: number,
+ *   prefetchAudioLanguages: !Array<string>,
+ *   disableVideoPrefetch: boolean,
  *   liveSync: boolean,
  *   liveSyncMaxLatency: number,
  *   liveSyncPlaybackRate: number,
@@ -1255,11 +1257,18 @@ shaka.extern.ManifestConfiguration;
  *   start date will not change, and would save parsing the segment multiple
  *   times needlessly.
  *   Defaults to <code>false</code>.
- * @property {boolean} segmentPrefetchLimit
+ * @property {number} segmentPrefetchLimit
  *   The maximum number of segments for each active stream to be prefetched
  *   ahead of playhead in parallel.
  *   If <code>0</code>, the segments will be fetched sequentially.
  *   Defaults to <code>0</code>.
+ * @property {!Array<string>} prefetchAudioLanguages
+ *   The audio languages to prefetch.
+ *   Defaults to an empty array.
+ * @property {boolean} disableVideoPrefetch
+ *   If set and prefetch limit is defined, it will prevent from prefetching data
+ *   for video.
+ *   Defaults to <code>false</code>.
  * @property {boolean} liveSync
  *   Enable the live stream sync against the live edge by changing the playback
  *   rate. Defaults to <code>false</code>.

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -434,10 +434,11 @@ shaka.media.SegmentIndex = class {
    * Playlist will contain at least one independent frame."
    *
    * @param {number} time
+   * @param {boolean=} allowNonIndepedent
    * @return {?shaka.media.SegmentIterator}
    * @export
    */
-  getIteratorForTime(time) {
+  getIteratorForTime(time, allowNonIndepedent = false) {
     let index = this.find(time);
     if (index == null) {
       return null;
@@ -455,14 +456,16 @@ shaka.media.SegmentIndex = class {
         let r = ref.partialReferences[i];
         // Note that a segment ends immediately before the end time.
         if ((time >= r.startTime) && (time < r.endTime)) {
-          // Find an independent partial segment by moving backwards.
-          while (i && !r.isIndependent()) {
-            i--;
-            r = ref.partialReferences[i];
-          }
-          if (!r.isIndependent()) {
-            shaka.log.alwaysError('No independent partial segment found!');
-            return null;
+          if (!allowNonIndepedent) {
+            // Find an independent partial segment by moving backwards.
+            while (i && (!r.isIndependent())) {
+              i--;
+              r = ref.partialReferences[i];
+            }
+            if (!r.isIndependent()) {
+              shaka.log.alwaysError('No independent partial segment found!');
+              return null;
+            }
           }
           // Call to next() should move the partial segment, not the full
           // segment.

--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -82,7 +82,8 @@ shaka.media.SegmentPrefetch = class {
       return;
     }
     const maxTime = Math.max(currTime, this.prefetchPosTime_);
-    const iterator = this.stream_.segmentIndex.getIteratorForTime(maxTime);
+    const iterator = this.stream_.segmentIndex.getIteratorForTime(
+        maxTime, /* allowNonIndepedent= */ true);
     if (!iterator) {
       return;
     }

--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -66,25 +66,13 @@ shaka.media.SegmentPrefetch = class {
   }
 
   /**
-   * Fetch next segments ahead of current segment.
-   *
-   * @param {(!shaka.media.SegmentReference)} startReference
-   * @param {boolean=} skipFirst
-   * @public
-   */
-  prefetchSegments(startReference, skipFirst = false) {
-    this.prefetchSegmentsByTime(startReference.startTime, false, skipFirst);
-  }
-
-  /**
    * Fetch next segments ahead of current time.
    *
    * @param {number} currTime
-   * @param {boolean=} fetchInit
    * @param {boolean=} skipFirst
    * @public
    */
-  prefetchSegmentsByTime(currTime, fetchInit = false, skipFirst = false) {
+  prefetchSegmentsByTime(currTime, skipFirst = false) {
     goog.asserts.assert(this.prefetchLimit_ > 0,
         'SegmentPrefetch can not be used when prefetchLimit <= 0.');
 
@@ -105,8 +93,8 @@ shaka.media.SegmentPrefetch = class {
     if (!reference) {
       return;
     }
-    if (fetchInit && reference.initSegmentReference) {
-      this.prefetchInitSegment(reference.initSegmentReference);
+    if (reference.initSegmentReference) {
+      this.prefetchInitSegment_(reference.initSegmentReference);
     }
     while (this.segmentPrefetchMap_.size < this.prefetchLimit_ &&
             reference != null) {
@@ -139,9 +127,9 @@ shaka.media.SegmentPrefetch = class {
    * Fetch init segment.
    *
    * @param {!shaka.media.InitSegmentReference} initSegmentReference
-   * @public
+   * @private
    */
-  prefetchInitSegment(initSegmentReference) {
+  prefetchInitSegment_(initSegmentReference) {
     goog.asserts.assert(this.prefetchLimit_ > 0,
         'SegmentPrefetch can not be used when prefetchLimit <= 0.');
 

--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -25,12 +25,13 @@ shaka.media.SegmentPrefetch = class {
    * @param {number} prefetchLimit
    * @param {shaka.extern.Stream} stream
    * @param {shaka.media.SegmentPrefetch.FetchDispatcher} fetchDispatcher
+   * @param {boolean} deleteOnGet
    */
-  constructor(prefetchLimit, stream, fetchDispatcher) {
+  constructor(prefetchLimit, stream, fetchDispatcher, deleteOnGet = true) {
     /** @private {number} */
     this.prefetchLimit_ = prefetchLimit;
 
-    /** @private {shaka.extern.Stream} */
+    /** @public {shaka.extern.Stream} */
     this.stream_ = stream;
 
     /** @private {number} */
@@ -39,12 +40,29 @@ shaka.media.SegmentPrefetch = class {
     /** @private {shaka.media.SegmentPrefetch.FetchDispatcher} */
     this.fetchDispatcher_ = fetchDispatcher;
 
+    /** @private {boolean} */
+    this.deleteOnGet_ = deleteOnGet;
+
     /**
      * @private {!Map.<
-     *        !(shaka.media.SegmentReference|shaka.media.InitSegmentReference),
+     *        !(shaka.media.SegmentReference),
      *        !shaka.media.SegmentPrefetchOperation>}
      */
     this.segmentPrefetchMap_ = new Map();
+
+    /**
+     * @private {!Map.<
+     *        !(shaka.media.InitSegmentReference),
+     *        !shaka.media.SegmentPrefetchOperation>}
+     */
+    this.initSegmentPrefetchMap_ = new Map();
+  }
+
+  /**
+   * @return {number}
+   */
+  getLastKnownPosition() {
+    return this.prefetchPosTime_;
   }
 
   /**
@@ -55,28 +73,40 @@ shaka.media.SegmentPrefetch = class {
    * @public
    */
   prefetchSegments(startReference, skipFirst = false) {
+    this.prefetchSegmentsByTime(startReference.startTime, false, skipFirst);
+  }
+
+  /**
+   * Fetch next segments ahead of current time.
+   *
+   * @param {number} currTime
+   * @param {boolean=} fetchInit
+   * @param {boolean=} skipFirst
+   * @public
+   */
+  prefetchSegmentsByTime(currTime, fetchInit = false, skipFirst = false) {
     goog.asserts.assert(this.prefetchLimit_ > 0,
         'SegmentPrefetch can not be used when prefetchLimit <= 0.');
 
     const logPrefix = shaka.media.SegmentPrefetch.logPrefix_(this.stream_);
     if (!this.stream_.segmentIndex) {
-      shaka.log.info(logPrefix, 'missing segmentIndex');
+      shaka.log.debug(logPrefix, 'missing segmentIndex');
       return;
     }
-    const currTime = startReference.startTime;
     const maxTime = Math.max(currTime, this.prefetchPosTime_);
     const iterator = this.stream_.segmentIndex.getIteratorForTime(maxTime);
     if (!iterator) {
       return;
     }
-    let reference = startReference;
+    let reference = iterator.next().value;
     if (skipFirst) {
       reference = iterator.next().value;
-      if (reference &&
-          reference.startTime == startReference.startTime &&
-          reference.endTime == startReference.endTime) {
-        reference = null;
-      }
+    }
+    if (!reference) {
+      return;
+    }
+    if (fetchInit && reference.initSegmentReference) {
+      this.prefetchInitSegment(reference.initSegmentReference);
     }
     while (this.segmentPrefetchMap_.size < this.prefetchLimit_ &&
             reference != null) {
@@ -117,17 +147,18 @@ shaka.media.SegmentPrefetch = class {
 
     const logPrefix = shaka.media.SegmentPrefetch.logPrefix_(this.stream_);
     if (!this.stream_.segmentIndex) {
-      shaka.log.info(logPrefix, 'missing segmentIndex');
+      shaka.log.debug(logPrefix, 'missing segmentIndex');
       return;
     }
 
+    // init segments are ignored from the prefetch limit
     if (this.segmentPrefetchMap_.size < this.prefetchLimit_) {
-      if (!this.segmentPrefetchMap_.has(initSegmentReference)) {
+      if (!this.initSegmentPrefetchMap_.has(initSegmentReference)) {
         const segmentPrefetchOperation =
           new shaka.media.SegmentPrefetchOperation(this.fetchDispatcher_);
         segmentPrefetchOperation.dispatchFetch(
             initSegmentReference, this.stream_);
-        this.segmentPrefetchMap_.set(
+        this.initSegmentPrefetchMap_.set(
             initSegmentReference, segmentPrefetchOperation);
       }
     }
@@ -147,22 +178,29 @@ shaka.media.SegmentPrefetch = class {
 
     const logPrefix = shaka.media.SegmentPrefetch.logPrefix_(this.stream_);
 
-    if (this.segmentPrefetchMap_.has(reference)) {
-      const segmentPrefetchOperation = this.segmentPrefetchMap_.get(reference);
+    let prefetchMap = this.segmentPrefetchMap_;
+    if (reference instanceof shaka.media.InitSegmentReference) {
+      prefetchMap = this.initSegmentPrefetchMap_;
+    }
+
+    if (prefetchMap.has(reference)) {
+      const segmentPrefetchOperation = prefetchMap.get(reference);
       if (streamDataCallback) {
         segmentPrefetchOperation.setStreamDataCallback(streamDataCallback);
       }
-      this.segmentPrefetchMap_.delete(reference);
+      if (this.deleteOnGet_) {
+        prefetchMap.delete(reference);
+      }
       if (reference instanceof shaka.media.SegmentReference) {
         shaka.log.debug(
             logPrefix,
             'reused prefetched segment at time:', reference.startTime,
-            'mapSize', this.segmentPrefetchMap_.size);
+            'mapSize', prefetchMap.size);
       } else {
         shaka.log.debug(
             logPrefix,
             'reused prefetched init segment at time, mapSize',
-            this.segmentPrefetchMap_.size);
+            prefetchMap.size);
       }
       return segmentPrefetchOperation.getOperation();
     } else {
@@ -170,14 +208,26 @@ shaka.media.SegmentPrefetch = class {
         shaka.log.debug(
             logPrefix,
             'missed segment at time:', reference.startTime,
-            'mapSize', this.segmentPrefetchMap_.size);
+            'mapSize', prefetchMap.size);
       } else {
         shaka.log.debug(
             logPrefix,
             'missed init segment at time, mapSize',
-            this.segmentPrefetchMap_.size);
+            prefetchMap.size);
       }
       return null;
+    }
+  }
+
+  /**
+   * Clear All Helper
+   * @private
+   */
+  clearMap_(map) {
+    for (const reference of map.keys()) {
+      if (reference) {
+        this.abortPrefetchedSegment_(reference);
+      }
     }
   }
 
@@ -186,17 +236,44 @@ shaka.media.SegmentPrefetch = class {
    * @public
    */
   clearAll() {
-    if (this.segmentPrefetchMap_.size === 0) {
-      return;
-    }
+    this.clearMap_(this.segmentPrefetchMap_);
+    this.clearMap_(this.initSegmentPrefetchMap_);
     const logPrefix = shaka.media.SegmentPrefetch.logPrefix_(this.stream_);
-    for (const reference of this.segmentPrefetchMap_.keys()) {
-      if (reference) {
-        this.abortPrefetchedSegment_(reference);
+    shaka.log.debug(logPrefix, 'cleared all');
+    this.prefetchPosTime_ = 0;
+  }
+
+  /**
+   * @param {number} time
+   */
+  evict(time) {
+    for (const ref of this.segmentPrefetchMap_.keys()) {
+      if (time > ref.endTime) {
+        this.abortPrefetchedSegment_(ref);
       }
     }
-    shaka.log.info(logPrefix, 'cleared all');
-    this.prefetchPosTime_ = 0;
+    this.clearInitSegments_();
+  }
+
+  /**
+   * Remove all init segments that don't have associated segments in
+   * the segment prefetch map.
+   * By default, with delete on get, the init segments should get removed as
+   * they are used. With deleteOnGet set to false, we need to clear them
+   * every so often once the segments that are associated with each init segment
+   * is no longer prefetched.
+   * @private
+   */
+  clearInitSegments_() {
+    const segmentReferences = Array.from(this.segmentPrefetchMap_.keys());
+    for (const initSegmentReference of this.initSegmentPrefetchMap_.keys()) {
+      // if no segment references this init segment, we should remove it.
+      if (!segmentReferences.some(
+          (segmentReference) =>
+            segmentReference.initSegmentReference === initSegmentReference)) {
+        this.abortPrefetchedSegment_(initSegmentReference);
+      }
+    }
   }
 
   /**
@@ -208,6 +285,9 @@ shaka.media.SegmentPrefetch = class {
   resetLimit(newPrefetchLimit) {
     goog.asserts.assert(newPrefetchLimit >= 0,
         'The new prefetch limit must be >= 0.');
+
+    const logPrefix = shaka.media.SegmentPrefetch.logPrefix_(this.stream_);
+    shaka.log.debug(logPrefix, 'resetting prefetch limit to', newPrefetchLimit);
     this.prefetchLimit_ = newPrefetchLimit;
     const keyArr = Array.from(this.segmentPrefetchMap_.keys());
     while (keyArr.length > newPrefetchLimit) {
@@ -219,11 +299,23 @@ shaka.media.SegmentPrefetch = class {
   }
 
   /**
+   * Update deleteOnGet.
+   * @param {boolean} newDeleteOnGet
+   * @public
+   */
+  deleteOnGet(newDeleteOnGet) {
+    this.deleteOnGet_ = newDeleteOnGet;
+  }
+
+  /**
    * Called by Streaming Engine when switching variant.
    * @param {shaka.extern.Stream} stream
    * @public
    */
   switchStream(stream) {
+    goog.asserts.assert(this.deleteOnGet_,
+        'switchStream should only be used if deleteOnGet is true');
+
     if (stream && stream !== this.stream_) {
       this.clearAll();
       this.stream_ = stream;
@@ -238,16 +330,23 @@ shaka.media.SegmentPrefetch = class {
    */
   abortPrefetchedSegment_(reference) {
     const logPrefix = shaka.media.SegmentPrefetch.logPrefix_(this.stream_);
-    const segmentPrefetchOperation = this.segmentPrefetchMap_.get(reference);
-    this.segmentPrefetchMap_.delete(reference);
+
+    let prefetchMap = this.segmentPrefetchMap_;
+    if (reference instanceof shaka.media.InitSegmentReference) {
+      prefetchMap = this.initSegmentPrefetchMap_;
+    }
+
+    const segmentPrefetchOperation = prefetchMap.get(reference);
+    prefetchMap.delete(reference);
+
     if (segmentPrefetchOperation) {
       segmentPrefetchOperation.abort();
       if (reference instanceof shaka.media.SegmentReference) {
-        shaka.log.info(
+        shaka.log.debug(
             logPrefix,
             'pop and abort prefetched segment at time:', reference.startTime);
       } else {
-        shaka.log.info(logPrefix, 'pop and abort prefetched init segment');
+        shaka.log.debug(logPrefix, 'pop and abort prefetched init segment');
       }
     }
   }

--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -31,7 +31,7 @@ shaka.media.SegmentPrefetch = class {
     /** @private {number} */
     this.prefetchLimit_ = prefetchLimit;
 
-    /** @public {shaka.extern.Stream} */
+    /** @private {shaka.extern.Stream} */
     this.stream_ = stream;
 
     /** @private {number} */
@@ -320,6 +320,15 @@ shaka.media.SegmentPrefetch = class {
       this.clearAll();
       this.stream_ = stream;
     }
+  }
+
+  /**
+   * Get the current stream.
+   * @public
+   * @return {shaka.extern.Stream}
+   */
+  getStream() {
+    return this.stream_;
   }
 
   /**

--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -94,9 +94,6 @@ shaka.media.SegmentPrefetch = class {
     if (!reference) {
       return;
     }
-    if (reference.initSegmentReference) {
-      this.prefetchInitSegment_(reference.initSegmentReference);
-    }
     while (this.segmentPrefetchMap_.size < this.prefetchLimit_ &&
             reference != null) {
       // By default doesn't prefech preload partial segments when using
@@ -108,6 +105,9 @@ shaka.media.SegmentPrefetch = class {
       if (reference.getStatus() ==
           shaka.media.SegmentReference.Status.MISSING) {
         prefetchAllowed = false;
+      }
+      if (prefetchAllowed && reference.initSegmentReference) {
+        this.prefetchInitSegment_(reference.initSegmentReference);
       }
       if (prefetchAllowed && !this.segmentPrefetchMap_.has(reference)) {
         const segmentPrefetchOperation =
@@ -122,6 +122,7 @@ shaka.media.SegmentPrefetch = class {
       }
       reference = iterator.next().value;
     }
+    this.clearInitSegments_();
   }
 
   /**
@@ -141,15 +142,13 @@ shaka.media.SegmentPrefetch = class {
     }
 
     // init segments are ignored from the prefetch limit
-    if (this.segmentPrefetchMap_.size < this.prefetchLimit_) {
-      if (!this.initSegmentPrefetchMap_.has(initSegmentReference)) {
-        const segmentPrefetchOperation =
-          new shaka.media.SegmentPrefetchOperation(this.fetchDispatcher_);
-        segmentPrefetchOperation.dispatchFetch(
-            initSegmentReference, this.stream_);
-        this.initSegmentPrefetchMap_.set(
-            initSegmentReference, segmentPrefetchOperation);
-      }
+    if (!this.initSegmentPrefetchMap_.has(initSegmentReference)) {
+      const segmentPrefetchOperation =
+        new shaka.media.SegmentPrefetchOperation(this.fetchDispatcher_);
+      segmentPrefetchOperation.dispatchFetch(
+          initSegmentReference, this.stream_);
+      this.initSegmentPrefetchMap_.set(
+          initSegmentReference, segmentPrefetchOperation);
     }
   }
 

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -191,6 +191,22 @@ shaka.media.StreamingEngine = class {
         new shaka.net.Backoff(failureRetryParams, autoReset);
 
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
+
+    // disable audio segment prefetch if this is now set
+    if (config.disableAudioPrefetch) {
+      const state = this.mediaStates_.get(ContentType.AUDIO);
+      if (state && state.segmentPrefetch) {
+        state.segmentPrefetch.clearAll();
+        state.segmentPrefetch = null;
+      }
+
+      for (const stream of this.audioPrefetchMap_.keys()) {
+        const prefetch = this.audioPrefetchMap_.get(stream);
+        prefetch.clearAll();
+        this.audioPrefetchMap_.delete(stream);
+      }
+    }
+
     // disable video segment prefetch if this is now set
     if (config.disableVideoPrefetch) {
       const state = this.mediaStates_.get(ContentType.VIDEO);
@@ -215,7 +231,9 @@ shaka.media.StreamingEngine = class {
       }
     }
 
-    this.updatePrefetchMapForAudio_();
+    if (!config.disableAudioPrefetch) {
+      this.updatePrefetchMapForAudio_();
+    }
   }
 
 
@@ -923,14 +941,19 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   createSegmentPrefetch_(stream) {
+    const ContentType = shaka.util.ManifestParserUtils.ContentType;
     if (
-      stream.type !== shaka.util.ManifestParserUtils.ContentType.VIDEO &&
-      stream.type !== shaka.util.ManifestParserUtils.ContentType.AUDIO
+      stream.type !== ContentType.VIDEO &&
+      stream.type !== ContentType.AUDIO
     ) {
       return null;
     }
-    if (stream.type === shaka.util.ManifestParserUtils.ContentType.VIDEO &&
+    if (stream.type === ContentType.VIDEO &&
         this.config_.disableVideoPrefetch) {
+      return null;
+    }
+    if (stream.type === ContentType.AUDIO &&
+        this.config_.disableAudioPrefetch) {
       return null;
     }
     if (this.audioPrefetchMap_.has(stream)) {

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -930,7 +930,8 @@ shaka.media.StreamingEngine = class {
         (stream.type);
     const mediaState = this.mediaStates_.get(type);
     const currentSegmentPrefetch = mediaState && mediaState.segmentPrefetch;
-    if (currentSegmentPrefetch && stream === currentSegmentPrefetch.stream_) {
+    if (currentSegmentPrefetch &&
+      stream === currentSegmentPrefetch.getStream()) {
       return currentSegmentPrefetch;
     }
     if (this.config_.segmentPrefetchLimit > 0) {

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -27,6 +27,7 @@ goog.require('shaka.util.Error');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.IDestroyable');
 goog.require('shaka.util.Id3Utils');
+goog.require('shaka.util.LanguageUtils');
 goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Mp4BoxParsers');
@@ -122,6 +123,11 @@ shaka.media.StreamingEngine = class {
 
     /** @private {number} */
     this.lastMediaSourceReset_ = Date.now() / 1000;
+
+    /**
+     * @private {!Map<shaka.extern.Stream, !shaka.media.SegmentPrefetch>}
+     */
+    this.audioPrefetchMap_ = new Map();
   }
 
   /** @override */
@@ -140,10 +146,14 @@ shaka.media.StreamingEngine = class {
       this.cancelUpdate_(state);
       aborts.push(this.abortOperations_(state));
     }
+    for (const prefetch of this.audioPrefetchMap_.values()) {
+      prefetch.clearAll();
+    }
 
     await Promise.all(aborts);
 
     this.mediaStates_.clear();
+    this.audioPrefetchMap_.clear();
 
     this.playerInterface_ = null;
     this.manifest_ = null;
@@ -194,6 +204,8 @@ shaka.media.StreamingEngine = class {
         state.segmentPrefetch = this.createSegmentPrefetch_(state.stream);
       }
     }
+
+    this.updatePrefetchMapForAudio_();
   }
 
 
@@ -472,7 +484,9 @@ shaka.media.StreamingEngine = class {
       return;
     }
 
-    if (mediaState.segmentPrefetch) {
+    if (this.audioPrefetchMap_.has(stream)) {
+      mediaState.segmentPrefetch = this.audioPrefetchMap_.get(stream);
+    } else if (mediaState.segmentPrefetch) {
       mediaState.segmentPrefetch.switchStream(stream);
     }
 
@@ -487,8 +501,11 @@ shaka.media.StreamingEngine = class {
     }
 
     // Releases the segmentIndex of the old stream.
-    if (mediaState.stream.closeSegmentIndex) {
-      mediaState.stream.closeSegmentIndex();
+    // Do not close segment indexes we are prefetching.
+    if (!this.audioPrefetchMap_.has(mediaState.stream)) {
+      if (mediaState.stream.closeSegmentIndex) {
+        mediaState.stream.closeSegmentIndex();
+      }
     }
 
     mediaState.stream = stream;
@@ -902,6 +919,20 @@ shaka.media.StreamingEngine = class {
     ) {
       return null;
     }
+    if (stream.type === shaka.util.ManifestParserUtils.ContentType.VIDEO &&
+        this.config_.disableVideoPrefetch) {
+      return null;
+    }
+    if (this.audioPrefetchMap_.has(stream)) {
+      return this.audioPrefetchMap_.get(stream);
+    }
+    const type = /** @type {!shaka.util.ManifestParserUtils.ContentType} */
+        (stream.type);
+    const mediaState = this.mediaStates_.get(type);
+    const currentSegmentPrefetch = mediaState && mediaState.segmentPrefetch;
+    if (currentSegmentPrefetch && stream === currentSegmentPrefetch.stream_) {
+      return currentSegmentPrefetch;
+    }
     if (this.config_.segmentPrefetchLimit > 0) {
       return new shaka.media.SegmentPrefetch(
           this.config_.segmentPrefetchLimit,
@@ -912,6 +943,80 @@ shaka.media.StreamingEngine = class {
       );
     }
     return null;
+  }
+
+  /**
+   * Populates the prefetch map depending on the configuration
+   * @private
+   */
+  updatePrefetchMapForAudio_() {
+    const prefetchLimit = this.config_.segmentPrefetchLimit;
+    const prefetchLanguages = this.config_.prefetchAudioLanguages;
+    const LanguageUtils = shaka.util.LanguageUtils;
+
+    for (const variant of this.manifest_.variants) {
+      if (!variant.audio) {
+        continue;
+      }
+
+      if (this.audioPrefetchMap_.has(variant.audio)) {
+        // if we already have a segment prefetch,
+        // update it's prefetch limit and if the new limit isn't positive,
+        // remove the segment prefetch from our prefetch map.
+        const prefetch = this.audioPrefetchMap_.get(variant.audio);
+        prefetch.resetLimit(prefetchLimit);
+        if (!(prefetchLimit > 0) ||
+            !prefetchLanguages.some(
+                (lang) => LanguageUtils.areLanguageCompatible(
+                    variant.audio.language, lang))
+        ) {
+          // if we're here, we are switching back to single stream prefetch,
+          // so we want to switch back to delete on get, even if the prefetch
+          // may end up getting deleted below.
+          prefetch.deleteOnGet(true);
+          const type = /** @type {!shaka.util.ManifestParserUtils.ContentType}*/
+            (variant.audio.type);
+          const mediaState = this.mediaStates_.get(type);
+          const currentSegmentPrefetch = mediaState &&
+              mediaState.segmentPrefetch;
+          // if this prefetch isn't the current one, we want to clear it
+          if (prefetch !== currentSegmentPrefetch) {
+            prefetch.clearAll();
+          }
+          this.audioPrefetchMap_.delete(variant.audio);
+        }
+        continue;
+      }
+
+      // don't try to create a new segment prefetch if the limit isn't positive.
+      if (!(prefetchLimit > 0)) {
+        continue;
+      }
+
+      // only create a segment prefetch if its language is configured
+      // to be prefetched
+      if (!prefetchLanguages.some(
+          (lang) => LanguageUtils.areLanguageCompatible(
+              variant.audio.language, lang))) {
+        continue;
+      }
+
+      // use the helper to create a segment prefetch to ensure that existing
+      // objects are reused.
+      const segmentPrefetch = this.createSegmentPrefetch_(variant.audio);
+      segmentPrefetch.deleteOnGet(false);
+
+      // if a segment prefetch wasn't created, skip the rest
+      if (!segmentPrefetch) {
+        continue;
+      }
+
+      if (!variant.audio.segmentIndex) {
+        variant.audio.createSegmentIndex();
+      }
+
+      this.audioPrefetchMap_.set(variant.audio, segmentPrefetch);
+    }
   }
 
   /**
@@ -1072,6 +1177,16 @@ shaka.media.StreamingEngine = class {
     // Compute how far we've buffered ahead of the playhead.
     const presentationTime = this.playerInterface_.getPresentationTime();
 
+    if (mediaState.type === ContentType.AUDIO) {
+      // evict all prefetched segments that are before the presentationTime
+      for (const stream of this.audioPrefetchMap_.keys()) {
+        const prefetch = this.audioPrefetchMap_.get(stream);
+        prefetch.evict(presentationTime);
+        prefetch.prefetchSegmentsByTime(presentationTime,
+            /* fetchInit= */ true);
+      }
+    }
+
     // Get the next timestamp we need.
     const timeNeeded = this.getTimeNeeded_(mediaState, presentationTime);
     shaka.log.v2(logPrefix, 'timeNeeded=' + timeNeeded);
@@ -1175,7 +1290,8 @@ shaka.media.StreamingEngine = class {
       return this.config_.updateIntervalSeconds;
     }
 
-    if (mediaState.segmentPrefetch && mediaState.segmentIterator) {
+    if (mediaState.segmentPrefetch && mediaState.segmentIterator &&
+        !this.audioPrefetchMap_.has(mediaState.stream)) {
       const initSegmentReference = reference.initSegmentReference;
       if (initSegmentReference && (!mediaState.lastSegmentReference ||
           !shaka.media.InitSegmentReference.equal(
@@ -2174,6 +2290,7 @@ shaka.media.StreamingEngine = class {
           'bufferBehind=' + bufferBehind);
       return;
     }
+
     const bufferedBehind = presentationTime - startTime;
 
     const overflow = bufferedBehind - bufferBehind;
@@ -2324,7 +2441,8 @@ shaka.media.StreamingEngine = class {
     mediaState.segmentIterator = null;
 
     shaka.log.debug(logPrefix, 'clearing buffer');
-    if (mediaState.segmentPrefetch) {
+    if (mediaState.segmentPrefetch &&
+        !this.audioPrefetchMap_.has(mediaState.stream)) {
       mediaState.segmentPrefetch.clearAll();
     }
 

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -989,7 +989,7 @@ shaka.media.StreamingEngine = class {
       }
 
       // don't try to create a new segment prefetch if the limit isn't positive.
-      if (!(prefetchLimit > 0)) {
+      if (prefetchLimit <= 0) {
         continue;
       }
 
@@ -2290,7 +2290,6 @@ shaka.media.StreamingEngine = class {
           'bufferBehind=' + bufferBehind);
       return;
     }
-
     const bufferedBehind = presentationTime - startTime;
 
     const overflow = bufferedBehind - bufferBehind;

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -190,6 +190,16 @@ shaka.media.StreamingEngine = class {
     this.failureCallbackBackoff_ =
         new shaka.net.Backoff(failureRetryParams, autoReset);
 
+    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    // disable video segment prefetch if this is now set
+    if (config.disableVideoPrefetch) {
+      const state = this.mediaStates_.get(ContentType.VIDEO);
+      if (state && state.segmentPrefetch) {
+        state.segmentPrefetch.clearAll();
+        state.segmentPrefetch = null;
+      }
+    }
+
     // Allow configuring the segment prefetch in middle of the playback.
     for (const type of this.mediaStates_.keys()) {
       const state = this.mediaStates_.get(type);

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1326,13 +1326,7 @@ shaka.media.StreamingEngine = class {
 
     if (mediaState.segmentPrefetch && mediaState.segmentIterator &&
         !this.audioPrefetchMap_.has(mediaState.stream)) {
-      const initSegmentReference = reference.initSegmentReference;
-      if (initSegmentReference && (!mediaState.lastSegmentReference ||
-          !shaka.media.InitSegmentReference.equal(
-              initSegmentReference, mediaState.lastInitSegmentReference))) {
-        mediaState.segmentPrefetch.prefetchInitSegment(initSegmentReference);
-      }
-      mediaState.segmentPrefetch.prefetchSegments(reference);
+      mediaState.segmentPrefetch.prefetchSegmentsByTime(reference.startTime);
     }
 
     const p = this.fetchAndAppend_(mediaState, presentationTime, reference);
@@ -1546,8 +1540,8 @@ shaka.media.StreamingEngine = class {
                   /* isChunkedData= */ true);
 
               if (mediaState.segmentPrefetch && mediaState.segmentIterator) {
-                mediaState.segmentPrefetch.prefetchSegments(
-                    reference, /* skipFirst= */ true);
+                mediaState.segmentPrefetch.prefetchSegmentsByTime(
+                    reference.startTime, /* skipFirst= */ true);
               }
             }
           } catch (error) {
@@ -1587,8 +1581,8 @@ shaka.media.StreamingEngine = class {
         }
 
         if (mediaState.segmentPrefetch && mediaState.segmentIterator) {
-          mediaState.segmentPrefetch.prefetchSegments(
-              reference, /* skipFirst= */ true);
+          mediaState.segmentPrefetch.prefetchSegmentsByTime(
+              reference.startTime, /* skipFirst= */ true);
         }
       } else {
         if (this.config_.lowLatencyMode && !isReadableStreamSupported) {

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -224,6 +224,8 @@ shaka.util.PlayerConfiguration = class {
       // When low latency streaming is enabled, segmentPrefetchLimit will
       // default to 2 if not specified.
       segmentPrefetchLimit: 0,
+      prefetchAudioLanguages: [],
+      disableVideoPrefetch: false,
       liveSync: false,
       liveSyncMaxLatency: 1,
       liveSyncPlaybackRate: 1.1,

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -225,6 +225,7 @@ shaka.util.PlayerConfiguration = class {
       // default to 2 if not specified.
       segmentPrefetchLimit: 0,
       prefetchAudioLanguages: [],
+      disableAudioPrefetch: false,
       disableVideoPrefetch: false,
       liveSync: false,
       liveSyncMaxLatency: 1,

--- a/test/media/segment_prefetch_unit.js
+++ b/test/media/segment_prefetch_unit.js
@@ -86,6 +86,89 @@ describe('SegmentPrefetch', () => {
     });
   });
 
+  describe('prefetchSegmentsByTime', () => {
+    it('should prefetch next 3 segments', async () => {
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
+      await expectSegmentsPrefetched(0);
+      const op = segmentPrefetch.getPrefetchedSegment(references[3]);
+      expect(op).toBeNull();
+      expect(fetchDispatcher).toHaveBeenCalledTimes(3);
+    });
+
+    it('prefetch last segment if position is at the end', async () => {
+      segmentPrefetch.prefetchSegmentsByTime(references[3].startTime);
+      const op = segmentPrefetch.getPrefetchedSegment(references[3]);
+      expect(op).toBeDefined();
+      const response = await op.promise;
+      const startTime = (3 * 10);
+      expect(response.uri).toBe(uri(startTime + '.' + (startTime + 10)));
+
+      for (let i = 0; i < 3; i++) {
+        const op = segmentPrefetch.getPrefetchedSegment(references[i]);
+        expect(op).toBeNull();
+      }
+      expect(fetchDispatcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('do not prefetch already fetched segment', async () => {
+      segmentPrefetch.prefetchSegmentsByTime(references[1].startTime);
+      // since 2 was alreay pre-fetched when prefetch 1, expect
+      // no extra fetch is made.
+      segmentPrefetch.prefetchSegmentsByTime(references[2].startTime);
+
+      expect(fetchDispatcher).toHaveBeenCalledTimes(3);
+      await expectSegmentsPrefetched(1);
+    });
+
+    it('does prefetch init segment if asked', async () => {
+      const references = [
+        makeReference(uri('0.10'), 0, 10),
+        makeReference(uri('10.20'), 10, 20),
+        makeReference(uri('20.30'), 20, 30),
+        makeReference(uri('30.40'), 30, 40),
+      ];
+      references[0].initSegmentReference =
+          new shaka.media.InitSegmentReference(() => ['init-0.mp4'], 0, 500);
+      references[1].initSegmentReference =
+          new shaka.media.InitSegmentReference(() => ['init-1.mp4'], 0, 500);
+      references[2].initSegmentReference =
+          new shaka.media.InitSegmentReference(() => ['init-2.mp4'], 0, 500);
+      references[3].initSegmentReference =
+          new shaka.media.InitSegmentReference(() => ['init-3.mp4'], 0, 500);
+
+      stream = createStream();
+      stream.segmentIndex = new shaka.media.SegmentIndex(references);
+      segmentPrefetch = new shaka.media.SegmentPrefetch(
+          3, stream, Util.spyFunc(fetchDispatcher),
+      );
+
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime,
+          /* fetchInit= */ true);
+
+      for (let i = 0; i < 3; i++) {
+        const op = segmentPrefetch.getPrefetchedSegment(references[i]);
+        expect(op).not.toBeNull();
+        /* eslint-disable-next-line no-await-in-loop */
+        const response = await op.promise;
+        const startTime = (i * 10);
+        expect(response.uri).toBe(uri(startTime + '.' + (startTime + 10)));
+      }
+
+      const op = segmentPrefetch.getPrefetchedSegment(
+          references[0].initSegmentReference);
+      expect(op).not.toBeNull();
+
+      for (let i = 1; i < 3; i++) {
+        const op = segmentPrefetch.getPrefetchedSegment(
+            references[i].initSegmentReference);
+        expect(op).toBeNull();
+      }
+      // this is 4 to account for the init segment,
+      // which is not part of the prefetch limit
+      expect(fetchDispatcher).toHaveBeenCalledTimes(4);
+    });
+  });
+
   describe('clearAll', () => {
     it('clears all prefetched segments', () => {
       segmentPrefetch.prefetchSegments(references[0]);
@@ -112,6 +195,52 @@ describe('SegmentPrefetch', () => {
       }
       expect(segmentPrefetch.getPrefetchedSegment(references[3])).toBeDefined();
       expect(fetchDispatcher).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('evict', () => {
+    it('does not evict a segment that straddles the given time', async () => {
+      segmentPrefetch.deleteOnGet(false);
+      segmentPrefetch.prefetchSegments(references[0]);
+      segmentPrefetch.evict(5);
+      await expectSegmentsPrefetched(0);
+      for (let i = 0; i < 3; i++) {
+        const op = segmentPrefetch.getPrefetchedSegment(references[i]);
+        expect(op).toBeDefined();
+        // eslint-disable-next-line no-await-in-loop
+        const response = await op.promise;
+        const startTime = (i * 10);
+        expect(response.uri).toBe(uri(startTime + '.' + (startTime + 10)));
+      }
+
+      expect(fetchDispatcher).toHaveBeenCalledTimes(3);
+    });
+
+    it('segments that end before the provided time', async () => {
+      segmentPrefetch.deleteOnGet(false);
+      segmentPrefetch.prefetchSegments(references[0]);
+      segmentPrefetch.evict(21);
+      for (let i = 0; i < 2; i++) {
+        const op = segmentPrefetch.getPrefetchedSegment(references[i]);
+        expect(op).toBeNull();
+      }
+      await expectSegmentsPrefetched(2, 1);
+      const op = segmentPrefetch.getPrefetchedSegment(references[2]);
+      expect(op).toBeDefined();
+      const response = await op.promise;
+      const startTime = (2 * 10);
+      expect(response.uri).toBe(uri(startTime + '.' + (startTime + 10)));
+      expect(fetchDispatcher).toHaveBeenCalledTimes(3);
+    });
+
+    it('all prefetched segments, if all before given time', () => {
+      segmentPrefetch.prefetchSegments(references[0]);
+      segmentPrefetch.evict(40);
+      for (let i = 0; i < 3; i++) {
+        const op = segmentPrefetch.getPrefetchedSegment(references[i]);
+        expect(op).toBeNull();
+      }
+      expect(fetchDispatcher).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -150,8 +279,8 @@ describe('SegmentPrefetch', () => {
       segmentPrefetch.prefetchSegments(references[0]);
       segmentPrefetch.resetLimit(1);
       // expecting prefetched reference 0 is kept
-      expectSegmentsPrefetched(0, 1);
-      // expecting prefetched references 1 and 2 are removd
+      await expectSegmentsPrefetched(0, 1);
+      // expecting prefetched references 1 and 2 are removed
       for (let i = 1; i < 3; i++) {
         const op = segmentPrefetch.getPrefetchedSegment(references[i]);
         expect(op).toBeNull();

--- a/test/media/segment_prefetch_unit.js
+++ b/test/media/segment_prefetch_unit.js
@@ -131,7 +131,7 @@ describe('SegmentPrefetch', () => {
 
   describe('clearAll', () => {
     it('clears all prefetched segments', () => {
-      segmentPrefetch.prefetchSegmentsByTime(references[0]);
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
       segmentPrefetch.clearAll();
       for (let i = 0; i < 3; i++) {
         const op = segmentPrefetch.getPrefetchedSegment(references[i]);
@@ -141,14 +141,14 @@ describe('SegmentPrefetch', () => {
     });
 
     it('resets time pos so prefetch can happen again', () => {
-      segmentPrefetch.prefetchSegmentsByTime(references[3]);
+      segmentPrefetch.prefetchSegmentsByTime(references[3].startTime);
       segmentPrefetch.clearAll();
       for (let i = 0; i < 3; i++) {
         const op = segmentPrefetch.getPrefetchedSegment(references[i]);
         expect(op).toBeNull();
       }
 
-      segmentPrefetch.prefetchSegmentsByTime(references[3]);
+      segmentPrefetch.prefetchSegmentsByTime(references[3].startTime);
       for (let i = 0; i < 3; i++) {
         const op = segmentPrefetch.getPrefetchedSegment(references[i]);
         expect(op).toBeNull();
@@ -161,7 +161,7 @@ describe('SegmentPrefetch', () => {
   describe('evict', () => {
     it('does not evict a segment that straddles the given time', async () => {
       segmentPrefetch.deleteOnGet(false);
-      segmentPrefetch.prefetchSegmentsByTime(references[0]);
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
       segmentPrefetch.evict(5);
       await expectSegmentsPrefetched(0);
       for (let i = 0; i < 3; i++) {
@@ -178,7 +178,7 @@ describe('SegmentPrefetch', () => {
 
     it('segments that end before the provided time', async () => {
       segmentPrefetch.deleteOnGet(false);
-      segmentPrefetch.prefetchSegmentsByTime(references[0]);
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
       segmentPrefetch.evict(21);
       for (let i = 0; i < 2; i++) {
         const op = segmentPrefetch.getPrefetchedSegment(references[i]);
@@ -194,7 +194,7 @@ describe('SegmentPrefetch', () => {
     });
 
     it('all prefetched segments, if all before given time', () => {
-      segmentPrefetch.prefetchSegmentsByTime(references[0]);
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
       segmentPrefetch.evict(40);
       for (let i = 0; i < 3; i++) {
         const op = segmentPrefetch.getPrefetchedSegment(references[i]);
@@ -206,7 +206,7 @@ describe('SegmentPrefetch', () => {
 
   describe('switchStream', () => {
     it('clears all prefetched segments', () => {
-      segmentPrefetch.prefetchSegmentsByTime(references[0]);
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
       segmentPrefetch.switchStream(createStream());
       for (let i = 0; i < 3; i++) {
         const op = segmentPrefetch.getPrefetchedSegment(references[i]);
@@ -216,7 +216,7 @@ describe('SegmentPrefetch', () => {
     });
 
     it('do nothing if its same stream', async () => {
-      segmentPrefetch.prefetchSegmentsByTime(references[0]);
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
       segmentPrefetch.switchStream(stream);
       await expectSegmentsPrefetched(0);
     });
@@ -224,19 +224,19 @@ describe('SegmentPrefetch', () => {
 
   describe('resetLimit', () => {
     it('do nothing if the new limit is larger', async () => {
-      segmentPrefetch.prefetchSegmentsByTime(references[0]);
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
       segmentPrefetch.resetLimit(4);
       await expectSegmentsPrefetched(0);
     });
 
     it('do nothing if the new limit is the same', async () => {
-      segmentPrefetch.prefetchSegmentsByTime(references[0]);
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
       segmentPrefetch.resetLimit(3);
       await expectSegmentsPrefetched(0);
     });
 
     it('clears all prefetched segments beyond new limit', async () => {
-      segmentPrefetch.prefetchSegmentsByTime(references[0]);
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
       segmentPrefetch.resetLimit(1);
       // expecting prefetched reference 0 is kept
       await expectSegmentsPrefetched(0, 1);
@@ -249,7 +249,7 @@ describe('SegmentPrefetch', () => {
       // clear all to test the new limit by re-fetching.
       segmentPrefetch.clearAll();
       // prefetch again.
-      segmentPrefetch.prefetchSegmentsByTime(references[0]);
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
       // expect only one is prefetched
       await expectSegmentsPrefetched(0, 1);
       // only dispatched fetch one more time.

--- a/test/media/segment_prefetch_unit.js
+++ b/test/media/segment_prefetch_unit.js
@@ -85,7 +85,7 @@ describe('SegmentPrefetch', () => {
       await expectSegmentsPrefetched(1);
     });
 
-    it('does prefetch init segment if asked', async () => {
+    it('does prefetch init segment', async () => {
       const references = [
         makeReference(uri('0.10'), 0, 10),
         makeReference(uri('10.20'), 10, 20),
@@ -107,8 +107,7 @@ describe('SegmentPrefetch', () => {
           3, stream, Util.spyFunc(fetchDispatcher),
       );
 
-      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime,
-          /* fetchInit= */ true);
+      segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
 
       for (let i = 0; i < 3; i++) {
         const op = segmentPrefetch.getPrefetchedSegment(references[i]);
@@ -119,18 +118,14 @@ describe('SegmentPrefetch', () => {
         expect(response.uri).toBe(uri(startTime + '.' + (startTime + 10)));
       }
 
-      const op = segmentPrefetch.getPrefetchedSegment(
-          references[0].initSegmentReference);
-      expect(op).not.toBeNull();
-
-      for (let i = 1; i < 3; i++) {
+      for (let i = 0; i < 3; i++) {
         const op = segmentPrefetch.getPrefetchedSegment(
             references[i].initSegmentReference);
-        expect(op).toBeNull();
+        expect(op).not.toBeNull();
       }
-      // this is 4 to account for the init segment,
+      // this is 6 to account for the init segments,
       // which is not part of the prefetch limit
-      expect(fetchDispatcher).toHaveBeenCalledTimes(4);
+      expect(fetchDispatcher).toHaveBeenCalledTimes(6);
     });
   });
 

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -3976,11 +3976,9 @@ describe('StreamingEngine', () => {
    */
   function expectSegmentRequest(hasRequest) {
     const segmentType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
-
     const context = {
       type: shaka.net.NetworkingEngine.AdvancedRequestType.MEDIA_SEGMENT,
     };
-
 
     const requests = [
       '0_audio_0', '0_video_0', '0_audio_1',
@@ -4105,6 +4103,9 @@ describe('StreamingEngine', () => {
 
     it('should prefetch all audio variants for the language', async () => {
       const segmentType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
+      const context = {
+        type: shaka.net.NetworkingEngine.AdvancedRequestType.MEDIA_SEGMENT,
+      };
 
       expect(segmentPrefetchesCreated).toBe(2);
 
@@ -4120,13 +4121,16 @@ describe('StreamingEngine', () => {
 
       expectHasBuffer();
       expectSegmentRequest(false);
-      netEngine.expectNoRequest('alt_11_audio_0', segmentType);
-      netEngine.expectNoRequest('alt_11_audio_1', segmentType);
+      netEngine.expectNoRequest('alt_11_audio_0', segmentType, context);
+      netEngine.expectNoRequest('alt_11_audio_1', segmentType, context);
       expect(segmentPrefetchesCreated).toBe(3);
     });
 
     it('should not prefetch video if disabled', async () => {
       const segmentType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
+      const context = {
+        type: shaka.net.NetworkingEngine.AdvancedRequestType.MEDIA_SEGMENT,
+      };
 
       const config = shaka.util.PlayerConfiguration.createDefault().streaming;
       config.segmentPrefetchLimit = 5;
@@ -4147,12 +4151,12 @@ describe('StreamingEngine', () => {
       await runTest();
 
       expectHasBuffer();
-      netEngine.expectNoRequest('alt_11_audio_0', segmentType);
-      netEngine.expectNoRequest('alt_11_audio_1', segmentType);
-      netEngine.expectRequest('0_video_0', segmentType);
-      netEngine.expectRequest('0_video_1', segmentType);
-      netEngine.expectRequest('1_video_2', segmentType);
-      netEngine.expectRequest('1_video_3', segmentType);
+      netEngine.expectNoRequest('alt_11_audio_0', segmentType, context);
+      netEngine.expectNoRequest('alt_11_audio_1', segmentType, context);
+      netEngine.expectRequest('0_video_0', segmentType, context);
+      netEngine.expectRequest('0_video_1', segmentType, context);
+      netEngine.expectRequest('1_video_2', segmentType, context);
+      netEngine.expectRequest('1_video_3', segmentType, context);
       expect(segmentPrefetchesCreated).toBe(2);
     });
 

--- a/test/test/util/fake_segment_prefetch.js
+++ b/test/test/util/fake_segment_prefetch.js
@@ -13,8 +13,16 @@
  * @extends {shaka.media.SegmentPrefetch}
  */
 shaka.test.FakeSegmentPrefetch = class {
-  constructor(stream, segmentData) {
-    /** @private {(Set.<!shaka.media.SegmentReference>)} */
+  /**
+   * Suppress the JSC_PRIVATE_OVERRIDE error for overriding prefetchPosTime_
+   * @suppress {visibility}
+   */
+  constructor(prefetchLimit, stream, segmentData) {
+    /** @private {number} */
+    this.prefetchLimit_ = prefetchLimit;
+
+    /** @private {(Set.<!shaka.media.SegmentReference|
+     *      !shaka.media.InitSegmentReference>)} */
     this.requestedReferences_ = new Set();
 
     /** @private {shaka.extern.Stream} */
@@ -24,14 +32,51 @@ shaka.test.FakeSegmentPrefetch = class {
      * @private {!Object.<string, shaka.test.FakeMediaSourceEngine.SegmentData>}
      */
     this.segmentData_ = segmentData;
+
+    /** @private {Array<number>} */
+    this.evictions_ = [];
+
+    /** @private {number} */
+    this.prefetchPosTime_ = 0;
+
+    /** @private {boolean} */
+    this.deleteOnGet_ = true;
+
+    /** @private {number} */
+    this.segmentNum_ = 0;
   }
 
   /** @override */
-  prefetchSegments(reference) {
-    if (!(reference instanceof shaka.media.SegmentReference)) {
+  getLastKnownPosition() {
+    return this.prefetchPosTime_;
+  }
+
+  /** @override */
+  prefetchSegments(startReference) {
+    if (!(startReference instanceof shaka.media.SegmentReference) &&
+        !(startReference instanceof shaka.media.InitSegmentReference)) {
       return;
     }
-    this.requestedReferences_.add(reference);
+
+    const currTime = startReference.startTime;
+    this.prefetchSegmentsByTime(currTime);
+  }
+
+  /** @override */
+  prefetchSegmentsByTime(currTime) {
+    const maxTime = Math.max(currTime, this.prefetchPosTime_);
+    const iterator = this.streamObj_.segmentIndex.getIteratorForTime(maxTime);
+    let reference = iterator.next().value;
+    while (this.segmentNum_ < this.prefetchLimit_ && reference != null) {
+      if (!this.requestedReferences_.has(reference)) {
+        if (reference instanceof shaka.media.SegmentReference) {
+          this.segmentNum_++;
+        }
+        this.requestedReferences_.add(reference);
+      }
+      this.prefetchPosTime_ = reference.startTime;
+      reference = iterator.next().value;
+    }
   }
 
   /** @override */
@@ -49,9 +94,25 @@ shaka.test.FakeSegmentPrefetch = class {
   /** @override */
   clearAll() {
     this.requestedReferences_.clear();
+    this.segmentNum_ = 0;
+    this.prefetchPosTime_ = 0;
   }
 
   /** @override */
+  evict(time) {
+    this.evictions_.push(time);
+  }
+
+  /** @override */
+  deleteOnGet(newDeleteOnGet) {
+    this.deleteOnGet_ = newDeleteOnGet;
+  }
+
+  /**
+    * @override
+    * @param {shaka.media.InitSegmentReference|
+    *     shaka.media.SegmentReference} reference
+    * */
   getPrefetchedSegment(reference) {
     if (!(reference instanceof shaka.media.SegmentReference)) {
       return null;

--- a/test/test/util/fake_segment_prefetch.js
+++ b/test/test/util/fake_segment_prefetch.js
@@ -52,17 +52,6 @@ shaka.test.FakeSegmentPrefetch = class {
   }
 
   /** @override */
-  prefetchSegments(startReference) {
-    if (!(startReference instanceof shaka.media.SegmentReference) &&
-        !(startReference instanceof shaka.media.InitSegmentReference)) {
-      return;
-    }
-
-    const currTime = startReference.startTime;
-    this.prefetchSegmentsByTime(currTime);
-  }
-
-  /** @override */
   prefetchSegmentsByTime(currTime) {
     const maxTime = Math.max(currTime, this.prefetchPosTime_);
     const iterator = this.streamObj_.segmentIndex.getIteratorForTime(maxTime);
@@ -119,7 +108,7 @@ shaka.test.FakeSegmentPrefetch = class {
     }
     /**
      * The unit tests assume a segment is already prefetched
-     * if it was ever passed to prefetchSegments() as param.
+     * if it was ever passed to prefetchSegmentsByTime() as param.
      * Otherwise return null so the streaming engine being tested
      * will do actual fetch.
      */
@@ -139,7 +128,4 @@ shaka.test.FakeSegmentPrefetch = class {
     }
     return null;
   }
-
-  /** @override */
-  prefetchInitSegment(reference) {}
 };

--- a/test/test/util/streaming_engine_util.js
+++ b/test/test/util/streaming_engine_util.js
@@ -33,7 +33,7 @@ shaka.test.StreamingEngineUtil = class {
       expect(request.uris.length).toBe(1);
 
       const parts = request.uris[0].split('_');
-      if (parts[3] === 'alt') {
+      if (parts[3] === 'secondaryAudioVariant') {
         expect(parts.length).toBe(4);
       } else {
         expect(parts.length).toBeGreaterThanOrEqual(3);
@@ -243,7 +243,7 @@ shaka.test.StreamingEngineUtil = class {
       const positionWithinPeriod = position - periodFirstPosition;
 
       const initSegmentUri = periodIndex + '_' + type + '_init' +
-          (secondaryAudioVariant ? '_alt' : '');
+          (secondaryAudioVariant ? '_secondaryAudioVariant' : '');
 
       // The type can be 'text', 'audio', 'video', or 'trickvideo',
       // but we pull video init segment metadata from the 'video' part of the
@@ -260,7 +260,7 @@ shaka.test.StreamingEngineUtil = class {
 
       const d = segmentDurations[type];
       const getUris = () => [periodIndex + '_' + type + '_' + position +
-          (secondaryAudioVariant ? '_alt' : '')];
+          (secondaryAudioVariant ? '_secondaryAudioVariant' : '')];
       const periodStart = periodStartTimes[periodIndex];
       const timestampOffset = (timestampOffsets && timestampOffsets[type]) || 0;
       const appendWindowStart = periodStartTimes[periodIndex];


### PR DESCRIPTION
Implements the behavior outlines in #6128.
Adds `streaming.prefetchAudioLanguages` and `streaming.disableVideoPrefetch` options.

Does not currently have `disableAudioPrefetch` and `disableTextPrefetch`.