### PR TITLE
fix(HLS): Ignore query params in the uri of EXT-X-SESSION-KEY tags

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -4429,7 +4429,7 @@ shaka.hls.HlsParser = class {
     }
 
     const uri = drmTag.getRequiredAttrValue('URI');
-    const parsedData = shaka.net.DataUriPlugin.parseRaw(uri);
+    const parsedData = shaka.net.DataUriPlugin.parseRaw(uri.split('?')[0]);
 
     // The data encoded in the URI is a PSSH box to be used as init data.
     const pssh = shaka.util.BufferUtils.toUint8(parsedData.data);
@@ -4472,7 +4472,7 @@ shaka.hls.HlsParser = class {
     }
 
     const uri = drmTag.getRequiredAttrValue('URI');
-    const parsedData = shaka.net.DataUriPlugin.parseRaw(uri);
+    const parsedData = shaka.net.DataUriPlugin.parseRaw(uri.split('?')[0]);
 
     // The data encoded in the URI is a PlayReady Pro Object, so we need
     // convert it to pssh.


### PR DESCRIPTION
With this change avoids errors like: 
`DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.`