### PR TITLE
chore: Remove old LCEVC code

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -893,21 +893,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    */
   setupLcevc_(config) {
     if (config.lcevc.enabled) {
-      const tracks = this.getVariantTracks();
-      if (tracks && tracks[0] && tracks[0].videoMimeType == 'video/mp2t') {
-        const edge = shaka.util.Platform.isEdge() ||
-          shaka.util.Platform.isLegacyEdge();
-        if (edge) {
-          if (!config.mediaSource.forceTransmux) {
-            // If forceTransmux is disabled for Microsoft Edge, LCEVC data
-            // is stripped out in case of a MPEG-2 TS container.
-            // Hence the warning for Microsoft Edge when playing content with
-            // MPEG-2 TS container.
-            shaka.log.alwaysWarn('LCEVC Warning: For MPEG-2 TS decoding '+
-            'the config.mediaSource.forceTransmux must be enabled.');
-          }
-        }
-      }
       this.closeLcevcDec_();
       this.createLcevcDec_(config.lcevc);
     } else {


### PR DESCRIPTION
Since the latest versions we always make TS transmux.