### PR TITLE
test: Fix exception calling setVolume() in ads test

### DIFF
--- a/test/ads/ad_manager_unit.js
+++ b/test/ads/ad_manager_unit.js
@@ -126,6 +126,10 @@ describe('Ad manager', () => {
             getVolume() {
               return 0;
             }
+
+            setVolume() {
+              // Nothing
+            }
           };
           return new MockAdManager();
         };


### PR DESCRIPTION
MockAdManager did not define setVolume() in this one test, causing the test to throw an exception.  This exception got swallowed and did not fail the test, but was noticed in the JS console during a Karma debug run.