### PR TITLE
test: Fix Karma debug.html support

### DIFF
--- a/test/test/externs/karma.js
+++ b/test/test/externs/karma.js
@@ -22,5 +22,13 @@ __karma__.config = {};
 __karma__.config.args;
 
 
+/** @const {boolean|undefined} */
+__karma__.config.useIframe;
+
+
+/** @const {boolean|undefined} */
+__karma__.config.runInParent;
+
+
 /** @param {?} error */
 __karma__.error = function(error) {};


### PR DESCRIPTION
To debug Karma tests, you can load debug.html in a browser.  However, this context has no back-channel to Karma and tries to load scripts by direct insertion into the document.  For compatibility, we need to have Closure inject scripts with the same methodology, to avoid having scripts load in the wrong order.  We also have to define the dump() method that Karma would normally inject into the testing context.