### PR TITLE
chore(DASH): Remove support for float durations.

### DIFF
--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -282,12 +282,6 @@ shaka.dash.MpdUtils = class {
     const durationStr =
         MpdUtils.inheritAttribute(context, callback, 'duration');
     let segmentDuration = TXml.parsePositiveInt(durationStr || '');
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
-    // TODO: The specification is not clear, check this once it is resolved:
-    // https://github.com/Dash-Industry-Forum/DASH-IF-IOP/issues/404
-    if (context.representation.contentType == ContentType.IMAGE) {
-      segmentDuration = TXml.parseFloat(durationStr || '');
-    }
     if (segmentDuration) {
       segmentDuration /= timescale;
     }


### PR DESCRIPTION
We previously supported float duration attributes in DASH SegmentTemplate, due to an ambiguity in the DASH samples.

The code linked to a DASH IOP issue asking if duration could be a float or it had to be an int.

That issue has since been closed, with the clarification that duration attributes must be an unsigned int and the sample was in violation of the spec.