### PR TITLE
ci: Fix main tags

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -32,7 +32,7 @@ jobs:
   tag-main:
     runs-on: ubuntu-latest
     needs: release
-    if: needs.release.outputs.release_created && needs.release.outputs.patch == '0'
+    if: needs.release.outputs.release_created && needs.release.outputs.patch != '0'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The condition for tagging the main branch was inverted after v4.7.11.

The main-branch tags for v4.6.16, v4.6.17, v4.7.12, v4.7.13, and v4.8.1 all had to be created and pushed by hand to correct this.