### PR TITLE
chore: Update maintained branches

### DIFF
--- a/maintained-branches.md
+++ b/maintained-branches.md
@@ -2,9 +2,8 @@
 
 We are currently maintaining the following branches of Shaka Player:
 
- - v4.9 (latest)
+ - v4.9 (latest, in use by the Cast Application Framework)
  - v4.8 (previous)
- - v4.3 (in use by the Cast Application Framework)
  - No active LTS branches at this time
 
 Other branches are no longer receiving bug fixes, and we recommend you upgrade


### PR DESCRIPTION
The next release of the Cast Application Framework is expected to ship with a release from the v4.9.x branch by default, so we are no longer maintaining v4.3.