### PR TITLE
test: Add error listener in codec switching integration test

### DIFF
--- a/test/codec_switching/codec_switching_integration.js
+++ b/test/codec_switching/codec_switching_integration.js
@@ -5,6 +5,8 @@
  */
 
 describe('Codec Switching', () => {
+  const Util = shaka.test.Util;
+
   /** @type {!HTMLVideoElement} */
   let video;
   /** @type {shaka.Player} */
@@ -35,6 +37,12 @@ describe('Codec Switching', () => {
     eventManager = new shaka.util.EventManager();
     waiter = new shaka.test.Waiter(eventManager);
     waiter.setPlayer(player);
+
+    const onErrorSpy = jasmine.createSpy('onError');
+    onErrorSpy.and.callFake((event) => {
+      fail(event.detail);
+    });
+    eventManager.listen(player, 'error', Util.spyFunc(onErrorSpy));
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Our QA occassionally see that shaka throws 3016 VIDEO_ERROR during codec switching on Tizen 3. Hopefully this test adjustment will help to investigate similar issues.