### PR TITLE
fix: Don't update captions when video is paused

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -72,7 +72,9 @@ shaka.text.UITextDisplayer = class {
 
     /** @private {shaka.util.Timer} */
     this.captionsTimer_ = new shaka.util.Timer(() => {
-      this.updateCaptions_();
+      if (!this.video_.paused) {
+        this.updateCaptions_();
+      }
     }).tickEvery(updatePeriod);
 
     /**
@@ -90,6 +92,10 @@ shaka.text.UITextDisplayer = class {
     this.eventManager_ = new shaka.util.EventManager();
 
     this.eventManager_.listen(document, 'fullscreenchange', () => {
+      this.updateCaptions_(/* forceUpdate= */ true);
+    });
+
+    this.eventManager_.listen(this.video_, 'seeking', () => {
       this.updateCaptions_(/* forceUpdate= */ true);
     });
 


### PR DESCRIPTION
This avoids wasting processing resources when it is not necessary