### PR TITLE
chore: Add createDrmInfoFromClearKeys and simplify DrmEngine

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -1215,56 +1215,8 @@ shaka.media.DrmEngine = class {
       return null;
     }
 
-    const StringUtils = shaka.util.StringUtils;
-    const Uint8ArrayUtils = shaka.util.Uint8ArrayUtils;
-    const keys = [];
-    const keyIds = [];
-
-    clearKeys.forEach((key, keyId) => {
-      let kid = keyId;
-      if (kid.length != 22) {
-        kid = Uint8ArrayUtils.toBase64(
-            Uint8ArrayUtils.fromHex(keyId), false);
-      }
-      let k = key;
-      if (k.length != 22) {
-        k = Uint8ArrayUtils.toBase64(
-            Uint8ArrayUtils.fromHex(key), false);
-      }
-      const keyObj = {
-        kty: 'oct',
-        kid: kid,
-        k: k,
-      };
-
-      keys.push(keyObj);
-      keyIds.push(keyObj.kid);
-    });
-
-    const jwkSet = {keys: keys};
-    const license = JSON.stringify(jwkSet);
-
-    // Use the keyids init data since is suggested by EME.
-    // Suggestion: https://bit.ly/2JYcNTu
-    // Format: https://www.w3.org/TR/eme-initdata-keyids/
-    const initDataStr = JSON.stringify({'kids': keyIds});
-    const initData =
-        shaka.util.BufferUtils.toUint8(StringUtils.toUTF8(initDataStr));
-    const initDatas = [{initData: initData, initDataType: 'keyids'}];
-
-    return {
-      keySystem: 'org.w3.clearkey',
-      licenseServerUri: 'data:application/json;base64,' + window.btoa(license),
-      distinctiveIdentifierRequired: false,
-      persistentStateRequired: false,
-      audioRobustness: '',
-      videoRobustness: '',
-      serverCertificate: null,
-      serverCertificateUri: '',
-      sessionType: '',
-      initData: initDatas,
-      keyIds: new Set(keyIds),
-    };
+    const ManifestParserUtils = shaka.util.ManifestParserUtils;
+    return ManifestParserUtils.createDrmInfoFromClearKeys(clearKeys);
   }
 
   /**

--- a/lib/util/manifest_parser_utils.js
+++ b/lib/util/manifest_parser_utils.js
@@ -12,6 +12,7 @@ goog.require('shaka.util.Error');
 goog.require('shaka.util.StringUtils');
 goog.require('shaka.util.Uint8ArrayUtils');
 
+
 /**
  * @summary Utility functions for manifest parsing.
  */

--- a/lib/util/manifest_parser_utils.js
+++ b/lib/util/manifest_parser_utils.js
@@ -7,8 +7,10 @@
 goog.provide('shaka.util.ManifestParserUtils');
 
 goog.require('goog.Uri');
+goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
-
+goog.require('shaka.util.StringUtils');
+goog.require('shaka.util.Uint8ArrayUtils');
 
 /**
  * @summary Utility functions for manifest parsing.
@@ -72,6 +74,65 @@ shaka.util.ManifestParserUtils = class {
       sessionType: '',
       initData: initData || [],
       keyIds: new Set(),
+    };
+  }
+
+  /**
+   * Creates a DrmInfo object from ClearKeys.
+   *
+   * @param {!Map.<string, string>} clearKeys
+   * @return {shaka.extern.DrmInfo}
+   */
+  static createDrmInfoFromClearKeys(clearKeys) {
+    const StringUtils = shaka.util.StringUtils;
+    const Uint8ArrayUtils = shaka.util.Uint8ArrayUtils;
+    const keys = [];
+    const keyIds = [];
+
+    clearKeys.forEach((key, keyId) => {
+      let kid = keyId;
+      if (kid.length != 22) {
+        kid = Uint8ArrayUtils.toBase64(
+            Uint8ArrayUtils.fromHex(keyId), false);
+      }
+      let k = key;
+      if (k.length != 22) {
+        k = Uint8ArrayUtils.toBase64(
+            Uint8ArrayUtils.fromHex(key), false);
+      }
+      const keyObj = {
+        kty: 'oct',
+        kid: kid,
+        k: k,
+      };
+
+      keys.push(keyObj);
+      keyIds.push(keyObj.kid);
+    });
+
+    const jwkSet = {keys: keys};
+    const license = JSON.stringify(jwkSet);
+
+    // Use the keyids init data since is suggested by EME.
+    // Suggestion: https://bit.ly/2JYcNTu
+    // Format: https://www.w3.org/TR/eme-initdata-keyids/
+    const initDataStr = JSON.stringify({'kids': keyIds});
+    const initData =
+        shaka.util.BufferUtils.toUint8(StringUtils.toUTF8(initDataStr));
+    const initDatas = [{initData: initData, initDataType: 'keyids'}];
+
+    return {
+      keySystem: 'org.w3.clearkey',
+      licenseServerUri: 'data:application/json;base64,' + window.btoa(license),
+      distinctiveIdentifierRequired: false,
+      persistentStateRequired: false,
+      audioRobustness: '',
+      videoRobustness: '',
+      serverCertificate: null,
+      serverCertificateUri: '',
+      sessionType: '',
+      initData: initDatas,
+      keyIds: new Set(keyIds),
     };
   }
 


### PR DESCRIPTION
This is a preliminary step to be able to support HLS identity without the user configuring clearkeys.