### PR TITLE
fix(demo): Remove max height of demo config tabs

### DIFF
--- a/demo/demo.less
+++ b/demo/demo.less
@@ -568,16 +568,12 @@ footer .mdl-mega-footer__link-list {
   text-align: left;
   opacity: 0;
   max-height: 0;
-  transition: 0.3s ease-in-out;
 }
 
 .input-container-style-accordion.show {
   opacity: 1;
 
-  /* If the max-height is too high (e.g. set to 100%), the "sliding out"
-   * animation is too fast to make out with the eye.
-   * So give it a fixed maximum instead. */
-  max-height: 1000px;
+  max-height: fit-content;
 }
 
 .input-header {


### PR DESCRIPTION
Each tab in the demo config had a max height of 1000px. That was not a problem previously, but the "streaming" config now has so many config values that it no longer fits into that limit. This PR removes that limit, by instead setting a max-height value of "fit-content".
Unfortunately, doing that seems to break the open/close animation of the tabs, and makes it look kind of bad, so this also removes the animation entirely; it's better to have no animation than an ugly one.