### PR TITLE
fix: Fix cea608 whitespace rendering

### DIFF
--- a/lib/cea/cea608_memory.js
+++ b/lib/cea/cea608_memory.js
@@ -293,7 +293,7 @@ shaka.cea.Cea608Memory.CharSet.BasicNorthAmericanChars = new Map([
  */
 shaka.cea.Cea608Memory.CharSet.SpecialNorthAmericanChars = new Map([
   [0x30, '®'], [0x31, '°'], [0x32, '½'], [0x33, '¿'], [0x34, '™'], [0x35, '¢'],
-  [0x36, '£'], [0x37, '♪'], [0x38, 'à'], [0x39, '⠀'], [0x3a, 'è'], [0x3b, 'â'],
+  [0x36, '£'], [0x37, '♪'], [0x38, 'à'], [0x39, ' '], [0x3a, 'è'], [0x3b, 'â'],
   [0x3c, 'ê'], [0x3d, 'î'], [0x3e, 'ô'], [0x3f, 'û'],
 ]);
 

--- a/test/cea/cea608_memory_unit.js
+++ b/test/cea/cea608_memory_unit.js
@@ -49,11 +49,12 @@ describe('Cea608Memory', () => {
   it('adds and emits a series of special characters from the buffer', () => {
     const startTime = 1;
     const endTime = 2;
-    const expectedText = '½¿èôÇ©ë»ö{ß│';
+    const expectedText = '½¿ èôÇ©ë»ö{ß│';
     const charGroups = [
       {
         set: CharSet.SPECIAL_NORTH_AMERICAN,
-        chars: [0x32, 0x33, 0x3a, 0x3e], // ½, ¿, è, ô
+        // Note TS is not at either end of avoid side effect of trim()
+        chars: [0x32, 0x33, 0x39, 0x3a, 0x3e], // ½, ¿, TS, è, ô
       },
 
       {

--- a/test/cea/cea608_memory_unit.js
+++ b/test/cea/cea608_memory_unit.js
@@ -53,7 +53,7 @@ describe('Cea608Memory', () => {
     const charGroups = [
       {
         set: CharSet.SPECIAL_NORTH_AMERICAN,
-        // Note TS is not at either end of avoid side effect of trim()
+        // Note TS is not at either end to avoid side effect of trim()
         chars: [0x32, 0x33, 0x39, 0x3a, 0x3e], // ½, ¿, TS, è, ô
       },
 

--- a/test/media/media_source_engine_integration.js
+++ b/test/media/media_source_engine_integration.js
@@ -33,7 +33,7 @@ describe('MediaSourceEngine', () => {
       jasmine.objectContaining({
         startTime: Util.closeTo(0.067, 0.001),
         endTime: Util.closeTo(1, 0.001),
-        payload: 'eng:⠀00:00:00:00',
+        payload: 'eng: 00:00:00:00',
         textAlign: Cue.textAlign.CENTER,
       }),
     ],


### PR DESCRIPTION
Ensure whitespace rendered in CEA-608 test streams instead of `⠀` (braille pattern blank).
Updated UT too, but avoiding this char at ends of the string hence vulnerable to trim() 🤦 

Fixes #6328