### PR TITLE
fix(preload): Fix preload load latency logic.

### DIFF
--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -38,11 +38,10 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
   /**
    * @param {string} assetUri
    * @param {?string} mimeType
-   * @param {number} startTimeOfLoad
    * @param {?number} startTime
    * @param {*} playerInterface
    */
-  constructor(assetUri, mimeType, startTimeOfLoad, startTime, playerInterface) {
+  constructor(assetUri, mimeType, startTime, playerInterface) {
     super();
 
     // Making the playerInterface a * and casting it to the right type allows
@@ -66,9 +65,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
 
     /** @private {?shaka.media.AdaptationSetCriteria} */
     this.currentAdaptationSetCriteria_ = null;
-
-    /** @private {number} */
-    this.startTimeOfLoad_ = startTimeOfLoad;
 
     /** @private {number} */
     this.startTimeOfDrm_ = 0;
@@ -206,11 +202,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
   /** @return {?number} */
   getStartTime() {
     return this.startTime_;
-  }
-
-  /** @return {number} */
-  getStartTimeOfLoad() {
-    return this.startTimeOfLoad_;
   }
 
   /** @return {number} */

--- a/lib/player.js
+++ b/lib/player.js
@@ -1616,8 +1616,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // asset.
       const shouldUseSrcEquals = !preloadManager;
 
-      const startTimeOfLoad = preloadManager ?
-          preloadManager.getStartTimeOfLoad() : (Date.now() / 1000);
+      const startTimeOfLoad = Date.now() / 1000;
 
       // Stats are for a single playback/load session. Stats must be initialized
       // before we allow calls to |updateStateHistory|.
@@ -1805,12 +1804,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         startTime = null;
       }
       // We have enough information to make a PreloadManager!
-      const startTimeOfLoad = Date.now() / 1000;
       preloadManager = await this.makePreloadManager_(
           this.assetUri_,
           startTime,
           this.mimeType_,
-          startTimeOfLoad,
           /* allowPrefetch= */ true,
           /* disableVideo= */ false,
           /* allowMakeAbrManager= */ false);
@@ -1898,7 +1895,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   async preloadInner_(assetUri, startTime, mimeType, standardLoad = false) {
     goog.asserts.assert(this.networkingEngine_, 'Should have a net engine!');
     goog.asserts.assert(this.config_, 'Config must not be null!');
-    const startTimeOfLoad = Date.now() / 1000;
     if (!mimeType) {
       mimeType = await this.guessMimeType_(assetUri);
     }
@@ -1925,7 +1921,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
     }
     let preloadManagerPromise = this.makePreloadManager_(
-        assetUri, startTime, mimeType || null, startTimeOfLoad,
+        assetUri, startTime, mimeType || null,
         /* allowPrefetch= */ !standardLoad, disableVideo, allowMakeAbrManager);
     if (!standardLoad) {
       // We only need to track the PreloadManager if it is not part of a
@@ -1945,14 +1941,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @param {string} assetUri
    * @param {?number} startTime
    * @param {?string} mimeType
-   * @param {number} startTimeOfLoad
    * @param {boolean=} allowPrefetch
    * @param {boolean=} disableVideo
    * @param {boolean=} allowMakeAbrManager
    * @return {!Promise.<!shaka.media.PreloadManager>}
    * @private
    */
-  async makePreloadManager_(assetUri, startTime, mimeType, startTimeOfLoad,
+  async makePreloadManager_(assetUri, startTime, mimeType,
       allowPrefetch = true, disableVideo = false, allowMakeAbrManager = true) {
     goog.asserts.assert(this.networkingEngine_, 'Must have net engine');
     /** @type {?shaka.media.PreloadManager} */
@@ -2173,7 +2168,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       allowMakeAbrManager,
     };
     preloadManager = new shaka.media.PreloadManager(
-        assetUri, mimeType, startTimeOfLoad, startTime, playerInterface);
+        assetUri, mimeType, startTime, playerInterface);
     return preloadManager;
   }
 


### PR DESCRIPTION
Previously, when preloading, we would measure startTimeOfLoad based on when the PreloadManager was created.
This meant that if a PreloadManager was created and then not used for a while, it would lead to the load latency stats reporting an extreme load latency.
This changes the startTimeOfLoad to instead record when the PreloadManager is consumed by the player.

Fixes #6871