### PR TITLE
chore(demo): fix pattern to allow <1 decimals if can't be zero

### DIFF
--- a/demo/input.js
+++ b/demo/input.js
@@ -253,15 +253,21 @@ shakaDemo.NumberInput = class extends shakaDemo.TextInput {
     }
 
     this.input_.pattern = '(Infinity|';
+
     if (canBeZero) {
-      this.input_.pattern += '[0-9]*';
-    } else {
-      this.input_.pattern += '[0-9]*[1-9][0-9]*';
+      this.input_.pattern += '0+|';
     }
+
+    this.input_.pattern += '([0-9]*[1-9][0-9]*)';
+
     if (canBeDecimal) {
+      // strictly allow for 0.xxxx decimals
+      this.input_.pattern += '?(0(?=\.))?';
       // TODO: Handle commas as decimal delimeters, for appropriate regions?
       this.input_.pattern += '(.[0-9]+)?';
     }
+
+
     this.input_.pattern += ')';
     if (canBeUnset) {
       this.input_.pattern += '?';

--- a/demo/input.js
+++ b/demo/input.js
@@ -262,7 +262,7 @@ shakaDemo.NumberInput = class extends shakaDemo.TextInput {
 
     if (canBeDecimal) {
       // strictly allow for 0.xxxx decimals
-      this.input_.pattern += '?(0(?=\.))?';
+      this.input_.pattern += '?(0(?=.))?';
       // TODO: Handle commas as decimal delimeters, for appropriate regions?
       this.input_.pattern += '(.[0-9]+)?';
     }


### PR DESCRIPTION
If an input in the demo can't be zero and a value <1 was given, the check pattern would fail for it, and it'll show the warning that the input isn't valid even though it is valid.

This slightly simplifies the regex creation as canBeZero adds `0+|` to the pattern and the main pattern `([0-9]*[1-9][0-9]*)` is always used. Then, if it can be a decimal, it uses the existing pattern but adds `?(0(?=\.))?'` which makes the main pattern optional and instead adds the optionally a `0` but only if it is followed by a `.`.

The main pattern `([0-9]*[1-9][0-9]*)` potentially could be simplified into `[1-9]\d*` but it would make leading zeros invalid.