### PR TITLE
fix(DRM): close properly webkit media key sessions

### DIFF
--- a/externs/polyfill.js
+++ b/externs/polyfill.js
@@ -11,5 +11,5 @@
  */
 
 
-/** @type {boolean} */
+/** @type {string} */
 window.shakaMediaKeysPolyfill;

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -179,12 +179,18 @@ shaka.media.DrmEngine = class {
 
     // |video_| will be |null| if we never attached to a video element.
     if (this.video_) {
-      goog.asserts.assert(!this.video_.src, 'video src must be removed first!');
+      // Webkit EME implementation requires the src to be defined to clear
+      // the MediaKeys.
+      if (!shaka.util.Platform.isMediaKeysPolyfilled('webkit')) {
+        goog.asserts.assert(!this.video_.src,
+            'video src must be removed first!');
+      }
 
       try {
         await this.video_.setMediaKeys(null);
       } catch (error) {
         // Ignore any failures while removing media keys from the video element.
+        shaka.log.debug(`DrmEngine.destroyNow_ exception`, error);
       }
 
       this.video_ = null;

--- a/lib/player.js
+++ b/lib/player.js
@@ -1356,6 +1356,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.playhead_ = null;
       }
 
+      // EME v0.1b requires the media element to clear the MediaKeys
+      if (shaka.util.Platform.isMediaKeysPolyfilled('webkit') &&
+          this.drmEngine_) {
+        await this.drmEngine_.destroy();
+        this.drmEngine_ = null;
+      }
+
       // Media source engine holds onto the media element, and in order to
       // detach the media keys (with drm engine), we need to break the
       // connection between media source engine and the media element.

--- a/lib/polyfill/patchedmediakeys_apple.js
+++ b/lib/polyfill/patchedmediakeys_apple.js
@@ -76,7 +76,7 @@ shaka.polyfill.PatchedMediaKeysApple = class {
     navigator.requestMediaKeySystemAccess =
         PatchedMediaKeysApple.requestMediaKeySystemAccess;
 
-    window.shakaMediaKeysPolyfill = true;
+    window.shakaMediaKeysPolyfill = PatchedMediaKeysApple.apiName_;
   }
 
   /**
@@ -115,7 +115,7 @@ shaka.polyfill.PatchedMediaKeysApple = class {
     PatchedMediaKeysApple.originalNavigatorRequestMediaKeySystemAccess = null;
     PatchedMediaKeysApple.originalHTMLMediaElementPrototypeMediaKeys = null;
 
-    window.shakaMediaKeysPolyfill = false;
+    window.shakaMediaKeysPolyfill = '';
   }
 
   /**
@@ -791,3 +791,10 @@ shaka.polyfill.PatchedMediaKeysApple.MediaKeyStatusMap = class {
     goog.asserts.assert(false, 'Not used!  Provided only for the compiler.');
   }
 };
+
+/**
+ * API name.
+ *
+ * @private {string}
+ */
+shaka.polyfill.PatchedMediaKeysApple.apiName_ = 'apple';

--- a/lib/polyfill/patchedmediakeys_nop.js
+++ b/lib/polyfill/patchedmediakeys_nop.js
@@ -50,7 +50,7 @@ shaka.polyfill.PatchedMediaKeysNop = class {
     window.MediaKeys = PatchedMediaKeysNop.MediaKeys;
     window.MediaKeySystemAccess = PatchedMediaKeysNop.MediaKeySystemAccess;
 
-    window.shakaMediaKeysPolyfill = true;
+    window.shakaMediaKeysPolyfill = PatchedMediaKeysNop.apiName_;
   }
 
   /**
@@ -135,6 +135,13 @@ shaka.polyfill.PatchedMediaKeysNop.MediaKeySystemAccess = class {
   /** @override */
   createMediaKeys() {}
 };
+
+/**
+ * API name.
+ *
+ * @private {string}
+ */
+shaka.polyfill.PatchedMediaKeysNop.apiName_ = 'nop';
 
 
 // A low priority ensures this is the last and acts as a fallback.

--- a/lib/polyfill/patchedmediakeys_webkit.js
+++ b/lib/polyfill/patchedmediakeys_webkit.js
@@ -73,7 +73,7 @@ shaka.polyfill.PatchedMediaKeysWebkit = class {
     window.MediaKeys = PatchedMediaKeysWebkit.MediaKeys;
     window.MediaKeySystemAccess = PatchedMediaKeysWebkit.MediaKeySystemAccess;
 
-    window.shakaMediaKeysPolyfill = true;
+    window.shakaMediaKeysPolyfill = PatchedMediaKeysWebkit.apiName_;
   }
 
   /**
@@ -860,7 +860,9 @@ class extends shaka.util.FakeEventTarget {
           PatchedMediaKeysWebkit.prefixApi_('cancelKeyRequest');
       try {
         this.media_[cancelKeyRequestName](this.keySystem_, this.sessionId);
-      } catch (exception) {}
+      } catch (exception) {
+        shaka.log.debug(`${cancelKeyRequestName} exception`, exception);
+      }
     }
 
     // Resolve the 'closed' promise and return it.
@@ -975,6 +977,14 @@ shaka.polyfill.PatchedMediaKeysWebkit.MediaKeyStatusMap = class {
  * @private {string}
  */
 shaka.polyfill.PatchedMediaKeysWebkit.prefix_ = '';
+
+
+/**
+ * API name.
+ *
+ * @private {string}
+ */
+shaka.polyfill.PatchedMediaKeysWebkit.apiName_ = 'webkit';
 
 
 shaka.polyfill.register(shaka.polyfill.PatchedMediaKeysWebkit.install);

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -648,15 +648,16 @@ shaka.util.Platform = class {
   /**
    * Returns true if MediaKeys is polyfilled
    *
+   * @param {string=} polyfillType
    * @return {boolean}
    */
-  static isMediaKeysPolyfilled() {
-    if (window.shakaMediaKeysPolyfill) {
-      return true;
+  static isMediaKeysPolyfilled(polyfillType) {
+    if (polyfillType) {
+      return polyfillType === window.shakaMediaKeysPolyfill;
     }
-
-    return false;
+    return !!window.shakaMediaKeysPolyfill;
   }
+
 
   /**
    * Detect the maximum resolution that the platform's hardware can handle.

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -236,6 +236,25 @@ describe('Player', () => {
       }
     });
 
+    it('destroys drmEngine before mediaSourceEngine with webkit polyfill',
+        async () => {
+          spyOn(shaka.util.Platform, 'isMediaKeysPolyfilled')
+              .and.returnValue(true);
+          goog.asserts.assert(manifest, 'Manifest should be non-null');
+
+          Util.funcSpy(drmEngine.destroy).and.callFake(async () => {
+            expect(mediaSourceEngine.destroy).not.toHaveBeenCalled();
+            await Util.shortDelay();
+            expect(mediaSourceEngine.destroy).not.toHaveBeenCalled();
+          });
+
+          await player.load(fakeManifestUri, 0, fakeMimeType);
+          await player.destroy();
+
+          expect(drmEngine.destroy).toHaveBeenCalled();
+          expect(mediaSourceEngine.destroy).toHaveBeenCalled();
+        });
+
     it('destroys mediaSourceEngine before drmEngine', async () => {
       goog.asserts.assert(manifest, 'Manifest should be non-null');
 

--- a/test/polyfill/patchedmediakeys_apple_unit.js
+++ b/test/polyfill/patchedmediakeys_apple_unit.js
@@ -95,7 +95,7 @@ describe('PatchedMediaKeys_Apple', () => {
           .toEqual(PatchedMediaKeysApple.MediaKeySystemAccess);
       expect(navigator.requestMediaKeySystemAccess)
           .toEqual(PatchedMediaKeysApple.requestMediaKeySystemAccess);
-      expect(window.shakaMediaKeysPolyfill).toBe(true);
+      expect(window.shakaMediaKeysPolyfill).toBe('apple');
     });
   });
 
@@ -124,7 +124,7 @@ describe('PatchedMediaKeys_Apple', () => {
           .toEqual(originalWindowMediaKeySystemAccess);
       expect(navigator.requestMediaKeySystemAccess)
           .toEqual(originalNavigatorRequestMediaKeySystemAccess);
-      expect(window.shakaMediaKeysPolyfill).toBe(false);
+      expect(window.shakaMediaKeysPolyfill).toBe('');
     });
   });
 });

--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -102,6 +102,42 @@ describe('Platform', () => {
     setUserAgent(webOs5);
     expect(shaka.util.Platform.isWebOS5()).toBe(true);
   });
+
+  describe('isMediaKeysPolyfilled', () => {
+    let shakaMediaKeysPolyfill;
+
+    beforeAll(() => {
+      shakaMediaKeysPolyfill = window.shakaMediaKeysPolyfill;
+    });
+
+    afterAll(() => {
+      window.shakaMediaKeysPolyfill = shakaMediaKeysPolyfill;
+    });
+
+    it('should return true if media keys are polyfilled', () => {
+      window.shakaMediaKeysPolyfill = 'webkit';
+      const result = shaka.util.Platform.isMediaKeysPolyfilled();
+      expect(result).toBe(true);
+    });
+
+    it('should return false if media keys are not polyfilled', () => {
+      window.shakaMediaKeysPolyfill = '';
+      const result = shaka.util.Platform.isMediaKeysPolyfilled();
+      expect(result).toBe(false);
+    });
+
+    it('should return true with a matching polyfill type', () => {
+      window.shakaMediaKeysPolyfill = 'webkit';
+      const result = shaka.util.Platform.isMediaKeysPolyfilled('webkit');
+      expect(result).toBe(true);
+    });
+
+    it('should return false with a non-matching polyfill type', () => {
+      window.shakaMediaKeysPolyfill = 'webkit';
+      const result = shaka.util.Platform.isMediaKeysPolyfilled('apple');
+      expect(result).toBe(false);
+    });
+  });
 });
 
 /** @param {string} userAgent */


### PR DESCRIPTION
On WebOS 3.0 we've noticed an issue in production, where TVs are slowly starting to throw the following error after a user has watched at least 30+ episodes: `Code: 6006 Category: 6 Severity: 2 ["EME v0.1b key error",{"errorCode":{"code":1,"systemCode":65535}},"0xffff"]` and can only be resolved by clearing the app cache, or unplugging the TV.
Further investigation revealed that current workflow, where MSE is destroyed before DRM Engine causes that old EME implementation is not able to close session properly.
![image](https://github.com/shaka-project/shaka-player/assets/27518393/99cba534-5d56-44f3-8345-5dde71d16e52)
