### PR TITLE
test: Fix several test failures

### DIFF
--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -1208,13 +1208,21 @@ describe('Player', () => {
         'com.widevine.alpha': bogusUrl,
         'com.microsoft.playready': bogusUrl,
       });
-      await player.load('test:sintel-enc_compiled');
+
+      // This load may be interrupted, so ignore errors and don't wait.
+      const loadPromise =
+          player.load('test:sintel-enc_compiled').catch(() => {});
 
       await errorPromise;
       expect(unloadPromise).not.toBeNull();
+
       if (unloadPromise) {
         await unloadPromise;
       }
+
+      // This should be done, and errors ignored.  But don't leave any Promise
+      // unresolved.
+      await loadPromise;
     });
   });  // describe('unloading')
 

--- a/test/player_load_graph_integration.js
+++ b/test/player_load_graph_integration.js
@@ -378,11 +378,11 @@ describe('Player Load Graph', () => {
 
       // Make the two requests one-after-another so that we don't have any idle
       // time between them.
-      const attachRequest = player.attach(video);
-      const loadRequest = player.load('test:sintel');
+      const attach = player.attach(video);
+      const load = player.load('test:sintel');
 
-      await attachRequest;
-      await expectAsync(loadRequest).toBeRejected();
+      await attach;
+      await expectAsync(load).toBeRejected();
 
       // Wait a couple interrupter cycles to allow the player to enter idle
       // state.
@@ -425,22 +425,23 @@ describe('Player Load Graph', () => {
       // Normally the player would initialize media source after attaching to
       // the media element, however since we don't support media source, it
       // should stop at the attach state.
-      player.attach(video, /* initMediaSource= */ true);
+      const attach = player.attach(video, /* initMediaSource= */ true);
 
       await shaka.test.Util.delay(/* seconds= */ 0.25);
       expect(lastStateChange).toBe('attach');
+
+      await attach;
     });
 
     it('loading ignores media source path', async () => {
       await player.attach(video, /* initMediaSource= */ false);
 
-      // Normally the player would load content like this with the media source
-      // path, but since we don't have media source support, it should use the
-      // src= path.
-      player.load(SMALL_MP4_CONTENT_URI);
+      const load = player.load(SMALL_MP4_CONTENT_URI);
 
       await shaka.test.Util.delay(/* seconds= */ 0.25);
       expect(lastStateChange).toBe('src-equals');
+
+      await load;
     });
 
     it('unloading ignores init media source flag', async () => {
@@ -450,10 +451,12 @@ describe('Player Load Graph', () => {
       // Normally the player would try to go to the media source state because
       // we are saying to initialize media source after unloading, but since we
       // don't have media source, it should stop at the attach state.
-      player.unload(/* initMediaSource= */ true);
+      const unload = player.unload(/* initMediaSource= */ true);
 
       await shaka.test.Util.delay(/* seconds= */ 0.25);
       expect(lastStateChange).toBe('unload');
+
+      await unload;
     });
   });
 

--- a/test/player_src_equals_integration.js
+++ b/test/player_src_equals_integration.js
@@ -115,8 +115,8 @@ describe('Player Src Equals', () => {
     expect(video.currentTime).toBeLessThan(2.0);
 
     // Trigger a seek and then wait for the seek to take effect.
-    // This seek target is very close to the duration of the video.
-    video.currentTime = 10;
+    // This seek target is very close to the duration of the video (10.01s).
+    video.currentTime = 9.5;
     await waiter.waitForMovementOrFailOnTimeout(video, /* timeout= */10);
 
     // Make sure the playhead is roughly where we expect it to be after


### PR DESCRIPTION
 - Fix bogus assertion failure in tests on Safari (#6272)
   - This test should not be seeking so close to the duration (10ms) as to cause flakiness on certain browsers.  Adjusting the seek time fixes the assertion without compromising the purpose of the test.
 - Fix uncaught rejections in load graph tests (#6274)
   - These tests had calls that were interrupted by the teardown process that occurs after the test body.  Waiting for the operations before ending the test fixes the issue.
 - Fix interrupted load in test on Tizen (#6274)
   - This test triggers a deliberate DRM error without waiting for load().  On most platforms in the lab, the load() operation completed before the error.  Not so on Tizen.  This exposed a general problem in which we should be catching errors in this test.  Only timing saved us on most platforms.

Closes #6272
Closes #6274