### PR TITLE
fix: Fix multi-codec filtering on DASH live

### DIFF
--- a/lib/media/manifest_filterer.js
+++ b/lib/media/manifest_filterer.js
@@ -61,6 +61,11 @@ shaka.media.ManifestFilterer = class {
     goog.asserts.assert(manifest, 'Manifest should exist!');
     await shaka.util.StreamUtils.filterManifest(this.drmEngine_, manifest,
         this.config_.drm.preferredKeySystems);
+    shaka.util.StreamUtils.chooseCodecsAndFilterManifest(
+        manifest,
+        this.config_.preferredVideoCodecs,
+        this.config_.preferredAudioCodecs,
+        this.config_.preferredDecodingAttributes);
     this.checkPlayableVariants_(manifest);
   }
 

--- a/lib/media/manifest_filterer.js
+++ b/lib/media/manifest_filterer.js
@@ -41,23 +41,13 @@ shaka.media.ManifestFilterer = class {
   }
 
   /**
-   * Filters a manifest, removing unplayable streams/variants.
+   * Filters a manifest, removing unplayable streams/variants and  choosing
+   * the codecs.
    *
    * @param {?shaka.extern.Manifest} manifest
    * @return {!Promise.<boolean>} tracksChanged
    */
   async filterManifest(manifest) {
-    await this.filterManifestWithStreamUtils_(manifest);
-    return this.filterManifestWithRestrictions(manifest);
-  }
-
-  /**
-   * Filters a manifest, removing unplayable streams/variants.
-   *
-   * @param {?shaka.extern.Manifest} manifest
-   * @private
-   */
-  async filterManifestWithStreamUtils_(manifest) {
     goog.asserts.assert(manifest, 'Manifest should exist!');
     await shaka.util.StreamUtils.filterManifest(this.drmEngine_, manifest,
         this.config_.drm.preferredKeySystems);
@@ -67,6 +57,7 @@ shaka.media.ManifestFilterer = class {
         this.config_.preferredAudioCodecs,
         this.config_.preferredDecodingAttributes);
     this.checkPlayableVariants_(manifest);
+    return this.filterManifestWithRestrictions(manifest);
   }
 
 

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -553,7 +553,9 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
 
     const tracksChangedInitial = this.manifestFilterer_.applyRestrictions(
         this.manifest_);
-    if (tracksChangedInitial) {
+    const tracksChangedBefore = await this.manifestFilterer_.filterManifest(
+        this.manifest_);
+    if (tracksChangedInitial || tracksChangedBefore) {
       const event = this.makeEvent_(
           shaka.util.FakeEvent.EventName.TracksChanged);
       await Promise.resolve();
@@ -568,7 +570,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
 
     // Now that we have drm information, filter the manifest (again) so that
     // we can ensure we only use variants with the selected key system.
-    // const tracksChanged =
     const tracksChangedAfter = await this.manifestFilterer_.filterManifest(
         this.manifest_);
     if (tracksChangedAfter) {
@@ -630,14 +631,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
               this.config_.preferredVideoLabel,
               this.config_.mediaSource.codecSwitchingStrategy,
               this.config_.manifest.dash.enableAudioGroups);
-
-      // If the content is multi-codec and the browser can play more than one of
-      // them, choose codecs now before we initialize streaming.
-      shaka.util.StreamUtils.chooseCodecsAndFilterManifest(
-          this.manifest_,
-          this.config_.preferredVideoCodecs,
-          this.config_.preferredAudioCodecs,
-          this.config_.preferredDecodingAttributes);
     }
 
     // Make the ABR manager.


### PR DESCRIPTION
Regression of Preload API

In HLS the definition of variants is only done once and it is the master playlist.
In DASH, the definition of variants is done in each manifest update.
If we make the codec choice only at the beginning, in HLS it works, but in DASH in the updates we lose this choice.