### PR TITLE
feat(Ads): Skip play detection in some devices

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -347,7 +347,9 @@ shakaDemo.Config = class {
     const docLink = this.resolveExternLink_('.AdsConfiguration');
     this.addSection_('Ads', docLink)
         .addBoolInput_('Custom playhead tracker',
-            'ads.customPlayheadTracker');
+            'ads.customPlayheadTracker')
+        .addBoolInput_('Skip play detection',
+            'ads.skipPlayDetection');
   }
 
   /**

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1458,8 +1458,8 @@ shaka.extern.MediaSourceConfiguration;
  *   IMA on platforms that do not support multiple video elements.
  *   This value defaults to <code>false</code>.
  * @property {boolean} skipPlayDetection
- *   If this is <code>true</code>, we avoid to detect play event to load the
- *   Client Side ads.
+ *   If this is true, we will load Client Side ads without waiting for a play
+ *   event.
  *   Defaults to <code>false</code> except on Tizen, WebOS, Chromecast,
  *   Hisense, PlayStation 4, PlayStation5, Xbox whose default value is
  *   <code>true</code>.

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1445,7 +1445,8 @@ shaka.extern.MediaSourceConfiguration;
 
 /**
  * @typedef {{
- *   customPlayheadTracker: boolean
+ *   customPlayheadTracker: boolean,
+ *   skipPlayDetection: boolean
  * }}
  *
  * @description
@@ -1456,6 +1457,12 @@ shaka.extern.MediaSourceConfiguration;
  *   Client Side. This is useful because it allows you to implement the use of
  *   IMA on platforms that do not support multiple video elements.
  *   This value defaults to <code>false</code>.
+ * @property {boolean} skipPlayDetection
+ *   If this is <code>true</code>, we avoid to detect play event to load the
+ *   Client Side ads.
+ *   Defaults to <code>false</code> except on Tizen, WebOS, Chromecast,
+ *   Hisense, PlayStation 4, PlayStation5, Xbox whose default value is
+ *   <code>true</code>.
  *
  * @exportDoc
  */

--- a/lib/ads/client_side_ad_manager.js
+++ b/lib/ads/client_side_ad_manager.js
@@ -308,7 +308,7 @@ shaka.ads.ClientSideAdManager = class {
       // seen the ads actually play until requestAds() is called.
       // Note: We listen for a play event to avoid autoplay issues that might
       // crash IMA.
-      if (this.videoPlayed_) {
+      if (this.videoPlayed_ || this.config_.skipPlayDetection) {
         this.imaAdsManager_.start();
       } else {
         this.eventManager_.listenOnce(this.video_, 'play', () => {

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -375,7 +375,7 @@ shaka.util.PlayerConfiguration = class {
 
     const ads = {
       customPlayheadTracker: false,
-      skipPlayDetection: skipPlayDetection,
+      skipPlayDetection,
     };
 
     const AutoShowText = shaka.config.AutoShowText;

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -362,8 +362,20 @@ shaka.util.PlayerConfiguration = class {
       },
     };
 
+    let skipPlayDetection = false;
+    if (shaka.util.Platform.isWebOS() ||
+        shaka.util.Platform.isTizen() ||
+        shaka.util.Platform.isChromecast() ||
+        shaka.util.Platform.isHisense() ||
+        shaka.util.Platform.isPS5() ||
+        shaka.util.Platform.isPS4() ||
+        shaka.util.Platform.isXboxOne()) {
+      skipPlayDetection = true;
+    }
+
     const ads = {
       customPlayheadTracker: false,
+      skipPlayDetection: skipPlayDetection,
     };
 
     const AutoShowText = shaka.config.AutoShowText;


### PR DESCRIPTION
This configuration solves problems with some devices not being able to play a pre-roll.