### PR TITLE
ci: Temporarily disable Edge on Windows in the lab

### DIFF
--- a/build/shaka-lab.yaml
+++ b/build/shaka-lab.yaml
@@ -161,6 +161,8 @@ FirefoxWindows:
     - *basic_firefox_config
 
 Edge:
+  # TODO(b/323916397): Edge on Windows not working currently
+  disabled: true
   browser: msedge
   os: Windows
   extra_configs:


### PR DESCRIPTION
shaka-lab-hub reports:

```
/wd/hub/session java.io.IOException:
org.openqa.grid.common.exception.GridException:
Cannot extract a capabilities from the request:
```

Generally, there should be a request object after this, but here it is blank.  It's not clear why or how this could be. There are no errors from shaka-lab-node on Windows.