### PR TITLE
revert: Fix potential AV sync issues after seek or adaptation

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -947,7 +947,6 @@ shaka.media.StreamingEngine = class {
       // The playhead might be seeking on startup, if a start time is set, so
       // start "seeked" as true.
       seeked: true,
-      needsResync: false,
       recovering: false,
       hasError: false,
       operation: null,
@@ -1417,11 +1416,6 @@ shaka.media.StreamingEngine = class {
       shaka.log.v1(
           logPrefix, 'looking up segment from new stream endTime:', time);
 
-      // Using a new iterator means we need to resync the stream in sequence
-      // mode.  The buffered range might not align perfectly with the last
-      // segment end time, so we may end up repeating a segment.  Resyncing
-      // makes this safe to do.
-      mediaState.needsResync = true;
       mediaState.segmentIterator =
           mediaState.stream.segmentIndex.getIteratorForTime(time);
       const ref = mediaState.segmentIterator &&
@@ -2062,9 +2056,7 @@ shaka.media.StreamingEngine = class {
       // Across discontinuity bounds, we should resync timestamps for
       // sequence mode playbacks.  The next segment appended should
       // land at its theoretical timestamp from the segment index.
-      if (reference.discontinuitySequence != lastDiscontinuitySequence ||
-          mediaState.needsResync) {
-        mediaState.needsResync = false;
+      if (reference.discontinuitySequence != lastDiscontinuitySequence) {
         operations.push(this.playerInterface_.mediaSourceEngine.resync(
             mediaState.type, reference.startTime));
       }
@@ -2792,7 +2784,6 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   clearBufferSafeMargin: number,
  *   clearingBuffer: boolean,
  *   seeked: boolean,
- *   needsResync: boolean,
  *   adaptation: boolean,
  *   recovering: boolean,
  *   hasError: boolean,
@@ -2847,9 +2838,6 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   True indicates that the presentation just seeked.
  * @property {boolean} adaptation
  *   True indicates that the presentation just automatically switched variants.
- * @property {boolean} needsResync
- *   True indicates that the stream needs to be resynced in sequence mode,
- *   regardless of discontinuity sequence.
  * @property {boolean} recovering
  *   True indicates that the last segment was not appended because it could not
  *   fit in the buffer.


### PR DESCRIPTION
This reverts #4886, which was found to cause issues with fetching segments after seeking.

Closes #5785
Re-open #4589