### PR TITLE
fix: Xbox - round gap jumping values

### DIFF
--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -13,6 +13,7 @@ goog.require('shaka.media.TimeRangesUtils');
 goog.require('shaka.util.EventManager');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.IReleasable');
+goog.require('shaka.util.Platform');
 goog.require('shaka.util.Timer');
 
 
@@ -217,7 +218,13 @@ shaka.media.GapJumpingController = class {
 
     // StreamingEngine can buffer past the seek end, but still don't allow
     // seeking past it.
-    const jumpTo = buffered.start(gapIndex);
+    let jumpTo = buffered.start(gapIndex);
+    // Workaround for Xbox with Legacy Edge. On this platform video element
+    // often rounds value we want to set as currentTime and we are not able
+    // to jump over the gap.
+    if (shaka.util.Platform.isLegacyEdge()) {
+      jumpTo = Math.ceil((jumpTo + 0.01) * 100) / 100;
+    }
     const seekEnd = this.timeline_.getSeekRangeEnd();
     if (jumpTo >= seekEnd) {
       return;

--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -222,7 +222,8 @@ shaka.media.GapJumpingController = class {
     // Workaround for Xbox with Legacy Edge. On this platform video element
     // often rounds value we want to set as currentTime and we are not able
     // to jump over the gap.
-    if (shaka.util.Platform.isLegacyEdge()) {
+    if (shaka.util.Platform.isLegacyEdge() || 
+        shaka.util.Platform.isXboxOne()) {
       jumpTo = Math.ceil((jumpTo + 0.01) * 100) / 100;
     }
     const seekEnd = this.timeline_.getSeekRangeEnd();

--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -222,7 +222,7 @@ shaka.media.GapJumpingController = class {
     // Workaround for Xbox with Legacy Edge. On this platform video element
     // often rounds value we want to set as currentTime and we are not able
     // to jump over the gap.
-    if (shaka.util.Platform.isLegacyEdge() || 
+    if (shaka.util.Platform.isLegacyEdge() ||
         shaka.util.Platform.isXboxOne()) {
       jumpTo = Math.ceil((jumpTo + 0.01) * 100) / 100;
     }


### PR DESCRIPTION
It looks like Xbox incorrectly rounds values to seek and it's not able to jump over gaps sometimes.