### PR TITLE
fix: Support for Zenterio

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -7103,12 +7103,19 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         shaka.util.FakeEvent.EventName.KeyStatusChanged);
     this.dispatchEvent(event);
 
-    const keyIds = Object.keys(keyStatusMap);
+    let keyIds = Object.keys(keyStatusMap);
     if (keyIds.length == 0) {
       shaka.log.warning(
           'Got a key status event without any key statuses, so we don\'t ' +
           'know the real key statuses. If we don\'t have all the keys, ' +
           'you\'ll need to set restrictions so we don\'t select those tracks.');
+    }
+
+    // Non-standard version of global key status. Modify it to match standard
+    // behavior.
+    if (keyIds.length == 1 && keyIds[0] == '') {
+      keyIds = ['00'];
+      keyStatusMap = {'00': keyStatusMap['']};
     }
 
     // If EME is using a synthetic key ID, the only key ID is '00' (a single 0
@@ -7120,14 +7127,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           'Got a synthetic key status event, so we don\'t know the real key ' +
           'statuses. If we don\'t have all the keys, you\'ll need to set ' +
           'restrictions so we don\'t select those tracks.');
-    }
-    const isEmptyKeyId = keyIds.length === 1 && keyIds[0] === '';
-    if (isEmptyKeyId) {
-      shaka.log.warning(
-          'Got a empty key status event, so we don\'t know the real key ' +
-          'statuses. We can workaround this by using the first and only ' +
-          'entry in the statuses map this workaround is specifically found ' +
-          'to be required for DT Zenterio G4 & G5 devices.');
     }
 
     const restrictedStatuses = shaka.media.ManifestFilterer.restrictedStatuses;
@@ -7149,13 +7148,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             variant.allowedByKeySystem = true;
 
             for (const keyId of stream.keyIds) {
-              let keyStatusMapId = keyId;
-              if (isGlobalStatus) {
-                keyStatusMapId = '00';
-              } else if (isEmptyKeyId && shaka.util.Platform.isZenterio()) {
-                keyStatusMapId = '';
-              }
-              const keyStatus = keyStatusMap[keyStatusMapId];
+              const keyStatus = keyStatusMap[isGlobalStatus ? '00' : keyId];
               if (keyStatus || this.drmEngine_.hasManifestInitData()) {
                 variant.allowedByKeySystem = variant.allowedByKeySystem &&
                     !!keyStatus && !restrictedStatuses.includes(keyStatus);

--- a/lib/player.js
+++ b/lib/player.js
@@ -7121,6 +7121,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           'statuses. If we don\'t have all the keys, you\'ll need to set ' +
           'restrictions so we don\'t select those tracks.');
     }
+    const isEmptyKeyId = keyIds.length === 1 && keyIds[0] === '';
+    if (isEmptyKeyId) {
+      shaka.log.warning(
+          'Got a empty key status event, so we don\'t know the real key ' +
+          'statuses. We can workaround this by using the first and only ' +
+          'entry in the statuses map this workaround is specifically found ' +
+          'to be required for DT Zenterio G4 & G5 devices.');
+    }
 
     const restrictedStatuses = shaka.media.ManifestFilterer.restrictedStatuses;
     let tracksChanged = false;
@@ -7141,7 +7149,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             variant.allowedByKeySystem = true;
 
             for (const keyId of stream.keyIds) {
-              const keyStatus = keyStatusMap[isGlobalStatus ? '00' : keyId];
+              let keyStatusMapId = keyId;
+              if (isGlobalStatus) {
+                keyStatusMapId = '00';
+              } else if (isEmptyKeyId && shaka.util.Platform.isZenterio()) {
+                keyStatusMapId = '';
+              }
+              const keyStatus = keyStatusMap[keyStatusMapId];
               if (keyStatus || this.drmEngine_.hasManifestInitData()) {
                 variant.allowedByKeySystem = variant.allowedByKeySystem &&
                     !!keyStatus && !restrictedStatuses.includes(keyStatus);

--- a/lib/polyfill/mediasource.js
+++ b/lib/polyfill/mediasource.js
@@ -67,6 +67,18 @@ shaka.polyfill.MediaSource = class {
         // Bug filed: https://bugs.webkit.org/show_bug.cgi?id=165342
         shaka.polyfill.MediaSource.stubAbort_();
       }
+    } else if (shaka.util.Platform.isZenterio()) {
+      // Zenterio uses WPE based on Webkit 607.x.x which do not correctly
+      // implement abort() on SourceBuffer.
+      // Calling abort() before appending a segment causes that segment to be
+      // incomplete in the buffer.
+      // Bug filed: https://bugs.webkit.org/show_bug.cgi?id=165342
+      shaka.polyfill.MediaSource.stubAbort_();
+      // If you remove up to a keyframe, Webkit 607.x.x incorrectly will also
+      // remove that keyframe and the content up to the next.
+      // Offsetting the end of the removal range seems to help.
+      // Bug filed: https://bugs.webkit.org/show_bug.cgi?id=177884
+      shaka.polyfill.MediaSource.patchRemovalRange_();
     } else if (shaka.util.Platform.isTizen2() ||
         shaka.util.Platform.isTizen3() ||
         shaka.util.Platform.isTizen4()) {

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -528,7 +528,7 @@ shaka.util.Platform = class {
         Platform.isEOS() || Platform.isAPL() ||
         Platform.isVirginMedia() || Platform.isOrange() ||
         Platform.isWPE() || Platform.isChromecast() ||
-        Platform.isHisense()) || Platform.isZenterio() {
+        Platform.isHisense() || Platform.isZenterio()) {
       return true;
     }
     return false;

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -299,7 +299,8 @@ shaka.util.Platform = class {
         !shaka.util.Platform.isOrange() &&
         !shaka.util.Platform.isPS4() &&
         !shaka.util.Platform.isAmazonFireTV() &&
-        !shaka.util.Platform.isWPE();
+        !shaka.util.Platform.isWPE() &&
+        !shaka.util.Platform.isZenterio();
   }
 
   /**
@@ -360,6 +361,14 @@ shaka.util.Platform = class {
    */
   static isWPE() {
     return shaka.util.Platform.userAgentContains_('WPE');
+  }
+
+  /**
+   * Check if the current platform is Deutsche Telecom Zenterio STB.
+   * @return {boolean}
+   */
+  static isZenterio() {
+    return shaka.util.Platform.userAgentContains_('DT_STB_BCM');
   }
 
   /**
@@ -519,7 +528,7 @@ shaka.util.Platform = class {
         Platform.isEOS() || Platform.isAPL() ||
         Platform.isVirginMedia() || Platform.isOrange() ||
         Platform.isWPE() || Platform.isChromecast() ||
-        Platform.isHisense()) {
+        Platform.isHisense()) || Platform.isZenterio() {
       return true;
     }
     return false;

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -3399,7 +3399,6 @@ describe('Player', () => {
     });
 
     it('doesn\'t remove when using empty map key status event', async () => {
-      spyOn(shaka.util.Platform, 'isZenterio').and.returnValue(true);
       manifest = shaka.test.ManifestGenerator.generate((manifest) => {
         manifest.addVariant(0, (variant) => {
           variant.addVideo(1, (stream) => {

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -3398,6 +3398,31 @@ describe('Player', () => {
       expect(tracks.length).toBe(2);
     });
 
+    it('doesn\'t remove when using empty map key status event', async () => {
+      spyOn(shaka.util.Platform, 'isZenterio').and.returnValue(true);
+      manifest = shaka.test.ManifestGenerator.generate((manifest) => {
+        manifest.addVariant(0, (variant) => {
+          variant.addVideo(1, (stream) => {
+            stream.keyIds = new Set(['abc']);
+            stream.size(10, 10);
+          });
+        });
+        manifest.addVariant(2, (variant) => {
+          variant.addVideo(3, (stream) => {
+            stream.size(20, 20);
+          });
+        });
+      });
+
+      await player.load(fakeManifestUri, 0, fakeMimeType);
+      expect(player.getVariantTracks().length).toBe(2);
+
+      // Empty key status event map ID.
+      onKeyStatus({'': 'usable'});
+
+      expect(player.getVariantTracks().length).toBe(2);
+    });
+
     it('doesn\'t remove when using synthetic key status', async () => {
       manifest = shaka.test.ManifestGenerator.generate((manifest) => {
         manifest.addVariant(0, (variant) => {


### PR DESCRIPTION
Few bugfixes to support DT Zenterio platform:
- Zenterio seems to have a problem with the EME onKeyStatus event payload (the key statuses map), where the map key ID comes in as empty. This is not correct based on the EME spec:
https://w3c.github.io/encrypted-media/#dom-mediakeysession-keystatuses
- Add polyfills that are used to fix issues with older webkits, same as for older safari browsers