### PR TITLE
fix: Fix seeking timeouts

### DIFF
--- a/lib/media/playhead.js
+++ b/lib/media/playhead.js
@@ -382,10 +382,10 @@ shaka.media.MediaSourcePlayhead = class {
       seekStart = seekEnd - this.minSeekRange_;
     }
 
-    if (currentTime < seekStart || currentTime > seekEnd) {
-      // playhead is outside of the seekrange.  Move playhead to catch up.
+    if (currentTime < seekStart) {
+      // The seek range has moved past the playhead.  Move ahead to catch up.
       const targetTime = this.reposition_(currentTime);
-      shaka.log.info('Jumping by ' + (targetTime - currentTime) +
+      shaka.log.info('Jumping forward ' + (targetTime - currentTime) +
                      ' seconds to catch up with the seek range.');
       this.mediaElement_.currentTime = targetTime;
     }

--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -682,7 +682,7 @@ describe('Playhead', () => {
 
     // It should allow a small buffer around the seek range.
     seekCount = 0;
-    currentTime = 1030;
+    currentTime = 1030.062441;
     jasmine.clock().tick(500);
     currentTime = 1027.9233;
     jasmine.clock().tick(500);


### PR DESCRIPTION
PR #6304 caused seeking timeouts in Cast Application Framework, in v4.7.13, v4.8.0, and v4.8.1.

Reverts "fix: Correct playhead when seek beyond seekRange (#6304)"

This reverts commit f91188eaecb91583385f49fdf1e39add3f77d7c2.

Reopens #5202