### PR TITLE
test: Bypass log settings for support dump

### DIFF
--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -429,7 +429,8 @@ function configureJasmineEnvironment() {
 async function logSupport() {
   try {
     const support = await shaka.Player.probeSupport();
-    console.log('Platform support:', JSON.stringify(support, null, 2));
+    // Bypass Karma's log settings and dump this to the console.
+    window.dump('Platform support:' + JSON.stringify(support, null, 2));
     // eslint-disable-next-line no-restricted-syntax
   } catch (error) {
     console.error('Support check failed at boot!', error);


### PR DESCRIPTION
Karma creates a dump() function on the context window that we can use to log something to the console without respect for the normal captureConsole setting.  Use this for the output of probeSupport(), so we always have it in CI logs.