### PR TITLE
feat: notify ABR manager of prefetched streams

### DIFF
--- a/externs/shaka/abr_manager.js
+++ b/externs/shaka/abr_manager.js
@@ -108,6 +108,14 @@ shaka.extern.AbrManager = class {
   trySuggestStreams() {}
 
   /**
+   * Updates the manager's prefetched streams collection
+   *
+   * @param {!Array.<!shaka.extern.Stream>} streams
+   * @exportDoc
+   */
+  setPrefetchStreams(streams) {}
+
+  /**
    * Gets an estimate of the current bandwidth in bit/sec.  This is used by the
    * Player to generate stats.
    *

--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -362,6 +362,11 @@ shaka.abr.SimpleAbrManager = class {
     this.variants_ = variants;
   }
 
+  /**
+   * @override
+   * @export
+   */
+  setPrefetchStreams(streams) {}
 
   /**
    * @override

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -248,6 +248,23 @@ shaka.media.StreamingEngine = class {
     if (!config.disableAudioPrefetch) {
       this.updatePrefetchMapForAudio_();
     }
+
+    const prefetchedStreamsSet = new Set();
+
+    for (const type of
+      [ContentType.VIDEO, ContentType.AUDIO, ContentType.TEXT]) {
+      const state = this.mediaStates_.get(type);
+      if (state && state.segmentPrefetch) {
+        prefetchedStreamsSet.add(state.stream);
+      }
+    }
+
+    for (const stream of this.audioPrefetchMap_.keys()) {
+      prefetchedStreamsSet.add(stream);
+    }
+
+    this.playerInterface_.setPrefetchStreams(
+        Array.from(prefetchedStreamsSet.values()));
   }
 
 
@@ -2815,7 +2832,8 @@ shaka.media.StreamingEngine = class {
  *   beforeAppendSegment: function(
  *     shaka.util.ManifestParserUtils.ContentType,!BufferSource):Promise,
  *   onMetadata: !function(!Array.<shaka.extern.ID3Metadata>, number, ?number),
- *   disableStream: function(!shaka.extern.Stream, number):boolean
+ *   disableStream: function(!shaka.extern.Stream, number):boolean,
+ *   setPrefetchStreams: function(!Array<!shaka.extern.Stream>)
  * }}
  *
  * @property {function():number} getPresentationTime
@@ -2852,6 +2870,8 @@ shaka.media.StreamingEngine = class {
  * @property {function(!shaka.extern.Stream, number):boolean} disableStream
  *   Called to temporarily disable a stream i.e. disabling all variant
  *   containing said stream.
+ * @property {function(!Array<!shaka.extern.Stream>)} setPrefetchStreams
+ *   Called whenever the list of prefetched streams changes.
  */
 shaka.media.StreamingEngine.PlayerInterface;
 

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -252,6 +252,11 @@ shaka.media.StreamingEngine = class {
     this.notifySetPrefetchStreams_();
   }
 
+  /**
+   * Collate all possible prefetched streams and notify the player interface.
+   *
+   * @private
+   */
   notifySetPrefetchStreams_() {
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
     const prefetchedStreamsSet = new Set();

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -249,6 +249,11 @@ shaka.media.StreamingEngine = class {
       this.updatePrefetchMapForAudio_();
     }
 
+    this.notifySetPrefetchStreams_();
+  }
+
+  notifySetPrefetchStreams_() {
+    const ContentType = shaka.util.ManifestParserUtils.ContentType;
     const prefetchedStreamsSet = new Set();
 
     for (const type of
@@ -940,6 +945,8 @@ shaka.media.StreamingEngine = class {
         this.scheduleUpdate_(mediaState, 0);
       }
     }
+
+    this.notifySetPrefetchStreams_();
   }
 
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -3485,6 +3485,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.processTimedMetadataMediaSrc_(metadata, offset, endTime);
       },
       disableStream: (stream, time) => this.disableStream(stream, time),
+      setPrefetchStreams: (streams) => {
+        this.abrManager_.setPrefetchStreams(streams);
+      },
     };
 
     return new shaka.media.StreamingEngine(this.manifest_, playerInterface);

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -268,6 +268,7 @@ describe('StreamingEngine', () => {
       beforeAppendSegment: () => Promise.resolve(),
       onMetadata: () => {},
       disableStream: (stream, time) => false,
+      setPrefetchStreams: (streams) => {},
     };
     streamingEngine = new shaka.media.StreamingEngine(
         /** @type {shaka.extern.Manifest} */(manifest), playerInterface);

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -4340,6 +4340,52 @@ describe('StreamingEngine', () => {
           expectSegmentRequest(false);
           expect(streamingEngine.audioPrefetchMap_.size).toBe(0);
         });
+
+    it('should set prefetched streams to empty array if prefetch is turned off', async () => {
+      streamingEngine.switchVariant(variant);
+      await streamingEngine.start();
+      playing = true;
+      expectNoBuffer();
+
+      await runTest();
+
+      expect(setPrefetchStreams).toHaveBeenCalledWith(
+        [variant.video, variant.audio, altVariant.audio]);
+
+      setPrefetchStreams.calls.reset();
+
+      const config = shaka.util.PlayerConfiguration.createDefault().streaming;
+      config.segmentPrefetchLimit = 0;
+      streamingEngine.configure(config);
+      streamingEngine.switchVariant(variant);
+      await runTest();
+
+      expect(setPrefetchStreams).toHaveBeenCalledWith([]);
+    });
+
+    it('should exclude prefetched streams based on config', async () => {
+      streamingEngine.switchVariant(variant);
+      await streamingEngine.start();
+      playing = true;
+      expectNoBuffer();
+
+      await runTest();
+
+      expect(setPrefetchStreams).toHaveBeenCalledWith(
+        [variant.video, variant.audio, altVariant.audio]);
+
+      setPrefetchStreams.calls.reset();
+
+      const config = shaka.util.PlayerConfiguration.createDefault().streaming;
+      config.segmentPrefetchLimit = 5;
+      config.prefetchAudioLanguages = ['und'];
+      config.disableVideoPrefetch = true;
+      streamingEngine.configure(config);
+      streamingEngine.switchVariant(variant);
+      await runTest();
+
+      expect(setPrefetchStreams).toHaveBeenCalledWith([variant.audio, altVariant.audio]);
+    });
   });
 
   /**

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -4103,30 +4103,32 @@ describe('StreamingEngine', () => {
       await runTest();
 
       expect(setPrefetchStreams).toHaveBeenCalledWith(
-        [variant.video, variant.audio]);
+          [variant.video, variant.audio]);
     });
 
-    it('should set prefetched streams to empty array if prefetch is turned off', async () => {
-      streamingEngine.switchVariant(variant);
-      await streamingEngine.start();
-      playing = true;
-      expectNoBuffer();
+    it('should set prefetched streams to empty array if prefetch is turned off',
+        async () => {
+          streamingEngine.switchVariant(variant);
+          await streamingEngine.start();
+          playing = true;
+          expectNoBuffer();
 
-      await runTest();
+          await runTest();
 
-      expect(setPrefetchStreams).toHaveBeenCalledWith(
-        [variant.video, variant.audio]);
+          expect(setPrefetchStreams).toHaveBeenCalledWith(
+              [variant.video, variant.audio]);
 
-      setPrefetchStreams.calls.reset();
+          setPrefetchStreams.calls.reset();
 
-      const config = shaka.util.PlayerConfiguration.createDefault().streaming;
-      config.segmentPrefetchLimit = 0;
-      streamingEngine.configure(config);
-      streamingEngine.switchVariant(variant);
-      await runTest();
+          const config =
+              shaka.util.PlayerConfiguration.createDefault().streaming;
+          config.segmentPrefetchLimit = 0;
+          streamingEngine.configure(config);
+          streamingEngine.switchVariant(variant);
+          await runTest();
 
-      expect(setPrefetchStreams).toHaveBeenCalledWith([]);
-    });
+          expect(setPrefetchStreams).toHaveBeenCalledWith([]);
+        });
 
     it('should exclude prefetched streams based on config', async () => {
       streamingEngine.switchVariant(variant);
@@ -4137,7 +4139,7 @@ describe('StreamingEngine', () => {
       await runTest();
 
       expect(setPrefetchStreams).toHaveBeenCalledWith(
-        [variant.video, variant.audio]);
+          [variant.video, variant.audio]);
 
       setPrefetchStreams.calls.reset();
 
@@ -4341,27 +4343,29 @@ describe('StreamingEngine', () => {
           expect(streamingEngine.audioPrefetchMap_.size).toBe(0);
         });
 
-    it('should set prefetched streams to empty array if prefetch is turned off', async () => {
-      streamingEngine.switchVariant(variant);
-      await streamingEngine.start();
-      playing = true;
-      expectNoBuffer();
+    it('should set prefetched streams to empty array if prefetch is turned off',
+        async () => {
+          streamingEngine.switchVariant(variant);
+          await streamingEngine.start();
+          playing = true;
+          expectNoBuffer();
 
-      await runTest();
+          await runTest();
 
-      expect(setPrefetchStreams).toHaveBeenCalledWith(
-        [variant.video, variant.audio, altVariant.audio]);
+          expect(setPrefetchStreams).toHaveBeenCalledWith(
+              [variant.video, variant.audio, altVariant.audio]);
 
-      setPrefetchStreams.calls.reset();
+          setPrefetchStreams.calls.reset();
 
-      const config = shaka.util.PlayerConfiguration.createDefault().streaming;
-      config.segmentPrefetchLimit = 0;
-      streamingEngine.configure(config);
-      streamingEngine.switchVariant(variant);
-      await runTest();
+          const config =
+              shaka.util.PlayerConfiguration.createDefault().streaming;
+          config.segmentPrefetchLimit = 0;
+          streamingEngine.configure(config);
+          streamingEngine.switchVariant(variant);
+          await runTest();
 
-      expect(setPrefetchStreams).toHaveBeenCalledWith([]);
-    });
+          expect(setPrefetchStreams).toHaveBeenCalledWith([]);
+        });
 
     it('should exclude prefetched streams based on config', async () => {
       streamingEngine.switchVariant(variant);
@@ -4372,7 +4376,7 @@ describe('StreamingEngine', () => {
       await runTest();
 
       expect(setPrefetchStreams).toHaveBeenCalledWith(
-        [variant.video, variant.audio, altVariant.audio]);
+          [variant.video, variant.audio, altVariant.audio]);
 
       setPrefetchStreams.calls.reset();
 
@@ -4384,7 +4388,8 @@ describe('StreamingEngine', () => {
       streamingEngine.switchVariant(variant);
       await runTest();
 
-      expect(setPrefetchStreams).toHaveBeenCalledWith([variant.audio, altVariant.audio]);
+      expect(setPrefetchStreams).toHaveBeenCalledWith(
+          [variant.audio, altVariant.audio]);
     });
   });
 

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -477,6 +477,7 @@ describe('StreamingEngine', () => {
       beforeAppendSegment: Util.spyFunc(beforeAppendSegment),
       onMetadata: Util.spyFunc(onMetadata),
       disableStream: Util.spyFunc(disableStream),
+      setPrefetchStreams: (streams) => {},
     };
     streamingEngine = new shaka.media.StreamingEngine(
         /** @type {shaka.extern.Manifest} */(manifest), playerInterface);

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -80,6 +80,8 @@ describe('StreamingEngine', () => {
   let onMetadata;
   /** @type {!jasmine.Spy} */
   let disableStream;
+  /** @type {!jasmine.Spy} */
+  let setPrefetchStreams;
 
   /** @type {function(function(), number)} */
   let realSetTimeout;
@@ -447,6 +449,7 @@ describe('StreamingEngine', () => {
     getPlaybackRate.and.returnValue(1);
     disableStream = jasmine.createSpy('disableStream');
     disableStream.and.callFake(() => false);
+    setPrefetchStreams = jasmine.createSpy('setPrefetchStreams');
 
     beforeAppendSegment.and.callFake((segment) => {
       return Promise.resolve();
@@ -477,7 +480,7 @@ describe('StreamingEngine', () => {
       beforeAppendSegment: Util.spyFunc(beforeAppendSegment),
       onMetadata: Util.spyFunc(onMetadata),
       disableStream: Util.spyFunc(disableStream),
-      setPrefetchStreams: (streams) => {},
+      setPrefetchStreams: Util.spyFunc(setPrefetchStreams),
     };
     streamingEngine = new shaka.media.StreamingEngine(
         /** @type {shaka.extern.Manifest} */(manifest), playerInterface);
@@ -4089,6 +4092,9 @@ describe('StreamingEngine', () => {
       await runTest();
       expectHasBuffer();
       expectSegmentRequest(true);
+    });
+
+    it('should let the player know about the prefetched stream', () => {
     });
   });
 

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -4094,7 +4094,15 @@ describe('StreamingEngine', () => {
       expectSegmentRequest(true);
     });
 
-    it('should let the player know about the prefetched stream', () => {
+    it('should let the player know about the prefetched stream', async () => {
+      streamingEngine.switchVariant(variant);
+      await streamingEngine.start();
+      playing = true;
+      expectNoBuffer();
+
+      await runTest();
+
+      expect(setPrefetchStreams).toHaveBeenCalledWith([variant.video, variant.audio]);
     });
   });
 

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -4102,7 +4102,53 @@ describe('StreamingEngine', () => {
 
       await runTest();
 
-      expect(setPrefetchStreams).toHaveBeenCalledWith([variant.video, variant.audio]);
+      expect(setPrefetchStreams).toHaveBeenCalledWith(
+        [variant.video, variant.audio]);
+    });
+
+    it('should set prefetched streams to empty array if prefetch is turned off', async () => {
+      streamingEngine.switchVariant(variant);
+      await streamingEngine.start();
+      playing = true;
+      expectNoBuffer();
+
+      await runTest();
+
+      expect(setPrefetchStreams).toHaveBeenCalledWith(
+        [variant.video, variant.audio]);
+
+      setPrefetchStreams.calls.reset();
+
+      const config = shaka.util.PlayerConfiguration.createDefault().streaming;
+      config.segmentPrefetchLimit = 0;
+      streamingEngine.configure(config);
+      streamingEngine.switchVariant(variant);
+      await runTest();
+
+      expect(setPrefetchStreams).toHaveBeenCalledWith([]);
+    });
+
+    it('should exclude prefetched streams based on config', async () => {
+      streamingEngine.switchVariant(variant);
+      await streamingEngine.start();
+      playing = true;
+      expectNoBuffer();
+
+      await runTest();
+
+      expect(setPrefetchStreams).toHaveBeenCalledWith(
+        [variant.video, variant.audio]);
+
+      setPrefetchStreams.calls.reset();
+
+      const config = shaka.util.PlayerConfiguration.createDefault().streaming;
+      config.segmentPrefetchLimit = 5;
+      config.disableVideoPrefetch = true;
+      streamingEngine.configure(config);
+      streamingEngine.switchVariant(variant);
+      await runTest();
+
+      expect(setPrefetchStreams).toHaveBeenCalledWith([variant.audio]);
     });
   });
 


### PR DESCRIPTION
This hooks up calling the streaming engine's player interface to let it know when the prefetched streams have changed. For simplicity, I have made it get called each time there's an opportunity for change, i.e., after configure and initStreams_ are called in the streaming engine.
The implementation in the simple abr manager is currently a noop to reduce the risk of leaking these values until and if the simple abr manager is updated to take these prefetched streams into account.

Fixes #6673.