### PR TITLE
ci: Tweak command parsing

### DIFF
--- a/.github/workflows/shaka-bot-commands/main.sh
+++ b/.github/workflows/shaka-bot-commands/main.sh
@@ -42,10 +42,12 @@ if [[ "$SHAKA_BOT_COMMAND" == "" ]]; then
   exit 0
 fi
 
-echo "PR $PR_NUMBER, detected command $SHAKA_BOT_COMMAND"
+echo "PR $PR_NUMBER"
+echo "Detected command \"$SHAKA_BOT_COMMAND\""
+echo "Detected arguments \"$SHAKA_BOT_ARGUMENTS\""
 
 case "$SHAKA_BOT_COMMAND" in
   help) . command-help.sh ;;
   test) . command-test.sh ;;
-  *) echo "Unknown command!" ;;
+  *) echo "Unknown command" ;;
 esac

--- a/.github/workflows/talk-to-shaka-bot.yaml
+++ b/.github/workflows/talk-to-shaka-bot.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   handle_command:
+    name: Handle Command
     # Only runs on PRs that contain '@shaka-bot' comments, but not comments
     # made by shaka-bot itself, who will sometimes use its own name.
     # Note that contains() is not case sensitive.


### PR DESCRIPTION
 - Fix wrong index variable in loop ("i" vs "INDEX") that prevented detection of commands at arbitrary places in a comment.
 - Fix parsing of comments with newlines.
 - Normalize commands to lowercase before checking them.
 - Enhance debugging of command parsing.
 - Allow the user to say "please" because it just feels nicer to me, even when I'm talking to a robot.