### PR TITLE
fix(preload): Fix timing of call to stopQueuingLatePhaseQueuedOperations

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -1557,13 +1557,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           await this.loadInner_(
               startTimeOfLoad, prefetchedVariant, segmentPrefetchById);
         }, 'loadInner_');
+        preloadManager.stopQueuingLatePhaseQueuedOperations();
       }
       this.dispatchEvent(shaka.Player.makeEvent_(
           shaka.util.FakeEvent.EventName.Loaded));
     } catch (error) {
       if (error.code != shaka.util.Error.Code.LOAD_INTERRUPTED) {
         await this.unload(/* initializeMediaSource= */ false);
-        preloadManager.stopQueuingLatePhaseQueuedOperations();
       }
       throw error;
     } finally {

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -715,6 +715,22 @@ describe('Player', () => {
         expect(player.getLoadMode()).toBe(shaka.Player.LoadMode.MEDIA_SOURCE);
       });
     });
+
+    it('fires keystatuschanged events', async () => {
+      const keyStatusChanged = jasmine.createSpy('keyStatusChanged');
+      player.addEventListener(
+          'keystatuschanged', Util.spyFunc(keyStatusChanged));
+      player.createDrmEngine = (playerInterface) => {
+        // Call the onKeyStatus on the playerInterface, before load is finished.
+        playerInterface.onKeyStatus({
+          'aaa': 'usable',
+          'bbb': 'output-restricted',
+        });
+        return drmEngine;
+      };
+      await player.load(fakeManifestUri, 0, fakeMimeType);
+      expect(keyStatusChanged).toHaveBeenCalled();
+    });
   });  // describe('load/unload')
 
   describe('getConfiguration', () => {


### PR DESCRIPTION
This method should be called after the load is successful, not if the load fails.
This also adds a new test that ensures that onKeyStatus_ messages work correctly, as a regression test.
This was exposed by the test failures, but was not the cause of them.

Issue #6225