### PR TITLE
fix: patch `setServerCertificate()` on older Tizens & webOS

### DIFF
--- a/build/types/polyfill
+++ b/build/types/polyfill
@@ -8,6 +8,7 @@
 +../../lib/polyfill/mediasource.js
 +../../lib/polyfill/media_capabilities.js
 +../../lib/polyfill/orientation.js
++../../lib/polyfill/patchedmediakeys_cert.js
 +../../lib/polyfill/patchedmediakeys_nop.js
 +../../lib/polyfill/patchedmediakeys_webkit.js
 +../../lib/polyfill/pip_webkit.js

--- a/lib/polyfill/patchedmediakeys_cert.js
+++ b/lib/polyfill/patchedmediakeys_cert.js
@@ -1,0 +1,62 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.provide('shaka.polyfill.PatchedMediaKeysCert');
+
+goog.require('shaka.log');
+goog.require('shaka.polyfill');
+goog.require('shaka.util.Platform');
+
+
+/**
+ * @summary A polyfill to fix setServerCertificate implementation on
+ * older platforms which claim to support modern EME.
+ * @export
+ */
+shaka.polyfill.PatchedMediaKeysCert = class {
+  /**
+   * Installs the polyfill if needed.
+   * @export
+   */
+  static install() {
+    if (!window.MediaKeys) {
+      // No MediaKeys available
+      return;
+    }
+    // eslint-disable-next-line no-restricted-syntax
+    if (MediaKeys.prototype.setServerCertificate &&
+        !shaka.polyfill.PatchedMediaKeysCert.hasInvalidImplementation_()) {
+      // setServerCertificate is there and userAgent seems to be valid.
+      return;
+    }
+
+    shaka.log.info('Patching MediaKeys.setServerCertificate');
+    // eslint-disable-next-line no-restricted-syntax
+    MediaKeys.prototype.setServerCertificate =
+      shaka.polyfill.PatchedMediaKeysCert.setServerCertificate_;
+  }
+
+  /**
+   * @param {!BufferSource} certificate
+   * @return {!Promise<boolean>}
+   * @private
+   */
+  static setServerCertificate_(certificate) {
+    shaka.log.debug('PatchedMediaKeysCert.setServerCertificate');
+    return Promise.resolve(false);
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  static hasInvalidImplementation_() {
+    return shaka.util.Platform.isTizen3() || shaka.util.Platform.isTizen4() ||
+      shaka.util.Platform.isTizen5_0();
+  }
+};
+
+shaka.polyfill.register(shaka.polyfill.PatchedMediaKeysCert.install);

--- a/lib/polyfill/patchedmediakeys_cert.js
+++ b/lib/polyfill/patchedmediakeys_cert.js
@@ -55,7 +55,7 @@ shaka.polyfill.PatchedMediaKeysCert = class {
    */
   static hasInvalidImplementation_() {
     return shaka.util.Platform.isTizen3() || shaka.util.Platform.isTizen4() ||
-      shaka.util.Platform.isTizen5_0();
+      shaka.util.Platform.isTizen5_0() || shaka.util.Platform.isWebOS3();
   }
 };
 

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -118,6 +118,15 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is a Tizen 5.0 TV.
+   *
+   * @return {boolean}
+   */
+  static isTizen5_0() {
+    return shaka.util.Platform.userAgentContains_('Tizen 5.0');
+  }
+
+  /**
    * Check if the current platform is a Tizen 5 TV.
    *
    * @return {boolean}

--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -40,6 +40,21 @@ describe('Platform', () => {
     expect(shaka.util.Platform.isTizen5()).toBe(false);
   });
 
+  it('checks is Tizen 5.0', () => {
+    setUserAgent(webOs3);
+    expect(shaka.util.Platform.isTizen5_0()).toBe(false);
+    setUserAgent(tizen50);
+    expect(shaka.util.Platform.isTizen5_0()).toBe(true);
+    setUserAgent(tizen55);
+    expect(shaka.util.Platform.isTizen5_0()).toBe(false);
+    setUserAgent(tizen60);
+    expect(shaka.util.Platform.isTizen5_0()).toBe(false);
+    setUserAgent(tizen65);
+    expect(shaka.util.Platform.isTizen5_0()).toBe(false);
+    setUserAgent(tizen70);
+    expect(shaka.util.Platform.isTizen5_0()).toBe(false);
+  });
+
   it('checks is Tizen 6', () => {
     setUserAgent(webOs3);
     expect(shaka.util.Platform.isTizen6()).toBe(false);


### PR DESCRIPTION
We've tried to enable setting server certificates to optimize playback start, but turned out that with our widevine certificate shaka was throwing 6004 error. The issue is not reproducible starting from Tizen 5.5. The same certificate was working properly also on Chrome.