### PR TITLE
test: Upgrade Karma to fork with additional fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "jimp": "^0.16.1",
         "js-yaml": "^4.1.0",
         "jsdoc": "github:joeyparrish/jsdoc#2ca85bb6",
-        "karma": "^6.4.3",
+        "karma": "github:joeyparrish/karma#shaka-fixes",
         "karma-coverage": "^2.2.0",
         "karma-jasmine": "^4.0.1",
         "karma-jasmine-ajax": "^0.1.13",
@@ -5537,9 +5537,9 @@
     },
     "node_modules/karma": {
       "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.3.tgz",
-      "integrity": "sha512-LuucC/RE92tJ8mlCwqEoRWXP38UMAqpnq98vktmS9SznSoUPPUJQbc91dHcxcunROvfQjdORVA/YFviH+Xci9Q==",
+      "resolved": "git+ssh://git@github.com/joeyparrish/karma.git#d98765e43fe801b35452fdb6cab3d1d0bac519a2",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -12947,10 +12947,9 @@
       }
     },
     "karma": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.3.tgz",
-      "integrity": "sha512-LuucC/RE92tJ8mlCwqEoRWXP38UMAqpnq98vktmS9SznSoUPPUJQbc91dHcxcunROvfQjdORVA/YFviH+Xci9Q==",
+      "version": "git+ssh://git@github.com/joeyparrish/karma.git#d98765e43fe801b35452fdb6cab3d1d0bac519a2",
       "dev": true,
+      "from": "karma@github:joeyparrish/karma#shaka-fixes",
       "requires": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jimp": "^0.16.1",
     "js-yaml": "^4.1.0",
     "jsdoc": "github:joeyparrish/jsdoc#2ca85bb6",
-    "karma": "^6.4.3",
+    "karma": "github:joeyparrish/karma#shaka-fixes",
     "karma-coverage": "^2.2.0",
     "karma-jasmine": "^4.0.1",
     "karma-jasmine-ajax": "^0.1.13",


### PR DESCRIPTION
The only fix right now is a minor one:

  https://github.com/joeyparrish/karma/commit/d98765e43fe801b35452fdb6cab3d1d0bac519a2

With the message:

> fix: Fix message event exception
>
> Message events may not have an origin, and they may not have an
> originalEvent field.  This happens in particular when loading Karma
> and the Chromecast SDK on a Chromecast.  An event arrives from the
> platform with neither of these properties.
>
> This fixes the error by checking for originalEvent before accessing
> a property of it.

To see a diff of all current fixes at any time, see:

  https://github.com/karma-runner/karma/compare/master...joeyparrish:karma:shaka-fixes
