### PR TITLE
fix(DASH): Firefox multi-period/multi-codec bug

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -113,6 +113,7 @@ Prakash Duggaraju <duggaraju@gmail.com>
 Robert Colantuoni <rgc@colantuoni.com>
 Robert Galluccio <robertnw5@gmail.com>
 Rodolphe Breton <robloche@gmail.com>
+Roger Pales <pales.roger@gmail.com>
 Rohit Makasana <rohitbm@google.com>
 Rohan Gupta <rohangupta1528@gmail.com>
 Roi Lipman <roilipman@gmail.com>

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -558,7 +558,7 @@ shaka.util.StreamUtils = class {
       if (!a) {
         return b;
       } else {
-        const res = shaka.util.ObjectUtils.cloneObject(a);
+        const res = shaka.util.ObjectUtils.shallowCloneObject(a);
         res.supported = a.supported && b.supported;
         res.powerEfficient = a.powerEfficient && b.powerEfficient;
         res.smooth = a.smooth && b.smooth;


### PR DESCRIPTION
I believe a bug was introduced as part of the refactor in this PR #6348 that affects Firefox.

This line here https://github.com/shaka-project/shaka-player/blob/main/lib/util/stream_utils.js#L561 , would clone mediacapabilitiesInfo only if this was a plain `Object`. This seems to be the case in Chrome, however, it looks like the Firefox implementation of `MediaCapabilities.decodingInfo()` returns a "non-simple" `MediaCapabilitiesInfo` object instead - that results in [cloneObject retuning null](https://github.com/shaka-project/shaka-player/blob/main/lib/util/object_utils.js#L56), see screens:

FF:
<img width="829" alt="Screenshot 2024-05-27 at 22 48 51" src="https://github.com/shaka-project/shaka-player/assets/31139314/78a1edb2-fe06-4653-b7dc-6c1c18cb4576">

Chrome:
<img width="883" alt="Screenshot 2024-05-28 at 10 23 00" src="https://github.com/shaka-project/shaka-player/assets/31139314/f81dd618-7eb3-401d-bd1c-63d911345b67">

Switching to use shallow clone instead fixes the problem.

Fixes #6690 