### PR TITLE
fix(TTML): Extended subtitle codec support

### DIFF
--- a/lib/text/mp4_ttml_parser.js
+++ b/lib/text/mp4_ttml_parser.js
@@ -111,6 +111,12 @@ shaka.text.TextEngine.registerParser(
     'application/mp4; codecs="stpp.ttml.im1t"',
     () => new shaka.text.Mp4TtmlParser());
 shaka.text.TextEngine.registerParser(
+    'application/mp4; codecs="stpp.ttml.im2t"',
+    () => new shaka.text.Mp4TtmlParser());
+shaka.text.TextEngine.registerParser(
+    'application/mp4; codecs="stpp.ttml.etd1"',
+    () => new shaka.text.Mp4TtmlParser());
+shaka.text.TextEngine.registerParser(
     'application/mp4; codecs="stpp.ttml.etd1|im1t"',
     () => new shaka.text.Mp4TtmlParser());
 shaka.text.TextEngine.registerParser(

--- a/lib/text/mp4_ttml_parser.js
+++ b/lib/text/mp4_ttml_parser.js
@@ -110,6 +110,13 @@ shaka.text.TextEngine.registerParser(
 shaka.text.TextEngine.registerParser(
     'application/mp4; codecs="stpp.ttml.im1t"',
     () => new shaka.text.Mp4TtmlParser());
+shaka.text.TextEngine.registerParser(
+    'application/mp4; codecs="stpp.ttml.etd1|im1t"',
+    () => new shaka.text.Mp4TtmlParser());
+shaka.text.TextEngine.registerParser(
+    'application/mp4; codecs="stpp.ttml.im1t|etd1"',
+    () => new shaka.text.Mp4TtmlParser());
+
 // Legacy codec string uses capital "TTML", i.e.: prior to HLS rfc8216bis:
 //   Note that if a Variant Stream specifies one or more Renditions that
 //   include IMSC subtitles, the CODECS attribute MUST indicate this with a


### PR DESCRIPTION
No need to reject the subtitles when the parser can already handle them.

> Quote from specs:
> Valid examples include:
> • "stpp.ttml.etd1" - TTML content suitable for presentation by an EBU-TT-D renderer
> • "stpp.ttml.etd1|im1t" or "stpp.ttml.im1t|etd1" - TTML content suitable for presentation by an EBU-TT-D or
IMSC1 renderer 

Fixes #6831 