### PR TITLE
test: Remove bad condition on extracts ID3 metadata from AAC when transmuxing

### DIFF
--- a/test/media/media_source_engine_integration.js
+++ b/test/media/media_source_engine_integration.js
@@ -707,9 +707,6 @@ describe('MediaSourceEngine', () => {
   });
 
   it('extracts ID3 metadata from AAC when transmuxing', async () => {
-    if (!MediaSource.isTypeSupported('audio/aac')) {
-      pending('Raw AAC codec is not supported by the platform.');
-    }
     metadata = shaka.test.TestScheme.DATA['id3-metadata_aac'];
     generators = shaka.test.TestScheme.GENERATORS['id3-metadata_aac'];
 


### PR DESCRIPTION
All browsers support transmusing to audio/mp4 with AAC, so this condition is wrong.