### PR TITLE
ci: Fix macOS CI failures

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -53,12 +53,17 @@ jobs:
             browser: Edge
             extra_flags: "--use-xvfb"
 
-          - os: macos-latest
+          # Use macos-13 for these browsers, due to
+          # https://github.com/shaka-project/shaka-player/issues/6508
+          # Matching checks for macos-13 below should be updated as well when
+          # this is reverted.
+          - os: macos-13
             browser: Chrome
-          - os: macos-latest
+          - os: macos-13
             browser: Firefox
-          - os: macos-latest
+          - os: macos-13
             browser: Edge
+
           - os: macos-latest
             browser: Safari
           - os: macos-latest
@@ -119,12 +124,20 @@ jobs:
       # causing many of our test scenarios to fail.  Deleting "Chrome for
       # Testing" fixes this.
       - name: 'Delete "Chrome for Testing" on Mac'
-        if: matrix.os == 'macos-latest' && matrix.browser == 'Chrome'
+        if: matrix.os == 'macos-13' && matrix.browser == 'Chrome'
         run: sudo rm -rf /Applications/Google\ Chrome\ for\ Testing.app
       - name: 'Overwrite "Chrome for Testing" on Windows'
         if: matrix.os == 'windows-latest' && matrix.browser == 'Chrome'
         shell: bash
         run: choco install -y googlechrome --ignore-checksums
+
+      # Firefox and Edge might be missing on Mac CI images.
+      - name: 'Install Firefox on Mac'
+        if: matrix.os == 'macos-13' && matrix.browser == 'Firefox'
+        run: brew install --cask firefox
+      - name: 'Install Edge on Mac'
+        if: matrix.os == 'macos-13' && matrix.browser == 'Edge'
+        run: brew install --cask microsoft-edge
 
       # Some CI images (self-hosted or otherwise) don't have the minimum Java
       # version necessary for the compiler (Java 11).


### PR DESCRIPTION
 - Install Edge & Firefox explicitly
 - Switch to macos-13 for now to resolve Edge & Chrome timeouts

Issue #6508