### PR TITLE
perf(DRM): pass `preferredKeySystems` to `filterManifest()`

### DIFF
--- a/lib/media/manifest_filterer.js
+++ b/lib/media/manifest_filterer.js
@@ -59,7 +59,8 @@ shaka.media.ManifestFilterer = class {
    */
   async filterManifestWithStreamUtils_(manifest) {
     goog.asserts.assert(manifest, 'Manifest should exist!');
-    await shaka.util.StreamUtils.filterManifest(this.drmEngine_, manifest);
+    await shaka.util.StreamUtils.filterManifest(this.drmEngine_, manifest,
+        this.config_.drm.preferredKeySystems);
     this.checkPlayableVariants_(manifest);
   }
 

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -664,7 +664,8 @@ shaka.offline.Storage = class {
     // Filter the manifest based on what we know MediaCapabilities will be able
     // to play later (no point storing something we can't play).
     await shaka.util.StreamUtils.filterManifestByMediaCapabilities(
-        drmEngine, manifest, config.offline.usePersistentLicense);
+        drmEngine, manifest, config.offline.usePersistentLicense,
+        config.drm.preferredKeySystems);
 
     // Gather all tracks.
     const allTracks = [];

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -337,10 +337,12 @@ shaka.util.StreamUtils = class {
    *
    * @param {shaka.media.DrmEngine} drmEngine
    * @param {shaka.extern.Manifest} manifest
+   * @param {!Array<string>} preferredKeySystems
    */
-  static async filterManifest(drmEngine, manifest) {
+  static async filterManifest(drmEngine, manifest, preferredKeySystems) {
     await shaka.util.StreamUtils.filterManifestByMediaCapabilities(
-        drmEngine, manifest, manifest.offlineSessionIds.length > 0);
+        drmEngine, manifest, manifest.offlineSessionIds.length > 0,
+        preferredKeySystems);
     shaka.util.StreamUtils.filterTextStreams_(manifest);
     await shaka.util.StreamUtils.filterImageStreams_(manifest);
   }
@@ -353,15 +355,16 @@ shaka.util.StreamUtils = class {
    * @param {shaka.media.DrmEngine} drmEngine
    * @param {shaka.extern.Manifest} manifest
    * @param {boolean} usePersistentLicenses
+   * @param {!Array<string>} preferredKeySystems
    */
   static async filterManifestByMediaCapabilities(
-      drmEngine, manifest, usePersistentLicenses) {
+      drmEngine, manifest, usePersistentLicenses, preferredKeySystems) {
     goog.asserts.assert(navigator.mediaCapabilities,
         'MediaCapabilities should be valid.');
 
     await shaka.util.StreamUtils.getDecodingInfosForVariants(
         manifest.variants, usePersistentLicenses, /* srcEquals= */ false,
-        /** preferredKeySystems= */ []);
+        preferredKeySystems);
 
     let keySystem = null;
     if (drmEngine) {

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -337,9 +337,9 @@ shaka.util.StreamUtils = class {
    *
    * @param {shaka.media.DrmEngine} drmEngine
    * @param {shaka.extern.Manifest} manifest
-   * @param {!Array<string>} preferredKeySystems
+   * @param {!Array<string>=} preferredKeySystems
    */
-  static async filterManifest(drmEngine, manifest, preferredKeySystems) {
+  static async filterManifest(drmEngine, manifest, preferredKeySystems = []) {
     await shaka.util.StreamUtils.filterManifestByMediaCapabilities(
         drmEngine, manifest, manifest.offlineSessionIds.length > 0,
         preferredKeySystems);

--- a/test/util/stream_utils_unit.js
+++ b/test/util/stream_utils_unit.js
@@ -625,8 +625,7 @@ describe('StreamUtils', () => {
         shaka.util.StreamUtils.filterManifestByCurrentVariant =
           shaka.test.Util.spyFunc(filterManifestByCurrentVariantSpy);
 
-        await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
-            /* preferredKeySystems= */ []);
+        await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
 
         expect(filterManifestByCurrentVariantSpy).not.toHaveBeenCalled();
       } finally {

--- a/test/util/stream_utils_unit.js
+++ b/test/util/stream_utils_unit.js
@@ -551,7 +551,8 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
+          /* preferredKeySystems= */ []);
 
       // Covers a regression in which we would remove streams with codecs.
       // The last two streams should be removed because their full MIME types
@@ -586,7 +587,8 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
+          /* preferredKeySystems= */ []);
 
       // Covers a regression in which we would remove streams with codecs.
       // The first 4 streams should be there because they are always supported.
@@ -625,7 +627,8 @@ describe('StreamUtils', () => {
         shaka.util.StreamUtils.filterManifestByCurrentVariant =
           shaka.test.Util.spyFunc(filterManifestByCurrentVariantSpy);
 
-        await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
+        await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
+            /* preferredKeySystems= */ []);
 
         expect(filterManifestByCurrentVariantSpy).not.toHaveBeenCalled();
       } finally {
@@ -647,7 +650,8 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
+          /* preferredKeySystems= */ []);
 
       // Covers a regression in which we would remove streams with codecs.
       // The last two streams should be removed because their full MIME types
@@ -673,7 +677,8 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
+          /* preferredKeySystems= */ []);
       expect(manifest.variants.length).toBe(1);
     });
 
@@ -689,7 +694,8 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
+          /* preferredKeySystems= */ []);
 
       expect(manifest.variants.length).toBe(1);
     });
@@ -711,7 +717,8 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
+          /* preferredKeySystems= */ []);
 
       expect(manifest.variants.length).toBe(2);
     });
@@ -733,7 +740,8 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
+          /* preferredKeySystems= */ []);
 
       expect(manifest.variants.length).toBe(2);
     });
@@ -750,7 +758,8 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
+          /* preferredKeySystems= */ []);
 
       expect(manifest.variants.length).toBe(1);
     });

--- a/test/util/stream_utils_unit.js
+++ b/test/util/stream_utils_unit.js
@@ -551,8 +551,7 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
-          /* preferredKeySystems= */ []);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
 
       // Covers a regression in which we would remove streams with codecs.
       // The last two streams should be removed because their full MIME types
@@ -587,8 +586,7 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
-          /* preferredKeySystems= */ []);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
 
       // Covers a regression in which we would remove streams with codecs.
       // The first 4 streams should be there because they are always supported.
@@ -650,8 +648,7 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
-          /* preferredKeySystems= */ []);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
 
       // Covers a regression in which we would remove streams with codecs.
       // The last two streams should be removed because their full MIME types
@@ -677,8 +674,7 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
-          /* preferredKeySystems= */ []);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
       expect(manifest.variants.length).toBe(1);
     });
 
@@ -694,8 +690,7 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
-          /* preferredKeySystems= */ []);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
 
       expect(manifest.variants.length).toBe(1);
     });
@@ -717,8 +712,7 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
-          /* preferredKeySystems= */ []);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
 
       expect(manifest.variants.length).toBe(2);
     });
@@ -740,8 +734,7 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
-          /* preferredKeySystems= */ []);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
 
       expect(manifest.variants.length).toBe(2);
     });
@@ -758,8 +751,7 @@ describe('StreamUtils', () => {
         });
       });
 
-      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest,
-          /* preferredKeySystems= */ []);
+      await shaka.util.StreamUtils.filterManifest(fakeDrmEngine, manifest);
 
       expect(manifest.variants.length).toBe(1);
     });


### PR DESCRIPTION
Follow up to #5391
Always use `preferredKeySystems` during manifest filtering, not only via DRM Engine.