### PR TITLE
chore: Fix deprecation messages

### DIFF
--- a/lib/ads/ad_manager.js
+++ b/lib/ads/ad_manager.js
@@ -656,7 +656,7 @@ shaka.ads.AdManager = class extends shaka.util.FakeEventTarget {
    */
   getServerSideCuePoints() {
     shaka.Deprecate.deprecateFeature(5,
-        'AdManager',
+        'AdManager.getServerSideCuePoints',
         'Please use getCuePoints function.');
     return this.getCuePoints();
   }

--- a/lib/deprecate/deprecate.js
+++ b/lib/deprecate/deprecate.js
@@ -107,7 +107,7 @@ shaka.Deprecate = class {
       libraryVersion,
       '. Additional information:',
       description,
-    ].join('');
+    ].join(' ');
 
     shaka.log.alwaysError(errorMessage);
     goog.asserts.assert(false, errorMessage);

--- a/lib/media/manifest_parser.js
+++ b/lib/media/manifest_parser.js
@@ -28,7 +28,7 @@ shaka.media.ManifestParser = class {
    */
   static registerParserByExtension(extension, parserFactory) {
     shaka.Deprecate.deprecateFeature(5,
-        'ManifestParser',
+        'ManifestParser.registerParserByExtension',
         'Please use an ManifestParser with registerParserByMime function.');
   }
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -752,7 +752,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // player having been initialized.
     if (mediaElement) {
       shaka.Deprecate.deprecateFeature(5,
-          'Player',
+          'Player w/ mediaElement',
           'Please migrate from initializing Player with a mediaElement; ' +
           'use the attach method instead.');
       this.attach(mediaElement, /* initializeMediaSource= */ true);
@@ -1532,19 +1532,19 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             this.abrManagerFactory_ = preloadManager.getAbrManagerFactory();
             if (typeof this.abrManager_.setMediaElement != 'function') {
               shaka.Deprecate.deprecateFeature(5,
-                  'AbrManager',
+                  'AbrManager w/o setMediaElement',
                   'Please use an AbrManager with setMediaElement function.');
               this.abrManager_.setMediaElement = () => {};
             }
             if (typeof this.abrManager_.setCmsdManager != 'function') {
               shaka.Deprecate.deprecateFeature(5,
-                  'AbrManager',
+                  'AbrManager w/o setCmsdManager',
                   'Please use an AbrManager with setCmsdManager function.');
               this.abrManager_.setCmsdManager = () => {};
             }
             if (typeof this.abrManager_.trySuggestStreams != 'function') {
               shaka.Deprecate.deprecateFeature(5,
-                  'AbrManager',
+                  'AbrManager w/o trySuggestStreams',
                   'Please use an AbrManager with trySuggestStreams function.');
               this.abrManager_.trySuggestStreams = () => {};
             }

--- a/lib/util/ts_parser.js
+++ b/lib/util/ts_parser.js
@@ -433,7 +433,7 @@ shaka.util.TsParser = class {
    */
   parseAvcNalus(pes, nextPes) {
     shaka.Deprecate.deprecateFeature(5,
-        'TsParser',
+        'TsParser.parseAvcNalus',
         'Please use parseNalus function instead.');
     return this.parseNalus(pes);
   }
@@ -769,7 +769,7 @@ shaka.util.TsParser = class {
    */
   getVideoResolution() {
     shaka.Deprecate.deprecateFeature(5,
-        'TsParser',
+        'TsParser.getVideoResolution',
         'Please use getVideoInfo function instead.');
     const videoInfo = this.getVideoInfo();
     return {


### PR DESCRIPTION
Some deprecation messages were misleading, and claimed that entire classes like AbrManager were deprected, when in fact, it was a particular form of AbrManager (without a method) that is deprecated.

This adds method and other details to the deprecation calls where needed.

We also had a malformed messsage where join('') was called on the pieces instead of join(' ').  This fixes the formatting.