### PR TITLE
fix: Fix webOS 4 & 5 utility methods

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -150,10 +150,9 @@ shaka.util.Platform = class {
    * @return {boolean}
    */
   static isWebOS3() {
-    // See: http://webostv.developer.lge.com/discover/specifications/web-engine/
-    return shaka.util.Platform.userAgentContains_('Web0S') &&
-        shaka.util.Platform.userAgentContains_(
-            'Chrome/38.0.2125.122 Safari/537.36');
+    // See: https://webostv.developer.lge.com/develop/specifications/web-api-and-web-engine#useragent-string
+    return shaka.util.Platform.isWebOS() &&
+        shaka.util.Platform.chromeVersion() === 38;
   }
 
   /**
@@ -162,18 +161,20 @@ shaka.util.Platform = class {
    * @return {boolean}
    */
   static isWebOS4() {
-    // See: http://webostv.developer.lge.com/discover/specifications/web-engine/
-    return !!navigator.userAgent.match(/webOS\/4/i);
+    // See: https://webostv.developer.lge.com/develop/specifications/web-api-and-web-engine#useragent-string
+    return shaka.util.Platform.isWebOS() &&
+        shaka.util.Platform.chromeVersion() === 53;
   }
 
   /**
-   * Check if the current platform is a WebOS 4.
+   * Check if the current platform is a WebOS 5.
    *
    * @return {boolean}
    */
   static isWebOS5() {
-    // See: http://webostv.developer.lge.com/discover/specifications/web-engine/
-    return !!navigator.userAgent.match(/webOS\/5/i);
+    // See: https://webostv.developer.lge.com/develop/specifications/web-api-and-web-engine#useragent-string
+    return shaka.util.Platform.isWebOS() &&
+        shaka.util.Platform.chromeVersion() === 68;
   }
 
   /**

--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -1,0 +1,52 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('Platform', () => {
+  const originalUserAgent = navigator.userAgent;
+  // eslint-disable-next-line max-len
+  const webOs3 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.2.1 Chrome/38.0.2125.122 Safari/537.36 WebAppManager';
+  // eslint-disable-next-line max-len
+  const webOs4 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.34 Safari/537.36 WebAppManager';
+  // eslint-disable-next-line max-len
+  const webOs5 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 WebAppManager';
+
+  afterEach(() => {
+    setUserAgent(originalUserAgent);
+  });
+
+  it('checks is webOS 3', () => {
+    setUserAgent(webOs3);
+    expect(shaka.util.Platform.isWebOS3()).toBe(true);
+    setUserAgent(webOs4);
+    expect(shaka.util.Platform.isWebOS3()).toBe(false);
+    setUserAgent(webOs5);
+    expect(shaka.util.Platform.isWebOS3()).toBe(false);
+  });
+
+  it('checks is webOS 4', () => {
+    setUserAgent(webOs3);
+    expect(shaka.util.Platform.isWebOS4()).toBe(false);
+    setUserAgent(webOs4);
+    expect(shaka.util.Platform.isWebOS4()).toBe(true);
+    setUserAgent(webOs5);
+    expect(shaka.util.Platform.isWebOS4()).toBe(false);
+  });
+
+  it('checks is webOS 5', () => {
+    setUserAgent(webOs3);
+    expect(shaka.util.Platform.isWebOS5()).toBe(false);
+    setUserAgent(webOs4);
+    expect(shaka.util.Platform.isWebOS5()).toBe(false);
+    setUserAgent(webOs5);
+    expect(shaka.util.Platform.isWebOS5()).toBe(true);
+  });
+});
+
+/** @param {string} userAgent */
+function setUserAgent(userAgent) {
+  Object.defineProperty(
+      navigator, 'userAgent', {value: userAgent, configurable: true});
+}

--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -6,6 +6,8 @@
 
 describe('Platform', () => {
   const originalUserAgent = navigator.userAgent;
+
+  // See: https://webostv.developer.lge.com/develop/specifications/web-api-and-web-engine#useragent-string
   // eslint-disable-next-line max-len
   const webOs3 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.2.1 Chrome/38.0.2125.122 Safari/537.36 WebAppManager';
   // eslint-disable-next-line max-len


### PR DESCRIPTION
webOS platforms don't contain OS version explicitly in user agent, instead they signal it via chrome version. This PR fixes webOS 4 & 5 methods and unifies all webOS check methods.