### PR TITLE
fix: AC-3 audio codec support on Tizen

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,6 +60,7 @@ Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Martin Stark <martin.stark@eyevinn.se>
 Matthias Van Parijs <matvp91@gmail.com>
 Mattias Wadman <mattias.wadman@gmail.com>
+Mirego <*@mirego.com>
 Mohamed Rashid <ge_rashid@hotmail.co.uk>
 Morten Hansen <mimo@mimo-design.com>
 Nick Desaulniers <nick@mozilla.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -88,6 +88,7 @@ Loïc Raux <loicraux@gmail.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Martin Stark <martin.stark@eyevinn.se>
 Matias Russitto <russitto@gmail.com>
+Mathieu Côté <mcote@mirego.com>
 Matthias Van Parijs <matvp91@gmail.com>
 Mattias Wadman <mattias.wadman@gmail.com>
 Michelle Zhuo <michellezhuo@google.com>

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -191,10 +191,23 @@ shaka.polyfill.MediaCapabilities = class {
       const videoCapabilities = [];
 
       if (mediaCapkeySystemConfig.audio) {
-        const capability = {
+        let capability = {
           robustness: mediaCapkeySystemConfig.audio.robustness || '',
           contentType: mediaDecodingConfig.audio.contentType,
         };
+
+        // Some Tizen devices seem to misreport AC-3 support, but correctly
+        // report EC-3 support. So query EC-3 as a fallback for AC-3.
+        // See https://github.com/shaka-project/shaka-player/issues/2989 for
+        // details.
+        if (shaka.util.Platform.isTizen() &&
+          mediaDecodingConfig.audio.contentType.includes('codecs="ac-3"')) {
+          capability = {
+            robustness: capability.robustness,
+            contentType: 'audio/mp4; codecs="ec-3"',
+          };
+        }
+
         audioCapabilities.push(capability);
       }
 

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -917,15 +917,7 @@ shaka.util.StreamUtils = class {
       return 'opus';
     }
 
-    // Some Tizen devices seem to misreport AC-3 support, but correctly
-    // report EC-3 support.  So query EC-3 as a fallback for AC-3.
-    // See https://github.com/shaka-project/shaka-player/issues/2989 for
-    // details.
-    if (shaka.util.Platform.isTizen()) {
-      return codecs.toLowerCase() == 'ac-3' ? 'ec-3' : codecs;
-    } else {
-      return codecs;
-    }
+    return codecs;
   }
 
 


### PR DESCRIPTION
## 📖 Description of the problem

A regression got introduced in version `4.2.7` where audio.codecs got rewrite (ref: https://github.com/shaka-project/shaka-player/pull/4858) with the corrected audio codecs.

After this change, the player tries to play the audio stream with codec EC-3 instead of AC-3 (the original value provided by the manifest representation) due to the current implementation of supporting AC-3 on Tizen.

## 📚 Fix

Delegating the check from ac-3 to ec-3 in `stream_utils` to the actual media capabilities polyfill so that when a system is requesting the support of `AC-3` audio codec on Tizen, we change the capabilities to `EC-3` and let it do its check.

## 📓 Reference

This completes the work on 🐛  https://github.com/shaka-project/shaka-player/issues/6160.

## 🗒 Note

It was tested locally on a real Samsung TV (Tizen 5.0) in our internal project using Shaka as well as a dumbed down project with Shaka only providing the manifest listed in the bug.
