### PR TITLE
fix: ensure all timelineregionenter events are fired

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -2405,7 +2405,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const setupPlayhead = (startTime) => {
       this.playhead_ = this.createPlayhead(startTime);
       this.playheadObservers_ =
-          this.createPlayheadObserversForMSE_(startTimeOfLoad);
+          this.createPlayheadObserversForMSE_(startTime);
 
       // We need to start the buffer management code near the end because it
       // will set the initial buffering state and that depends on other
@@ -3242,16 +3242,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Create the observers for MSE playback. These observers are responsible for
    * notifying the app and player of specific events during MSE playback.
    *
-   * @param {number} startTimeOfLoad
+   * @param {number} startTime
    * @return {!shaka.media.PlayheadObserverManager}
    * @private
    */
-  createPlayheadObserversForMSE_(startTimeOfLoad) {
+  createPlayheadObserversForMSE_(startTime) {
     goog.asserts.assert(this.manifest_, 'Must have manifest');
     goog.asserts.assert(this.regionTimeline_, 'Must have region timeline');
     goog.asserts.assert(this.video_, 'Must have video element');
 
-    const startsPastZero = this.isLive() || startTimeOfLoad > 0;
+    const startsPastZero = this.isLive() || startTime > 0;
 
     // Create the region observer. This will allow us to notify the app when we
     // move in and out of timeline regions.


### PR DESCRIPTION
We aren't sure if this is the best solution, because we don't entirely understand the original reason for using `startTimeOfLoad`, the wall clock time that the load started, instead of `startTime`, the playhead time offset passed to `player.load()`. We are looking for some clarity and this is our initial fix. This issue results in DAI impressions being missed, especially on lower powered and network constrained devices.

Resolves #6711