### PR TITLE
feat: add option to use custom fetch API for player

### DIFF
--- a/lib/net/http_fetch_plugin.js
+++ b/lib/net/http_fetch_plugin.js
@@ -14,7 +14,7 @@ goog.require('shaka.util.AbortableOperation');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.MapUtils');
 goog.require('shaka.util.Timer');
-
+goog.require('shaka.Player');
 
 /**
  * @summary A networking plugin to handle http and https URIs via the Fetch API.
@@ -101,7 +101,8 @@ shaka.net.HttpFetchPlugin = class {
    */
   static async request_(uri, requestType, init, abortStatus, progressUpdated,
       headersReceived, streamDataCallback) {
-    const fetch = shaka.net.HttpFetchPlugin.fetch_;
+    const fetch =
+      shaka.Player.getHttpFetchUtil() || shaka.net.HttpFetchPlugin.fetch_;
     const ReadableStream = shaka.net.HttpFetchPlugin.ReadableStream_;
     let response;
     let arrayBuffer;

--- a/lib/player.js
+++ b/lib/player.js
@@ -1320,12 +1320,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   }
 
   /**
-   * Updates the custom HTTP fetcher
+   * Sets the custom HTTP fetcher
    *
    * @param {function(string, !RequestInit)} fetcher - custom fetch function.
    * @export
    */
-  updateHttpFetchUtil(fetcher) {
+  setHttpFetchUtil(fetcher) {
     shaka.Player.httpFetch_ = fetcher;
   }
 
@@ -1349,15 +1349,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *    <code>undefined</code>, playback will start at the default start time (0
    *    for VOD and liveEdge for LIVE).
    * @param {?string=} mimeType
-   * @param {?function(string, !RequestInit)=} fetcher
    * @return {!Promise}
    * @export
    */
-  async load(assetUri, startTime = null, mimeType = null, fetcher = null) {
-    if (fetcher) {
-      this.updateHttpFetchUtil(fetcher);
-    }
-
+  async load(assetUri, startTime = null, mimeType) {
     // Do not allow the player to be used after |destroy| is called.
     if (this.loadMode_ == shaka.Player.LoadMode.DESTROYED) {
       throw this.createAbortLoadError_();

--- a/lib/player.js
+++ b/lib/player.js
@@ -1320,6 +1320,26 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   }
 
   /**
+   * Updates the custom HTTP fetcher
+   *
+   * @param {function(string, !RequestInit)} fetcher - custom fetch function.
+   * @export
+   */
+  updateHttpFetchUtil(fetcher) {
+    shaka.Player.httpFetch_ = fetcher;
+  }
+
+  /**
+   * Retrieves the current custom HTTP fetcher function.
+   *
+   * @return {?function(string, !RequestInit)}
+   * @export
+   */
+  static getHttpFetchUtil() {
+    return shaka.Player.httpFetch_;
+  }
+
+  /**
    * Loads a new stream.
    * If another stream was already playing, first unloads that stream.
    *
@@ -1329,10 +1349,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *    <code>undefined</code>, playback will start at the default start time (0
    *    for VOD and liveEdge for LIVE).
    * @param {?string=} mimeType
+   * @param {?function(string, !RequestInit)=} fetcher
    * @return {!Promise}
    * @export
    */
-  async load(assetUri, startTime = null, mimeType) {
+  async load(assetUri, startTime = null, mimeType = null, fetcher = null) {
+    if (fetcher) {
+      this.updateHttpFetchUtil(fetcher);
+    }
+
     // Do not allow the player to be used after |destroy| is called.
     if (this.loadMode_ == shaka.Player.LoadMode.DESTROYED) {
       throw this.createAbortLoadError_();
@@ -6955,3 +6980,7 @@ shaka.Player.adManagerFactory_ = null;
  * @const {string}
  */
 shaka.Player.TextTrackLabel = 'Shaka Player TextTrack';
+
+
+/** @private {?function(string, !RequestInit)} */
+shaka.Player.httpFetch_ = null;


### PR DESCRIPTION
- #6173

# changes

- Introduced a new `setHttpFetchUtil` method in `shaka.Player` class to help set a custom Fetcher function (replacing the default Fetch API provided via `shaka.net.HttpFetchPlugin.fetch_`)