### PR TITLE
fix(PS4): Fix serverCertificate defaulted to null

### DIFF
--- a/lib/util/object_utils.js
+++ b/lib/util/object_utils.js
@@ -41,8 +41,7 @@ shaka.util.ObjectUtils = class {
 
           // This covers Uint8Array and friends, even without a TypedArray
           // base-class constructor.
-          const isTypedArray =
-              val.buffer && val.buffer.constructor == ArrayBuffer;
+          const isTypedArray = val.buffer instanceof ArrayBuffer;
           if (isTypedArray) {
             return val;
           }


### PR DESCRIPTION
For some reason on PS4, the check `val.buffer.constructor == ArrayBuffer` returns `false` when it should be `true` which causes the object cloning to return `null` instead of the array buffer.

Modifying this to `val.buffer instanceof ArrayBuffer` now returns true which fixes the issue. This should work across devices.
Original author: @nick-michael 