### PR TITLE
fix: `getPresentationStartTimeAsDate()` should return time unaffected by clock drift

### DIFF
--- a/lib/media/presentation_timeline.js
+++ b/lib/media/presentation_timeline.js
@@ -98,7 +98,7 @@ shaka.media.PresentationTimeline = class {
     this.startTimeLocked_ = false;
 
     /** @private {?number} */
-    this.initialProgramDateTime_ = null;
+    this.initialProgramDateTime_ = presentationStartTime;
   }
 
 


### PR DESCRIPTION
For our Seek To Date feature, we need the presentation start date directly from the manifest since all of the client’s key play times are based directly on the `availabilityStartTime` from the manifest directly.
