### PR TITLE
ci: Add overall test timeout of 30 minutes

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -150,6 +150,7 @@ jobs:
         run: python build/all.py
 
       - name: Test Player
+        timeout-minutes: 30
         shell: bash
         run: |
           browser=${{ matrix.browser }}

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -274,6 +274,7 @@ jobs:
       # ALLOCATED_PORT must be defined by the self-hosted runner, and mapped
       # from the host to the container.
       - name: Test Player
+        timeout-minutes: 30
         run: |
           # Use of an array keeps elements intact, and allows an element to
           # contain spaces without being expanded into multiple arguments in a


### PR DESCRIPTION
When tests occasionally timeout (as is currently happening with IndexedDB hangs on Mac), we should stop the test run after 30 minutes and allow the "deflake" workflow to rerun them.  Without this timeout, the test run can takes hours.

A successful test run takes 15-20 minutes currently.