### PR TITLE
fix: Do not use `replaceAll` in XPath parsing

### DIFF
--- a/lib/util/tXml.js
+++ b/lib/util/tXml.js
@@ -755,7 +755,7 @@ shaka.util.TXml = class {
         returnPaths.push({
           name: nodeName[0],
           id: idAttr ?
-            idAttr[0].match(/'(.*?)'/)[0].replaceAll('\'', '') : null,
+            idAttr[0].match(/'(.*?)'/)[0].replace(/'/gm, '') : null,
         });
       }
     }


### PR DESCRIPTION
`replaceAll` is not supported on Tizen 3.