### PR TITLE
feat(DASH): add  `MPD_PATCH` advanced request type

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -326,13 +326,14 @@ shaka.dash.DashParser = class {
    */
   async requestManifest_() {
     const requestType = shaka.net.NetworkingEngine.RequestType.MANIFEST;
-    const type = shaka.net.NetworkingEngine.AdvancedRequestType.MPD;
+    let type = shaka.net.NetworkingEngine.AdvancedRequestType.MPD;
     let rootElement = 'MPD';
     const patchLocationUris = this.getPatchLocationUris_();
     let manifestUris = this.manifestUris_;
     if (patchLocationUris.length) {
       manifestUris = patchLocationUris;
       rootElement = 'Patch';
+      type = shaka.net.NetworkingEngine.AdvancedRequestType.MPD_PATCH;
     } else if (this.manifestUris_.length > 1 && this.contentSteeringManager_) {
       const locations = this.contentSteeringManager_.getLocations(
           'Location', /* ignoreBaseUrls= */ true);

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -871,6 +871,7 @@ shaka.net.NetworkingEngine.AdvancedRequestType = {
   'MASTER_PLAYLIST': 3,
   'MPD': 4,
   'MSS': 5,
+  'MPD_PATCH': 6,
 };
 
 

--- a/test/dash/dash_parser_patch_unit.js
+++ b/test/dash/dash_parser_patch_unit.js
@@ -17,6 +17,9 @@ describe('DashParser Patch', () => {
   const manifestContext = {
     type: shaka.net.NetworkingEngine.AdvancedRequestType.MPD,
   };
+  const patchContext = {
+    type: shaka.net.NetworkingEngine.AdvancedRequestType.MPD_PATCH,
+  };
 
   /** @type {!shaka.test.FakeNetworkingEngine} */
   let fakeNetEngine;
@@ -121,7 +124,7 @@ describe('DashParser Patch', () => {
 
       await updateManifest();
       expect(fakeNetEngine.request).toHaveBeenCalledTimes(1);
-      fakeNetEngine.expectRequest('dummy://bar', manifestRequest, manifestContext);
+      fakeNetEngine.expectRequest('dummy://bar', manifestRequest, patchContext);
       expect(onError).toHaveBeenCalledWith(new shaka.util.Error(
           shaka.util.Error.Severity.RECOVERABLE,
           shaka.util.Error.Category.MANIFEST,
@@ -155,7 +158,7 @@ describe('DashParser Patch', () => {
 
       await updateManifest();
       expect(fakeNetEngine.request).toHaveBeenCalledTimes(1);
-      fakeNetEngine.expectRequest('dummy://bar', manifestRequest, manifestContext);
+      fakeNetEngine.expectRequest('dummy://bar', manifestRequest, patchContext);
       expect(onError).toHaveBeenCalledWith(new shaka.util.Error(
           shaka.util.Error.Severity.RECOVERABLE,
           shaka.util.Error.Category.MANIFEST,
@@ -215,7 +218,7 @@ describe('DashParser Patch', () => {
 
       await updateManifest();
       expect(fakeNetEngine.request).toHaveBeenCalledTimes(1);
-      fakeNetEngine.expectRequest('dummy://bar', manifestRequest, manifestContext);
+      fakeNetEngine.expectRequest('dummy://bar', manifestRequest, patchContext);
     });
 
     it('does not use PatchLocation if publishTime is not defined', async () => {
@@ -250,7 +253,7 @@ describe('DashParser Patch', () => {
       await updateManifest();
       expect(fakeNetEngine.request).toHaveBeenCalledTimes(1);
       fakeNetEngine.expectRequest('dummy://foo', manifestRequest, manifestContext);
-      fakeNetEngine.expectNoRequest('dummy://bar', manifestRequest, manifestContext);
+      fakeNetEngine.expectNoRequest('dummy://bar', manifestRequest, patchContext);
     });
 
     it('does not use PatchLocation if it expired', async () => {
@@ -265,7 +268,7 @@ describe('DashParser Patch', () => {
       await updateManifest();
       expect(fakeNetEngine.request).toHaveBeenCalledTimes(1);
       fakeNetEngine.expectRequest('dummy://foo', manifestRequest, manifestContext);
-      fakeNetEngine.expectNoRequest('dummy://bar', manifestRequest, manifestContext);
+      fakeNetEngine.expectNoRequest('dummy://bar', manifestRequest, patchContext);
     });
 
     it('replaces PatchLocation with new URL', async () => {
@@ -287,14 +290,14 @@ describe('DashParser Patch', () => {
 
       await updateManifest();
       expect(fakeNetEngine.request).toHaveBeenCalledTimes(1);
-      fakeNetEngine.expectRequest('dummy://bar', manifestRequest, manifestContext);
+      fakeNetEngine.expectRequest('dummy://bar', manifestRequest, patchContext);
       fakeNetEngine.request.calls.reset();
 
       fakeNetEngine.setResponseText('dummy://bar2', patchText);
       // Another request should be made to new URI.
       await updateManifest();
       expect(fakeNetEngine.request).toHaveBeenCalledTimes(1);
-      fakeNetEngine.expectRequest('dummy://bar2', manifestRequest, manifestContext);
+      fakeNetEngine.expectRequest('dummy://bar2', manifestRequest, patchContext);
     });
   });
 


### PR DESCRIPTION
Add `shaka.net.NetworkingEngine.AdvancedRequestType.MPD_PATCH` to distinguish regular MPD requests from MPD Patch requests.