### PR TITLE
fix: Exclude fetch polyfill from fetch plugin

### DIFF
--- a/lib/net/http_fetch_plugin.js
+++ b/lib/net/http_fetch_plugin.js
@@ -267,7 +267,8 @@ shaka.net.HttpFetchPlugin = class {
     } else {
       return false;
     }
-    return !!(window.fetch && window.AbortController);
+    return !!(window.fetch && !('polyfill' in window.fetch) &&
+      window.AbortController);
   }
 };
 


### PR DESCRIPTION
This fix excludes the use of https://www.npmjs.com/package/fetch-polyfill because it does not support a signal to cancel requests in progress.