### PR TITLE
fix: reBufferingGoal is not respected 

### DIFF
--- a/lib/media/play_rate_controller.js
+++ b/lib/media/play_rate_controller.js
@@ -107,10 +107,10 @@ shaka.media.PlayRateController = class {
     this.timer_.stop();
 
     shaka.log.v1('Changing effective playback rate to', this.rate_);
-
-    if (this.rate_ >= 0) {
+    const rate = this.calculateCurrentRate_();
+    if (rate >= 0) {
       try {
-        this.applyRate_(this.isBuffering_ ? 0 : this.rate_);
+        this.applyRate_(rate);
         return;
       } catch (e) {
         // Fall through to the next clause.
@@ -128,6 +128,17 @@ shaka.media.PlayRateController = class {
     // seek backwards with out fighting the playhead.
     this.timer_.tickEvery(this.pollRate_);
     this.applyRate_(0);
+  }
+
+  /**
+   * Calculate the rate that the controller wants the media element to have
+   * based on the current state of the controller.
+   *
+   * @return {number}
+   * @private
+   */
+  calculateCurrentRate_() {
+    return this.isBuffering_ ? 0 : this.rate_;
   }
 
   /**

--- a/lib/media/play_rate_controller.js
+++ b/lib/media/play_rate_controller.js
@@ -30,6 +30,9 @@ shaka.media.PlayRateController = class {
     /** @private {number} */
     this.rate_ = this.harness_.getRate();
 
+    /** @private {boolean} */
+    this.isBuffering_ = false;
+
     /** @private {number} */
     this.pollRate_ = 0.25;
 
@@ -48,6 +51,16 @@ shaka.media.PlayRateController = class {
     }
 
     this.harness_ = null;
+  }
+
+  /**
+   * Sets the buffering flag, which controls the effective playback rate.
+   *
+   * @param {boolean} isBuffering If true, forces playback rate to 0 internally.
+   */
+  setBuffering(isBuffering) {
+    this.isBuffering_ = isBuffering;
+    this.apply_();
   }
 
   /**
@@ -97,7 +110,7 @@ shaka.media.PlayRateController = class {
 
     if (this.rate_ >= 0) {
       try {
-        this.applyRate_(this.rate_);
+        this.applyRate_(this.isBuffering_ ? 0 : this.rate_);
         return;
       } catch (e) {
         // Fall through to the next clause.

--- a/lib/media/play_rate_controller.js
+++ b/lib/media/play_rate_controller.js
@@ -106,8 +106,9 @@ shaka.media.PlayRateController = class {
     // Always stop the timer. We may not start it again.
     this.timer_.stop();
 
-    shaka.log.v1('Changing effective playback rate to', this.rate_);
     const rate = this.calculateCurrentRate_();
+    shaka.log.v1('Changing effective playback rate to', rate);
+
     if (rate >= 0) {
       try {
         this.applyRate_(rate);

--- a/lib/media/stall_detector.js
+++ b/lib/media/stall_detector.js
@@ -181,7 +181,8 @@ shaka.media.StallDetector.MediaElementImplementation = class {
       return false;
     }
     // the playback rate is at 0, the player is not stalled but simply pausing
-    // it's buffering due to not enough buffer to respect rebuffering goal or minbufferTime
+    // it's buffering due to not enough buffer to respect reBufferingGoal
+    // or minbufferTime
     if (this.mediaElement_.playbackRate == 0) {
       return false;
     }

--- a/lib/media/stall_detector.js
+++ b/lib/media/stall_detector.js
@@ -180,6 +180,11 @@ shaka.media.StallDetector.MediaElementImplementation = class {
     if (this.mediaElement_.buffered.length == 0) {
       return false;
     }
+    // the playback rate is at 0, the player is not stalled but simply pausing
+    // it's buffering due to not enough buffer to respect rebuffering goal or minbufferTime
+    if (this.mediaElement_.playbackRate == 0) {
+      return false;
+    }
 
     return shaka.media.StallDetector.MediaElementImplementation.hasContentFor_(
         this.mediaElement_.buffered,

--- a/lib/player.js
+++ b/lib/player.js
@@ -5717,7 +5717,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const loaded = this.stats_ && this.bufferObserver_ && this.playhead_;
 
     if (loaded) {
-      this.playRateController_.set(isBuffering? 0: this.playRateController_.getDefaultRate());
+      let default_rate =  this.playRateController_.getDefaultRate() || 1.0;
+      this.playRateController_.set(isBuffering? 0: default_rate);
       if (this.cmcdManager_) {
         this.cmcdManager_.setBuffering(isBuffering);
       }

--- a/lib/player.js
+++ b/lib/player.js
@@ -5717,8 +5717,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const loaded = this.stats_ && this.bufferObserver_ && this.playhead_;
 
     if (loaded) {
-      const defaultRate = this.playRateController_.getDefaultRate() || 1.0;
-      this.playRateController_.set(isBuffering? 0: defaultRate);
+      this.playRateController_.setBuffering(isBuffering);
       if (this.cmcdManager_) {
         this.cmcdManager_.setBuffering(isBuffering);
       }

--- a/lib/player.js
+++ b/lib/player.js
@@ -5717,8 +5717,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const loaded = this.stats_ && this.bufferObserver_ && this.playhead_;
 
     if (loaded) {
-      let default_rate =  this.playRateController_.getDefaultRate() || 1.0;
-      this.playRateController_.set(isBuffering? 0: default_rate);
+      const defaultRate = this.playRateController_.getDefaultRate() || 1.0;
+      this.playRateController_.set(isBuffering? 0: defaultRate);
       if (this.cmcdManager_) {
         this.cmcdManager_.setBuffering(isBuffering);
       }

--- a/lib/player.js
+++ b/lib/player.js
@@ -5717,6 +5717,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const loaded = this.stats_ && this.bufferObserver_ && this.playhead_;
 
     if (loaded) {
+      this.playRateController_.set(isBuffering? 0: this.playRateController_.getDefaultRate());
       if (this.cmcdManager_) {
         this.cmcdManager_.setBuffering(isBuffering);
       }

--- a/test/media/play_rate_controller_unit.js
+++ b/test/media/play_rate_controller_unit.js
@@ -66,4 +66,52 @@ describe('PlayRateController', () => {
     controller.set(1);
     expect(setPlayRateSpy).not.toHaveBeenCalled();
   });
+
+  it('buffering state sets rate to zero', () => {
+    controller.setBuffering(true);
+    expect(setPlayRateSpy).toHaveBeenCalledWith(0);
+
+    setPlayRateSpy.calls.reset();
+
+    controller.setBuffering(false);
+    expect(setPlayRateSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('entering buffering state twice has no effect', () => {
+    controller.setBuffering(true);
+    expect(setPlayRateSpy).toHaveBeenCalledWith(0);
+
+    // Reset the calls so that we can make sure it was not called again.
+    setPlayRateSpy.calls.reset();
+
+    controller.setBuffering(true);
+    expect(setPlayRateSpy).not.toHaveBeenCalled();
+  });
+
+  it('leaving buffering state twice has no effect', () => {
+    controller.setBuffering(true);
+    controller.setBuffering(false);
+
+    // Reset the calls so that we can make sure it was not called again.
+    setPlayRateSpy.calls.reset();
+
+    controller.setBuffering(false);
+    expect(setPlayRateSpy).not.toHaveBeenCalled();
+  });
+
+  // When we set the rate while in a buffering state, we should see the new
+  // rate be used once we leave the buffering state.
+  it('set takes effect after buffering state ends', () => {
+    controller.setBuffering(true);
+    expect(setPlayRateSpy).toHaveBeenCalledWith(0);
+
+    // Reset so that we can make sure it was not called after we call |set(4)|.
+    setPlayRateSpy.calls.reset();
+
+    controller.set(4);
+    expect(setPlayRateSpy).not.toHaveBeenCalled();
+
+    controller.setBuffering(false);
+    expect(setPlayRateSpy).toHaveBeenCalledWith(4);
+  });
 });

--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -948,6 +948,76 @@ describe('Player', () => {
     });
   });
 
+  describe('rebufferGoal', () => {
+    const startBuffering = jasmine.objectContaining({buffering: true});
+    const endBuffering = jasmine.objectContaining({buffering: false});
+    /** @type {!jasmine.Spy} */
+    const onBuffering = jasmine.createSpy('onBuffering');
+    /** @type {!jasmine.Spy} */
+    const onSeeking = jasmine.createSpy('onSeeking');
+    /** @type {!jasmine.Spy} */
+    const onPlaying = jasmine.createSpy('onPlaying');
+    /** @type {!jasmine.Spy} */
+    const onTimeUpdate = jasmine.createSpy('onTimeUpdate');
+    /** @type {!shaka.test.Waiter} */
+    let waiter;
+
+    beforeEach(() => {
+      player.addEventListener('buffering', Util.spyFunc(onBuffering));
+      eventManager.listen(video, 'seeking', Util.spyFunc(onSeeking));
+      eventManager.listen(video, 'timeupdate', Util.spyFunc(onTimeUpdate));
+      eventManager.listen(video, 'playing', Util.spyFunc(onPlaying));
+      video.autoplay = false;
+      waiter = new shaka.test.Waiter(eventManager)
+          .setPlayer(player)
+          .timeoutAfter(10)
+          .failOnTimeout(true);
+    });
+
+    it('state orchestration and buffer lenght', async () => {
+      // the expected player behaviour should be the folowing one
+      // buffering event start
+      // playing event but player is not playing
+      // because of the rebufferingGoal > to the buffer )
+      // buffering event stop
+      // timeupdate
+
+      // create a delay in the request to check the event's order
+      const netEngine = player.getNetworkingEngine();
+      netEngine.registerResponseFilter(
+          async (type, response, context) => {
+            await shaka.test.Util.delay(2);
+          });
+
+      player.configure('streaming.rebufferingGoal', 25);
+      player.configure('streaming.bufferingGoal', 60);
+      player.configure('manifest.dash.ignoreMinBufferTime', true);
+      video.autoplay = true;
+      await player.load('test:sintel_long_compiled');
+
+      expect(onBuffering).toHaveBeenCalledTimes(1);
+      expect(onBuffering).toHaveBeenCalledWith(startBuffering);
+      expect(onSeeking).not.toHaveBeenCalled();
+      expect(onTimeUpdate).not.toHaveBeenCalled();
+      expect(getBufferedAhead()).toBeLessThanOrEqual(25);
+      onBuffering.calls.reset();
+
+      await waiter.waitForEvent(video, 'playing');
+      expect(getBufferedAhead()).toBeLessThanOrEqual(25);
+
+      await waiter.waitForEvent(player, 'buffering');
+      await shaka.test.Util.delay(1);
+      expect(onSeeking).not.toHaveBeenCalled();
+      expect(onTimeUpdate).toHaveBeenCalled();
+      expect(onBuffering).toHaveBeenCalledTimes(1);
+      expect(onBuffering).toHaveBeenCalledWith(endBuffering);
+      await waiter.waitForEvent(video, 'timeupdate');
+      // segment duration are 10s meaning
+      // that the expected buffer should be 30..
+      expect(getBufferedAhead()).toBeGreaterThanOrEqual(25);
+    });
+  });
+
   describe('buffering', () => {
     const startBuffering = jasmine.objectContaining({buffering: true});
     const endBuffering = jasmine.objectContaining({buffering: false});
@@ -1066,14 +1136,6 @@ describe('Player', () => {
       expect(getBufferedBehind()).toBeLessThanOrEqual(10);
     });
 
-    function getBufferedAhead() {
-      const end = shaka.media.TimeRangesUtils.bufferEnd(video.buffered);
-      if (end == null) {
-        return 0;
-      }
-      return end - video.currentTime;
-    }
-
     function getBufferedBehind() {
       const start = shaka.media.TimeRangesUtils.bufferStart(video.buffered);
       if (start == null) {
@@ -1082,6 +1144,14 @@ describe('Player', () => {
       return video.currentTime - start;
     }
   });  // describe('buffering')
+
+  function getBufferedAhead() {
+    const end = shaka.media.TimeRangesUtils.bufferEnd(video.buffered);
+    if (end == null) {
+      return 0;
+    }
+    return end - video.currentTime;
+  }
 
   describe('configuration', () => {
     it('has the correct number of arguments in compiled callbacks', () => {

--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -970,7 +970,7 @@ describe('Player', () => {
       video.autoplay = false;
       waiter = new shaka.test.Waiter(eventManager)
           .setPlayer(player)
-          .timeoutAfter(10)
+          .timeoutAfter(20)
           .failOnTimeout(true);
     });
 
@@ -992,7 +992,7 @@ describe('Player', () => {
       player.configure('streaming.rebufferingGoal', 25);
       player.configure('streaming.bufferingGoal', 60);
       player.configure('streaming.stallEnabled', true);
-      player.configure('streaming.stallThreshold', 0.1);
+      player.configure('streaming.stallThreshold', 1);
       player.configure('manifest.dash.ignoreMinBufferTime', true);
       video.autoplay = true;
       await player.load('test:sintel_long_compiled');

--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -974,8 +974,8 @@ describe('Player', () => {
           .failOnTimeout(true);
     });
 
-    it('state orchestration and buffer lenght', async () => {
-      // the expected player behaviour should be the folowing one
+    it('state orchestration and buffer length', async () => {
+      // the expected player behaviours should be the following one
       // buffering event start
       // playing event but player is not playing
       // because of the rebufferingGoal > to the buffer )
@@ -991,6 +991,8 @@ describe('Player', () => {
 
       player.configure('streaming.rebufferingGoal', 25);
       player.configure('streaming.bufferingGoal', 60);
+      player.configure('streaming.stallEnabled', true);
+      player.configure('streaming.stallThreshold', 0.1);
       player.configure('manifest.dash.ignoreMinBufferTime', true);
       video.autoplay = true;
       await player.load('test:sintel_long_compiled');
@@ -1004,6 +1006,7 @@ describe('Player', () => {
 
       await waiter.waitForEvent(video, 'playing');
       expect(getBufferedAhead()).toBeLessThanOrEqual(25);
+      expect(video.currentTime).toBe(0);
 
       await waiter.waitForEvent(player, 'buffering');
       await shaka.test.Util.delay(1);

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -2709,7 +2709,8 @@ describe('Player', () => {
       expect(stats.estimatedBandwidth).toBe(25);
     });
 
-    it('tracks info about current stream', () => {
+    it('tracks info about current stream', async () => {
+      forceBufferingTo(false);
       let stats = player.getStats();
       // Should have chosen the first of each type of stream.
       expect(stats.width).toBe(100);

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -2709,7 +2709,7 @@ describe('Player', () => {
       expect(stats.estimatedBandwidth).toBe(25);
     });
 
-    it('tracks info about current stream', async () => {
+    it('tracks info about current stream', () => {
       forceBufferingTo(false);
       let stats = player.getStats();
       // Should have chosen the first of each type of stream.


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/6355

it's still in draft until having proper unit tests to control this

This PR is doing the following
At startup time and at buffering it will set the playback rate to 0. like it was before and reset it to the default value we no buffer.
I'm still passing all the unit test but i'm still thinging if we have an impact with the live catchup feature that is changing the playback rate.

Maybe we should just re introduce the isBuffering_ value in playbackrate class.
Happy to do it if you think so

here the link the PR that introduce the regression
https://github.com/shaka-project/shaka-player/pull/5696/files#diff-274a4cc3948f85eed18f86e04c6260b93faa97b995d38f0e3b1af618fd01fab7L34
