### PR TITLE
feat: Optionally force HTTP content URIs

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -451,6 +451,7 @@ shakaDemo.Config = class {
             /* canBeDecimal= */ true)
         .addBoolInput_('Low Latency Mode', 'streaming.lowLatencyMode')
         .addBoolInput_('Auto Low Latency Mode', 'streaming.autoLowLatencyMode')
+        .addBoolInput_('Force HTTP', 'streaming.forceHTTP')
         .addBoolInput_('Force HTTPS', 'streaming.forceHTTPS')
         .addBoolInput_('Prefer native HLS playback when available',
             'streaming.preferNativeHls')

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1228,6 +1228,7 @@ shaka.extern.ManifestConfiguration;
  *   inaccurateManifestTolerance: number,
  *   lowLatencyMode: boolean,
  *   autoLowLatencyMode: boolean,
+ *   forceHTTP: boolean,
  *   forceHTTPS: boolean,
  *   preferNativeHls: boolean,
  *   updateIntervalSeconds: number,
@@ -1352,6 +1353,8 @@ shaka.extern.ManifestConfiguration;
  *   lowLatencyMode, but if it has been configured to activate the
  *   lowLatencyMode if a stream of this type is detected, we automatically
  *   activate the lowLatencyMode. Defaults to false.
+ * @property {boolean} forceHTTP
+ *   If true, if the protocol is HTTPs change it to HTTP.
  * @property {boolean} forceHTTPS
  *   If true, if the protocol is HTTP change it to HTTPs.
  * @property {boolean} preferNativeHls

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1355,8 +1355,10 @@ shaka.extern.ManifestConfiguration;
  *   activate the lowLatencyMode. Defaults to false.
  * @property {boolean} forceHTTP
  *   If true, if the protocol is HTTPs change it to HTTP.
+ *   If both forceHTTP and forceHTTPS are set, forceHTTPS wins.
  * @property {boolean} forceHTTPS
  *   If true, if the protocol is HTTP change it to HTTPs.
+ *   If both forceHTTP and forceHTTPS are set, forceHTTPS wins.
  * @property {boolean} preferNativeHls
  *   If true, prefer native HLS playback when possible, regardless of platform.
  * @property {number} updateIntervalSeconds

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -97,7 +97,18 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
     this.onResponse_ = onResponse || null;
 
     /** @private {boolean} */
+    this.forceHTTP_ = false;
+
+    /** @private {boolean} */
     this.forceHTTPS_ = false;
+  }
+
+  /**
+   * @param {boolean} forceHTTP
+   * @export
+   */
+  setForceHTTP(forceHTTP) {
+    this.forceHTTP_ = forceHTTP;
   }
 
   /**
@@ -450,6 +461,9 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
    */
   send_(type, request, context, backoff, index, lastError,
       numBytesRemainingObj) {
+    if (this.forceHTTP_) {
+      request.uris[index] = request.uris[index].replace('https://', 'http://');
+    }
     if (this.forceHTTPS_) {
       request.uris[index] = request.uris[index].replace('http://', 'https://');
     }

--- a/lib/player.js
+++ b/lib/player.js
@@ -758,6 +758,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.cmsdManager_ = this.createCmsd_();
 
     this.networkingEngine_ = this.createNetworkingEngine();
+    this.networkingEngine_.setForceHTTP(this.config_.streaming.forceHTTP);
     this.networkingEngine_.setForceHTTPS(this.config_.streaming.forceHTTPS);
 
     /** @private {shaka.extern.IAdManager} */
@@ -3573,6 +3574,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
     }
     if (this.networkingEngine_) {
+      this.networkingEngine_.setForceHTTP(this.config_.streaming.forceHTTP);
       this.networkingEngine_.setForceHTTPS(this.config_.streaming.forceHTTPS);
     }
 

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -222,6 +222,7 @@ shaka.util.PlayerConfiguration = class {
       inaccurateManifestTolerance: 2,
       lowLatencyMode: false,
       autoLowLatencyMode: false,
+      forceHTTP: false,
       forceHTTPS: false,
       preferNativeHls: false,
       updateIntervalSeconds: 1,

--- a/test/test/util/fake_networking_engine.js
+++ b/test/test/util/fake_networking_engine.js
@@ -47,6 +47,9 @@ shaka.test.FakeNetworkingEngine = class {
     this.responseFilter_ = null;
 
     /** @type {!jasmine.Spy} */
+    this.setForceHTTP = jasmine.createSpy('setForceHTTP').and.stub();
+
+    /** @type {!jasmine.Spy} */
     this.setForceHTTPS = jasmine.createSpy('setForceHTTPS').and.stub();
 
     /** @private {number} */


### PR DESCRIPTION
This may be necessary on older devices where not all certificates are present.