### PR TITLE
fix: Handle non existing navigator.platform string (#6517)

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -416,7 +416,10 @@ shaka.util.Platform = class {
       return navigator.userAgentData.platform.toLowerCase() == 'macos';
     }
     // Fall back to the old API, with less strict matching.
-    return navigator.platform.toLowerCase().includes('mac');
+    if (navigator.platform) {
+      return navigator.platform.toLowerCase().includes('mac');
+    }
+    return false;
   }
 
   /**
@@ -430,7 +433,10 @@ shaka.util.Platform = class {
       return navigator.userAgentData.platform.toLowerCase() == 'windows';
     }
     // Fall back to the old API, with less strict matching.
-    return navigator.platform.toLowerCase().includes('windows');
+    if (navigator.platform) {
+      return navigator.platform.toLowerCase().includes('windows');
+    }
+    return false;
   }
 
   /**

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -433,10 +433,10 @@ shaka.util.Platform = class {
       return navigator.userAgentData.platform.toLowerCase() == 'windows';
     }
     // Fall back to the old API, with less strict matching.
-    if (navigator.platform) {
-      return navigator.platform.toLowerCase().includes('windows');
+    if (!navigator.platform) {
+      return false;
     }
-    return false;
+    return navigator.platform.toLowerCase().includes('windows');
   }
 
   /**

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -416,10 +416,10 @@ shaka.util.Platform = class {
       return navigator.userAgentData.platform.toLowerCase() == 'macos';
     }
     // Fall back to the old API, with less strict matching.
-    if (navigator.platform) {
-      return navigator.platform.toLowerCase().includes('mac');
+    if (!navigator.platform) {
+      return false;
     }
-    return false;
+    return navigator.platform.toLowerCase().includes('mac');
   }
 
   /**


### PR DESCRIPTION
This fix will make it possible to use v4.8 in Cobalt browser. The problem is that navigator.platform doesn't exist in Cobalt browser.

Fixes https://github.com/shaka-project/shaka-player/issues/6517