### PR TITLE
fix(preload): Fix load interruption

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -1440,11 +1440,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         // "preload" here without prefetch.
         // That way, both a preload and normal load can follow the same code
         // paths.
+	// NOTE: await preloadInner_ can be outside the mutex because it should
+	// not mutate "this".
         preloadManager = await this.preloadInner_(
             assetUri, startTime, mimeType, /* standardLoad= */ true);
         if (preloadManager) {
           preloadManager.setEventHandoffTarget(this);
-          await preloadManager.start();
+          await mutexWrapOperation(async () => {
+            return preloadManager.start();
+          }, 'preload');
         }
       } else {
         // Hook up events, so any events emitted by the preloadManager will

--- a/lib/player.js
+++ b/lib/player.js
@@ -1446,9 +1446,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             assetUri, startTime, mimeType, /* standardLoad= */ true);
         if (preloadManager) {
           preloadManager.setEventHandoffTarget(this);
-          await mutexWrapOperation(async () => {
-            return preloadManager.start();
-          }, 'preload');
+          await mutexWrapOperation(() => preloadManager.start(), 'preload');
         }
       } else {
         // Hook up events, so any events emitted by the preloadManager will

--- a/lib/player.js
+++ b/lib/player.js
@@ -1440,8 +1440,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         // "preload" here without prefetch.
         // That way, both a preload and normal load can follow the same code
         // paths.
-	// NOTE: await preloadInner_ can be outside the mutex because it should
-	// not mutate "this".
+        // NOTE: await preloadInner_ can be outside the mutex because it should
+        // not mutate "this".
         preloadManager = await this.preloadInner_(
             assetUri, startTime, mimeType, /* standardLoad= */ true);
         if (preloadManager) {

--- a/test/player_load_graph_integration.js
+++ b/test/player_load_graph_integration.js
@@ -756,6 +756,7 @@ describe('Player Load Graph', () => {
         'manifest-parser',
         'manifest',
         'drm-engine',
+        // Excludes 'unload'.
       ]);
 
       /** @type {!Set.<string>} */
@@ -774,6 +775,7 @@ describe('Player Load Graph', () => {
         await player.attach(video);
         player.load('test:sintel').catch(() => {});
       } else {
+        goog.asserts.assert(state == 'unload', 'Unrecognized testing state!');
         await player.attach(video);
         await player.load('test:sintel');
         player.unload().catch(() => {});


### PR DESCRIPTION
Interrupting load() was causing two concurrent sets of load() operations to happen at once, which led the asset URI for the second operation to be overwritten by the first.

This was exposed by a test failure on Safari.  There is nothing special about Safari, but the timing happened to work out such that the concurrent load() calls would intefere with each other.

This fixes the issue by acquiring the mutex in load() for the preloadManager.start() operation.

This issue did not affect any releases.

Closes #6225