### PR TITLE
fix: Clear preload array before awaiting destroy

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -893,8 +893,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         preloadManagerDestroys.push(preloadManager.destroy());
       }
     }
-    await Promise.all(preloadManagerDestroys);
     this.createdPreloadManagers_ = [];
+    await Promise.all(preloadManagerDestroys);
 
     // Tear-down the event managers to ensure handlers stop firing.
     if (this.globalEventManager_) {


### PR DESCRIPTION
This could be relevant if destroy() is called multiple times in a row.

Based on a comment on #6576