### PR TITLE
fix: `selectAudioLanguage()` should ignore unplayable variants

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -4825,6 +4825,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             this.currentAdaptationSetCriteria_.create(this.manifest_.variants);
       let bestVariant = null;
       for (const curVariant of set.values()) {
+        if (!shaka.util.StreamUtils.isPlayable(curVariant)) {
+          continue;
+        }
         if (!bestVariant ||
               diff(bestVariant, active) > diff(curVariant, active)) {
           bestVariant = curVariant;

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -2292,6 +2292,14 @@ describe('Player', () => {
       expect(getActiveVariantTrack().roles).toContain('commentary');
     });
 
+    it('selectAudioLanguage() ignores unplayable variants', () => {
+      player.configure({
+        restrictions: {minChannelsCount: 6},
+      });
+      player.selectAudioLanguage('es');
+      expect(getActiveVariantTrack().channelsCount).toBe(6);
+    });
+
     it('selectAudioLanguage() respects selected audio codec', () => {
       player.selectAudioLanguage('es', '', 0, 0, 'mp4a.40.2');
       expect(getActiveVariantTrack().audioCodec).toBe('mp4a.40.2');


### PR DESCRIPTION
When restrictions are set, `selectAudioLanguage()` ignores them and may suggest variant that is marked as unplayable.