### PR TITLE
feat(HLS): Only process DATE-RANGE in AUDIO and VIDEO playlists

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -3646,6 +3646,12 @@ shaka.hls.HlsParser = class {
    * @private
    */
   processDateRangeTags_(tags, contentType, variables, getUris) {
+    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    if (contentType != ContentType.VIDEO && contentType != ContentType.AUDIO) {
+      // DATE-RANGE should only appear in AUDIO or VIDEO playlists.
+      // We ignore those that appear in other playlists.
+      return;
+    }
     const Utils = shaka.hls.Utils;
     const initialProgramDateTime =
         this.presentationTimeline_.getInitialProgramDateTime();


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-6.2.4

```
If any Playlist contains Date Ranges, then at least one Playlist
      in any playable combination of Renditions of any Variant Stream
      MUST contain Date Ranges.  Any Playlist with Date Ranges MUST
      contain the same set of Date Ranges as the others that do.  The
      EXT-X-DATERANGE tags of corresponding Date Ranges MUST have the
      same ID attribute value and contain the same set of attribute/
      value pairs.
```

So it would not be allowed. We can omit Date Ranges from img and subtitle Playlists in a Rendition that has Date Ranges in the Variant Playlists (main video STREAM-INF Playlists).

