### PR TITLE
fix(preload): Fix memory leak with preload feature

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -157,6 +157,10 @@ shaka.media.StreamingEngine = class {
     for (const state of this.mediaStates_.values()) {
       this.cancelUpdate_(state);
       aborts.push(this.abortOperations_(state));
+      if (state.segmentPrefetch) {
+        state.segmentPrefetch.clearAll();
+        state.segmentPrefetch = null;
+      }
     }
     for (const prefetch of this.audioPrefetchMap_.values()) {
       prefetch.clearAll();
@@ -244,6 +248,7 @@ shaka.media.StreamingEngine = class {
         if (!(config.segmentPrefetchLimit > 0)) {
           // ResetLimit is still needed in this case,
           // to abort existing prefetch operations.
+          state.segmentPrefetch.clearAll();
           state.segmentPrefetch = null;
         }
       } else if (config.segmentPrefetchLimit > 0) {


### PR DESCRIPTION
There was a memory leak where the segments that the PreloadManager prefetched did not get cleaned up, after the player unloads. This fixes that memory leak.

Fixes #6883