### PR TITLE
fix: Fix default value of liveSyncMinPlaybackRate

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1435,7 +1435,7 @@ shaka.extern.ManifestConfiguration;
  * @property {number} liveSyncMinPlaybackRate
  *   Minimum playback rate used for latency chasing. It is recommended to use a
  *   value between 0 and 1. Effective only if liveSync is true. Defaults to
- *   <code>1</code>.
+ *   <code>0.95</code>.
  * @property {boolean} liveSyncPanicMode
  *   If <code>true</code>, panic mode for live sync is enabled. When enabled,
  *   will set the playback rate to the <code>liveSyncMinPlaybackRate</code>

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -241,7 +241,7 @@ shaka.util.PlayerConfiguration = class {
       liveSyncMaxLatency: 1,
       liveSyncPlaybackRate: 1.1,
       liveSyncMinLatency: 0,
-      liveSyncMinPlaybackRate: 1,
+      liveSyncMinPlaybackRate: 0.95,
       liveSyncPanicMode: false,
       liveSyncPanicThreshold: 60,
       allowMediaSourceRecoveries: true,


### PR DESCRIPTION
The previous default value served no purpose and was a mistake in the PR that added the functionality.