### PR TITLE
feat(Mcap): Add config for media capabilities cache

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -136,7 +136,9 @@ shakaDemo.Config = class {
             'drm.parseInbandPsshEnabled')
         .addTextInput_('Min HDCP version', 'drm.minHdcpVersion')
         .addBoolInput_('Ignore duplicate init data',
-            'drm.ignoreDuplicateInitData');
+            'drm.ignoreDuplicateInitData')
+        .addBoolInput_('Enable cache for mediacapabilities',
+            'drm.enableMediaCapabilitiesCache');
     const advanced = shakaDemoMain.getConfiguration().drm.advanced || {};
     const addDRMAdvancedField = (name, valueName, suggestions) => {
       // All advanced fields of a given type are set at once.

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -802,7 +802,8 @@ shaka.extern.PersistentSessionMetadata;
  *   keySystemsMapping: !Object.<string, string>,
  *   parseInbandPsshEnabled: boolean,
  *   minHdcpVersion: string,
- *   ignoreDuplicateInitData: boolean
+ *   ignoreDuplicateInitData: boolean,
+ *   enableMediaCapabilitiesCache: boolean
  * }}
  *
  * @property {shaka.extern.RetryParameters} retryParameters
@@ -865,6 +866,10 @@ shaka.extern.PersistentSessionMetadata;
  *   Note: Tizen 2015 and 2016 models will send multiple webkitneedkey events
  *   with the same init data. If the duplicates are supressed, playback
  *   will stall without errors.
+ * @property {boolean} enableMediaCapabilitiesCache
+ *   Custom optimization, enable aggressive cache on mediaCapabilities call.
+ *   Should only be enabled on platform where polyfill for mediaCapabilities
+ *   is used.
  * @exportDoc
  */
 shaka.extern.DrmConfiguration;

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -401,7 +401,8 @@ shaka.media.DrmEngine = class {
     // in the drm infos, and before queryMediaKeys_().
     await shaka.util.StreamUtils.getDecodingInfosForVariants(variants,
         this.usePersistentLicenses_, this.srcEquals_,
-        this.config_.preferredKeySystems);
+        this.config_.preferredKeySystems,
+        this.config_.enableMediaCapabilitiesCache);
 
     const hasDrmInfo = hadDrmInfo || Object.keys(this.config_.servers).length;
     // An unencrypted content is initialized.

--- a/lib/media/manifest_filterer.js
+++ b/lib/media/manifest_filterer.js
@@ -60,10 +60,10 @@ shaka.media.ManifestFilterer = class {
   async filterManifestWithStreamUtils_(manifest) {
     goog.asserts.assert(manifest, 'Manifest should exist!');
     await shaka.util.StreamUtils.filterManifest(this.drmEngine_, manifest,
-        this.config_.drm.preferredKeySystems);
+        this.config_.drm.preferredKeySystems,
+        this.config_.drm.enableMediaCapabilitiesCache);
     this.checkPlayableVariants_(manifest);
   }
-
 
   /**
    * @param {?shaka.extern.Manifest} manifest

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -92,6 +92,7 @@ shaka.util.PlayerConfiguration = class {
       parseInbandPsshEnabled: shaka.util.Platform.isXboxOne(),
       minHdcpVersion: '',
       ignoreDuplicateInitData: !shaka.util.Platform.isTizen2(),
+      enableMediaCapabilitiesCache: false,
     };
 
     // The Xbox One and PS4 only support the Playready DRM, so they should

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -716,10 +716,11 @@ shaka.util.StreamUtils = class {
     } // for (const preferredKeySystem of preferredKeySystems)
 
     /**
-     * For LR devices, polyfill is used, which calls isTypeSupported and
+     * For platforms which use the MediaCapabilities polyfill, calls to media
+     * capabilities are replaced with isTypeSupported and
      * requestMediaKeySystemAccess instead.
-     * Group similar variants, and share results.
-     * Helpful for video with a lot of variants on LR.
+     * By grouping similar variants, we can improve performance for manifests
+     * with lots of variants.
      */
     const enableCache = enableMediaCapabilitiesCache &&
       !srcEquals && !shaka.util.Platform.isChromecast();
@@ -745,11 +746,7 @@ shaka.util.StreamUtils = class {
           for (const videoFullMimeType of video.fullMimeTypes) {
             for (const audioFullMimeType of audio.fullMimeTypes) {
               cacheKeys.push(
-                  `${videoFullMimeType}#${video.hdr}
-                  #${audioFullMimeType}#${audio.spatialAudio}
-                  #${audio.channelsCount}
-                  #${keySystem}`);
-              // video.hdr + audio.spatialAudio + audio.channelsCount
+                  `${videoFullMimeType}#${audioFullMimeType}#${keySystem}`);
             }
           }
         }
@@ -759,52 +756,27 @@ shaka.util.StreamUtils = class {
       // sort variants, so that high bandwidth checked first.
       // High bandwidth tends to be less likely to be supported, or smooth
       const sortedVariants = variants.sort((a, b) => b.bandwidth - a.bandwidth);
-      const keyToCheck = 'supported';
 
       for (const variant of sortedVariants) {
         const cacheKeys = buildCacheKey(variant);
         const useCache = cacheKeys && cacheKeys.length &&
-          cacheKeys.reduce((hasCache, key) =>
-            (hasCache && decodeInfoCache[key] &&
-            // If not meet criteria, won't use cache.
-            decodeInfoCache[key][keyToCheck])
-          , true);
-        shaka.log.info('getDecodingInfosForVariants used cache.',
-            useCache, cacheKeys, variant);
+            cacheKeys.every((key) => {
+              return decodeInfoCache[key] && decodeInfoCache[key].supported;
+            });
         if (useCache) {
           variant.decodingInfos =
               cacheKeys.map((key) => decodeInfoCache[key]);
           continue;
         }
 
-        /** @type {!Array.<!Array.<!MediaDecodingConfiguration>>} */
-        const decodingConfigs = shaka.util.StreamUtils.getDecodingConfigs_(
-            variant, usePersistentLicenses, srcEquals)
-            .filter((configs) => {
-            // All configs in a batch will have the same keySystem.
-              const config = configs[0];
-              const keySystem = config.keySystemConfiguration &&
-              config.keySystemConfiguration.keySystem;
-              // Avoid checking preferred systems twice.
-              return !keySystem || !preferredKeySystems.includes(keySystem);
-            });
+        // eslint-disable-next-line no-await-in-loop
+        await shaka.util.StreamUtils.getAndApplyDecodingInfosForVariant_(
+            variant, usePersistentLicenses, srcEquals, preferredKeySystems);
 
-        // The reason we are performing this await in a loop rather than
-        // batching into a `promise.all` is performance related.
-        // https://github.com/shaka-project/shaka-player/pull/4708#discussion_r1022581178
-        for (let i = 0; i < decodingConfigs.length; i++) {
-          const configs = decodingConfigs[i];
-          // eslint-disable-next-line no-await-in-loop
-          await shaka.util.StreamUtils.getDecodingInfosForVariant_(
-              variant, configs);
-
-          // getDecodingInfosForVariant_ could fail.
-          const result = variant.decodingInfos.length ?
-            variant.decodingInfos[i] : null;
-          if (cacheKeys && result) {
+        if (cacheKeys) {
+          for (let i = 0; i < variant.decodingInfos.length; i++) {
             const cacheKey = cacheKeys[i];
-
-            decodeInfoCache[cacheKey] = result;
+            decodeInfoCache[cacheKey] = variant.decodingInfos[i];
             delete decodeInfoCache[cacheKey]['configuration'];
           }
         }
@@ -813,26 +785,42 @@ shaka.util.StreamUtils = class {
     }
 
     for (const variant of variants) {
-      /** @type {!Array.<!Array.<!MediaDecodingConfiguration>>} */
-      const decodingConfigs = shaka.util.StreamUtils.getDecodingConfigs_(
-          variant, usePersistentLicenses, srcEquals)
-          .filter((configs) => {
-            // All configs in a batch will have the same keySystem.
-            const config = configs[0];
-            const keySystem = config.keySystemConfiguration &&
-              config.keySystemConfiguration.keySystem;
-            // Avoid checking preferred systems twice.
-            return !keySystem || !preferredKeySystems.includes(keySystem);
-          });
+      // eslint-disable-next-line no-await-in-loop
+      await shaka.util.StreamUtils.getAndApplyDecodingInfosForVariant_(
+          variant, usePersistentLicenses, srcEquals, preferredKeySystems);
+    }
+  }
 
-      // The reason we are performing this await in a loop rather than
-      // batching into a `promise.all` is performance related.
-      // https://github.com/shaka-project/shaka-player/pull/4708#discussion_r1022581178
-      for (const configs of decodingConfigs) {
-        // eslint-disable-next-line no-await-in-loop
-        await shaka.util.StreamUtils.getDecodingInfosForVariant_(
-            variant, configs);
-      }
+  /**
+   * Call mediaCapabilities
+   * Generate input for querying mediaCapabilities and call the API .
+   * @param {!shaka.extern.Variant} variant
+   * @param {boolean} usePersistentLicenses
+   * @param {boolean} srcEquals
+   * @param {!Array<string>=} preferredKeySystems
+   * @private
+   */
+  static async getAndApplyDecodingInfosForVariant_(
+      variant, usePersistentLicenses, srcEquals, preferredKeySystems = []) {
+    /** @type {!Array.<!Array.<!MediaDecodingConfiguration>>} */
+    const decodingConfigs = shaka.util.StreamUtils.getDecodingConfigs_(
+        variant, usePersistentLicenses, srcEquals)
+        .filter((configs) => {
+          // All configs in a batch will have the same keySystem.
+          const config = configs[0];
+          const keySystem = config.keySystemConfiguration &&
+              config.keySystemConfiguration.keySystem;
+          // Avoid checking preferred systems twice.
+          return !keySystem || !preferredKeySystems.includes(keySystem);
+        });
+
+    // The reason we are performing this await in a loop rather than
+    // batching into a `promise.all` is performance related.
+    // https://github.com/shaka-project/shaka-player/pull/4708#discussion_r1022581178
+    for (const configs of decodingConfigs) {
+      // eslint-disable-next-line no-await-in-loop
+      await shaka.util.StreamUtils.getDecodingInfosForVariant_(
+          variant, configs);
     }
   }
 

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -721,9 +721,10 @@ shaka.util.StreamUtils = class {
      * Group similar variants, and share results.
      * Helpful for video with a lot of variants on LR.
      */
-    const enableCahe = enableMediaCapabilitiesCache &&
+    const enableCache = enableMediaCapabilitiesCache &&
       !srcEquals && !shaka.util.Platform.isChromecast();
-    if (enableCahe) {
+    if (enableCache) {
+      /** @type {!Object.<string, MediaCapabilitiesDecodingInfo>} */
       const decodeInfoCache = {};
       const buildCacheKey = (variant) => {
         if (variant.audio.fullMimeTypes.size < 1 ||
@@ -738,13 +739,16 @@ shaka.util.StreamUtils = class {
         const audioDrmInfos = audio ? audio.drmInfos : [];
         const allDrmInfos = videoDrmInfos.concat(audioDrmInfos);
 
-        const keySystems= new Set(allDrmInfos.map((info) => info.keySystem));
+        const keySystems = new Set(allDrmInfos.map((info) => info.keySystem));
         const cacheKeys = [];
         for (const keySystem of keySystems) {
           for (const videoFullMimeType of video.fullMimeTypes) {
             for (const audioFullMimeType of audio.fullMimeTypes) {
               cacheKeys.push(
-                  `${videoFullMimeType}#${audioFullMimeType}#${keySystem}`);
+                  `${videoFullMimeType}#${video.hdr}
+                  #${audioFullMimeType}#${audio.spatialAudio}
+                  #${audio.channelsCount}
+                  #${keySystem}`);
               // video.hdr + audio.spatialAudio + audio.channelsCount
             }
           }
@@ -760,16 +764,16 @@ shaka.util.StreamUtils = class {
       for (const variant of sortedVariants) {
         const cacheKeys = buildCacheKey(variant);
         const useCache = cacheKeys && cacheKeys.length &&
-            cacheKeys.reduce((hasCache, key) =>
-              (hasCache && decodeInfoCache[key] &&
-                // If not meet criteria, won't use cache.
-                decodeInfoCache[key][keyToCheck])
-            , true);
+          cacheKeys.reduce((hasCache, key) =>
+            (hasCache && decodeInfoCache[key] &&
+            // If not meet criteria, won't use cache.
+            decodeInfoCache[key][keyToCheck])
+          , true);
         shaka.log.info('getDecodingInfosForVariants used cache.',
             useCache, cacheKeys, variant);
         if (useCache) {
           variant.decodingInfos =
-            cacheKeys.map((key) => decodeInfoCache[key]);
+              cacheKeys.map((key) => decodeInfoCache[key]);
           continue;
         }
 
@@ -777,10 +781,10 @@ shaka.util.StreamUtils = class {
         const decodingConfigs = shaka.util.StreamUtils.getDecodingConfigs_(
             variant, usePersistentLicenses, srcEquals)
             .filter((configs) => {
-              // All configs in a batch will have the same keySystem.
+            // All configs in a batch will have the same keySystem.
               const config = configs[0];
               const keySystem = config.keySystemConfiguration &&
-                config.keySystemConfiguration.keySystem;
+              config.keySystemConfiguration.keySystem;
               // Avoid checking preferred systems twice.
               return !keySystem || !preferredKeySystems.includes(keySystem);
             });
@@ -788,14 +792,14 @@ shaka.util.StreamUtils = class {
         // The reason we are performing this await in a loop rather than
         // batching into a `promise.all` is performance related.
         // https://github.com/shaka-project/shaka-player/pull/4708#discussion_r1022581178
-        for (let i=0; i<decodingConfigs.length; i++) {
+        for (let i = 0; i < decodingConfigs.length; i++) {
           const configs = decodingConfigs[i];
           // eslint-disable-next-line no-await-in-loop
           await shaka.util.StreamUtils.getDecodingInfosForVariant_(
               variant, configs);
 
           // getDecodingInfosForVariant_ could fail.
-          const result = variant.decodingInfos.length?
+          const result = variant.decodingInfos.length ?
             variant.decodingInfos[i] : null;
           if (cacheKeys && result) {
             const cacheKey = cacheKeys[i];

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -730,19 +730,22 @@ shaka.util.StreamUtils = class {
           variant.video.fullMimeTypes.size < 1) {
           return undefined;
         }
-        // if pure function for calculate the fulltype
-        const videoDrmInfos = variant.video ? variant.video.drmInfos : [];
-        const audioDrmInfos = variant.audio ? variant.audio.drmInfos : [];
+        const audio = variant.audio;
+        const video = variant.video;
+
+        // if pure function for calculating the fulltype
+        const videoDrmInfos = video ? video.drmInfos : [];
+        const audioDrmInfos = audio ? audio.drmInfos : [];
         const allDrmInfos = videoDrmInfos.concat(audioDrmInfos);
 
         const keySystems= new Set(allDrmInfos.map((info) => info.keySystem));
-        //  # of cachekey should match the result of getDecodingConfigs_
         const cacheKeys = [];
         for (const keySystem of keySystems) {
-          for (const fullVideoMimeType of variant.video.fullMimeTypes) {
-            for (const fullAudioMimeType of variant.audio.fullMimeTypes) {
+          for (const videoFullMimeType of video.fullMimeTypes) {
+            for (const audioFullMimeType of audio.fullMimeTypes) {
               cacheKeys.push(
-                  `${fullVideoMimeType}#${fullAudioMimeType}#${keySystem}`);
+                  `${videoFullMimeType}#${audioFullMimeType}#${keySystem}`);
+              // video.hdr + audio.spatialAudio + audio.channelsCount
             }
           }
         }
@@ -751,19 +754,18 @@ shaka.util.StreamUtils = class {
 
       // sort variants, so that high bandwidth checked first.
       // High bandwidth tends to be less likely to be supported, or smooth
-      const sortedVariants = variants.sort((a, b) => b.bandwidth-a.bandwidth);
+      const sortedVariants = variants.sort((a, b) => b.bandwidth - a.bandwidth);
       const keyToCheck = 'supported';
 
       for (const variant of sortedVariants) {
         const cacheKeys = buildCacheKey(variant);
-        // If not meet criteria, will continue query.
         const useCache = cacheKeys && cacheKeys.length &&
             cacheKeys.reduce((hasCache, key) =>
               (hasCache && decodeInfoCache[key] &&
-                // needs to meet criteria.
+                // If not meet criteria, won't use cache.
                 decodeInfoCache[key][keyToCheck])
             , true);
-        shaka.log.info('MediaCapabilities.decodingInfo() buildCacheKey.',
+        shaka.log.info('getDecodingInfosForVariants used cache.',
             useCache, cacheKeys, variant);
         if (useCache) {
           variant.decodingInfos =

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -348,11 +348,13 @@ shaka.util.StreamUtils = class {
    * @param {shaka.media.DrmEngine} drmEngine
    * @param {shaka.extern.Manifest} manifest
    * @param {!Array<string>=} preferredKeySystems
+   * @param {boolean} enableMediaCapabilitiesCache
    */
-  static async filterManifest(drmEngine, manifest, preferredKeySystems = []) {
+  static async filterManifest(drmEngine, manifest,
+      preferredKeySystems = [], enableMediaCapabilitiesCache = false) {
     await shaka.util.StreamUtils.filterManifestByMediaCapabilities(
         drmEngine, manifest, manifest.offlineSessionIds.length > 0,
-        preferredKeySystems);
+        preferredKeySystems, enableMediaCapabilitiesCache);
     shaka.util.StreamUtils.filterTextStreams_(manifest);
     await shaka.util.StreamUtils.filterImageStreams_(manifest);
   }
@@ -366,15 +368,17 @@ shaka.util.StreamUtils = class {
    * @param {shaka.extern.Manifest} manifest
    * @param {boolean} usePersistentLicenses
    * @param {!Array<string>} preferredKeySystems
+   * @param {boolean} enableMediaCapabilitiesCache
    */
   static async filterManifestByMediaCapabilities(
-      drmEngine, manifest, usePersistentLicenses, preferredKeySystems) {
+      drmEngine, manifest, usePersistentLicenses,
+      preferredKeySystems, enableMediaCapabilitiesCache = false) {
     goog.asserts.assert(navigator.mediaCapabilities,
         'MediaCapabilities should be valid.');
 
     await shaka.util.StreamUtils.getDecodingInfosForVariants(
         manifest.variants, usePersistentLicenses, /* srcEquals= */ false,
-        preferredKeySystems);
+        preferredKeySystems, enableMediaCapabilitiesCache);
 
     let keySystem = null;
     if (drmEngine) {
@@ -666,10 +670,11 @@ shaka.util.StreamUtils = class {
    * @param {boolean} usePersistentLicenses
    * @param {boolean} srcEquals
    * @param {!Array<string>} preferredKeySystems
+   * @param {boolean} enableMediaCapabilitiesCache
    * @exportDoc
    */
   static async getDecodingInfosForVariants(variants, usePersistentLicenses,
-      srcEquals, preferredKeySystems) {
+      srcEquals, preferredKeySystems, enableMediaCapabilitiesCache = false) {
     const gotDecodingInfo = variants.some((variant) =>
       variant.decodingInfos.length);
     if (gotDecodingInfo) {
@@ -709,6 +714,97 @@ shaka.util.StreamUtils = class {
         return;
       }
     } // for (const preferredKeySystem of preferredKeySystems)
+
+    /**
+     * For LR devices, polyfill is used, which calls isTypeSupported and
+     * requestMediaKeySystemAccess instead.
+     * Group similar variants, and share results.
+     * Helpful for video with a lot of variants on LR.
+     */
+    const enableCahe = enableMediaCapabilitiesCache &&
+      !srcEquals && !shaka.util.Platform.isChromecast();
+    if (enableCahe) {
+      const decodeInfoCache = {};
+      const buildCacheKey = (variant) => {
+        if (variant.audio.fullMimeTypes.size < 1 ||
+          variant.video.fullMimeTypes.size < 1) {
+          return undefined;
+        }
+        // if pure function for calculate the fulltype
+        const videoDrmInfos = variant.video ? variant.video.drmInfos : [];
+        const audioDrmInfos = variant.audio ? variant.audio.drmInfos : [];
+        const allDrmInfos = videoDrmInfos.concat(audioDrmInfos);
+
+        const keySystems= new Set(allDrmInfos.map((info) => info.keySystem));
+        //  # of cachekey should match the result of getDecodingConfigs_
+        const cacheKeys = [];
+        for (const keySystem of keySystems) {
+          for (const fullVideoMimeType of variant.video.fullMimeTypes) {
+            for (const fullAudioMimeType of variant.audio.fullMimeTypes) {
+              cacheKeys.push(
+                  `${fullVideoMimeType}#${fullAudioMimeType}#${keySystem}`);
+            }
+          }
+        }
+        return cacheKeys;
+      };
+
+      // sort variants, so that high bandwidth checked first.
+      // High bandwidth tends to be less likely to be supported, or smooth
+      const sortedVariants = variants.sort((a, b) => b.bandwidth-a.bandwidth);
+      const keyToCheck = 'supported';
+
+      for (const variant of sortedVariants) {
+        const cacheKeys = buildCacheKey(variant);
+        // If not meet criteria, will continue query.
+        const useCache = cacheKeys && cacheKeys.length &&
+            cacheKeys.reduce((hasCache, key) =>
+              (hasCache && decodeInfoCache[key] &&
+                // needs to meet criteria.
+                decodeInfoCache[key][keyToCheck])
+            , true);
+        shaka.log.info('MediaCapabilities.decodingInfo() buildCacheKey.',
+            useCache, cacheKeys, variant);
+        if (useCache) {
+          variant.decodingInfos =
+            cacheKeys.map((key) => decodeInfoCache[key]);
+          continue;
+        }
+
+        /** @type {!Array.<!Array.<!MediaDecodingConfiguration>>} */
+        const decodingConfigs = shaka.util.StreamUtils.getDecodingConfigs_(
+            variant, usePersistentLicenses, srcEquals)
+            .filter((configs) => {
+              // All configs in a batch will have the same keySystem.
+              const config = configs[0];
+              const keySystem = config.keySystemConfiguration &&
+                config.keySystemConfiguration.keySystem;
+              // Avoid checking preferred systems twice.
+              return !keySystem || !preferredKeySystems.includes(keySystem);
+            });
+
+        // The reason we are performing this await in a loop rather than
+        // batching into a `promise.all` is performance related.
+        // https://github.com/shaka-project/shaka-player/pull/4708#discussion_r1022581178
+        for (let i=0; i<decodingConfigs.length; i++) {
+          const configs = decodingConfigs[i];
+          // eslint-disable-next-line no-await-in-loop
+          await shaka.util.StreamUtils.getDecodingInfosForVariant_(
+              variant, configs);
+
+          // getDecodingInfosForVariant_ could fail.
+          const result = variant.decodingInfos.length?
+            variant.decodingInfos[i] : null;
+          if (cacheKeys && result) {
+            const cacheKey = cacheKeys[i];
+
+            decodeInfoCache[cacheKey] = result;
+            delete decodeInfoCache[cacheKey]['configuration'];
+          }
+        }
+      }
+      return;
+    }
 
     for (const variant of variants) {
       /** @type {!Array.<!Array.<!MediaDecodingConfiguration>>} */


### PR DESCRIPTION
Related to https://github.com/shaka-project/shaka-player/issues/6219

For drm contents with many variants, calling mediaCapabilities on all variants can take quiet some times. This PR is trying to provide a way to check availability of variants in a performance way, but with potential false positive. It tries to group/cache variants by some enum, contentType and keysystem, and share results to reduce call to calculating input for mediaCapabilities, building cachekey, and calling mediaCapabilities itself. 
