### PR TITLE
fix(preload): Copy net filters to preload manager

### DIFF
--- a/docs/tutorials/preload.md
+++ b/docs/tutorials/preload.md
@@ -35,6 +35,8 @@ You need a player instance to preload an asset, and you must use the returned
 preloadManager on the same player instance.
 The preloading process loads the manifest and first segments of the asset. It
 will not load the whole asset ahead of time.
+If you need to define any response or request filters for your assets to be
+downloaded, remember to do it before calling `player.preload`.
 
 The preload method can be provided an optional startTime and mimeType parameter,
 much the same as the load method.

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -158,6 +158,19 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
   }
 
   /**
+   * Copies all of the filters from this networking engine into another.
+   * @param {!shaka.net.NetworkingEngine} other
+   */
+  copyFiltersInto(other) {
+    for (const filter of this.requestFilters_) {
+      other.requestFilters_.add(filter);
+    }
+    for (const filter of this.responseFilters_) {
+      other.responseFilters_.add(filter);
+    }
+  }
+
+  /**
    * Registers a new request filter.  All filters are applied in the order they
    * are registered.
    *

--- a/lib/player.js
+++ b/lib/player.js
@@ -2107,6 +2107,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // Sadly, as the network engine creation code must be replaceable by tests,
     // it cannot be made and use the utilities defined in this function.
     const networkingEngine = this.createNetworkingEngine(getPreloadManager);
+    this.networkingEngine_.copyFiltersInto(networkingEngine);
 
     /** @return {!shaka.media.DrmEngine} */
     const createDrmEngine = () => {

--- a/test/test/util/fake_networking_engine.js
+++ b/test/test/util/fake_networking_engine.js
@@ -145,6 +145,17 @@ shaka.test.FakeNetworkingEngine = class {
   }
 
   /**
+   * @param {!shaka.net.NetworkingEngine} other
+   * @override
+   */
+  copyFiltersInto(other) {
+    if (this.responseFilter_) {
+      other.registerResponseFilter(this.responseFilter_);
+    }
+    // FakeNetworkingEngine does not have request filters.
+  }
+
+  /**
    * Useable by tests directly.  Library code will only call this via the Spy on
    * registerResponseFilter.
    *


### PR DESCRIPTION
Some assets might rely on networking engine filters (request and response filters) to properly download their assets. However, the preload manager's need to use a fresh networking engine also caused it to not use any filters set on the player already. This changes the process of setting up a preload manager, to make it copy over any filters defined on the player's networking engine.

Fixes #6698