### PR TITLE
fix: Fix detection of flac support on Safari

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,6 +54,7 @@ Jonas Birmé <jonas.birme@eyevinn.se>
 Jozef Chúťka <jozefchutka@gmail.com>
 Jun Hong Chong <chongjunhong@gmail.com>
 Jürgen Kartnaller <kartnaller@lovelysystems.com>
+Justin Swaney <justin.mark.swaney@gmail.com>
 JW Player <*@jwplayer.com>
 Konstantin Grushetsky <github@grushetsky.net>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -82,6 +82,7 @@ Jozef Chúťka <jozefchutka@gmail.com>
 Julian Domingo <juliandomingo@google.com>
 Jun Hong Chong <chongjunhong@gmail.com>
 Jürgen Kartnaller <kartnaller@lovelysystems.com>
+Justin Swaney <justin.mark.swaney@gmail.com>
 Konstantin Grushetsky <github@grushetsky.net>
 Leandro Ribeiro Moreira <leandro.ribeiro.moreira@gmail.com>
 Loïc Raux <loicraux@gmail.com>

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -915,7 +915,7 @@ shaka.util.StreamUtils = class {
     // currently don't support 'fLaC', while 'flac' is supported by most
     // major browsers.
     // See https://bugs.chromium.org/p/chromium/issues/detail?id=1422728
-    if (codecs === 'fLaC') {
+    if (codecs === 'fLaC' && !shaka.util.Platform.isSafari()) {
       return 'flac';
     }
 


### PR DESCRIPTION
When constructing the MediaDecodingConfigurations to query media capabilities in `stream_utils.js`, the spelling of "fLaC" should not change to "flac" on Safari. This is because on Safari the query will return `supported: false` for "flac" but `supported: true` for "fLaC".

This change allows manifests with "fLaC" codecs to work properly on Safari when using MSE / Managed Media Source.

Fixes #6249