### PR TITLE
fix: Destroy preload managers on player destroy

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -715,6 +715,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.manifestFilterer_ = new shaka.media.ManifestFilterer(
         this.config_, this.maxHwRes_, null);
 
+    /** @private {!Array.<shaka.media.PreloadManager>} */
+    this.createdPreloadManagers_ = [];
+
     /** @private {shaka.util.Stats} */
     this.stats_ = null;
 
@@ -880,6 +883,18 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.loadMode_ = shaka.Player.LoadMode.DESTROYED;
 
     await detachPromise;
+
+    // A PreloadManager can only be used with the Player instance that created
+    // it, so all PreloadManagers this Player has created are now useless.
+    // Destroy any remaining managers now, to help prevent memory leaks.
+    const preloadManagerDestroys = [];
+    for (const preloadManager of this.createdPreloadManagers_) {
+      if (!preloadManager.isDestroyed()) {
+        preloadManagerDestroys.push(preloadManager.destroy());
+      }
+    }
+    await Promise.all(preloadManagerDestroys);
+    this.createdPreloadManagers_ = [];
 
     // Tear-down the event managers to ensure handlers stop firing.
     if (this.globalEventManager_) {
@@ -1977,6 +1992,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     };
     preloadManager = new shaka.media.PreloadManager(
         assetUri, mimeType, startTimeOfLoad, startTime, playerInterface);
+    this.createdPreloadManagers_.push(preloadManager);
     return preloadManager;
   }
 


### PR DESCRIPTION
A PreloadManager can only be used on the Player instance that created it. That means that once that Player instance is destroyed any PreloadManagers it made are basically useless, so they should be automatically destroyed too.