### PR TITLE
fix(HLS): Fix AC-4 codec selection in HLS

### DIFF
--- a/lib/util/manifest_parser_utils.js
+++ b/lib/util/manifest_parser_utils.js
@@ -295,7 +295,7 @@ shaka.util.ManifestParserUtils.AUDIO_CODEC_REGEXPS_ = [
   /^flac$/, // some manifests wrongfully use this
   /^mp4a/,
   /^[ae]c-3$/,
-  /^ac-4$/,
+  /^ac-4/,
   /^dts[cex]$/, // DTS Digital Surround (dtsc), DTS Express (dtse), DTS:X (dtsx)
   /^iamf/,
 ];


### PR DESCRIPTION
See: https://ott.dolby.com/OnDelKits/AC-4/Dolby_AC-4_Online_Delivery_Kit_1.5/Documentation/Specs/AC4_HLS/help_files/topics/hls_playlist_c_codec_indication.html