### PR TITLE
ci: Update all actions

### DIFF
--- a/.github/workflows/appspot.yaml
+++ b/.github/workflows/appspot.yaml
@@ -15,13 +15,13 @@ jobs:
   appspot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
 
@@ -89,7 +89,7 @@ jobs:
         run: sudo apt -y update && sudo apt -y install ffmpeg
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
 
@@ -128,7 +128,7 @@ jobs:
 
       # Some CI images (self-hosted or otherwise) don't have the minimum Java
       # version necessary for the compiler (Java 11).
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 11
@@ -178,7 +178,7 @@ jobs:
           fi
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() && steps.coverage.outputs.coverage_found }}
         with:
           name: coverage
@@ -194,7 +194,7 @@ jobs:
 
       # Upload new screenshots and diffs on failure; ignore if missing
       - name: Upload screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: screenshots-${{ matrix.browser }}
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/demo-version-index.yaml
+++ b/.github/workflows/demo-version-index.yaml
@@ -22,7 +22,7 @@ jobs:
   appspot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # We need a list of all tags for this, so fetch the entire history.
           fetch-depth: 0

--- a/.github/workflows/nightly-demo.yaml
+++ b/.github/workflows/nightly-demo.yaml
@@ -11,12 +11,12 @@ jobs:
   appspot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -34,7 +34,7 @@ jobs:
     needs: release
     if: needs.release.outputs.release_created && endsWith(needs.release.outputs.tag_name, '.0') == false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Check out the origin repo, and do it at main, not the PR branch.
           ref: main
@@ -55,12 +55,12 @@ jobs:
     needs: release
     if: needs.release.outputs.release_created
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'
@@ -126,12 +126,12 @@ jobs:
     needs: release
     if: needs.release.outputs.release_created
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'
@@ -180,7 +180,7 @@ jobs:
     needs: release
     if: needs.release.outputs.release_created && endsWith(needs.release.outputs.tag_name, '.0')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           # Use a special shaka-bot access token for releases.

--- a/.github/workflows/report-incremental-coverage.yaml
+++ b/.github/workflows/report-incremental-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Compute incremental code coverage
         id: compute

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -71,7 +71,7 @@ jobs:
       INCLUDE: ${{ steps.configure.outputs.INCLUDE }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.compute-ref.outputs.REF }}
 
@@ -133,7 +133,7 @@ jobs:
     needs: compute-ref
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.compute-ref.outputs.REF }}
 
@@ -159,21 +159,21 @@ jobs:
               --filter ThisFilterMatchesNoTests || true
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: npm-cache
         with:
           path: node_modules/
           key: node-${{ hashFiles('package-lock.json') }}
 
       - name: Cache Babel output
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: babel-cache
         with:
           path: .babel-cache
           key: babel-${{ hashFiles('*.js', 'demo/**.js', 'lib/**.js', 'ui/**.js', 'test/**.js', 'third_party/**.js') }}
 
       - name: Store Player build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: shaka-player
           path: dist/
@@ -201,7 +201,7 @@ jobs:
     name: ${{ matrix.browser }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.compute-ref.outputs.REF }}
 
@@ -213,19 +213,19 @@ jobs:
           state: pending
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'
 
       # The Docker image for this self-hosted runner doesn't contain java.
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 11
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: npm-cache
         with:
           path: node_modules/
@@ -234,7 +234,7 @@ jobs:
           enableCrossOsArchive: true  # Share archives from Linux to Windows
 
       - name: Cache Babel output
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: babel-cache
         with:
           path: .babel-cache
@@ -249,7 +249,7 @@ jobs:
       # Instead of building Shaka N times, build it once and fetch the build to
       # each Selenium runner in the matrix.
       - name: Fetch Player build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: shaka-player
           path: dist/
@@ -331,7 +331,7 @@ jobs:
           fi
 
       - name: Upload coverage report (Edge only)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         # If there's a coverage report, upload it, even if a previous step
         # failed.
         if: ${{ always() && steps.coverage.outputs.coverage_report }}
@@ -347,7 +347,7 @@ jobs:
 
       # Upload new screenshots and diffs on failure; ignore if missing
       - name: Upload screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() || inputs.ignore_test_status }}
         with:
           # In this workflow, "browser" is the selenium node name, which can

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: shaka-project/shaka-github-tools
 

--- a/.github/workflows/talk-to-shaka-bot.yaml
+++ b/.github/workflows/talk-to-shaka-bot.yaml
@@ -23,7 +23,7 @@ jobs:
       COMMENT_BODY: ${{ github.event.comment.body }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Handle command
         shell: bash

--- a/.github/workflows/update-issues.yaml
+++ b/.github/workflows/update-issues.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: shaka-project/shaka-github-tools
 

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Set Pending Status
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ inputs.pr }}/head
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [run-lab-tests]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ inputs.pr }}/head
 
@@ -53,26 +53,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          path: new-screenshots
-
-      - name: Move screenshots
-        run: |
-          # The download-artifact action puts zip file contents into folders by
-          # the name of the artifact, so we can't have them downloaded directly
-          # to the screenshots folder.  Here we move them into the correct
-          # locations.
-          cd new-screenshots
-
-          # "$i" is a folder for an artifact (eg "screenshots-ChromeAndroid"),
-          # and it contains a single folder with the name we use in our
-          # screenshots (eg "chrome-Android").  We want the contents of that
-          # inner folder to be copied to test/test/assets/screenshots/, where a
-          # folder with the same name (eg "chrome-Android") already exists.
-          for i in screenshots*; do
-            cp -a $i/* ../test/test/assets/screenshots/
-          done
+          path: test/test/assets/screenshots/
+          pattern: screenshots-*
+          merge-multiple: true
 
       - name: Update screenshots
         run: |
@@ -116,7 +101,7 @@ jobs:
     # Will run on success or failure, but not if the workflow is cancelled.
     if: ${{ success() || failure() }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ inputs.pr }}/head
 


### PR DESCRIPTION
This eliminates warnings about outdated node runtimes in GitHub Actions.

actions/download-artifact and actions/upload-artifact are the only ones with any potential breaking changes, and adjustments have been made and tested.

See https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md