### PR TITLE
feat: add includeKeys to CMCD config to allow filtering of CMCD data

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1563,7 +1563,7 @@ shaka.extern.AdvancedAbrConfiguration;
  * @property {number} rtpSafetyFactor
  *   RTP safety factor.
  *   Defaults to <code>5</code>.
- * @property {Array<string>} includeKeys
+ * @property {!Array<string>} includeKeys
  *   An array of keys to include in the CMCD data. If not provided, all keys
  *   will be included.
  * @exportDoc

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1536,7 +1536,8 @@ shaka.extern.AdvancedAbrConfiguration;
  *   useHeaders: boolean,
  *   sessionId: string,
  *   contentId: string,
- *   rtpSafetyFactor: number
+ *   rtpSafetyFactor: number,
+ *   includeKeys: !Array<string>
  * }}
  *
  * @description
@@ -1562,6 +1563,9 @@ shaka.extern.AdvancedAbrConfiguration;
  * @property {number} rtpSafetyFactor
  *   RTP safety factor.
  *   Defaults to <code>5</code>.
+ * @property {Array<string>} includeKeys
+ *   An array of keys to include in the CMCD data. If not provided, all keys
+ *   will be included.
  * @exportDoc
  */
 shaka.extern.CmcdConfiguration;

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -401,7 +401,7 @@ shaka.util.CmcdManager = class {
   filterKeys_(data) {
     const includeKeys = this.config_.includeKeys;
 
-    if (!includeKeys || !includeKeys.length) {
+    if (!includeKeys.length) {
       return data;
     }
 

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -369,15 +369,17 @@ shaka.util.CmcdManager = class {
       data.su = this.buffering_;
     }
 
+    const output = this.filterKeys_(data);
+
     if (useHeaders) {
-      const headers = shaka.util.CmcdManager.toHeaders(data);
+      const headers = shaka.util.CmcdManager.toHeaders(output);
       if (!Object.keys(headers).length) {
         return;
       }
 
       Object.assign(request.headers, headers);
     } else {
-      const query = shaka.util.CmcdManager.toQuery(data);
+      const query = shaka.util.CmcdManager.toQuery(output);
       if (!query) {
         return;
       }
@@ -386,6 +388,29 @@ shaka.util.CmcdManager = class {
         return shaka.util.CmcdManager.appendQueryToUri(uri, query);
       });
     }
+  }
+
+  /**
+   * Filter the CMCD data object to include only the keys specified in the
+   * configuration.
+   *
+   * @param {CmcdData} data
+   * @return {CmcdData}
+   * @private
+   */
+  filterKeys_(data) {
+    const includeKeys = this.config_.includeKeys;
+
+    if (!includeKeys || !includeKeys.length) {
+      return data;
+    }
+
+    return Object.keys(data).reduce((acc, key) => {
+      if (includeKeys.includes(key)) {
+        acc[key] = data[key];
+      }
+      return acc;
+    }, {});
   }
 
   /**

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -327,6 +327,7 @@ shaka.util.PlayerConfiguration = class {
       contentId: '',
       rtpSafetyFactor: 5,
       useHeaders: false,
+      includeKeys: [],
     };
 
     const cmsd = {

--- a/test/util/cmcd_manager_unit.js
+++ b/test/util/cmcd_manager_unit.js
@@ -129,6 +129,7 @@ describe('CmcdManager', () => {
       contentId: 'testing',
       rtpSafetyFactor: 5,
       useHeaders: false,
+      includeKeys: [],
     };
 
     /** @type shaka.util.CmcdManager */
@@ -214,11 +215,25 @@ describe('CmcdManager', () => {
         expect(r.uris[0].includes(sessionId)).toBe(false);
         expect(sidRegex.test(r.uris[0])).toBe(true);
       });
+
+      it('filters keys if includeKeys is provided', () => {
+        config.sessionId = sid;
+        config.includeKeys = ['sid', 'cid'];
+        cmcdManager = new CmcdManager(playerInterface, config);
+
+        const r = ObjectUtils.cloneObject(request);
+        cmcdManager.applyManifestData(r, manifestInfo);
+
+        const uri = 'https://test.com/test.mpd?CMCD=cid%3D%22testing%22' +
+          '%2Csid%3D%222ed2d1cd-970b-48f2-bfb3-50a79e87cfa3%22';
+        expect(r.uris[0]).toBe(uri);
+      });
     });
 
     describe('query mode', () => {
       beforeAll(() => {
         config.sessionId = sid;
+        config.includeKeys = [];
         cmcdManager = new CmcdManager(playerInterface, config);
       });
 


### PR DESCRIPTION
This PR adds the ability to filter/limit the amount of data transmitted when CMCD is enabled. It matches the functionality provided in [`dash.js`](https://github.com/Dash-Industry-Forum/dash.js/blob/9e3da3cb35da71d339444158db359bfec63035a0/src/core/Settings.js#L712-L713) and [`hls.js`](https://github.com/video-dev/hls.js/blob/dfb384dc765f400ea3d401b790cfc4d53a44410f/src/config.ts#L70-L75) and addresses concernes raised by video providers:

https://github.com/cta-wave/common-media-client-data/issues/122


