### PR TITLE
ci: Remove ChromecastHub from shaka bot commands

### DIFF
--- a/.github/workflows/shaka-bot-commands/command-test.sh
+++ b/.github/workflows/shaka-bot-commands/command-test.sh
@@ -25,7 +25,7 @@ WORKFLOW_ARGS=( "pr=$PR_NUMBER" )
 
 case "${SHAKA_BOT_ARGUMENTS[0]}" in
   # CE devices only.
-  ce) WORKFLOW_ARGS+=( "browser_filter=Tizen ChromecastHub ChromecastUltra ChromecastGTV ChromeAndroid" ) ;;
+  ce) WORKFLOW_ARGS+=( "browser_filter=Tizen ChromecastUltra ChromecastGTV ChromeAndroid" ) ;;
 
   # No command argument, no extra workflow arguments.
   "") ;;


### PR DESCRIPTION
ChromecastHub is currently disabled, so we don't want to trigger it explicitly on `test ce` commands.