### PR TITLE
feat!: Prefer MSE HLS over native HLS in Apple platform when not encrypted

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ NOTES:
 NOTES:
  - ¹: By default, FairPlay is handled using Apple's native HLS player, when on
    Safari. We do support FairPlay through MSE/EME, however. See the
-   `streaming.useNativeHlsOnSafari` configuration value.
+   `streaming.useNativeHlsForFairPlay` configuration value.
 
 
 ## Media container and subtitle support

--- a/demo/common/assets.js
+++ b/demo/common/assets.js
@@ -1454,9 +1454,6 @@ shakaAssets.testAssets = [
       .addFeature(shakaAssets.Feature.LCEVC)
       .addDescription('LCEVC Enhanced eSports content selection.')
       .setExtraConfig({
-        streaming: {
-          useNativeHlsOnSafari: false,
-        },
         mediaSource: {
           forceTransmux: true,
         },
@@ -1496,9 +1493,6 @@ shakaAssets.testAssets = [
       .addFeature(shakaAssets.Feature.OFFLINE)
       .addFeature(shakaAssets.Feature.LCEVC)
       .setExtraConfig({
-        streaming: {
-          useNativeHlsOnSafari: false,
-        },
         mediaSource: {
           forceTransmux: true,
         },
@@ -1520,9 +1514,6 @@ shakaAssets.testAssets = [
       .addFeature(shakaAssets.Feature.OFFLINE)
       .addFeature(shakaAssets.Feature.LCEVC)
       .setExtraConfig({
-        streaming: {
-          useNativeHlsOnSafari: false,
-        },
         mediaSource: {
           forceTransmux: true,
         },

--- a/demo/config.js
+++ b/demo/config.js
@@ -529,8 +529,8 @@ shakaDemo.Config = class {
         .addBoolInput_('Ignore Text Stream Failures',
             'streaming.ignoreTextStreamFailures')
         .addBoolInput_('Stall Detector Enabled', 'streaming.stallEnabled')
-        .addBoolInput_('Use native HLS on Safari',
-            'streaming.useNativeHlsOnSafari');
+        .addBoolInput_('Use native HLS for FairPlay',
+            'streaming.useNativeHlsForFairPlay');
     this.addRetrySection_('streaming', 'Streaming Retry Parameters');
   }
 

--- a/docs/tutorials/upgrade.md
+++ b/docs/tutorials/upgrade.md
@@ -98,6 +98,7 @@ application:
       (deprecated in v4.3.0)
     - `manifest.dash.manifestPreprocessor` callback now receives a type of `shaka.externs.xml.Node` instead of `Element`.
     - `manifest.mss.manifestPreprocessor` callback now receives a type of `shaka.externs.xml.Node` instead of `Element`.
+    - `streaming.useNativeHlsOnSafari` has removed. Now we have another config to do the same for FairPlay `streaming.useNativeHlsForFairPlay` or for HLS (any browser) `streaming.preferNativeHls`.
 
   - Plugin changes:
     - `Transmuxer` plugins now has three new parameters in `transmux()` method.

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1147,7 +1147,7 @@ shaka.extern.ManifestConfiguration;
  *   stallEnabled: boolean,
  *   stallThreshold: number,
  *   stallSkip: number,
- *   useNativeHlsOnSafari: boolean,
+ *   useNativeHlsForFairPlay: boolean,
  *   inaccurateManifestTolerance: number,
  *   lowLatencyMode: boolean,
  *   autoLowLatencyMode: boolean,
@@ -1239,12 +1239,13 @@ shaka.extern.ManifestConfiguration;
  *   been detected.  If 0, the player will pause and immediately play instead of
  *   seeking.  A value of 0 is recommended and provided as default on TV
  *   platforms (WebOS, Tizen, Chromecast, etc).
- * @property {boolean} useNativeHlsOnSafari
+ * @property {boolean} useNativeHlsForFairPlay
  *   Desktop Safari has both MediaSource and their native HLS implementation.
  *   Depending on the application's needs, it may prefer one over the other.
  *   Warning when disabled: Where single-key DRM streams work fine, multi-keys
  *   streams is showing unexpected behaviours (stall, audio playing with video
  *   freezes, ...). Use with care.
+ *   Defaults to <code>true</code>.
  * @property {number} inaccurateManifestTolerance
  *   The maximum difference, in seconds, between the times in the manifest and
  *   the times in the segments.  Larger values allow us to compensate for more

--- a/lib/player.js
+++ b/lib/player.js
@@ -1516,10 +1516,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           return true;
         }
 
-        // For Safari, we have an older flag which only applies to this one
-        // browser:
-        if (Platform.isApple()) {
-          return this.config_.streaming.useNativeHlsOnSafari;
+        // Native FairPlay HLS can be preferred on Apple platfforms.
+        if (Platform.isApple() &&
+            (this.config_.drm.servers['com.apple.fps'] ||
+            this.config_.drm.servers['com.apple.fps.1_0'])) {
+          return this.config_.streaming.useNativeHlsForFairPlay;
         }
       }
 

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -205,7 +205,7 @@ shaka.util.PlayerConfiguration = class {
       stallEnabled: true,
       stallThreshold: 1 /* seconds */,
       stallSkip: 0.1 /* seconds */,
-      useNativeHlsOnSafari: true,
+      useNativeHlsForFairPlay: true,
       // If we are within 2 seconds of the start of a live segment, fetch the
       // previous one.  This allows for segment drift, but won't download an
       // extra segment if we aren't close to the start.

--- a/test/hls/hls_parser_integration.js
+++ b/test/hls/hls_parser_integration.js
@@ -63,8 +63,6 @@ filterDescribe('HlsParser', checkNoBrokenEdgeHls, () => {
     player = new compiledShaka.Player();
     await player.attach(video);
 
-    player.configure('streaming.useNativeHlsOnSafari', false);
-
     // Disable stall detection, which can interfere with playback tests.
     player.configure('streaming.stallEnabled', false);
 

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -683,7 +683,6 @@ describe('Player', () => {
         video.canPlayType.and.returnValue('maybe');
         spyOn(shaka.util.Platform, 'anyMediaElement').and.returnValue(video);
         spyOn(shaka.util.Platform, 'supportsMediaSource').and.returnValue(true);
-        spyOn(shaka.util.Platform, 'isApple').and.returnValue(false);
         // Make sure player.load() resolves for src=
         spyOn(shaka.util.MediaReadyState, 'waitForReadyState').and.callFake(
             (mediaElement, readyState, eventManager, callback) => {
@@ -693,7 +692,6 @@ describe('Player', () => {
         player.configure({
           streaming: {
             preferNativeHls: true,
-            useNativeHlsOnSafari: false,
           },
         });
 
@@ -705,12 +703,10 @@ describe('Player', () => {
       it('does not apply to non-HLS streams', async () => {
         video.canPlayType.and.returnValue('maybe');
         spyOn(shaka.util.Platform, 'supportsMediaSource').and.returnValue(true);
-        spyOn(shaka.util.Platform, 'isApple').and.returnValue(false);
 
         player.configure({
           streaming: {
             preferNativeHls: true,
-            useNativeHlsOnSafari: false,
           },
         });
 

--- a/test/transmuxer/transmuxer_integration.js
+++ b/test/transmuxer/transmuxer_integration.js
@@ -106,7 +106,6 @@ filterDescribe('Transmuxer Player', checkNoBrokenEdge, () => {
     await player.attach(video);
 
     player.configure('mediaSource.forceTransmux', true);
-    player.configure('streaming.useNativeHlsOnSafari', false);
 
     // Disable stall detection, which can interfere with playback tests.
     player.configure('streaming.stallEnabled', false);


### PR DESCRIPTION
Our HLS implementation is stable and robust enough that we can enable it by default.