### PR TITLE
fix(CEA): reset PTS on new init segment

### DIFF
--- a/lib/cea/cea_decoder.js
+++ b/lib/cea/cea_decoder.js
@@ -97,6 +97,7 @@ shaka.cea.CeaDecoder = class {
    * @override
    */
   clear() {
+    shaka.log.debug('Clearing CEA decoder');
     this.badFrames_ = 0;
     this.cea608DataArray_ = [];
     this.cea708DataArray_ = [];
@@ -113,6 +114,7 @@ shaka.cea.CeaDecoder = class {
    * Resets the decoder.
    */
   reset() {
+    shaka.log.debug('Resetting CEA decoder');
     this.currentField1Channel_ = 0;
     this.currentField2Channel_ = 0;
     for (const stream of this.cea608ModeToStream_.values()) {
@@ -128,6 +130,7 @@ shaka.cea.CeaDecoder = class {
    */
   extract(userDataSeiMessage, pts) {
     if (this.waitingForFirstPacket_) {
+      shaka.log.debug('Setting first pts value to', pts);
       for (const stream of this.cea608ModeToStream_.values()) {
         stream.firstPts(pts);
       }

--- a/lib/media/closed_caption_parser.js
+++ b/lib/media/closed_caption_parser.js
@@ -9,6 +9,7 @@ goog.provide('shaka.media.IClosedCaptionParser');
 
 goog.require('shaka.cea.DummyCaptionDecoder');
 goog.require('shaka.cea.DummyCeaParser');
+goog.require('shaka.log');
 goog.require('shaka.util.BufferUtils');
 
 
@@ -22,7 +23,8 @@ goog.require('shaka.util.BufferUtils');
  */
 shaka.media.IClosedCaptionParser = class {
   /**
-   * Initialize the caption parser. This should be called only once.
+   * Initialize the caption parser. This should be called whenever new init
+   * segment arrives.
    * @param {BufferSource} initSegment
    */
   init(initSegment) {}
@@ -88,6 +90,10 @@ shaka.media.ClosedCaptionParser = class {
    * @override
    */
   init(initSegment) {
+    shaka.log.debug('Passing new init segment to CEA parser');
+    // Reset underlying decoder when new init segment arrives
+    // to clear stored pts values.
+    this.reset();
     this.ceaParser_.init(initSegment);
   }
 


### PR DESCRIPTION
Fixes #6605
Resets cache (including last used presentation timestamp) of CEA Decoder on every init segment append.
Adds few debug logs to easify investigations in the future.
 