### PR TITLE
feat: Retain segment in memory on QuotaExceededError

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1326,7 +1326,7 @@ shaka.extern.ManifestConfiguration;
  *   The maximum number of segments for each active stream to be prefetched
  *   ahead of playhead in parallel.
  *   If <code>0</code>, the segments will be fetched sequentially.
- *   Defaults to <code>0</code>.
+ *   Defaults to <code>1</code>.
  * @property {!Array<string>} prefetchAudioLanguages
  *   The audio languages to prefetch.
  *   Defaults to an empty array.

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -224,7 +224,7 @@ shaka.util.PlayerConfiguration = class {
       parsePrftBox: false,
       // When low latency streaming is enabled, segmentPrefetchLimit will
       // default to 2 if not specified.
-      segmentPrefetchLimit: 0,
+      segmentPrefetchLimit: 1,
       prefetchAudioLanguages: [],
       disableAudioPrefetch: false,
       disableTextPrefetch: false,

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -702,14 +702,14 @@ describe('StreamingEngine', () => {
     // audio/video MP4 segment.
     // appendBuffer should be called once for each init segment of the
     // audio / video segment, and twice for each segment.
-    // 4 init segments + 8 audio/video segments * 2 + 4 text segments = 24.
+    // 2 init segments + 8 audio/video segments * 2 + 4 text segments = 22.
     if (window.ReadableStream) {
-      expect(mediaSourceEngine.appendBuffer).toHaveBeenCalledTimes(24);
+      expect(mediaSourceEngine.appendBuffer).toHaveBeenCalledTimes(22);
     } else {
       // If ReadableStream is not supported by the browser, fall back to regular
       // streaming.
-      // 4 init segments + 8 audio/video segments + 4 text segments = 16.
-      expect(mediaSourceEngine.appendBuffer).toHaveBeenCalledTimes(16);
+      // 2 init segments + 8 audio/video segments + 4 text segments = 14.
+      expect(mediaSourceEngine.appendBuffer).toHaveBeenCalledTimes(14);
     }
   });
 


### PR DESCRIPTION
Closes https://github.com/shaka-project/shaka-player/issues/1352

Segment prefetch keeps the segments until the position of the segment to be requested changes, which is exactly what happens when the QuotaExceededError error occurs. So enabling this by default with a value of 1 solves this problem.