### PR TITLE
feat: Add segmentData info to SegmentReference

### DIFF
--- a/lib/media/segment_reference.js
+++ b/lib/media/segment_reference.js
@@ -320,6 +320,9 @@ shaka.media.SegmentReference = class {
 
     /** @type {?string} */
     this.mimeType = null;
+
+    /** @type {BufferSource|null} */
+    this.segmentData = null;
   }
 
   /**
@@ -597,6 +600,26 @@ shaka.media.SegmentReference = class {
     if (Math.abs(offset) >= 0.001) {
       this.offset(offset);
     }
+  }
+
+  /**
+   * Set the segment data.
+   *
+   * @param {!BufferSource} segmentData
+   * @export
+   */
+  setSegmentData(segmentData) {
+    this.segmentData = segmentData;
+  }
+
+  /**
+   * Return the segment data.
+   *
+   * @return {?BufferSource}
+   * @export
+   */
+  getSegmentData() {
+    return this.segmentData;
   }
 };
 

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -2406,11 +2406,9 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   async fetch_(mediaState, reference, streamDataCallback) {
-    if (reference instanceof shaka.media.InitSegmentReference) {
-      const segmentData = reference.getSegmentData();
-      if (segmentData) {
-        return segmentData;
-      }
+    const segmentData = reference.getSegmentData();
+    if (segmentData) {
+      return segmentData;
     }
     let op = null;
     if (mediaState.segmentPrefetch) {


### PR DESCRIPTION
This is useful when creating custom manifests, which are actually a single segment. For example, a custom AAC manifest or any other audio format.