### PR TITLE
test: Fix test infra failure on non-ES6 devices

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -377,6 +377,7 @@ module.exports = (config) => {
         'ui/**/*.js': ['babel', 'sourcemap'],
         'test/**/*.js': ['babel', 'sourcemap'],
         'third_party/**/*.js': ['babel', 'sourcemap'],
+        'proxy-cast-platform.js': ['babel', 'sourcemap'],
       },
 
       babelPreprocessor: {


### PR DESCRIPTION
Splitting code from test/test/boot.js into proxy-cast-platform.js caused issues with non-ES6 devices because the new file did not match the list of files run through Babel before being served by Karma.