### PR TITLE
test: Fix Fuchsia background-video errors

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -198,6 +198,17 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is a Google Chromecast with Android
+   * (i.e. Chromecast with GoogleTV).
+   *
+   * @return {boolean}
+   */
+  static isFuchsiaCastDevice() {
+    const Platform = shaka.util.Platform;
+    return Platform.isChromecast() && Platform.isFuchsia();
+  }
+
+  /**
    * Returns a major version number for Chrome, or Chromium-based browsers.
    *
    * For example:
@@ -457,6 +468,15 @@ shaka.util.Platform = class {
    */
   static isAndroid() {
     return shaka.util.Platform.userAgentContains_('Android');
+  }
+
+  /**
+   * Return true if the platform is a Fuchsia, regardless of the browser.
+   *
+   * @return {boolean}
+   */
+  static isFuchsia() {
+    return shaka.util.Platform.userAgentContains_('Fuchsia');
   }
 
   /**

--- a/test/offline/storage_integration.js
+++ b/test/offline/storage_integration.js
@@ -736,8 +736,7 @@ filterDescribe('Storage', storageSupport, () => {
     /** @type {!shaka.util.EventManager} */
     let eventManager;
     /** @type {!HTMLVideoElement} */
-    const videoElement = /** @type {!HTMLVideoElement} */(
-      document.createElement('video'));
+    const videoElement = shaka.test.UiUtils.createVideoElement();
 
     beforeEach(async () => {
       netEngine = makeNetworkEngine();

--- a/test/test/util/ui_utils.js
+++ b/test/test/util/ui_utils.js
@@ -171,9 +171,11 @@ shaka.test.UiUtils = class {
     const video = /** @type {!HTMLVideoElement} */(document.createElement(
         'video'));
 
-    // Tizen has issues with audio-only playbacks on muted video elements.
-    // Don't mute Tizen.
-    if (!shaka.util.Platform.isTizen()) {
+    // Some platforms have issues with audio-only playbacks on muted video
+    // elements. Don't mute them.
+    // Fuchsia reference: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/media/web_media_player_impl.cc;l=3535;drc=d23075f3
+    if (!shaka.util.Platform.isTizen() &&
+        !shaka.util.Platform.isFuchsiaCastDevice()) {
       video.muted = true;
     }
     video.width = 600;

--- a/test/ui/ui_unit.js
+++ b/test/ui/ui_unit.js
@@ -123,8 +123,7 @@ describe('UI', () => {
         // multi-video use case. It could be replaces with any other
         // (reasonable) number.
         for (let i = 0; i < 4; i++) {
-          const video = /** @type {!HTMLVideoElement} */
-              (document.createElement('video'));
+          const video = shaka.test.UiUtils.createVideoElement();
 
           document.body.appendChild(video);
           videos.push(video);


### PR DESCRIPTION
In some cases, Fuchsia Chromecast tests will fail with the error: "The play() request was interrupted because video-only background media was paused to save power."

This resolves the issue by ensuring tests run un-muted on that platform, based on this Chrome code, which indicates the "paused to save power" logic does not activate when sound is playing: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/media/web_media_player_impl.cc;l=3535;drc=d23075f3

This also fixes two places in our tests where the `createVideoElement()` was bypassed.  This should always be used, because it is a central place to apply workarounds such as this.