### PR TITLE
fix: Fix exceptions in StreamingEngine when reloading

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1922,9 +1922,16 @@ shaka.media.StreamingEngine = class {
           otherState = this.mediaStates_.get(ContentType.VIDEO);
         }
         if (otherState) {
+          // First, abort all operations in progress on the other stream.
+          await this.abortOperations_(otherState).catch(() => {});
+          // Then clear our cache of the last init segment, since MSE will be
+          // reloaded and no init segment will be there post-reload.
           otherState.lastInitSegmentReference = null;
+          // Now force the existing buffer to be cleared.  It is not necessary
+          // to perform the MSE clear operation, but this has the side-effect
+          // that our state for that stream will then match MSE's post-reload
+          // state.
           this.forceClearBuffer_(otherState);
-          this.abortOperations_(otherState).catch(() => {});
         }
       }
 
@@ -1955,19 +1962,6 @@ shaka.media.StreamingEngine = class {
               appendWindowEnd, ignoreTimestampOffset,
               reference.mimeType || mediaState.stream.mimeType,
               reference.codecs || mediaState.stream.codecs, streamsByType);
-          if (isResetMediaSourceNecessary) {
-            let otherState = null;
-            if (mediaState.type === ContentType.VIDEO) {
-              otherState = this.mediaStates_.get(ContentType.AUDIO);
-            } else if (mediaState.type === ContentType.AUDIO) {
-              otherState = this.mediaStates_.get(ContentType.VIDEO);
-            }
-            if (otherState) {
-              otherState.waitingToClearBuffer = false;
-              otherState.performingUpdate = false;
-              this.forceClearBuffer_(otherState);
-            }
-          }
         } catch (error) {
           mediaState.lastAppendWindowStart = null;
           mediaState.lastAppendWindowEnd = null;


### PR DESCRIPTION
When reloading MediaSourceEngine via StreamingEngine, some logic executed before the reload cancels operations and aligns StreamingEngine state with MediaSourceEngine.

However, additional logic was executed after setStreamProperties, which caused a race condition that broke StreamingEngine state by manipulating it out of the usual sequence and outside the usual methods, leading to exceptions and failed assertions.  This removes that unnecessary logic and leaves subtle state management to the functions that are meant to do it.

Closes #6458