### PR TITLE
fix: Ban smooth codec switching on Tizen 5 & 6

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -109,6 +109,24 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is a Tizen 6 TV.
+   *
+   * @return {boolean}
+   */
+  static isTizen6() {
+    return shaka.util.Platform.userAgentContains_('Tizen 6');
+  }
+
+  /**
+   * Check if the current platform is a Tizen 5 TV.
+   *
+   * @return {boolean}
+   */
+  static isTizen5() {
+    return shaka.util.Platform.userAgentContains_('Tizen 5');
+  }
+
+  /**
    * Check if the current platform is a Tizen 4 TV.
    *
    * @return {boolean}
@@ -588,8 +606,8 @@ shaka.util.Platform = class {
    */
   static supportsSmoothCodecSwitching() {
     const Platform = shaka.util.Platform;
-    if (Platform.isTizen2() || Platform.isTizen3() ||
-        Platform.isTizen4() || Platform.isWebOS3() ||
+    if (Platform.isTizen2() || Platform.isTizen3() || Platform.isTizen4() ||
+        Platform.isTizen5() || Platform.isTizen6() || Platform.isWebOS3() ||
         Platform.isWebOS4() || Platform.isWebOS5()) {
       return false;
     }

--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -7,19 +7,57 @@
 describe('Platform', () => {
   const originalUserAgent = navigator.userAgent;
 
+  /* eslint-disable max-len */
+  // See: https://developer.samsung.com/smarttv/develop/guides/fundamentals/retrieving-platform-information.html
+  const tizen50 = 'Mozilla/5.0 (SMART-TV; LINUX; Tizen 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/5.0 TV Safari/537.36';
+  const tizen55 = 'Mozilla/5.0 (SMART-TV; LINUX; Tizen 5.5) AppleWebKit/537.36 (KHTML, like Gecko) 69.0.3497.106.1/5.5 TV Safari/537.36';
+  const tizen60 = 'Mozilla/5.0 (SMART-TV; LINUX; Tizen 6.0) AppleWebKit/537.36 (KHTML, like Gecko) 76.0.3809.146/6.0 TV Safari/537.36';
+  const tizen65 = 'Mozilla/5.0 (SMART-TV; LINUX; Tizen 6.5) AppleWebKit/537.36 (KHTML, like Gecko) 85.0.4183.93/6.5 TV Safari/537.36';
+  const tizen70 = 'Mozilla/5.0 (SMART-TV; LINUX; Tizen 7.0) AppleWebKit/537.36 (KHTML, like Gecko) 94.0.4606.31/7.0 TV Safari/537.36';
+
   // See: https://webostv.developer.lge.com/develop/specifications/web-api-and-web-engine#useragent-string
-  // eslint-disable-next-line max-len
   const webOs3 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.2.1 Chrome/38.0.2125.122 Safari/537.36 WebAppManager';
-  // eslint-disable-next-line max-len
   const webOs4 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.34 Safari/537.36 WebAppManager';
-  // eslint-disable-next-line max-len
   const webOs5 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 WebAppManager';
+  /* eslint-enable max-len */
 
   afterEach(() => {
     setUserAgent(originalUserAgent);
   });
 
+  it('checks is Tizen 5', () => {
+    setUserAgent(webOs3);
+    expect(shaka.util.Platform.isTizen5()).toBe(false);
+    setUserAgent(tizen50);
+    expect(shaka.util.Platform.isTizen5()).toBe(true);
+    setUserAgent(tizen55);
+    expect(shaka.util.Platform.isTizen5()).toBe(true);
+    setUserAgent(tizen60);
+    expect(shaka.util.Platform.isTizen5()).toBe(false);
+    setUserAgent(tizen65);
+    expect(shaka.util.Platform.isTizen5()).toBe(false);
+    setUserAgent(tizen70);
+    expect(shaka.util.Platform.isTizen5()).toBe(false);
+  });
+
+  it('checks is Tizen 6', () => {
+    setUserAgent(webOs3);
+    expect(shaka.util.Platform.isTizen6()).toBe(false);
+    setUserAgent(tizen50);
+    expect(shaka.util.Platform.isTizen6()).toBe(false);
+    setUserAgent(tizen55);
+    expect(shaka.util.Platform.isTizen6()).toBe(false);
+    setUserAgent(tizen60);
+    expect(shaka.util.Platform.isTizen6()).toBe(true);
+    setUserAgent(tizen65);
+    expect(shaka.util.Platform.isTizen6()).toBe(true);
+    setUserAgent(tizen70);
+    expect(shaka.util.Platform.isTizen6()).toBe(false);
+  });
+
   it('checks is webOS 3', () => {
+    setUserAgent(tizen50);
+    expect(shaka.util.Platform.isWebOS3()).toBe(false);
     setUserAgent(webOs3);
     expect(shaka.util.Platform.isWebOS3()).toBe(true);
     setUserAgent(webOs4);
@@ -29,6 +67,8 @@ describe('Platform', () => {
   });
 
   it('checks is webOS 4', () => {
+    setUserAgent(tizen50);
+    expect(shaka.util.Platform.isWebOS4()).toBe(false);
     setUserAgent(webOs3);
     expect(shaka.util.Platform.isWebOS4()).toBe(false);
     setUserAgent(webOs4);
@@ -38,6 +78,8 @@ describe('Platform', () => {
   });
 
   it('checks is webOS 5', () => {
+    setUserAgent(tizen50);
+    expect(shaka.util.Platform.isWebOS5()).toBe(false);
     setUserAgent(webOs3);
     expect(shaka.util.Platform.isWebOS5()).toBe(false);
     setUserAgent(webOs4);


### PR DESCRIPTION
My recent tests on using smooth codec switch on Tizen 6.0 unfortunately failed. Ban this platform together with Tizen 5.