### PR TITLE
chore: Remove old comment

### DIFF
--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -346,7 +346,6 @@ describe('Playhead', () => {
 
     // This is important for recovering from drift.
     // See: https://github.com/shaka-project/shaka-player/issues/1105
-    // TODO: Re-evaluate after https://github.com/shaka-project/shaka-player/issues/999
     it('does not change once the initial position is set', () => {
       timeline.isLive.and.returnValue(true);
       timeline.getDuration.and.returnValue(Infinity);


### PR DESCRIPTION
The playhead test, "does not change once the initial position is set", is not really as important as it was when it was first added. The playhead class has been refactored significantly since then, and drift tolerance has been improved (see #999).

However, the behavior of the getTime method not changing until the video starts... it's not something we would write a test for today, perhaps, but it's still worthwhile enough to at least keep. Perhaps if it was a slow integration test it'd be worth trimming, but as a simple synchronous unit test it won't have any major effects on the durations of test runs.

Closes #1754