### PR TITLE
fix: ignore buffered content less than 1e-4s

### DIFF
--- a/lib/media/time_ranges_utils.js
+++ b/lib/media/time_ranges_utils.js
@@ -23,7 +23,8 @@ shaka.media.TimeRangesUtils = class {
       return null;
     }
     // Workaround Safari bug: https://bit.ly/2trx6O8
-    if (b.length == 1 && b.end(0) - b.start(0) < 1e-6) {
+    // Firefox may leave <1e-4s of data in buffer after clearing all content
+    if (b.length == 1 && b.end(0) - b.start(0) < 1e-4) {
       return null;
     }
     // Workaround Edge bug: https://bit.ly/2JYLPeB
@@ -46,7 +47,8 @@ shaka.media.TimeRangesUtils = class {
       return null;
     }
     // Workaround Safari bug: https://bit.ly/2trx6O8
-    if (b.length == 1 && b.end(0) - b.start(0) < 1e-6) {
+    // Firefox may leave <1e-4s of data in buffer after clearing all content
+    if (b.length == 1 && b.end(0) - b.start(0) < 1e-4) {
       return null;
     }
     return b.length ? b.end(b.length - 1) : null;
@@ -65,7 +67,8 @@ shaka.media.TimeRangesUtils = class {
       return false;
     }
     // Workaround Safari bug: https://bit.ly/2trx6O8
-    if (b.length == 1 && b.end(0) - b.start(0) < 1e-6) {
+    // Firefox may leave <1e-4s of data in buffer after clearing all content
+    if (b.length == 1 && b.end(0) - b.start(0) < 1e-4) {
       return false;
     }
 
@@ -93,7 +96,8 @@ shaka.media.TimeRangesUtils = class {
       return 0;
     }
     // Workaround Safari bug: https://bit.ly/2trx6O8
-    if (b.length == 1 && b.end(0) - b.start(0) < 1e-6) {
+    // Firefox may leave <1e-4s of data in buffer after clearing all content
+    if (b.length == 1 && b.end(0) - b.start(0) < 1e-4) {
       return 0;
     }
 
@@ -129,7 +133,8 @@ shaka.media.TimeRangesUtils = class {
       return null;
     }
     // Workaround Safari bug: https://bit.ly/2trx6O8
-    if (b.length == 1 && b.end(0) - b.start(0) < 1e-6) {
+    // Firefox may leave <1e-4s of data in buffer after clearing all content
+    if (b.length == 1 && b.end(0) - b.start(0) < 1e-4) {
       return null;
     }
 

--- a/lib/media/time_ranges_utils.js
+++ b/lib/media/time_ranges_utils.js
@@ -12,6 +12,19 @@ goog.provide('shaka.media.TimeRangesUtils');
  */
 shaka.media.TimeRangesUtils = class {
   /**
+   * Returns whether the buffer is small enough to be ignored.
+   *
+   * @param {TimeRanges} b
+   * @return {boolean}
+   * @private
+   */
+  static isBufferNegligible_(b) {
+    // Workaround Safari bug: https://bit.ly/2trx6O8
+    // Firefox may leave <1e-4s of data in buffer after clearing all content
+    return b.length == 1 && b.end(0) - b.start(0) < 1e-4;
+  }
+
+  /**
    * Gets the first timestamp in the buffer.
    *
    * @param {TimeRanges} b
@@ -22,9 +35,7 @@ shaka.media.TimeRangesUtils = class {
     if (!b) {
       return null;
     }
-    // Workaround Safari bug: https://bit.ly/2trx6O8
-    // Firefox may leave <1e-4s of data in buffer after clearing all content
-    if (b.length == 1 && b.end(0) - b.start(0) < 1e-4) {
+    if (shaka.media.TimeRangesUtils.isBufferNegligible_(b)) {
       return null;
     }
     // Workaround Edge bug: https://bit.ly/2JYLPeB
@@ -46,9 +57,7 @@ shaka.media.TimeRangesUtils = class {
     if (!b) {
       return null;
     }
-    // Workaround Safari bug: https://bit.ly/2trx6O8
-    // Firefox may leave <1e-4s of data in buffer after clearing all content
-    if (b.length == 1 && b.end(0) - b.start(0) < 1e-4) {
+    if (shaka.media.TimeRangesUtils.isBufferNegligible_(b)) {
       return null;
     }
     return b.length ? b.end(b.length - 1) : null;
@@ -66,9 +75,7 @@ shaka.media.TimeRangesUtils = class {
     if (!b || !b.length) {
       return false;
     }
-    // Workaround Safari bug: https://bit.ly/2trx6O8
-    // Firefox may leave <1e-4s of data in buffer after clearing all content
-    if (b.length == 1 && b.end(0) - b.start(0) < 1e-4) {
+    if (shaka.media.TimeRangesUtils.isBufferNegligible_(b)) {
       return false;
     }
 
@@ -95,9 +102,7 @@ shaka.media.TimeRangesUtils = class {
     if (!b || !b.length) {
       return 0;
     }
-    // Workaround Safari bug: https://bit.ly/2trx6O8
-    // Firefox may leave <1e-4s of data in buffer after clearing all content
-    if (b.length == 1 && b.end(0) - b.start(0) < 1e-4) {
+    if (shaka.media.TimeRangesUtils.isBufferNegligible_(b)) {
       return 0;
     }
 
@@ -132,9 +137,7 @@ shaka.media.TimeRangesUtils = class {
     if (!b || !b.length) {
       return null;
     }
-    // Workaround Safari bug: https://bit.ly/2trx6O8
-    // Firefox may leave <1e-4s of data in buffer after clearing all content
-    if (b.length == 1 && b.end(0) - b.start(0) < 1e-4) {
+    if (shaka.media.TimeRangesUtils.isBufferNegligible_(b)) {
       return null;
     }
 


### PR DESCRIPTION
On Firefox, in some cases after a period ends, seeking shortly after will cause playback to fail or stall.
This occurs when the next period has small gaps and we're seeking to after the gap. Seeking to before the gap succeeds. Even though the seek requests the soure buffers to be fully cleared, Firefox actually keeps around less than 1e-4s of content and won't let us forcibly remove this content. Trying to call flush causes in infinite loop.
This leftover content makes shaka think that the buffer end in where we used to be even though the presentation time reflects where we seeked to. This means that playback doesn't continue. The buffer contitues getting filled and playback will either fail when the SourcBuffer is filled and triggers a QuotaExceededError or contiue when the buffer will reach the presentationTime.