### PR TITLE
fix: call to load in MediaElement using src= in HLS Safari

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -2578,6 +2578,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       mediaElement.load();
     }
 
+    // In Safari using HLS won't load anything unless you call load()
+    // explicitly, no matter the value of the preload attribute.
+    // Note: this only happens when there are not autoplay.
+    if (mediaElement.preload != 'none' && !mediaElement.autoplay &&
+        shaka.util.MimeUtils.isHlsType(mimeType) &&
+        shaka.util.Platform.safariVersion()) {
+      mediaElement.load();
+    }
+
     // Set the load mode last so that we know that all our components are
     // initialized.
     this.loadMode_ = shaka.Player.LoadMode.SRC_EQUALS;


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/6447