### PR TITLE
fix: don't double wrap URIs for HLS key requests

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -2845,12 +2845,12 @@ shaka.hls.HlsParser = class {
       // Don't download the key object until the segment is parsed, to avoid a
       // startup delay for long manifests with lots of keys.
       keyInfo.fetchKey = async () => {
-        const keyUri = shaka.hls.Utils.constructSegmentUris(
+        const keyUris = shaka.hls.Utils.constructSegmentUris(
             getUris(), drmTag.getRequiredAttrValue('URI'), variables);
 
         const requestType = shaka.net.NetworkingEngine.RequestType.KEY;
         const request = shaka.net.NetworkingEngine.makeRequest(
-            [keyUri], this.config_.retryParameters);
+            keyUris, this.config_.retryParameters);
         const keyResponse =
             await this.makeNetworkRequest_(request, requestType);
 


### PR DESCRIPTION
The `constructSegmentUris` util already returns an array, so the call to `makeRequest` was being made with an array of arrays. This wasn't causing errors for requests that use the `fetch` plugin, since `fetch` will stringify the first argument if it's an array. But the data URI plugin expects to receive a string and calls `.split()` on it, so keys using data URIs throw an error if the URI is wrapped in an array.


Thanks to https://github.com/shaka-project/shaka-player/pull/6243 and @andrew0