### PR TITLE
fix: Add Opus and AV1 detection in TS

### DIFF
--- a/lib/media/segment_utils.js
+++ b/lib/media/segment_utils.js
@@ -72,6 +72,10 @@ shaka.media.SegmentUtils = class {
         codecs.push('ec-3');
         hasAudio = true;
         break;
+      case 'opus':
+        codecs.push('opus');
+        hasAudio = true;
+        break;
     }
     switch (tsCodecs.video) {
       case 'avc':
@@ -88,6 +92,10 @@ shaka.media.SegmentUtils = class {
         } else {
           codecs.push('hvc1.1.6.L93.90');
         }
+        hasVideo = true;
+        break;
+      case 'av1':
+        codecs.push('av01.0.01M.08');
         hasVideo = true;
         break;
     }

--- a/lib/util/ts_parser.js
+++ b/lib/util/ts_parser.js
@@ -10,6 +10,7 @@ goog.require('shaka.Deprecate');
 goog.require('shaka.log');
 goog.require('shaka.util.ExpGolomb');
 goog.require('shaka.util.Id3Utils');
+goog.require('shaka.util.StringUtils');
 goog.require('shaka.util.Uint8ArrayUtils');
 
 
@@ -233,6 +234,7 @@ shaka.util.TsParser = class {
    * @private
    */
   parsePMT_(data, offset) {
+    const StringUtils = shaka.util.StringUtils;
     const result = {
       audio: -1,
       video: -1,
@@ -255,26 +257,52 @@ shaka.util.TsParser = class {
         case 0x06:
           // stream_type 6 can mean a lot of different things in case of DVB.
           // We need to look at the descriptors. Right now, we're only
-          // interested in AC-3 and EC-3 audio, so we do the descriptor parsing
-          // only when we don't have an audio PID yet.
-          if (result.audio == -1 && esInfoLength > 0) {
+          // interested in a few audio and video formats,.
+          if (esInfoLength > 0) {
             let parsePos = offset + 5;
             let remaining = esInfoLength;
+            // Descriptor info: https://www.streamguru.de/mpeg-analyzer/supported-descriptor-list/
             while (remaining > 2) {
               const descriptorId = data[parsePos];
+              const descriptorLen = data[parsePos + 1] + 2;
               switch (descriptorId) {
+                // Registration descriptor
+                case 0x05: {
+                  const registrationData =
+                      data.subarray(parsePos + 2, parsePos + descriptorLen);
+                  const registration =
+                      StringUtils.fromCharCode(registrationData);
+                  if (result.audio == -1 && registration === 'Opus') {
+                    result.audio = pid;
+                    result.audioCodec = 'opus';
+                  } else if (result.video == -1 && registration === 'AV01') {
+                    result.audio = pid;
+                    result.audioCodec = 'av1';
+                  }
+                  break;
+                }
                 // DVB Descriptor for AC-3
                 case 0x6a:
-                  result.audio = pid;
-                  result.audioCodec = 'ac3';
+                  if (result.audio == -1) {
+                    result.audio = pid;
+                    result.audioCodec = 'ac3';
+                  }
                   break;
                 // DVB Descriptor for EC-3
                 case 0x7a:
-                  result.audio = pid;
-                  result.audioCodec = 'ec3';
+                  if (result.audio == -1) {
+                    result.audio = pid;
+                    result.audioCodec = 'ec3';
+                  }
+                  break;
+                // DVB Descriptor for AAC
+                case 0x7c:
+                  if (result.audio == -1) {
+                    result.audio = pid;
+                    result.audioCodec = 'aac';
+                  }
                   break;
               }
-              const descriptorLen = data[parsePos + 1] + 2;
               parsePos += descriptorLen;
               remaining -= descriptorLen;
             }

--- a/lib/util/ts_parser.js
+++ b/lib/util/ts_parser.js
@@ -276,8 +276,8 @@ shaka.util.TsParser = class {
                     result.audio = pid;
                     result.audioCodec = 'opus';
                   } else if (result.video == -1 && registration === 'AV01') {
-                    result.audio = pid;
-                    result.audioCodec = 'av1';
+                    result.video = pid;
+                    result.videoCodec = 'av1';
                   }
                   break;
                 }


### PR DESCRIPTION
This detection is necessary to be able to correctly detect whether a media playlist of HLS that has TS segments is compatible or not.

Example: https://raw.githubusercontent.com/obecny/hls-opus-testing/main/stream.m3u8 (media playlist with Opus)