### PR TITLE
feat!: Remove com.adobe.primetime keysystem

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -1877,7 +1877,6 @@ shakaDemo.Main.commonDrmSystems = [
   'com.widevine.alpha',
   'com.microsoft.playready',
   'com.apple.fps',
-  'com.adobe.primetime',
   'org.w3.clearkey',
 ];
 

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -1831,7 +1831,6 @@ shaka.media.DrmEngine = class {
       'com.microsoft.playready.recommendation',
       'com.apple.fps.1_0',
       'com.apple.fps',
-      'com.adobe.primetime',
     ];
 
     const basicVideoCapabilities = [

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -1654,7 +1654,6 @@ shaka.offline.Storage.defaultSystemIds_ = new Map()
     .set('com.microsoft.playready.software',
         '9a04f07998404286ab92e65be0885f95')
     .set('com.microsoft.playready.hardware',
-        '9a04f07998404286ab92e65be0885f95')
-    .set('com.adobe.primetime', 'f239e769efa348509c16a903c6932efb');
+        '9a04f07998404286ab92e65be0885f95');
 
 shaka.Player.registerSupportPlugin('offline', shaka.offline.Storage.support);

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -133,8 +133,6 @@ shaka.util.PlayerConfiguration = class {
             'com.microsoft.playready',
           'urn:uuid:79f0049a-4098-8642-ab92-e65be0885f95':
             'com.microsoft.playready',
-          'urn:uuid:f239e769-efa3-4850-9c16-a903c6932efb':
-            'com.adobe.primetime',
         },
         manifestPreprocessor: (element) => {
           return shaka.util.ConfigUtils.referenceParametersAndReturn(

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -222,8 +222,6 @@ describe('DashParser ContentProtection', () => {
         ['9a04f079-9840-4286-ab92-e65be0885f95'], ['com.microsoft.playready']);
     testKeySystemMappings('for old PlayReady',
         ['79f0049a-4098-8642-ab92-e65be0885f95'], ['com.microsoft.playready']);
-    testKeySystemMappings('for Adobe Primetime',
-        ['f239e769-efa3-4850-9c16-a903c6932efb'], ['com.adobe.primetime']);
 
     testKeySystemMappings('for multiple DRMs in the specified order',
         [
@@ -238,11 +236,9 @@ describe('DashParser ContentProtection', () => {
         [
           'EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED',
           '9A04F079-9840-4286-AB92-E65BE0885F95',
-          'F239E769-EFA3-4850-9C16-A903C6932EFB',
         ], [
           'com.widevine.alpha',
           'com.microsoft.playready',
-          'com.adobe.primetime',
         ]);
   });
 
@@ -393,7 +389,6 @@ describe('DashParser ContentProtection', () => {
     const drmInfos = jasmine.arrayContaining([
       buildDrmInfo('com.widevine.alpha'),
       buildDrmInfo('com.microsoft.playready'),
-      buildDrmInfo('com.adobe.primetime'),
     ]);
     const expected = buildExpectedManifest(
         /** @type {!Array.<shaka.extern.DrmInfo>} */(drmInfos),
@@ -420,7 +415,6 @@ describe('DashParser ContentProtection', () => {
     const drmInfos = jasmine.arrayContaining([
       buildDrmInfo('com.widevine.alpha'),
       buildDrmInfo('com.microsoft.playready'),
-      buildDrmInfo('com.adobe.primetime'),
     ]);
     const expected = buildExpectedManifest(
         /** @type {!Array.<shaka.extern.DrmInfo>} */(drmInfos),
@@ -454,7 +448,6 @@ describe('DashParser ContentProtection', () => {
       // PlayReady has two associated UUIDs, so it appears twice.
       buildDrmInfo('com.microsoft.playready', keyIds),
       buildDrmInfo('com.microsoft.playready', keyIds),
-      buildDrmInfo('com.adobe.primetime', keyIds),
     ], variantKeyIds);
     await testDashParser(source, expected, /* ignoreDrmInfo= */ true);
   });


### PR DESCRIPTION
`com.adobe.primetime` is not implemented in any browser and no one has reported any problems in the 8 years of Shaka Player.