### PR TITLE
feat: Dynamic target latency

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -588,13 +588,23 @@ shakaDemo.Config = class {
         .addNumberInput_('Max playback rate',
             'streaming.liveSync.maxPlaybackRate',
             /* canBeDecimal= */ true,
-            /* canBeZero= */ false)
+            /* canBeZero= */ true)
         .addNumberInput_('Min playback rate',
             'streaming.liveSync.minPlaybackRate',
             /* canBeDecimal= */ true)
         .addBoolInput_('Panic Mode', 'streaming.liveSync.panicMode')
         .addNumberInput_('Panic Mode Threshold',
-            'streaming.liveSync.panicThreshold');
+            'streaming.liveSync.panicThreshold')
+        .addBoolInput_('Dynamic Target Latency',
+            'streaming.liveSync.dynamicTargetLatency.enabled')
+        .addNumberInput_('Dynamic Target Latency Stability Threshold',
+            'streaming.liveSync.dynamicTargetLatency.stabilityThreshold')
+        .addNumberInput_('Dynamic Target Latency Rebuffer Increment',
+            'streaming.liveSync.dynamicTargetLatency.rebufferIncrement',
+            /* canBeDecimal= */ true,
+            /* canBeZero= */ true)
+        .addNumberInput_('Dynamic Target Latency Max Attempts',
+            'streaming.liveSyncDynamicTargetLatencyMaxAttempts')
   }
 
   /** @private */

--- a/demo/config.js
+++ b/demo/config.js
@@ -588,7 +588,7 @@ shakaDemo.Config = class {
         .addNumberInput_('Max playback rate',
             'streaming.liveSync.maxPlaybackRate',
             /* canBeDecimal= */ true,
-            /* canBeZero= */ true)
+            /* canBeZero= */ false)
         .addNumberInput_('Min playback rate',
             'streaming.liveSync.minPlaybackRate',
             /* canBeDecimal= */ true)

--- a/demo/config.js
+++ b/demo/config.js
@@ -604,7 +604,11 @@ shakaDemo.Config = class {
             /* canBeDecimal= */ true,
             /* canBeZero= */ true)
         .addNumberInput_('Dynamic Target Latency Max Attempts',
-            'streaming.liveSyncDynamicTargetLatencyMaxAttempts')
+            'streaming.liveSync.dynamicTargetLatency.maxAttempts')
+        .addNumberInput_('Dynamic Target Latency Max Latency',
+            'streaming.liveSync.dynamicTargetLatency.maxLatency')
+        .addNumberInput_('Dynamic Target Latency Min Latency',
+            'streaming.liveSync.dynamicTargetLatency.minLatency');
   }
 
   /** @private */

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1269,17 +1269,39 @@ shaka.extern.ManifestConfiguration;
  *   enabled: boolean,
  *   stabilityThreshold: number,
  *   rebufferIncrement: number,
- *   maxAttempts: number
+ *   maxAttempts: number,
+ *   maxLatency: number,
+ *   minLatency: number
  * }}
  *
  * @description
  * Dynamic Target Latency configuration options.
  *
  * @property {boolean} enabled
- *   Enable the live stream sync against the live edge by changing the playback
- *   rate. Defaults to <code>false</code>.
- *   Note: on some SmartTVs, if this is activated, it may not work or the sound
- *   may be lost when activated.
+ *   If <code>true</code>, dynamic latency for live sync is enabled. When
+ *   enabled, the target latency will be adjusted closer to the min latency
+ *   when playback is stable (see <code>stabilityThreshold</code>). If
+ *   there are rebuffering events, then the target latency will move towards
+ *   the max latency value in increments of <code>rebufferIncrement</code>.
+ *   Defaults to <code>false</code>.
+ * @property {number} rebufferIncrement
+ *   The value, in seconds, to increment the target latency towards
+ *   <code>maxLatency</code> after a rebuffering event. Defaults to
+ *   <code>0.5</code>.
+ * @property {number} stabilityThreshold
+ *   Number of seconds after a rebuffering before we are considered stable and
+ *   will move the target latency towards <code>minLatency</code>
+ *   value. Defaults to <code>60</code>
+ * @property {number} maxAttempts
+ *   Number of times that dynamic target latency will back off to
+ *   <code>maxLatency</code> and attempt to adjust it closer to
+ *   <code>minLatency</code>. Defaults to <code>5</code>
+ * @property {number} maxLatency
+ *   The latency to use when a rebuffering event causes us to back off from
+ *   the live edge. Defaults to <code>4</code>
+ * @property {number} minLatency
+ *   The latency to work towards when the network is stable and we want to get
+ *   closer to the live edge. Defaults to <code>1</code>
  * @exportDoc
  */
 shaka.extern.DynamicTargetLatencyConfiguration;

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1263,6 +1263,28 @@ shaka.extern.MssManifestConfiguration;
 shaka.extern.ManifestConfiguration;
 
 
+
+/**
+ * @typedef {{
+ *   enabled: boolean,
+ *   stabilityThreshold: number,
+ *   rebufferIncrement: number,
+ *   maxAttempts: number
+ * }}
+ *
+ * @description
+ * Dynamic Target Latency configuration options.
+ *
+ * @property {boolean} enabled
+ *   Enable the live stream sync against the live edge by changing the playback
+ *   rate. Defaults to <code>false</code>.
+ *   Note: on some SmartTVs, if this is activated, it may not work or the sound
+ *   may be lost when activated.
+ * @exportDoc
+ */
+shaka.extern.DynamicTargetLatencyConfiguration;
+
+
 /**
  * @typedef {{
  *   enabled: boolean,
@@ -1271,7 +1293,8 @@ shaka.extern.ManifestConfiguration;
  *   maxPlaybackRate: number,
  *   minPlaybackRate: number,
  *   panicMode: boolean,
- *   panicThreshold: number
+ *   panicThreshold: number,
+ *   dynamicTargetLatency: shaka.extern.DynamicTargetLatencyConfiguration
  * }}
  *
  * @description
@@ -1304,6 +1327,10 @@ shaka.extern.ManifestConfiguration;
  * @property {number} panicThreshold
  *   Number of seconds that playback stays in panic mode after a rebuffering.
  *   Defaults to <code>60</code>
+ * @property {shaka.extern.DynamicTargetLatencyConfiguration} dynamicTargetLatency
+ *   The dynamic target latency config for dynamically adjusting the target
+ *   latency to be closer to edge when network conditions are good and to back
+ *   off when network conditions are bad.
  * @exportDoc
  */
 shaka.extern.LiveSyncConfiguration;

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1262,8 +1262,6 @@ shaka.extern.MssManifestConfiguration;
  */
 shaka.extern.ManifestConfiguration;
 
-
-
 /**
  * @typedef {{
  *   enabled: boolean,
@@ -1349,7 +1347,9 @@ shaka.extern.DynamicTargetLatencyConfiguration;
  * @property {number} panicThreshold
  *   Number of seconds that playback stays in panic mode after a rebuffering.
  *   Defaults to <code>60</code>
- * @property {shaka.extern.DynamicTargetLatencyConfiguration} dynamicTargetLatency
+ * @property {shaka.extern.DynamicTargetLatencyConfiguration}
+ * dynamicTargetLatency
+ *
  *   The dynamic target latency config for dynamically adjusting the target
  *   latency to be closer to edge when network conditions are good and to back
  *   off when network conditions are bad.

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1293,7 +1293,7 @@ shaka.extern.ManifestConfiguration;
  * @property {number} maxAttempts
  *   Number of times that dynamic target latency will back off to
  *   <code>maxLatency</code> and attempt to adjust it closer to
- *   <code>minLatency</code>. Defaults to <code>5</code>
+ *   <code>minLatency</code>. Defaults to <code>10</code>
  * @property {number} maxLatency
  *   The latency to use when a rebuffering event causes us to back off from
  *   the live edge. Defaults to <code>4</code>

--- a/lib/player.js
+++ b/lib/player.js
@@ -6537,12 +6537,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.config_.streaming.liveSync.dynamicTargetLatency.maxAttempts;
     if (dynamicTargetLatency && this.targetLatencyReached_ &&
       typeof this.currentTargetLatency_ === 'number' &&
-      typeof targetLatency === 'number' && 
+      typeof targetLatency === 'number' &&
       this.rebufferingCount_ < maxAttempts &&
       (Date.now() - this.targetLatencyReached_) > stabilityThreshold * 1000) {
       const dynamicMinLatency =
           this.config_.streaming.liveSync.dynamicTargetLatency.minLatency;
-      const latencyIncrement = (targetLatency - dynamicTargetLatency) / 2;
+      const latencyIncrement = (targetLatency - dynamicMinLatency) / 2;
       this.currentTargetLatency_ = Math.max(
           this.currentTargetLatency_ - latencyIncrement,
           // current target latency should be within the tolerance of the min
@@ -6550,7 +6550,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           dynamicMinLatency + targetLatencyTolerance);
       this.targetLatencyReached_ = Date.now();
     }
-    if (dynamicTargetLatency) {
+    if (dynamicTargetLatency && typeof this.currentTargetLatency_ == 'number') {
       maxLatency = this.currentTargetLatency_ + targetLatencyTolerance;
       minLatency = this.currentTargetLatency_ - targetLatencyTolerance;
     }

--- a/lib/player.js
+++ b/lib/player.js
@@ -707,6 +707,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @private {?shaka.extern.PlayerConfiguration} */
     this.config_ = this.defaultConfig_();
 
+    /** @private {?number} */
+    this.currentTargetLatency_ = null;
+
+    /** @private {number} */
+    this.rebufferingCount_ = -1;
+
+    /** @private {?number} */
+    this.targetLatencyReached_ = null;
+
     /**
      * The TextDisplayerFactory that was last used to make a text displayer.
      * Stored so that we can tell if a new type of text displayer is desired.
@@ -1452,6 +1461,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.manifest_ = null;
       this.stats_ = new shaka.util.Stats(); // Replace with a clean object.
       this.lastTextFactory_ = null;
+
+      this.targetLatencyReached_ = null;
+      this.currentTargetLatency_ = null;
+      this.rebufferingCount_ = -1;
 
       this.externalSrcEqualsThumbnailsStreams_ = [];
 
@@ -6320,6 +6333,29 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.cmcdManager_.setBuffering(isBuffering);
       }
       this.updateStateHistory_();
+
+      const dynamicTargetLatency =
+          this.config_.streaming.liveSync.dynamicTargetLatency.enabled;
+      const maxAttempts =
+          this.config_.streaming.liveSync.dynamicTargetLatency.maxAttempts;
+
+
+      if (dynamicTargetLatency && isBuffering &&
+        this.rebufferingCount_ < maxAttempts) {
+        let maxLatency =
+            this.config_.streaming.liveSync.dynamicTargetLatency.maxLatency;
+
+        const targetLatencyTolerance =
+          this.config_.streaming.liveSync.targetLatencyTolerance;
+        const rebufferIncrement =
+          this.config_.streaming.liveSync.dynamicTargetLatency.rebufferIncrement;
+        if (this.currentTargetLatency_) {
+          this.currentTargetLatency_ = Math.min(
+              this.currentTargetLatency_ +
+            ++this.rebufferingCount_ * rebufferIncrement,
+              maxLatency - targetLatencyTolerance);
+        }
+      }
     }
 
     // Surface the buffering event so that the app knows if/when we are
@@ -6446,16 +6482,21 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return;
     }
 
+    let targetLatency;
     let maxLatency;
     let maxPlaybackRate;
     let minLatency;
     let minPlaybackRate;
     const targetLatencyTolerance =
       this.config_.streaming.liveSync.targetLatencyTolerance;
+    const dynamicTargetLatency =
+      this.config_.streaming.liveSync.dynamicTargetLatency.enabled;
+    const stabilityThreshold =
+      this.config_.streaming.liveSync.dynamicTargetLatency.stabilityThreshold;
 
     if (this.config_.streaming.liveSync &&
       this.config_.streaming.liveSync.enabled) {
-      const targetLatency = this.config_.streaming.liveSync.targetLatency;
+      targetLatency = this.config_.streaming.liveSync.targetLatency;
       maxLatency = targetLatency + targetLatencyTolerance;
       minLatency = Math.max(0, targetLatency - targetLatencyTolerance);
       maxPlaybackRate = this.config_.streaming.liveSync.maxPlaybackRate;
@@ -6464,6 +6505,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // serviceDescription must override if it is defined in the MPD and
       // liveSync configuration is not set.
       if (this.manifest_ && this.manifest_.serviceDescription) {
+        targetLatency = this.manifest_.serviceDescription.targetLatency;
         if (this.manifest_.serviceDescription.targetLatency != null) {
           maxLatency = this.manifest_.serviceDescription.targetLatency +
               targetLatencyTolerance;
@@ -6484,6 +6526,26 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           this.manifest_.serviceDescription.minPlaybackRate ||
           this.config_.streaming.liveSync.minPlaybackRate;
       }
+    }
+
+    if (!this.currentTargetLatency_) {
+      this.currentTargetLatency_ = targetLatency;
+    }
+
+    const maxAttempts = this.config_.liveSync.dynamicTargetLatency.maxAttempts;
+    if (dynamicTargetLatency && typeof this.currentTargetLatency_ === 'number'
+      this.targetLatencyReached_ && typeof minLatency === "number"
+      (Date.now() - this.targetLatencyReached_) > stabilityThreshold * 1000 &&
+      this.rebufferingCount_ < maxAttempts) {
+      const latencyIncrement = (targetLatency - minLatency) / 2;
+      this.currentTargetLatency_ = Math.max(
+        this.currentTargetLatency_ - latencyIncrement,
+        // current target latency should be within the tolerance of the min
+          // latency to not overshoot it
+          minLatency + targetLatencyTolerance);
+      maxLatency = this.currentTargetLatency_ + targetLatencyTolerance;
+      minLatency = this.currentTargetLatency_ - targetLatencyTolerance;
+      this.targetLatencyReached_ = null;
     }
 
     const latency = seekRange.end - this.video_.currentTime;
@@ -6526,6 +6588,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           'Updating playbackRate to ' + maxPlaybackRate);
         this.trickPlay(maxPlaybackRate);
       }
+      this.targetLatencyReached_ = null;
     } else if (minLatency && minPlaybackRate &&
         (latency - offset) < minLatency) {
       if (playbackRate != minPlaybackRate) {
@@ -6534,6 +6597,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           'Updating playbackRate to ' + minPlaybackRate);
         this.trickPlay(minPlaybackRate);
       }
+      this.targetLatencyReached_ = null;
     } else if (playbackRate !== this.playRateController_.getDefaultRate()) {
       this.cancelTrickPlay();
     }

--- a/lib/player.js
+++ b/lib/player.js
@@ -6537,18 +6537,22 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.config_.streaming.liveSync.dynamicTargetLatency.maxAttempts;
     if (dynamicTargetLatency && this.targetLatencyReached_ &&
       typeof this.currentTargetLatency_ === 'number' &&
-      typeof targetLatency === 'number' && typeof minLatency === 'number' &&
+      typeof targetLatency === 'number' && 
       this.rebufferingCount_ < maxAttempts &&
       (Date.now() - this.targetLatencyReached_) > stabilityThreshold * 1000) {
-      const latencyIncrement = (targetLatency - minLatency) / 2;
+      const dynamicMinLatency =
+          this.config_.streaming.liveSync.dynamicTargetLatency.minLatency;
+      const latencyIncrement = (targetLatency - dynamicTargetLatency) / 2;
       this.currentTargetLatency_ = Math.max(
           this.currentTargetLatency_ - latencyIncrement,
           // current target latency should be within the tolerance of the min
           // latency to not overshoot it
-          minLatency + targetLatencyTolerance);
+          dynamicMinLatency + targetLatencyTolerance);
+      this.targetLatencyReached_ = Date.now();
+    }
+    if (dynamicTargetLatency) {
       maxLatency = this.currentTargetLatency_ + targetLatencyTolerance;
       minLatency = this.currentTargetLatency_ - targetLatencyTolerance;
-      this.targetLatencyReached_ = null;
     }
 
     const latency = seekRange.end - this.video_.currentTime;
@@ -6603,6 +6607,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.targetLatencyReached_ = null;
     } else if (playbackRate !== this.playRateController_.getDefaultRate()) {
       this.cancelTrickPlay();
+      this.targetLatencyReached_ = Date.now();
     }
   }
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -6342,13 +6342,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
       if (dynamicTargetLatency && isBuffering &&
         this.rebufferingCount_ < maxAttempts) {
-        let maxLatency =
+        const maxLatency =
             this.config_.streaming.liveSync.dynamicTargetLatency.maxLatency;
 
         const targetLatencyTolerance =
           this.config_.streaming.liveSync.targetLatencyTolerance;
         const rebufferIncrement =
-          this.config_.streaming.liveSync.dynamicTargetLatency.rebufferIncrement;
+          this.config_.streaming.liveSync.dynamicTargetLatency
+              .rebufferIncrement;
         if (this.currentTargetLatency_) {
           this.currentTargetLatency_ = Math.min(
               this.currentTargetLatency_ +
@@ -6528,19 +6529,21 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
     }
 
-    if (!this.currentTargetLatency_) {
+    if (!this.currentTargetLatency_ && typeof targetLatency === 'number') {
       this.currentTargetLatency_ = targetLatency;
     }
 
-    const maxAttempts = this.config_.liveSync.dynamicTargetLatency.maxAttempts;
-    if (dynamicTargetLatency && typeof this.currentTargetLatency_ === 'number'
-      this.targetLatencyReached_ && typeof minLatency === "number"
-      (Date.now() - this.targetLatencyReached_) > stabilityThreshold * 1000 &&
-      this.rebufferingCount_ < maxAttempts) {
+    const maxAttempts =
+        this.config_.streaming.liveSync.dynamicTargetLatency.maxAttempts;
+    if (dynamicTargetLatency && this.targetLatencyReached_ &&
+      typeof this.currentTargetLatency_ === 'number' &&
+      typeof targetLatency === 'number' && typeof minLatency === 'number' &&
+      this.rebufferingCount_ < maxAttempts &&
+      (Date.now() - this.targetLatencyReached_) > stabilityThreshold * 1000) {
       const latencyIncrement = (targetLatency - minLatency) / 2;
       this.currentTargetLatency_ = Math.max(
-        this.currentTargetLatency_ - latencyIncrement,
-        // current target latency should be within the tolerance of the min
+          this.currentTargetLatency_ - latencyIncrement,
+          // current target latency should be within the tolerance of the min
           // latency to not overshoot it
           minLatency + targetLatencyTolerance);
       maxLatency = this.currentTargetLatency_ + targetLatencyTolerance;

--- a/lib/player.js
+++ b/lib/player.js
@@ -6536,7 +6536,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const maxAttempts =
         this.config_.streaming.liveSync.dynamicTargetLatency.maxAttempts;
     if (dynamicTargetLatency && this.targetLatencyReached_ &&
-      typeof this.currentTargetLatency_ === 'number' &&
+      this.currentTargetLatency_ !== null &&
       typeof targetLatency === 'number' &&
       this.rebufferingCount_ < maxAttempts &&
       (Date.now() - this.targetLatencyReached_) > stabilityThreshold * 1000) {
@@ -6550,7 +6550,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           dynamicMinLatency + targetLatencyTolerance);
       this.targetLatencyReached_ = Date.now();
     }
-    if (dynamicTargetLatency && typeof this.currentTargetLatency_ == 'number') {
+    if (dynamicTargetLatency && this.currentTargetLatency_ !== null) {
       maxLatency = this.currentTargetLatency_ + targetLatencyTolerance;
       minLatency = this.currentTargetLatency_ - targetLatencyTolerance;
     }

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -250,7 +250,7 @@ shaka.util.PlayerConfiguration = class {
           enabled: false,
           stabilityThreshold: 60,
           rebufferIncrement: 0.5,
-          maxAttempts: 5,
+          maxAttempts: 10,
           maxLatency: 4,
           minLatency: 1,
         },

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -253,7 +253,7 @@ shaka.util.PlayerConfiguration = class {
           maxAttempts: 5,
           maxLatency: 4,
           minLatency: 1,
-        }
+        },
       },
       allowMediaSourceRecoveries: true,
       minTimeBetweenRecoveries: 5,

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -246,6 +246,14 @@ shaka.util.PlayerConfiguration = class {
         minPlaybackRate: 0.95,
         panicMode: false,
         panicThreshold: 60,
+        dynamicTargetLatency: {
+          enabled: false,
+          stabilityThreshold: 60,
+          rebufferIncrement: 0.5,
+          maxAttempts: 5,
+          maxLatency: 4,
+          minLatency: 1,
+        }
       },
       allowMediaSourceRecoveries: true,
       minTimeBetweenRecoveries: 5,

--- a/test/cast/cast_receiver_integration.js
+++ b/test/cast/cast_receiver_integration.js
@@ -205,7 +205,7 @@ filterDescribe('CastReceiver', castReceiverIntegrationSupport, () => {
         // Check that the update message is of a reasonable size. From previous
         // testing we found that the socket would silently reject data that got
         // too big. 6KB is safely below the limit.
-        expect(message.length).toBeLessThan(6077);
+        expect(message.length).toBeLessThan(7000);
       }
     });
 

--- a/test/cast/cast_receiver_integration.js
+++ b/test/cast/cast_receiver_integration.js
@@ -204,7 +204,7 @@ filterDescribe('CastReceiver', castReceiverIntegrationSupport, () => {
       for (const message of messages) {
         // Check that the update message is of a reasonable size. From previous
         // testing we found that the socket would silently reject data that got
-        // too big. 6KB is safely below the limit.
+        // too big. 7KB is safely below the limit.
         expect(message.length).toBeLessThan(7000);
       }
     });

--- a/test/cast/cast_receiver_integration.js
+++ b/test/cast/cast_receiver_integration.js
@@ -205,7 +205,7 @@ filterDescribe('CastReceiver', castReceiverIntegrationSupport, () => {
         // Check that the update message is of a reasonable size. From previous
         // testing we found that the socket would silently reject data that got
         // too big. 6KB is safely below the limit.
-        expect(message.length).toBeLessThan(6000);
+        expect(message.length).toBeLessThan(6077);
       }
     });
 


### PR DESCRIPTION
This adds a new feature for adjusting the target latency closer to the live edge when playback is stable and back off away from the live edge when playback rebuffers. It is off by default and will only run a default of 5 times before it will stop trying to adjust the target latency.

Closes https://github.com/shaka-project/shaka-player/issues/6131.