### PR TITLE
ci: Compute sha1 from ref in advance in lab and screenshot workflows

### DIFF
--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -58,7 +58,7 @@ jobs:
       REF: ${{ steps.compute.outputs.REF }}
 
     steps:
-      - name: Fetch REF information
+      - name: Compute ref
         id: compute
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -65,15 +65,13 @@ jobs:
           RUN_AT: ${{ github.event_name == 'workflow_call' && github.event.comment.created_at || github.event.repository.updated_at }}
         run: |
           if [[ -z "${{ inputs.pr }}" ]]; then
-            REF="main"
+            REF=$(git rev-parse refs/heads/main)
           else
-            pr="$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr }})"
-            head_sha="$(echo "$pr" | jq -r .head.sha)"
-            updated_at="$(echo "$pr" | jq -r .updated_at)"
+            REF=$(git rev-parse refs/pull/${{ inputs.pr }}/head)
+            updated_at="$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr }} | jq -r .updated_at)"
             if [[ $(date -d "$updated_at") > $(date -d "$RUN_AT") ]]; then
               exit 1
             fi
-            REF="$head_sha"
           fi
           echo "REF=$REF" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -70,6 +70,7 @@ jobs:
             REF=$(git rev-parse refs/pull/${{ inputs.pr }}/head)
             updated_at="$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr }} | jq -r .updated_at)"
             if [[ $(date -d "$updated_at") > $(date -d "$RUN_AT") ]]; then
+              echo "PR updated after trigger!  Quitting with error."
               exit 1
             fi
           fi

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -58,15 +58,25 @@ jobs:
       REF: ${{ steps.compute.outputs.REF }}
 
     steps:
-      - name: Compute ref
+      - name: Fetch REF information
         id: compute
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_AT: ${{ github.event_name == 'workflow_call' && github.event.comment.created_at || github.event.repository.updated_at }}
         run: |
-          if [[ "${{ inputs.pr }}" != "" ]]; then
-            LAB_TEST_REF="refs/pull/${{ inputs.pr }}/head"
+          if [[ -z "${{ inputs.pr }}" ]]; then
+            REF="main"
           else
-            LAB_TEST_REF="main"
+            pr="$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr }})"
+            head_sha="$(echo "$pr" | jq -r .head.sha)"
+            updated_at="$(echo "$pr" | jq -r .updated_at)"
+            if [[ $(date -d "$updated_at") > $(date -d "$RUN_AT") ]]; then
+              exit 1
+            fi
+            REF="$head_sha"
           fi
-          echo "REF=$LAB_TEST_REF" | tee -a $GITHUB_OUTPUT
+          echo "REF=$REF" >> $GITHUB_OUTPUT
+
 
   # Configure the build matrix based on our grid's YAML config.
   # The matrix contents will be computed by this first job and deserialized

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -73,7 +73,7 @@ jobs:
           # If "sha" is given, it overrides PR.  If neither is given, we fall
           # back to testing "main".
           sha: ${{ inputs.sha }}
-          ref: ${{ inputs.pr && ('refs/pull/' + inputs.pr + '/head') || 'refs/heads/main' }}
+          ref: ${{ inputs.pr && format('refs/pull/{0}/head', inputs.pr) || 'refs/heads/main' }}
 
   # Configure the build matrix based on our grid's YAML config.
   # The matrix contents will be computed by this first job and deserialized

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -64,16 +64,24 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_AT: ${{ github.event_name == 'workflow_call' && github.event.comment.created_at || github.event.repository.updated_at }}
         run: |
+          # Decide on the symbolic reference first.
+          if [[ "${{ inputs.pr }}" != "" ]]; then
+            # We're testing against a PR head.
+            SYMREF="refs/pull/${{ inputs.pr }}/head"
+          else
+            # We're testing against main.
+            SYMREF=refs/heads/main
+          fi
+
           # Compute a specific sha1 now.  We should use that in all other jobs
           # instead of a symbolic reference that can change meaning if the repo
           # changes.
-          if [[ -z "${{ inputs.pr }}" ]]; then
-            # We're testing against main.  Turn "main" into a sha1.
-            REF=$(git rev-parse refs/heads/main)
-          else
-            # We're testing against a PR.  Turn that PR head into a sha1.
-            REF=$(git rev-parse refs/pull/${{ inputs.pr }}/head)
+          REF=$(git ls-remote https://github.com/${{ github.repository }} "$SYMREF" | cut -f 1)
 
+          # Output the ref for other jobs to consume.
+          echo "REF=$REF" >> $GITHUB_OUTPUT
+
+          if [[ "${{ inputs.pr }}" != "" ]]; then
             # Check if the PR has been updated since the workflow was triggered.
             # If so, exit with an error message.
             updated_at="$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr }} | jq -r .updated_at)"
@@ -82,9 +90,6 @@ jobs:
               exit 1
             fi
           fi
-
-          # Output the ref for other jobs to consume.
-          echo "REF=$REF" >> $GITHUB_OUTPUT
 
   # Configure the build matrix based on our grid's YAML config.
   # The matrix contents will be computed by this first job and deserialized

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -6,10 +6,10 @@ on:
     # avoid malicious code executing in the lab.
     inputs:
       pr:
-        description: "A PR number to build and test in the lab.  Overridden by \"ref\" input.  If both are empty, will build and test from main."
+        description: "A PR number to build and test in the lab.  Overridden by \"sha\" input.  If both are empty, will build and test from main."
         required: false
-      ref:
-        description: "A specific git reference to build and test in the lab.  Overrides \"pr\" input.  If both are empty, will build and test from main."
+      sha:
+        description: "A specific git SHA to build and test in the lab.  Overrides \"pr\" input.  If both are empty, will build and test from main."
         required: false
       test_filter:
         description: "A regex filter to run a subset of the tests.  If empty, all tests will run."
@@ -22,7 +22,11 @@ on:
     # workflow.
     inputs:
       pr:
-        description: "A PR number to build and test in the lab.  If empty, will build and test from main."
+        description: "A PR number to build and test in the lab.  Overridden by \"sha\" input.  If both are empty, will build and test from main."
+        required: false
+        type: string
+      sha:
+        description: "A specific git SHA to build and test in the lab.  Overrides \"pr\" input.  If both are empty, will build and test from main."
         required: false
         type: string
       test_filter:
@@ -54,29 +58,29 @@ on:
 concurrency: selenium-lab
 
 jobs:
-  compute-ref:
-    name: Compute ref
+  compute-sha:
+    name: Compute SHA
     runs-on: ubuntu-latest
     outputs:
-      REF: ${{ steps.compute.outputs.REF }}
+      SHA: ${{ steps.compute.outputs.SHA }}
 
     steps:
-      - name: Compute ref
+      - name: Compute SHA
         id: compute
-        #uses: shaka-project/shaka-github-tools/compute-ref@main
-        uses: joeyparrish/shaka-github-tools/compute-ref@compute-ref  # FIXME
+        #uses: shaka-project/shaka-github-tools/compute-sha@main
+        uses: joeyparrish/shaka-github-tools/compute-sha@compute-sha  # FIXME
         with:
-          # If ref is given, it overrides PR.  If neither is given, we fall
+          # If "sha" is given, it overrides PR.  If neither is given, we fall
           # back to testing "main".
-          pr: ${{ inputs.pr }}
-          ref: ${{ inputs.pr == '' && (inputs.ref || 'refs/heads/main') }}
+          ref: ${{ inputs.pr == '' ? 'refs/heads/main' : 'refs/pull/${{ inputs.pr }}/head' }}
+          sha: ${{ inputs.sha }}
 
   # Configure the build matrix based on our grid's YAML config.
   # The matrix contents will be computed by this first job and deserialized
   # into the second job's config.
   matrix-config:
     name: Matrix config
-    needs: compute-ref
+    needs: compute-sha
     runs-on: ubuntu-latest
     outputs:
       INCLUDE: ${{ steps.configure.outputs.INCLUDE }}
@@ -84,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.compute-ref.outputs.REF }}
+          sha: ${{ needs.compute-sha.outputs.SHA }}
 
       - name: Install dependencies
         run: npm ci
@@ -144,12 +148,12 @@ jobs:
   # self-hosted Selenium jobs are run in containers on one machine).
   build-shaka:
     name: Pre-build Player
-    needs: compute-ref
+    needs: compute-sha
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.compute-ref.outputs.REF }}
+          ref: ${{ needs.compute-sha.outputs.SHA }}
 
       - name: Set commit status to pending
         if: ${{ inputs.skip_test_status == false }}
@@ -209,7 +213,7 @@ jobs:
     # This is a self-hosted runner in a Docker container, with access to our
     # lab's Selenium grid on port 4444.
     runs-on: self-hosted-selenium
-    needs: [compute-ref, build-shaka, matrix-config]
+    needs: [compute-sha, build-shaka, matrix-config]
     strategy:
       fail-fast: false
       matrix:
@@ -219,7 +223,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.compute-ref.outputs.REF }}
+          ref: ${{ needs.compute-sha.outputs.SHA }}
 
       - name: Set commit status to pending
         if: ${{ inputs.skip_commit_status == false }}

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -64,18 +64,27 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_AT: ${{ github.event_name == 'workflow_call' && github.event.comment.created_at || github.event.repository.updated_at }}
         run: |
+          # Compute a specific sha1 now.  We should use that in all other jobs
+          # instead of a symbolic reference that can change meaning if the repo
+          # changes.
           if [[ -z "${{ inputs.pr }}" ]]; then
+            # We're testing against main.  Turn "main" into a sha1.
             REF=$(git rev-parse refs/heads/main)
           else
+            # We're testing against a PR.  Turn that PR head into a sha1.
             REF=$(git rev-parse refs/pull/${{ inputs.pr }}/head)
+
+            # Check if the PR has been updated since the workflow was triggered.
+            # If so, exit with an error message.
             updated_at="$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr }} | jq -r .updated_at)"
             if [[ $(date -d "$updated_at") > $(date -d "$RUN_AT") ]]; then
               echo "PR updated after trigger!  Quitting with error."
               exit 1
             fi
           fi
-          echo "REF=$REF" >> $GITHUB_OUTPUT
 
+          # Output the ref for other jobs to consume.
+          echo "REF=$REF" >> $GITHUB_OUTPUT
 
   # Configure the build matrix based on our grid's YAML config.
   # The matrix contents will be computed by this first job and deserialized

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -73,7 +73,7 @@ jobs:
           # If "sha" is given, it overrides PR.  If neither is given, we fall
           # back to testing "main".
           sha: ${{ inputs.sha }}
-          ref: ${{ inputs.pr ? ('refs/pull/' + inputs.pr + '/head') : 'refs/heads/main' }}
+          ref: ${{ inputs.pr && ('refs/pull/' + inputs.pr + '/head') || 'refs/heads/main' }}
 
   # Configure the build matrix based on our grid's YAML config.
   # The matrix contents will be computed by this first job and deserialized

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -67,8 +67,7 @@ jobs:
     steps:
       - name: Compute SHA
         id: compute
-        #uses: shaka-project/shaka-github-tools/compute-sha@main
-        uses: joeyparrish/shaka-github-tools/compute-sha@compute-sha  # FIXME
+        uses: shaka-project/shaka-github-tools/compute-sha@main
         with:
           # If "sha" is given, it overrides PR.  If neither is given, we fall
           # back to testing "main".

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -72,8 +72,8 @@ jobs:
         with:
           # If "sha" is given, it overrides PR.  If neither is given, we fall
           # back to testing "main".
-          ref: ${{ inputs.pr == '' ? 'refs/heads/main' : 'refs/pull/${{ inputs.pr }}/head' }}
           sha: ${{ inputs.sha }}
+          ref: ${{ inputs.pr ? ('refs/pull/' + inputs.pr + '/head') : 'refs/heads/main' }}
 
   # Configure the build matrix based on our grid's YAML config.
   # The matrix contents will be computed by this first job and deserialized

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -69,7 +69,7 @@ jobs:
           # If ref is given, it overrides PR.  If neither is given, we fall
           # back to testing "main".
           pr: ${{ inputs.pr }}
-          ref: ${{ inputs.ref || "refs/heads/main" }}
+          ref: ${{ inputs.ref || 'refs/heads/main' }}
 
   # Configure the build matrix based on our grid's YAML config.
   # The matrix contents will be computed by this first job and deserialized

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -69,7 +69,7 @@ jobs:
           # If ref is given, it overrides PR.  If neither is given, we fall
           # back to testing "main".
           pr: ${{ inputs.pr }}
-          ref: ${{ inputs.ref || 'refs/heads/main' }}
+          ref: ${{ inputs.pr == '' && (inputs.ref || 'refs/heads/main') }}
 
   # Configure the build matrix based on our grid's YAML config.
   # The matrix contents will be computed by this first job and deserialized

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -6,7 +6,10 @@ on:
     # avoid malicious code executing in the lab.
     inputs:
       pr:
-        description: "A PR number to build and test in the lab.  If empty, will build and test from main."
+        description: "A PR number to build and test in the lab.  Overridden by \"ref\" input.  If both are empty, will build and test from main."
+        required: false
+      ref:
+        description: "A specific git reference to build and test in the lab.  Overrides \"pr\" input.  If both are empty, will build and test from main."
         required: false
       test_filter:
         description: "A regex filter to run a subset of the tests.  If empty, all tests will run."
@@ -60,36 +63,13 @@ jobs:
     steps:
       - name: Compute ref
         id: compute
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_AT: ${{ github.event_name == 'workflow_call' && github.event.comment.created_at || github.event.repository.updated_at }}
-        run: |
-          # Decide on the symbolic reference first.
-          if [[ "${{ inputs.pr }}" != "" ]]; then
-            # We're testing against a PR head.
-            SYMREF="refs/pull/${{ inputs.pr }}/head"
-          else
-            # We're testing against main.
-            SYMREF=refs/heads/main
-          fi
-
-          # Compute a specific sha1 now.  We should use that in all other jobs
-          # instead of a symbolic reference that can change meaning if the repo
-          # changes.
-          REF=$(git ls-remote https://github.com/${{ github.repository }} "$SYMREF" | cut -f 1)
-
-          # Output the ref for other jobs to consume.
-          echo "REF=$REF" >> $GITHUB_OUTPUT
-
-          if [[ "${{ inputs.pr }}" != "" ]]; then
-            # Check if the PR has been updated since the workflow was triggered.
-            # If so, exit with an error message.
-            updated_at="$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr }} | jq -r .updated_at)"
-            if [[ $(date -d "$updated_at") > $(date -d "$RUN_AT") ]]; then
-              echo "PR updated after trigger!  Quitting with error."
-              exit 1
-            fi
-          fi
+        #uses: shaka-project/shaka-github-tools/compute-ref@main
+        uses: joeyparrish/shaka-github-tools/compute-ref@compute-ref  # FIXME
+        with:
+          # If ref is given, it overrides PR.  If neither is given, we fall
+          # back to testing "main".
+          pr: ${{ inputs.pr }}
+          ref: ${{ inputs.ref || "refs/heads/main" }}
 
   # Configure the build matrix based on our grid's YAML config.
   # The matrix contents will be computed by this first job and deserialized

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -12,13 +12,36 @@ on:
         required: true
 
 jobs:
+  compute-ref:
+    name: Compute ref
+    runs-on: ubuntu-latest
+    outputs:
+      REF: ${{ steps.compute.outputs.REF }}
+
+    steps:
+      - name: Compute ref
+        id: compute
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Compute a specific sha1 now.  We should use that in all other jobs
+          # instead of a symbolic reference that can change meaning if the repo
+          # changes.
+
+          # We're testing against a PR.  Turn that PR head into a sha1.
+          REF=$(git rev-parse refs/pull/${{ inputs.pr }}/head)
+
+          # Output the ref for other jobs to consume.
+          echo "REF=$REF" >> $GITHUB_OUTPUT
+
   set-pending-status:
     name: Set Pending Status
+    needs: compute-ref
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ inputs.pr }}/head
+          ref: ${{ needs.compute-ref.outputs.REF }}
 
       - name: Set commit status to pending
         uses: shaka-project/shaka-github-tools/set-commit-status@main
@@ -40,11 +63,11 @@ jobs:
   update-pr:
     name: Update PR
     runs-on: ubuntu-latest
-    needs: [run-lab-tests]
+    needs: [compute-ref, run-lab-tests]
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ inputs.pr }}/head
+          ref: ${{ needs.compute-ref.outputs.REF }}
 
       - name: Get artifacts
         uses: actions/download-artifact@v4
@@ -91,13 +114,13 @@ jobs:
   set-final-status:
     name: Set Final Status
     runs-on: ubuntu-latest
-    needs: [run-lab-tests, update-pr]
+    needs: [compute-ref, run-lab-tests, update-pr]
     # Will run on success or failure, but not if the workflow is cancelled.
     if: ${{ success() || failure() }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ inputs.pr }}/head
+          ref: ${{ needs.compute-ref.outputs.REF }}
 
       - name: Compute final status
         id: compute

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -21,8 +21,7 @@ jobs:
     steps:
       - name: Compute SHA
         id: compute
-        #uses: shaka-project/shaka-github-tools/compute-sha@main
-        uses: joeyparrish/shaka-github-tools/compute-sha@compute-sha  # FIXME
+        uses: shaka-project/shaka-github-tools/compute-sha@main
         with:
           ref: refs/pull/${{ inputs.pr }}/head
 

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -8,11 +8,8 @@ on:
     # avoid malicious code executing in the lab.
     inputs:
       pr:
-        description: "A PR number to build and test in the lab."
-        required: false
-      sha:
-        description: "A specific git SHA to build and test in the lab.  Overrides \"pr\" input.  If both are empty, this workflow will fail."
-        required: false
+        description: "A PR number to build and test in the lab.  Required even if \"pr\" is given."
+        required: true
 
 jobs:
   compute-sha:
@@ -27,9 +24,7 @@ jobs:
         #uses: shaka-project/shaka-github-tools/compute-sha@main
         uses: joeyparrish/shaka-github-tools/compute-sha@compute-sha  # FIXME
         with:
-          # If sha is given, it overrides PR.  If neither is given, we fail.
-          sha: ${{ inputs.sha }}
-          ref: ${{ inputs.pr && format('refs/pull/{0}/head', inputs.pr) || '' }}
+          ref: refs/pull/${{ inputs.pr }}/head
 
   set-pending-status:
     name: Set Pending Status

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -8,37 +8,37 @@ on:
     # avoid malicious code executing in the lab.
     inputs:
       pr:
-        description: "A PR number to build and test in the lab.  Overridden by \"ref\" input.  If both are empty, will fail."
+        description: "A PR number to build and test in the lab."
         required: false
-      ref:
-        description: "A specific git reference to build and test in the lab.  Overrides \"pr\" input.  If both are empty, will fail."
+      sha:
+        description: "A specific git SHA to build and test in the lab.  Overrides \"pr\" input.  If both are empty, this workflow will fail."
         required: false
 
 jobs:
-  compute-ref:
-    name: Compute ref
+  compute-sha:
+    name: Compute SHA
     runs-on: ubuntu-latest
     outputs:
-      REF: ${{ steps.compute.outputs.REF }}
+      SHA: ${{ steps.compute.outputs.SHA }}
 
     steps:
-      - name: Compute ref
+      - name: Compute SHA
         id: compute
-        #uses: shaka-project/shaka-github-tools/compute-ref@main
-        uses: joeyparrish/shaka-github-tools/compute-ref@compute-ref  # FIXME
+        #uses: shaka-project/shaka-github-tools/compute-sha@main
+        uses: joeyparrish/shaka-github-tools/compute-sha@compute-sha  # FIXME
         with:
-          # If ref is given, it overrides PR.  If neither is given, we fail.
-          pr: ${{ inputs.pr }}
-          ref: ${{ inputs.ref }}
+          # If sha is given, it overrides PR.  If neither is given, we fail.
+          ref: refs/pull/${{ inputs.pr }}/head
+          sha: ${{ inputs.sha }}
 
   set-pending-status:
     name: Set Pending Status
-    needs: compute-ref
+    needs: compute-sha
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.compute-ref.outputs.REF }}
+          ref: ${{ needs.compute-sha.outputs.SHA }}
 
       - name: Set commit status to pending
         uses: shaka-project/shaka-github-tools/set-commit-status@main
@@ -52,7 +52,9 @@ jobs:
     needs: [set-pending-status]
     uses: ./.github/workflows/selenium-lab-tests.yaml
     with:
-      ref: ${{ needs.compute-ref.outputs.REF }}
+      # Pass the pre-computed SHA directly to the nested workflow.
+      # Do NOT pass "pr" and reinterpret it into a SHA in the nested workflow.
+      sha: ${{ needs.compute-sha.outputs.SHA }}
       test_filter: layout
       ignore_test_status: true
       job_name_prefix: "Get Selenium Lab Screenshots / "
@@ -60,11 +62,11 @@ jobs:
   update-pr:
     name: Update PR
     runs-on: ubuntu-latest
-    needs: [compute-ref, run-lab-tests]
+    needs: [compute-sha, run-lab-tests]
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.compute-ref.outputs.REF }}
+          ref: ${{ needs.compute-sha.outputs.SHA }}
 
       - name: Get artifacts
         uses: actions/download-artifact@v4
@@ -111,13 +113,13 @@ jobs:
   set-final-status:
     name: Set Final Status
     runs-on: ubuntu-latest
-    needs: [compute-ref, run-lab-tests, update-pr]
+    needs: [compute-sha, run-lab-tests, update-pr]
     # Will run on success or failure, but not if the workflow is cancelled.
     if: ${{ success() || failure() }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.compute-ref.outputs.REF }}
+          ref: ${{ needs.compute-sha.outputs.SHA }}
 
       - name: Compute final status
         id: compute

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -24,12 +24,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Decide on the symbolic reference first.
+          # We're testing against a PR head.
+          SYMREF="refs/pull/${{ inputs.pr }}/head"
+
           # Compute a specific sha1 now.  We should use that in all other jobs
           # instead of a symbolic reference that can change meaning if the repo
           # changes.
-
-          # We're testing against a PR.  Turn that PR head into a sha1.
-          REF=$(git rev-parse refs/pull/${{ inputs.pr }}/head)
+          REF=$(git ls-remote https://github.com/${{ github.repository }} "$SYMREF" | cut -f 1)
 
           # Output the ref for other jobs to consume.
           echo "REF=$REF" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -28,8 +28,8 @@ jobs:
         uses: joeyparrish/shaka-github-tools/compute-sha@compute-sha  # FIXME
         with:
           # If sha is given, it overrides PR.  If neither is given, we fail.
-          ref: refs/pull/${{ inputs.pr }}/head
           sha: ${{ inputs.sha }}
+          ref: ${{ inputs.pr ? ('refs/pull/' + inputs.pr + '/head') : '' }}
 
   set-pending-status:
     name: Set Pending Status

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           # If sha is given, it overrides PR.  If neither is given, we fail.
           sha: ${{ inputs.sha }}
-          ref: ${{ inputs.pr ? ('refs/pull/' + inputs.pr + '/head') : '' }}
+          ref: ${{ inputs.pr && ('refs/pull/' + inputs.pr + '/head') || '' }}
 
   set-pending-status:
     name: Set Pending Status

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -8,8 +8,11 @@ on:
     # avoid malicious code executing in the lab.
     inputs:
       pr:
-        description: "A PR number to build and test in the lab, then update all the screenshots."
-        required: true
+        description: "A PR number to build and test in the lab.  Overridden by \"ref\" input.  If both are empty, will fail."
+        required: false
+      ref:
+        description: "A specific git reference to build and test in the lab.  Overrides \"pr\" input.  If both are empty, will fail."
+        required: false
 
 jobs:
   compute-ref:
@@ -21,20 +24,12 @@ jobs:
     steps:
       - name: Compute ref
         id: compute
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Decide on the symbolic reference first.
-          # We're testing against a PR head.
-          SYMREF="refs/pull/${{ inputs.pr }}/head"
-
-          # Compute a specific sha1 now.  We should use that in all other jobs
-          # instead of a symbolic reference that can change meaning if the repo
-          # changes.
-          REF=$(git ls-remote https://github.com/${{ github.repository }} "$SYMREF" | cut -f 1)
-
-          # Output the ref for other jobs to consume.
-          echo "REF=$REF" >> $GITHUB_OUTPUT
+        #uses: shaka-project/shaka-github-tools/compute-ref@main
+        uses: joeyparrish/shaka-github-tools/compute-ref@compute-ref  # FIXME
+        with:
+          # If ref is given, it overrides PR.  If neither is given, we fail.
+          pr: ${{ inputs.pr }}
+          ref: ${{ inputs.ref }}
 
   set-pending-status:
     name: Set Pending Status
@@ -57,7 +52,7 @@ jobs:
     needs: [set-pending-status]
     uses: ./.github/workflows/selenium-lab-tests.yaml
     with:
-      pr: ${{ inputs.pr }}
+      ref: ${{ needs.compute-ref.outputs.REF }}
       test_filter: layout
       ignore_test_status: true
       job_name_prefix: "Get Selenium Lab Screenshots / "

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           # If sha is given, it overrides PR.  If neither is given, we fail.
           sha: ${{ inputs.sha }}
-          ref: ${{ inputs.pr && ('refs/pull/' + inputs.pr + '/head') || '' }}
+          ref: ${{ inputs.pr && format('refs/pull/{0}/head', inputs.pr) || '' }}
 
   set-pending-status:
     name: Set Pending Status


### PR DESCRIPTION
Always compute sha1 in lab and screenshot workflows in advance.  A symbolic ref can change mid-workflow if the repo changes.