### PR TITLE
test: Flatten test environment for Chromecast

### DIFF
--- a/build/test.py
+++ b/build/test.py
@@ -167,17 +167,6 @@ class Launcher:
              'browser to connect to it.',
         action='store_true')
     running_commands.add_argument(
-        '--single-run',
-        help='Run the test when browsers capture and exit.',
-        dest='single_run',
-        action='store_true',
-        default=True)
-    running_commands.add_argument(
-        '--no-single-run',
-        help='Do not shut down Karma when tests are complete.',
-        dest='single_run',
-        action='store_false')
-    running_commands.add_argument(
         '--random',
         help='Run the tests in a random order. This can be used with --seed '
              'to control the random order. If used without --seed, a seed '
@@ -412,7 +401,6 @@ class Launcher:
       'reporters',
       'report_slower_than',
       'seed',
-      'single_run',
       'spec_hide_passed',
       'test_custom_asset',
       'test_custom_license_server',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -221,6 +221,7 @@ module.exports = (config) => {
       'node_modules/eme-encryption-scheme-polyfill/dist/eme-encryption-scheme-polyfill.js',
 
       // load closure base, the deps tree, and the uncompiled library
+      'test/test/closure-boot.js',
       'node_modules/google-closure-library/closure/goog/base.js',
       'dist/deps.js',
       'shaka-player.uncompiled.js',
@@ -309,6 +310,12 @@ module.exports = (config) => {
       // Hide the list of connected clients in Karma, to make screenshots more
       // stable.
       clientDisplayNone: true,
+      // Run directly in the top frame, instead of in an iframe.  This makes it
+      // easier to work around cross-origin frame issues or frame permissions
+      // issues when testing platforms like Chromecast, where there is already
+      // an iframe involved in the test framework.
+      useIframe: false,  // No iframe
+      runInParent: true,  // No new window
       // Only capture the client's logs if the settings want logging.
       captureConsole: !!settings.logging && settings.logging != 'none',
       // |args| must be an array; pass a key-value map as the sole client
@@ -369,8 +376,9 @@ module.exports = (config) => {
     autoWatch: settings.auto_watch,
 
     // Do a single run of the tests on captured browsers and then quit.
-    // Defaults to true.
-    singleRun: settings.single_run,
+    // This is required when running tests without Karma's iframe.
+    // (See useIframe above.)
+    singleRun: true,
 
     // Set the time limit (ms) that should be used to identify slow tests.
     reportSlowerThan: settings.report_slower_than,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5537,7 +5537,7 @@
     },
     "node_modules/karma": {
       "version": "6.4.3",
-      "resolved": "git+ssh://git@github.com/joeyparrish/karma.git#9875e9898b999684c2b2767c34d766ab2220f351",
+      "resolved": "git+ssh://git@github.com/joeyparrish/karma.git#f2132cc2cf72f9408fbce2a20b5a21999f1e9416",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12947,7 +12947,7 @@
       }
     },
     "karma": {
-      "version": "git+ssh://git@github.com/joeyparrish/karma.git#9875e9898b999684c2b2767c34d766ab2220f351",
+      "version": "git+ssh://git@github.com/joeyparrish/karma.git#f2132cc2cf72f9408fbce2a20b5a21999f1e9416",
       "dev": true,
       "from": "karma@github:joeyparrish/karma#shaka-fixes",
       "requires": {

--- a/test/test/closure-boot.js
+++ b/test/test/closure-boot.js
@@ -1,0 +1,15 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// These definitions will override the defaults when the Closure base library
+// is loaded.  This is necessary to get Closure to load dependencies by
+// creating DOM elements in JavaScript, rather than the legacy default of using
+// document.write().  This is more compatible with a wider variety of setups,
+// and allows us to enable Karma options {useIframe: false, runInParent: true}
+// to test in a single frame.
+window['CLOSURE_UNCOMPILED_DEFINES'] = {
+  'goog.ENABLE_CHROME_APP_SAFE_SCRIPT_LOADING': true,
+};

--- a/test/test/util/layout_tests.js
+++ b/test/test/util/layout_tests.js
@@ -62,10 +62,10 @@ shaka.test.LayoutTests = class {
     // We need our own ID for Karma to look up the WebDriver connection.
     // For manually-connected browsers, this ID may not exist.  In those cases,
     // this method is expected to return false.
-    const parentUrlParams = window.parent.location.search;
+    const urlParams = location.search;
 
     const buffer = await shaka.test.Util.fetch(
-        '/screenshot/isSupported' + parentUrlParams);
+        '/screenshot/isSupported' + urlParams);
     const json = shaka.util.StringUtils.fromUTF8(buffer);
     const ok = /** @type {boolean} */(JSON.parse(json));
     return ok;
@@ -96,18 +96,12 @@ shaka.test.LayoutTests = class {
     // We need our own ID for Karma to look up the WebDriver connection.
     // By this point, we should have passed supportsScreenshots(), so the ID
     // should definitely be there.
-    const parentUrlParams = window.parent.location.search;
-    goog.asserts.assert(parentUrlParams.includes('id='), 'No ID in URL!');
+    const urlParams = location.search;
+    goog.asserts.assert(urlParams.includes('id='), 'No ID in URL!');
 
-    // Tests run in an iframe.  So we also need the coordinates of that iframe
-    // within the page, so that the screenshot can be consistently cropped to
-    // the element we care about.
-    const iframe = /** @type {HTMLIFrameElement} */(
-      window.parent.document.getElementById('context'));
-    const iframeRect = iframe.getBoundingClientRect();
     const elementRect = element.getBoundingClientRect();
-    const x = iframeRect.left + elementRect.left;
-    const y = iframeRect.top + elementRect.top;
+    const x = elementRect.left;
+    const y = elementRect.top;
     const width = elementRect.width;
     const height = elementRect.height;
 
@@ -116,8 +110,8 @@ shaka.test.LayoutTests = class {
     // so it can convert coordinates before cropping.  This value, as opposed to
     // document.body.getBoundingClientRect(), seems to most accurately reflect
     // the size of the screenshot area.
-    const bodyWidth = window.parent.innerWidth;
-    const bodyHeight = window.parent.innerHeight;
+    const bodyWidth = window.innerWidth;
+    const bodyHeight = window.innerHeight;
 
     // In addition to the id param from the top-level window, pass these
     // parameters to the screenshot endpoint in Karma.
@@ -129,7 +123,7 @@ shaka.test.LayoutTests = class {
     }
 
     const buffer = await shaka.test.Util.fetch(
-        '/screenshot/diff' + parentUrlParams + paramsString);
+        '/screenshot/diff' + urlParams + paramsString);
     const json = shaka.util.StringUtils.fromUTF8(buffer);
     const similarity = /** @type {number} */(JSON.parse(json));
 
@@ -154,8 +148,7 @@ shaka.test.LayoutTests = class {
     // cropping issues.
     element.style.backgroundColor = 'green';
 
-    // Make sure the element is in the top-left corner of the iframe that
-    // contains the tests.
+    // Make sure the element is in the top-left corner of the window.
     element.style.top = '0';
     element.style.left = '0';
     element.style.position = 'fixed';


### PR DESCRIPTION
Chromecast WebDriver Server and Karma both used iframes, which caused complications when testing on Chromecast.  The test environment couldn't directly access `cast.__platform__` APIs, and more recently stopped being able to access EME due to presumed mistakes in the platform's implementation of iframe permission policies.

This resolves the issue by removing iframes at both levels.

 - Flatten Karma's environment using "useIframe: false" and "runInParent: true"
 - Remove test flag --single-run; not supported in combination with Karma's "useIframe: false" option
 - Add a test boot file to force closure to use dynamic script tags instead of document.write; required with Karma's "useIframe: false" option
 - Adjust screenshot tests not to assume an iframe host
 - Fix compatibilty between Tizen and Karma's useIframe:false
   - https://github.com/joeyparrish/karma/commit/32e87357a0ca4bf5d3de6d78d80dae2d065fd407
   - https://github.com/joeyparrish/karma/commit/f2132cc2cf72f9408fbce2a20b5a21999f1e9416