### PR TITLE
test: Fix Android DRM test failure

### DIFF
--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -19,10 +19,18 @@ filterDescribe('Offline', supportsStorage, () => {
   let eventManager;
   /** @type {shaka.test.Waiter} */
   let waiter;
+  /** @type {boolean} */
+  let widevineSupport;
+  /** @type {boolean} */
+  let playreadySupport;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     video = shaka.test.UiUtils.createVideoElement();
     document.body.appendChild(video);
+
+    const support = await shaka.Player.probeSupport();
+    widevineSupport = support.drm['com.widevine.alpha'];
+    playreadySupport = support.drm['com.microsoft.playready'];
   });
 
   afterAll(() => {
@@ -81,9 +89,6 @@ filterDescribe('Offline', supportsStorage, () => {
   drmIt(
       'stores, plays, and deletes protected content with a persistent license',
       async () => {
-        const support = await shaka.Player.probeSupport();
-        const widevineSupport = support.drm['com.widevine.alpha'];
-
         if (!widevineSupport || !widevineSupport.persistentState) {
           pending('Widevine persistent licenses are not supported');
           return;
@@ -116,10 +121,6 @@ filterDescribe('Offline', supportsStorage, () => {
   drmIt(
       'stores, plays, and deletes protected content with a temporary license',
       async () => {
-        const support = await shaka.Player.probeSupport();
-        const widevineSupport = support.drm['com.widevine.alpha'];
-        const playreadySupport = support.drm['com.microsoft.playready'];
-
         if (!(widevineSupport || playreadySupport)) {
           pending('Widevine and PlayReady are not supported');
           return;

--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -19,9 +19,9 @@ filterDescribe('Offline', supportsStorage, () => {
   let eventManager;
   /** @type {shaka.test.Waiter} */
   let waiter;
-  /** @type {boolean} */
+  /** @type {?shaka.extern.DrmSupportType} */
   let widevineSupport;
-  /** @type {boolean} */
+  /** @type {?shaka.extern.DrmSupportType} */
   let playreadySupport;
 
   beforeAll(async () => {


### PR DESCRIPTION
These two offline DRM tests, even when run alone, would fail 80% of the time on the second test.  This was eventually determined to be related to https://crbug.com/1108158 and the timeout workaround in DrmEngine.

When close() hangs and we time out and move on, we leave sessions open that consume hardware resources at the OEMCrypto level in Android.  This eventually leads to failures like `Failed to execute 'createMediaKeys' on 'MediaKeySystemAccess': MediaDrmBridge creation failed`.  Logs from `adb logcat` show that 17 sessions are open when this fails, which likely means our lab device has a limit of 16 open sessions.

A delay of 60 seconds between these two test cases was found to eliminate the failure, which means that the hanging close() calls must have eventually resolved.  A 20-second delay only brought the failure rate down from 80% to 60%.  The suggests the time required for a "natural" resolution varies, which leads me to believe it may be related to JavaScript garbage collection.

A delay between test cases is not ideal.  Because there were too many sessions, though, I reasoned that maybe deduping the probeSupport() call and moving it to beforeAll() might reduce the number of open sessions.  This appears to work, with 20 test runs in a row passing, compared to 4/20 before the fix.