### PR TITLE
fix(Cast): Force TS content to be transmuxed on Chromecast

### DIFF
--- a/lib/polyfill/mediasource.js
+++ b/lib/polyfill/mediasource.js
@@ -32,11 +32,12 @@ shaka.polyfill.MediaSource = class {
 
     if (!window.MediaSource) {
       shaka.log.info('No MSE implementation available.');
-    } else if (window.cast && cast.__platform__ &&
-               cast.__platform__.canDisplayType) {
+    } else if (shaka.util.Platform.isChromecast()) {
       shaka.log.info('Patching Chromecast MSE bugs.');
-      // Chromecast cannot make accurate determinations via isTypeSupported.
-      shaka.polyfill.MediaSource.patchCastIsTypeSupported_();
+      // Chromecast fails on some TS content, even though it is supposed to
+      // support it.  Better to transmux.
+      // See https://github.com/shaka-project/shaka-player/issues/5278
+      shaka.polyfill.MediaSource.rejectContainer_('mp2t');
     } else if (safariVersion) {
       // NOTE:  shaka.Player.isBrowserSupported() has its own restrictions on
       // Safari version.
@@ -179,38 +180,6 @@ shaka.polyfill.MediaSource = class {
     MediaSource.isTypeSupported = (mimeType) => {
       const actualCodec = shaka.util.MimeUtils.getCodecBase(mimeType);
       return actualCodec != codec && isTypeSupported(mimeType);
-    };
-  }
-
-  /**
-   * Patch isTypeSupported() to chain to a private API on the Chromecast which
-   * can query for support of detailed content parameters.
-   *
-   * @private
-   */
-  static patchCastIsTypeSupported_() {
-    const originalIsTypeSupported = MediaSource.isTypeSupported;
-
-    MediaSource.isTypeSupported = (mimeType) => {
-      // Parse the basic MIME type from its parameters.
-      const pieces = mimeType.split(/ *; */);
-      pieces.shift();  // Remove basic MIME type from pieces.
-
-      const hasCodecs = pieces.some((piece) => piece.startsWith('codecs='));
-      if (!hasCodecs) {
-        // Though the original reason for this special case was not documented,
-        // it is presumed to be because the platform won't accept a MIME type
-        // without codecs in canDisplayType.  It is valid, however, in
-        // isTypeSupported.
-        return originalIsTypeSupported(mimeType);
-      }
-
-      // Only canDisplayType can check extended MIME type parameters on this
-      // platform (such as frame rate, resolution, etc).
-      // In previous versions of this polyfill, the MIME type parameters were
-      // manipulated, filtered, or extended.  This is no longer true, so we pass
-      // the full MIME type to the platform as we received it.
-      return cast.__platform__.canDisplayType(mimeType);
     };
   }
 


### PR DESCRIPTION
Although Chromecast natively supports TS content, it does not work in all cases.  In particular, we have some sample live streams where some TS segments can be parsed by external tools as valid TS, but cause the Chromecast to throw a parsing error.

We should reject TS content on Chromecast, and allow the builtin transmuxer to take over parsing.

This also removes the use of `cast.__platform__.canDisplayType` to patch MediaSource.isTypeSupported on Chromecast.  Current versions of Shaka Player are doing very rough filtering with isTypeSupported before calling MediaCapabilities.decodingInfo.  And our MediaCapabilities polyfill calls `cast.__platform__.canDisplayType` directly, bypassing any polyfill we might install on isTypeSupported.  So there is no longer any purpose to canDisplayType in isTypeSupported.

Closes #5278