### PR TITLE
feat: add config to clear decodingInfo cache on unload

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -519,7 +519,9 @@ shakaDemo.Config = class {
             'streaming.vodDynamicPlaybackRateBufferRatio',
             /* canBeDecimal= */ true)
         .addBoolInput_('Infinite Live Stream Duration',
-            'streaming.infiniteLiveStreamDuration');
+            'streaming.infiniteLiveStreamDuration')
+        .addBoolInput_('Clear decodingInfo cache',
+            'streaming.clearDecodingCache');
     if (!shakaDemoMain.getNativeControlsEnabled()) {
       this.addBoolInput_('Always Stream Text', 'streaming.alwaysStreamText');
     } else {

--- a/demo/config.js
+++ b/demo/config.js
@@ -520,7 +520,7 @@ shakaDemo.Config = class {
             /* canBeDecimal= */ true)
         .addBoolInput_('Infinite Live Stream Duration',
             'streaming.infiniteLiveStreamDuration')
-        .addBoolInput_('Clear decodingInfo cache',
+        .addBoolInput_('Clear decodingInfo cache on unload',
             'streaming.clearDecodingCache');
     if (!shakaDemoMain.getNativeControlsEnabled()) {
       this.addBoolInput_('Always Stream Text', 'streaming.alwaysStreamText');

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1270,7 +1270,8 @@ shaka.extern.ManifestConfiguration;
  *   vodDynamicPlaybackRateLowBufferRate: number,
  *   vodDynamicPlaybackRateBufferRatio: number,
  *   infiniteLiveStreamDuration: boolean,
- *   preloadNextUrlWindow: number
+ *   preloadNextUrlWindow: number,
+ *   clearDecodingCache: boolean
  * }}
  *
  * @description
@@ -1470,6 +1471,12 @@ shaka.extern.ManifestConfiguration;
  *   in DASH. Measured in seconds. If the value is 0, the next URL will not
  *   be preloaded at all.
  *   Defaults to <code> 30 </code>.
+ * @property {boolean} clearDecodingCache
+ *   Clears decodingInfo and MediaKeySystemAccess cache during player unload
+ *   as these objects may become corrupt and cause issues during subsequent
+ *   playbacks on some platforms.
+ *   Defaults to <code>true</code> on PlayStation devices and to
+ *   <code>false</code> on other devices.
  * @exportDoc
  */
 shaka.extern.StreamingConfiguration;

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -2719,6 +2719,72 @@ shaka.media.DrmEngine = class {
     this.newInitData('cenc', combinedData);
     return this.allSessionsLoaded_;
   }
+
+  /**
+   * A method for generating a key for the MediaKeySystemAccessRequests cache.
+   *
+   * @param {string} videoCodec
+   * @param {string} audioCodec
+   * @param {string} keySystem
+   * @return {string}
+   * @private
+   */
+  static generateKeySystemCacheKey_(videoCodec, audioCodec, keySystem) {
+    return `${videoCodec}#${audioCodec}#${keySystem}`;
+  }
+
+  /**
+   * A method for generating a key for the MediaKeySystemAccessRequests cache.
+   *
+   * @param {string} videoCodec
+   * @param {string} audioCodec
+   * @param {string} keySystem
+   * @return {boolean}
+   */
+  static hasMediaKeySystemAccess(videoCodec, audioCodec, keySystem) {
+    const DrmEngine = shaka.media.DrmEngine;
+    const key = DrmEngine.generateKeySystemCacheKey_(
+        videoCodec, audioCodec, keySystem);
+    return DrmEngine.memoizedMediaKeySystemAccessRequests_.has(key);
+  }
+
+  /**
+   * A method for generating a key for the MediaKeySystemAccessRequests cache.
+   *
+   * @param {string} videoCodec
+   * @param {string} audioCodec
+   * @param {string} keySystem
+   * @return {?MediaKeySystemAccess}
+   */
+  static getMediaKeySystemAccess(videoCodec, audioCodec, keySystem) {
+    const DrmEngine = shaka.media.DrmEngine;
+    const key = DrmEngine.generateKeySystemCacheKey_(
+        videoCodec, audioCodec, keySystem);
+    return DrmEngine.memoizedMediaKeySystemAccessRequests_.get(key) || null;
+  }
+
+  /**
+   * A method for generating a key for the MediaKeySystemAccessRequests cache.
+   *
+   * @param {string} videoCodec
+   * @param {string} audioCodec
+   * @param {string} keySystem
+   * @param {!MediaKeySystemAccess} mksa
+   */
+  static setMediaKeySystemAccess(videoCodec, audioCodec, keySystem, mksa) {
+    const DrmEngine = shaka.media.DrmEngine;
+    const key = DrmEngine.generateKeySystemCacheKey_(
+        videoCodec, audioCodec, keySystem);
+    return DrmEngine.memoizedMediaKeySystemAccessRequests_.set(key, mksa);
+  }
+
+  /**
+   * Clears underlying cache.
+   */
+  static clearMediaKeySystemAccessMap() {
+    const DrmEngine = shaka.media.DrmEngine;
+    DrmEngine.memoizedMediaKeySystemAccessRequests_.clear();
+  }
 };
 
 
@@ -2812,3 +2878,13 @@ shaka.media.DrmEngine.KEY_STATUS_BATCH_TIME = 0.5;
  */
 shaka.media.DrmEngine.DUMMY_KEY_ID = new shaka.util.Lazy(
     () => shaka.util.BufferUtils.toArrayBuffer(new Uint8Array([0])));
+
+
+/**
+ * A cache that stores the MediaKeySystemAccess result of calling
+ * `navigator.requestMediaKeySystemAccess` by a key combination of
+ * video/audio codec and key system string.
+ *
+ * @private {!Map<string, !MediaKeySystemAccess>}
+ */
+shaka.media.DrmEngine.memoizedMediaKeySystemAccessRequests_ = new Map();

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -2734,7 +2734,8 @@ shaka.media.DrmEngine = class {
   }
 
   /**
-   * A method for generating a key for the MediaKeySystemAccessRequests cache.
+   * Check does MediaKeySystemAccess cache contains something for following
+   * attributes.
    *
    * @param {string} videoCodec
    * @param {string} audioCodec
@@ -2749,7 +2750,7 @@ shaka.media.DrmEngine = class {
   }
 
   /**
-   * A method for generating a key for the MediaKeySystemAccessRequests cache.
+   * Get MediaKeySystemAccess object for following attributes.
    *
    * @param {string} videoCodec
    * @param {string} audioCodec
@@ -2764,7 +2765,7 @@ shaka.media.DrmEngine = class {
   }
 
   /**
-   * A method for generating a key for the MediaKeySystemAccessRequests cache.
+   * Store MediaKeySystemAccess object associated with specified attributes.
    *
    * @param {string} videoCodec
    * @param {string} audioCodec

--- a/lib/player.js
+++ b/lib/player.js
@@ -1450,7 +1450,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         }
       }
 
-      // On PlayStation, cached MediaKeySystemAccess objects may corrupt
+      // On some devices, cached MediaKeySystemAccess objects may corrupt
       // after several playbacks, and they are not able anymore to properly
       // create MediaKeys objects. To prevent it, clear the cache after
       // each playback.

--- a/lib/player.js
+++ b/lib/player.js
@@ -1450,6 +1450,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         }
       }
 
+      // On PlayStation, cached MediaKeySystemAccess objects may corrupt
+      // after several playbacks, and they are not able anymore to properly
+      // create MediaKeys objects. To prevent it, clear the cache after
+      // each playback.
+      if (shaka.util.Platform.isPS4() || shaka.util.Platform.isPS5()) {
+        shaka.util.StreamUtils.clearDecodingConfigCache();
+        shaka.media.DrmEngine.clearMediaKeySystemAccessMap();
+      }
+
       this.manifest_ = null;
       this.stats_ = new shaka.util.Stats(); // Replace with a clean object.
       this.lastTextFactory_ = null;

--- a/lib/player.js
+++ b/lib/player.js
@@ -1454,7 +1454,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // after several playbacks, and they are not able anymore to properly
       // create MediaKeys objects. To prevent it, clear the cache after
       // each playback.
-      if (shaka.util.Platform.isPS4() || shaka.util.Platform.isPS5()) {
+      if (this.config_.streaming.clearDecodingCache) {
         shaka.util.StreamUtils.clearDecodingConfigCache();
         shaka.media.DrmEngine.clearMediaKeySystemAccessMap();
       }

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -8,6 +8,7 @@ goog.provide('shaka.polyfill.MediaCapabilities');
 
 goog.require('shaka.log');
 goog.require('shaka.media.Capabilities');
+goog.require('shaka.media.DrmEngine');
 goog.require('shaka.polyfill');
 goog.require('shaka.util.Platform');
 
@@ -274,25 +275,22 @@ shaka.polyfill.MediaCapabilities = class {
       mediaKeySystemConfig.videoCapabilities = videoCapabilities;
     }
 
-    const cacheKey = shaka.polyfill.MediaCapabilities
-        .generateKeySystemCacheKey_(
-            videoConfig ? videoConfig.contentType : '',
-            audioConfig ? audioConfig.contentType : '',
-            mcapKeySystemConfig.keySystem);
+    const videoCodec = videoConfig ? videoConfig.contentType : '';
+    const audioCodec = audioConfig ? audioConfig.contentType : '';
+    const keySystem = mcapKeySystemConfig.keySystem;
 
     /** @type {MediaKeySystemAccess} */
     let keySystemAccess = null;
     try {
-      if (cacheKey in shaka.polyfill.MediaCapabilities
-          .memoizedMediaKeySystemAccessRequests_) {
-        keySystemAccess = shaka.polyfill.MediaCapabilities
-            .memoizedMediaKeySystemAccessRequests_[cacheKey];
+      if (shaka.media.DrmEngine.hasMediaKeySystemAccess(
+          videoCodec, audioCodec, keySystem)) {
+        keySystemAccess = shaka.media.DrmEngine.getMediaKeySystemAccess(
+            videoCodec, audioCodec, keySystem);
       } else {
         keySystemAccess = await navigator.requestMediaKeySystemAccess(
             mcapKeySystemConfig.keySystem, [mediaKeySystemConfig]);
-        shaka.polyfill.MediaCapabilities
-            .memoizedMediaKeySystemAccessRequests_[cacheKey] =
-              keySystemAccess;
+        shaka.media.DrmEngine.setMediaKeySystemAccess(
+            videoCodec, audioCodec, keySystem, keySystemAccess);
       }
     } catch (e) {
       shaka.log.info('navigator.requestMediaKeySystemAccess failed.');
@@ -344,19 +342,6 @@ shaka.polyfill.MediaCapabilities = class {
     }
     return result;
   }
-
-  /**
-   * A method for generating a key for the MediaKeySystemAccessRequests cache.
-   *
-   * @param {!string} videoCodec
-   * @param {!string} audioCodec
-   * @param {!string} keySystem
-   * @return {!string}
-   * @private
-   */
-  static generateKeySystemCacheKey_(videoCodec, audioCodec, keySystem) {
-    return `${videoCodec}#${audioCodec}#${keySystem}`;
-  }
 };
 
 /**
@@ -368,16 +353,6 @@ shaka.polyfill.MediaCapabilities = class {
  * @export
  */
 shaka.polyfill.MediaCapabilities.originalMcap = null;
-
-/**
- * A cache that stores the MediaKeySystemAccess result of calling
- * `navigator.requestMediaKeySystemAccess` by a key combination of
- * video/audio codec and key system string.
- *
- * @type {(Object<(!string), (!MediaKeySystemAccess)>)}
- * @export
- */
-shaka.polyfill.MediaCapabilities.memoizedMediaKeySystemAccessRequests_ = {};
 
 /**
  * A cache that stores the canDisplayType result of calling

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -251,6 +251,8 @@ shaka.util.PlayerConfiguration = class {
       vodDynamicPlaybackRateBufferRatio: 0.5,
       infiniteLiveStreamDuration: false,
       preloadNextUrlWindow: 30,
+      clearDecodingCache: shaka.util.Platform.isPS4() ||
+        shaka.util.Platform.isPS5(),
     };
 
     // WebOS, Tizen, Chromecast and Hisense have long hardware pipelines

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1853,6 +1853,14 @@ shaka.util.StreamUtils = class {
 
     return 'unexpected stream type';
   }
+
+
+  /**
+   * Clears underlying decoding config cache.
+   */
+  static clearDecodingConfigCache() {
+    shaka.util.StreamUtils.decodingConfigCache_ = {};
+  }
 };
 
 

--- a/test/polyfill/media_capabilities_unit.js
+++ b/test/polyfill/media_capabilities_unit.js
@@ -68,7 +68,7 @@ describe('MediaCapabilities', () => {
         width: 512,
       },
     };
-    shaka.polyfill.MediaCapabilities.memoizedMediaKeySystemAccessRequests_ = {};
+    shaka.media.DrmEngine.clearMediaKeySystemAccessMap();
     supportMap.clear();
 
     mockCanDisplayType = jasmine.createSpy('canDisplayType');
@@ -163,7 +163,7 @@ describe('MediaCapabilities', () => {
           expect(result.keySystemAccess).toEqual(mockResult);
         });
 
-    it('should read previously requested codec/key system'+
+    it('should read previously requested codec/key system ' +
         'combinations from cache', async () => {
       const mockResult = {mockKeySystemAccess: 'mockKeySystemAccess'};
       spyOn(window['MediaSource'], 'isTypeSupported').and.returnValue(true);

--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -372,7 +372,7 @@ function configureJasmineEnvironment() {
 
   // Reset decoding config cache after each test.
   afterEach(/** @suppress {accessControls} */ () => {
-    shaka.util.StreamUtils.decodingConfigCache_ = {};
+    shaka.util.StreamUtils.clearDecodingConfigCache();
     shaka.media.Capabilities.MediaSourceTypeSupportMap.clear();
   });
 


### PR DESCRIPTION
On PlayStation, cached `MediaKeySystemAccess` objects may corrupt after several playbacks, and they are not able anymore to properly create `MediaKeys` objects. To prevent it, clear the cache after each playback.
Make it configurable via `streaming.clearDecodingCache`.