### PR TITLE
ci: Migrate Firefox from macos-13 to macos-latest

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -60,9 +60,10 @@ jobs:
           - os: macos-13
             browser: Chrome
           - os: macos-13
-            browser: Firefox
-          - os: macos-13
             browser: Edge
+
+          - os: macos-latest
+            browser: Firefox
 
           - os: macos-latest
             browser: Safari
@@ -133,7 +134,7 @@ jobs:
 
       # Firefox and Edge might be missing on Mac CI images.
       - name: 'Install Firefox on Mac'
-        if: matrix.os == 'macos-13' && matrix.browser == 'Firefox'
+        if: matrix.os == 'macos-latest' && matrix.browser == 'Firefox'
         run: brew install --cask firefox
       - name: 'Install Edge on Mac'
         if: matrix.os == 'macos-13' && matrix.browser == 'Edge'


### PR DESCRIPTION
Using arm (macos-latest) wherever possible reduces build times by 3 minutes.

We have a limited number of macos runners, so if we save time even on Firefox alone (all we can do pending #6508), we can speed up the queue of pending jobs across PRs.
