### PR TITLE
fix: Make UITextDisplayer constructor backward compatible

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -65,12 +65,16 @@ shaka.text.UITextDisplayer = class {
 
     this.videoContainer_.appendChild(this.textContainer_);
 
+    /** @private {number} */
+    const updatePeriod = (config && config.captionsUpdatePeriod) ?
+       config.captionsUpdatePeriod : 0.25;
+
     /** @private {shaka.util.Timer} */
     this.captionsTimer_ = new shaka.util.Timer(() => {
       if (!this.video_.paused) {
         this.updateCaptions_();
       }
-    }).tickEvery(config.captionsUpdatePeriod);
+    }).tickEvery(updatePeriod);
 
     /**
      * Maps cues to cue elements. Specifically points out the wrapper element of

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -8,6 +8,7 @@
 goog.provide('shaka.text.UITextDisplayer');
 
 goog.require('goog.asserts');
+goog.require('shaka.Deprecate');
 goog.require('shaka.text.Cue');
 goog.require('shaka.text.CueRegion');
 goog.require('shaka.util.Dom');
@@ -64,6 +65,12 @@ shaka.text.UITextDisplayer = class {
     this.textContainer_.style.justifyContent = 'flex-end';
 
     this.videoContainer_.appendChild(this.textContainer_);
+
+    if (!config || !config.captionsUpdatePeriod) {
+      shaka.Deprecate.deprecateFeature(5,
+          'UITextDisplayer w/ config',
+          'Please migrate to initializing UITextDisplayer with a config.');
+    }
 
     /** @private {number} */
     const updatePeriod = (config && config.captionsUpdatePeriod) ?

--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -615,4 +615,11 @@ describe('UITextDisplayer', () => {
 
     expect(videoContainer.childNodes.length).toBe(0);
   });
+
+  it('Backward compatible UITextDisplayer constructor', () => {
+    // The third argument to UITextDisplayer constructor is new in v4.8.0.
+    // Test without, to support existing applications.
+    /** @suppress {checkTypes} */
+    textDisplayer = new shaka.text.UITextDisplayer(video, videoContainer);
+  });
 });


### PR DESCRIPTION
Keep constructor backward compatible with earlier that had two arguments, i.e. make the new third optional for existing applications.

Fixes https://github.com/shaka-project/shaka-player/issues/6531