### PR TITLE
test: Fix missing HLS parser in tests

### DIFF
--- a/lib/media/manifest_parser.js
+++ b/lib/media/manifest_parser.js
@@ -125,7 +125,8 @@ shaka.media.ManifestParser = class {
         shaka.util.Error.Severity.CRITICAL,
         shaka.util.Error.Category.MANIFEST,
         shaka.util.Error.Code.UNABLE_TO_GUESS_MANIFEST_TYPE,
-        uri);
+        uri,
+        mimeType);
   }
 
 

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -527,6 +527,7 @@ shaka.util.Error.Code = {
    *   <li>Configure the server to accept a HEAD request for the manifest.
    * </ul>
    * <br> error.data[0] is the manifest URI.
+   * <br> error.data[1] is the detected or specified MIME type.
    */
   'UNABLE_TO_GUESS_MANIFEST_TYPE': 4000,
 

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -667,15 +667,21 @@ describe('Player', () => {
     });
 
     describe('when config.streaming.preferNativeHls is set to true', () => {
-      beforeEach(() => {
+      beforeAll(() => {
         shaka.media.ManifestParser.registerParserByMime(
             'application/x-mpegurl',
             () => new shaka.test.FakeManifestParser(manifest));
       });
 
+      afterAll(() => {
+        // IMPORTANT: restore the ORIGINAL parser.  DO NOT just unregister the
+        // fake!
+        shaka.media.ManifestParser.registerParserByMime(
+            'application/x-mpegurl',
+            () => new shaka.hls.HlsParser());
+      });
+
       afterEach(() => {
-        shaka.media.ManifestParser.unregisterParserByMime(
-            'application/x-mpegurl');
         video.canPlayType.calls.reset();
       });
 


### PR DESCRIPTION
A test suite that overwrites the HLS parser needs to restore it afterward.  To aid in debugging future parser issues, this adds the detected or specified MIME type to the error object for UNABLE_TO_GUESS_MANIFEST_TYPE.

Closes #5834