### PR TITLE
fix(Ads): Fix ad pausing when using customPlayheadTracker

### DIFF
--- a/lib/ads/client_side_ad_manager.js
+++ b/lib/ads/client_side_ad_manager.js
@@ -533,7 +533,9 @@ shaka.ads.ClientSideAdManager = class {
         shaka.ads.AdManager.AD_STARTED, data));
     if (this.ad_.isLinear()) {
       this.adContainer_.setAttribute('ad-active', 'true');
-      this.video_.pause();
+      if (!this.config_.customPlayheadTracker) {
+        this.video_.pause();
+      }
       if (this.video_.muted) {
         this.ad_.setInitialMuted(this.video_.volume);
       } else {
@@ -551,7 +553,7 @@ shaka.ads.ClientSideAdManager = class {
         (new Map()).set('originalEvent', e)));
     if (this.ad_ && this.ad_.isLinear()) {
       this.adContainer_.removeAttribute('ad-active');
-      if (!this.video_.ended) {
+      if (!this.config_.customPlayheadTracker && !this.video_.ended) {
         this.video_.play();
       }
     }


### PR DESCRIPTION
When using customPlayheadTracker the content of video could have been replaced by the advertisement (case of SmartTVs where only one video element is supported at a time), so we want to prevent actions from being taken on the advertisement.