### PR TITLE
fix: Avoid filter manifest when the DRM is not initialized

### DIFF
--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -553,9 +553,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
 
     const tracksChangedInitial = this.manifestFilterer_.applyRestrictions(
         this.manifest_);
-    const tracksChangedBefore = await this.manifestFilterer_.filterManifest(
-        this.manifest_);
-    if (tracksChangedInitial || tracksChangedBefore) {
+    if (tracksChangedInitial) {
       const event = this.makeEvent_(
           shaka.util.FakeEvent.EventName.TracksChanged);
       await Promise.resolve();


### PR DESCRIPTION
Regression of https://github.com/shaka-project/shaka-player/commit/90710023466dcad4d1d14a2869ae50e8da4e93ee

Fixes https://github.com/shaka-project/shaka-player/issues/6710