### PR TITLE
ci: Fix appspot promotion during deployment

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -156,7 +156,7 @@ jobs:
           else
             APPSPOT_PROMOTE=false
           fi
-          APPSPOT_PROMOTE=$APPSPOT_PROMOTE >> $GITHUB_ENV
+          echo APPSPOT_PROMOTE=$APPSPOT_PROMOTE >> $GITHUB_ENV
 
           # Debug the decisions made here.
           echo "Subdomain: $APPSPOT_SUBDOMAIN"


### PR DESCRIPTION
Since upgrading the deployment action from v0 to v2, and stumbling into google-github-actions/deploy-appengine#361, new versions were not properly promoted.  However, our promotion setting in the workflow was actually ignored the whole time due to a missing "echo".

Closes #6502