### PR TITLE
ci: Fix Edge launcher for local testing and GitHub CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "karma-coverage": "^2.2.0",
         "karma-jasmine": "^4.0.1",
         "karma-jasmine-ajax": "^0.1.13",
-        "karma-local-wd-launcher": "^1.6.6",
+        "karma-local-wd-launcher": "^1.6.7",
         "karma-opera-launcher": "^1.0.0",
         "karma-sourcemap-loader": "^0.3.8",
         "karma-spec-reporter": "^0.0.34",
@@ -5627,9 +5627,9 @@
       "dev": true
     },
     "node_modules/karma-local-wd-launcher": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/karma-local-wd-launcher/-/karma-local-wd-launcher-1.6.6.tgz",
-      "integrity": "sha512-8An620Xk5o6o0qVq0ATSgI2xY3+QAzEgrYvwoy4N0eDPzPrCOy99RYPCEOit8XL2AKeOCJ3Q7Puc+mjtBiVwpg==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/karma-local-wd-launcher/-/karma-local-wd-launcher-1.6.7.tgz",
+      "integrity": "sha512-rqGX9TRUzfzqnUHdFWhvAAy321n7iFe2FGHS3KVseRMWhD3Wz1bCfcL2jp9Y+/3tHSWovoIey98V1F4yH80POQ==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.21",
@@ -13040,9 +13040,9 @@
       }
     },
     "karma-local-wd-launcher": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/karma-local-wd-launcher/-/karma-local-wd-launcher-1.6.6.tgz",
-      "integrity": "sha512-8An620Xk5o6o0qVq0ATSgI2xY3+QAzEgrYvwoy4N0eDPzPrCOy99RYPCEOit8XL2AKeOCJ3Q7Puc+mjtBiVwpg==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/karma-local-wd-launcher/-/karma-local-wd-launcher-1.6.7.tgz",
+      "integrity": "sha512-rqGX9TRUzfzqnUHdFWhvAAy321n7iFe2FGHS3KVseRMWhD3Wz1bCfcL2jp9Y+/3tHSWovoIey98V1F4yH80POQ==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "karma-coverage": "^2.2.0",
     "karma-jasmine": "^4.0.1",
     "karma-jasmine-ajax": "^0.1.13",
-    "karma-local-wd-launcher": "^1.6.6",
+    "karma-local-wd-launcher": "^1.6.7",
     "karma-opera-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma-spec-reporter": "^0.0.34",


### PR DESCRIPTION
This updated version of karma-local-wd-launcher incorporates https://github.com/shaka-project/karma-local-wd-launcher/pull/65 to supply a path to the Edge binary on all platforms.  This fixes local testing and GitHub CI testing of Edge.

Though the tests run once more, there are still some test failures that need to be dealt with.