### PR TITLE
test: Skip offline DRM tests on Android

### DIFF
--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -19,10 +19,18 @@ filterDescribe('Offline', supportsStorage, () => {
   let eventManager;
   /** @type {shaka.test.Waiter} */
   let waiter;
+  /** @type {?shaka.extern.DrmSupportType} */
+  let widevineSupport;
+  /** @type {?shaka.extern.DrmSupportType} */
+  let playreadySupport;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     video = shaka.test.UiUtils.createVideoElement();
     document.body.appendChild(video);
+
+    const support = await shaka.Player.probeSupport();
+    widevineSupport = support.drm['com.widevine.alpha'];
+    playreadySupport = support.drm['com.microsoft.playready'];
   });
 
   afterAll(() => {
@@ -81,11 +89,12 @@ filterDescribe('Offline', supportsStorage, () => {
   drmIt(
       'stores, plays, and deletes protected content with a persistent license',
       async () => {
-        const support = await shaka.Player.probeSupport();
-        const widevineSupport = support.drm['com.widevine.alpha'];
-
         if (!widevineSupport || !widevineSupport.persistentState) {
           pending('Widevine persistent licenses are not supported');
+          return;
+        }
+        if (shaka.util.Platform.isAndroid()) {
+          pending('Skipping offline DRM tests on Android - crbug.com/1108158');
           return;
         }
 
@@ -116,12 +125,12 @@ filterDescribe('Offline', supportsStorage, () => {
   drmIt(
       'stores, plays, and deletes protected content with a temporary license',
       async () => {
-        const support = await shaka.Player.probeSupport();
-        const widevineSupport = support.drm['com.widevine.alpha'];
-        const playreadySupport = support.drm['com.microsoft.playready'];
-
         if (!(widevineSupport || playreadySupport)) {
           pending('Widevine and PlayReady are not supported');
+          return;
+        }
+        if (shaka.util.Platform.isAndroid()) {
+          pending('Skipping offline DRM tests on Android - crbug.com/1108158');
           return;
         }
 


### PR DESCRIPTION
The offline DRM tests have begun failing on Android at a rate of 80% or more.  This was eventually determined to be related to https://crbug.com/1108158 and the timeout workaround in DrmEngine.

When close() hangs and we time out and move on, we leave sessions open that consume hardware resources at the OEMCrypto level in Android.  This eventually leads to failures like `Failed to execute 'createMediaKeys' on 'MediaKeySystemAccess': MediaDrmBridge creation failed`.  Logs from `adb logcat` show that 17 sessions are open when this fails, which likely means our lab device has a limit of 16 open sessions.

Initially, delays between these offline DRM test cases were found to be an effective workaround, but full test runs showed this to be ineffective after all.

The only recourse, until Chrome and Widevine fix their bug, is to skip these tests on Android.