### PR TITLE
fix: Fix gitpkg.now.sh dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5797,7 +5797,7 @@
     "node_modules/less": {
       "version": "4.1.2",
       "resolved": "https://gitpkg.now.sh/joeyparrish/less.js/packages/less?28c63a43",
-      "integrity": "sha512-i5qb64PowTQ7eCLt7rlRcsNwFK9M5htl1ioP3Y/7WdU5NNpjpE8JgbUInlA97w4Vqqcd7PdCTgSBPLrs+Yvxag==",
+      "integrity": "sha512-AxZPQSmyVgtkNwrSXux9yYU0Kskcvj6AcAjWRmvyLAIkLaXRDN660R2XcsRNavXOr6tCQknVw5TvRtvCPiOW0Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13166,7 +13166,7 @@
     },
     "less": {
       "version": "https://gitpkg.now.sh/joeyparrish/less.js/packages/less?28c63a43",
-      "integrity": "sha512-i5qb64PowTQ7eCLt7rlRcsNwFK9M5htl1ioP3Y/7WdU5NNpjpE8JgbUInlA97w4Vqqcd7PdCTgSBPLrs+Yvxag==",
+      "integrity": "sha512-AxZPQSmyVgtkNwrSXux9yYU0Kskcvj6AcAjWRmvyLAIkLaXRDN660R2XcsRNavXOr6tCQknVw5TvRtvCPiOW0Q==",
       "dev": true,
       "requires": {
         "copy-anything": "^2.0.1",


### PR DESCRIPTION
gitpkg.now.sh dependencies started to have broken SHA for some reason which breaks CI infrastructure here & in our fork.