### PR TITLE
ci: Fix workflow request for disabled browsers

### DIFF
--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -121,7 +121,7 @@ jobs:
             // A browser is enabled if it's requested, or if it's on by default
             // and nothing was requested.
             const enabled = thisBrowserRequested ||
-                (nothingRequested == 0 && thisBrowserOnByDefault);
+                (nothingRequested && thisBrowserOnByDefault);
 
             if (enabled) {
               include.push({browser: name});

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -114,11 +114,14 @@ jobs:
               continue;
             }
 
-            // A browser is enabled if it's not disabled and (either the browser
-            // filter is empty or it contains the browser name).
-            const enabled = !gridBrowserMetadata[name].disabled &&
-                (browserFilter.size == 0 ||
-                 browserFilter.has(name.toLowerCase()));
+            const thisBrowserRequested = browserFilter.has(name.toLowerCase());
+            const nothingRequested = browserFilter.size == 0;
+            const thisBrowserOnByDefault = !gridBrowserMetadata[name].disabled;
+
+            // A browser is enabled if it's requested, or if it's on by default
+            // and nothing was requested.
+            const enabled = thisBrowserRequested ||
+                (nothingRequested == 0 && thisBrowserOnByDefault);
 
             if (enabled) {
               include.push({browser: name});


### PR DESCRIPTION
You should be able to request a browser explicitly even if it is disabled by default.  This fixed the workflow logic that limited this.