### PR TITLE
perf(HLS): avoid unnecessary memory allocation when checking stream content

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -2439,23 +2439,26 @@ shaka.hls.HlsParser = class {
     if (!this.manifest_) {
       return false;
     }
-    const videos = [];
-    const audios = [];
+
+    let hasVideoSegmentIndex = false;
+    let hasAudioSegmentIndex = false;
+
     for (const variant of this.manifest_.variants) {
-      if (variant.video) {
-        videos.push(variant.video);
+      if (variant.video && variant.video.segmentIndex) {
+        hasVideoSegmentIndex = true;
       }
-      if (variant.audio) {
-        audios.push(variant.audio);
+
+      if (variant.audio && variant.audio.segmentIndex) {
+        hasAudioSegmentIndex = true;
+      }
+
+      // Break the loop if both conditions are satisfied.
+      if (hasVideoSegmentIndex && hasAudioSegmentIndex) {
+        break;
       }
     }
-    if (videos.length > 0 && !videos.some((stream) => stream.segmentIndex)) {
-      return false;
-    }
-    if (audios.length > 0 && !audios.some((stream) => stream.segmentIndex)) {
-      return false;
-    }
-    return true;
+
+    return hasVideoSegmentIndex || hasAudioSegmentIndex;
   }
 
   /**


### PR DESCRIPTION
This commit aims to minimize unnecessary memory allocation during stream content checks. It will indirectly reduce the load on the garbage collector.