### PR TITLE
feat: add an audiotrackchanged event for when label, language, or roles of an audio track change

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -644,6 +644,8 @@ shaka.extern.TimelineRegionInfo;
  *   height: ?number,
  *   mimeType: ?string,
  *   label: ?string,
+ *   roles: ?Array.<string>,
+ *   language: ?string,
  *   channelsCount: ?number,
  *   pixelAspectRatio: ?string,
  *   width: ?number
@@ -669,6 +671,10 @@ shaka.extern.TimelineRegionInfo;
  *   The MIME type.
  * @property {?string} label
  *   The stream's label, when available.
+ * @property {?Array.<string>} roles
+ *   The stream's role, when available.
+ * @property {?string} language
+ *   The stream's language, when available.
  * @property {?number} channelsCount
  *   The number of audio channels, or null if unknown.
  * @property {?string} pixelAspectRatio

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -643,6 +643,7 @@ shaka.extern.TimelineRegionInfo;
  *   frameRate: ?number,
  *   height: ?number,
  *   mimeType: ?string,
+ *   label: ?string,
  *   channelsCount: ?number,
  *   pixelAspectRatio: ?string,
  *   width: ?number
@@ -666,6 +667,8 @@ shaka.extern.TimelineRegionInfo;
  *   The video height in pixels.
  * @property {string} mimeType
  *   The MIME type.
+ * @property {?string} label
+ *   The stream's label, when available.
  * @property {?number} channelsCount
  *   The number of audio channels, or null if unknown.
  * @property {?string} pixelAspectRatio

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -1786,19 +1786,7 @@ shaka.dash.DashParser = class {
     const language = shaka.util.LanguageUtils.normalize(
         context.adaptationSet.language || 'und');
 
-    // This attribute is currently non-standard, but it is supported by Kaltura.
-    let label = elem.attributes['label'];
-
-    // See DASH IOP 4.3 here https://dashif.org/docs/DASH-IF-IOP-v4.3.pdf (page 35)
-    const labelElements = TXml.findChildren(elem, 'Label');
-    if (labelElements && labelElements.length) {
-      // NOTE: Right now only one label field is supported.
-      const firstLabelElement = labelElements[0];
-      const textContent = shaka.util.TXml.getTextContents(firstLabelElement);
-      if (textContent) {
-        label = textContent;
-      }
-    }
+    const label = context.adaptationSet.label;
 
     // Parse Representations into Streams.
     const representations = TXml.findChildren(elem, 'Representation');
@@ -2423,6 +2411,19 @@ shaka.dash.DashParser = class {
       }
     }
 
+    // This attribute is currently non-standard, but it is supported by Kaltura.
+    let label = elem.attributes['label'];
+
+    // See DASH IOP 4.3 here https://dashif.org/docs/DASH-IF-IOP-v4.3.pdf (page 35)
+    const labelElements = TXml.findChildren(elem, 'Label');
+    if (labelElements && labelElements.length) {
+      // NOTE: Right now only one label field is supported.
+      const firstLabelElement = labelElements[0];
+      if (TXml.getTextContents(firstLabelElement)) {
+        label = TXml.getTextContents(firstLabelElement);
+      }
+    }
+
     return {
       getBaseUris:
           () => ManifestParserUtils.resolveUris(getBaseUris(), getFrameUris()),
@@ -2446,6 +2447,7 @@ shaka.dash.DashParser = class {
       initialization: null,
       segmentSequenceCadence:
           segmentSequenceCadence || parent.segmentSequenceCadence,
+      label: label || null,
     };
   }
 
@@ -2949,7 +2951,8 @@ shaka.dash.DashParser.RequestSegmentCallback;
  *   availabilityTimeOffset: number,
  *   initialization: ?string,
  *   aesKey: (shaka.extern.aesKey|undefined),
- *   segmentSequenceCadence: number
+ *   segmentSequenceCadence: number,
+ *   label: ?string
  * }}
  *
  * @description
@@ -2997,6 +3000,8 @@ shaka.dash.DashParser.RequestSegmentCallback;
  * @property {number} segmentSequenceCadence
  *   Specifies the cadence of independent segments in Segment Sequence
  *   Representation.
+ * @property {?string} label
+ *   Label or null if unknown.
  */
 shaka.dash.DashParser.InheritanceFrame;
 

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -694,6 +694,7 @@ shaka.dash.DashParser = class {
       availabilityTimeOffset: availabilityTimeOffset,
       mediaPresentationDuration: null,
       profiles: profiles.split(','),
+      roles: null,
     };
 
     this.gapCount_ = 0;
@@ -972,6 +973,7 @@ shaka.dash.DashParser = class {
       profiles: this.manifestPatchContext_.profiles,
       mediaPresentationDuration:
           this.manifestPatchContext_.mediaPresentationDuration,
+      roles: null,
     };
 
     const periodsAndDuration = this.parsePeriods_(context,
@@ -1874,7 +1876,7 @@ shaka.dash.DashParser = class {
    * @param {shaka.dash.ContentProtection.Context} contentProtection
    * @param {(string|undefined)} kind
    * @param {string} language
-   * @param {string} label
+   * @param {?string} label
    * @param {boolean} isPrimary
    * @param {!Array.<string>} roles
    * @param {Map.<string, string>} closedCaptions
@@ -1917,6 +1919,8 @@ shaka.dash.DashParser = class {
     // https://github.com/shaka-project/shaka-player/issues/938#issuecomment-317278180
     context.bandwidth =
         TXml.parseAttr(node, 'bandwidth', TXml.parsePositiveInt) || 0;
+
+    context.roles = roles;
 
     /** @type {?shaka.dash.DashParser.StreamInfo} */
     let streamInfo;
@@ -3018,7 +3022,8 @@ shaka.dash.DashParser.InheritanceFrame;
  *   indexRangeWarningGiven: boolean,
  *   availabilityTimeOffset: number,
  *   mediaPresentationDuration: ?number,
- *   profiles: !Array.<string>
+ *   profiles: !Array.<string>,
+ *   roles: ?Array.<string>
  * }}
  *
  * @description

--- a/lib/dash/segment_base.js
+++ b/lib/dash/segment_base.js
@@ -386,6 +386,7 @@ shaka.dash.SegmentBase = class {
       channelsCount: representation.numChannels,
       pixelAspectRatio: representation.pixelAspectRatio || null,
       width: representation.width || null,
+      label: context.adaptationSet.label || null,
     };
   }
 };

--- a/lib/dash/segment_base.js
+++ b/lib/dash/segment_base.js
@@ -387,6 +387,8 @@ shaka.dash.SegmentBase = class {
       pixelAspectRatio: representation.pixelAspectRatio || null,
       width: representation.width || null,
       label: context.adaptationSet.label || null,
+      roles: context.roles || null,
+      language: context.adaptationSet.language || null,
     };
   }
 };

--- a/lib/media/quality_observer.js
+++ b/lib/media/quality_observer.js
@@ -8,6 +8,7 @@ goog.provide('shaka.media.QualityObserver');
 
 goog.require('shaka.media.IPlayheadObserver');
 goog.require('shaka.log');
+goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.FakeEventTarget');
 
@@ -162,9 +163,22 @@ shaka.media.QualityObserver = class extends shaka.util.FakeEventTarget {
       const differentLabel = qualityAtPosition &&
           contentTypeState.currentQuality &&
           qualityAtPosition.label &&
+          contentTypeState.currentQuality.label &&
           contentTypeState.currentQuality.label !== qualityAtPosition.label;
+      const differentLanguage = qualityAtPosition &&
+          contentTypeState.currentQuality &&
+          qualityAtPosition.language &&
+          contentTypeState.currentQuality.language &&
+          contentTypeState.currentQuality.language !==
+              qualityAtPosition.language;
+      const differentRoles = qualityAtPosition &&
+          contentTypeState.currentQuality &&
+          qualityAtPosition.roles &&
+          contentTypeState.currentQuality.roles &&
+          !shaka.util.ArrayUtils.equal(contentTypeState.currentQuality.roles,
+              qualityAtPosition.roles);
 
-      if (differentLabel) {
+      if (differentLabel || differentLanguage || differentRoles) {
         if (this.positionIsBuffered_(
             positionInSeconds, qualityAtPosition.contentType)) {
           contentTypeState.currentQuality = qualityAtPosition;

--- a/lib/media/quality_observer.js
+++ b/lib/media/quality_observer.js
@@ -155,9 +155,29 @@ shaka.media.QualityObserver = class extends shaka.util.FakeEventTarget {
       const qualityAtPosition =
         shaka.media.QualityObserver.getMediaQualityAtPosition_(
             positionInSeconds, contentTypeState);
-      if (qualityAtPosition &&
+
+      const differentQualities = qualityAtPosition &&
           !shaka.media.QualityObserver.mediaQualitiesAreTheSame_(
-              contentTypeState.currentQuality, qualityAtPosition)) {
+              contentTypeState.currentQuality, qualityAtPosition);
+      const differentLabel = qualityAtPosition &&
+          contentTypeState.currentQuality &&
+          qualityAtPosition.label &&
+          contentTypeState.currentQuality.label !== qualityAtPosition.label;
+
+      if (differentLabel) {
+        if (this.positionIsBuffered_(
+            positionInSeconds, qualityAtPosition.contentType)) {
+          contentTypeState.currentQuality = qualityAtPosition;
+
+          const event = new shaka.util.FakeEvent('audiotrackchange', new Map([
+            ['quality', qualityAtPosition],
+            ['position', positionInSeconds],
+          ]));
+          this.dispatchEvent(event);
+        }
+      }
+
+      if (differentQualities) {
         if (this.positionIsBuffered_(
             positionInSeconds, qualityAtPosition.contentType)) {
           contentTypeState.currentQuality = qualityAtPosition;

--- a/lib/player.js
+++ b/lib/player.js
@@ -2132,6 +2132,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         const position = event['position'];
         this.onMediaQualityChange_(mediaQualityInfo, position);
       });
+
+      qualityObserver.addEventListener('audiotrackchange', (event) => {
+        /** @type {shaka.extern.MediaQualityInfo} */
+        const mediaQualityInfo = event['quality'];
+        /** @type {number} */
+        const position = event['position'];
+        this.onMediaQualityChange_(mediaQualityInfo, position,
+            /* audioTrackChanged= */ true);
+      });
     }
     let firstEvent = true;
     const drmPlayerInterface = {
@@ -7351,6 +7360,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       pixelAspectRatio: mediaQuality.pixelAspectRatio,
       width: mediaQuality.width,
       label: mediaQuality.label,
+      roles: mediaQuality.roles,
+      language: mediaQuality.language,
     };
 
     const data = new Map()

--- a/lib/player.js
+++ b/lib/player.js
@@ -187,8 +187,7 @@ goog.requireType('shaka.media.PresentationTimeline');
 /**
  * @event shaka.Player.AudioTrackChangedEvent
  * @description Fired when the audio track changes at the playhead.
- * That may be caused by an adaptation change or a DASH period transition.
- * Separate events are emitted for audio and video contentTypes.
+ * That may be caused by a user requesting to chang audio tracks.
  * This is supported for only DASH streams at this time.
  * @property {string} type
  *   'audiotrackchanged'

--- a/lib/player.js
+++ b/lib/player.js
@@ -184,6 +184,21 @@ goog.requireType('shaka.media.PresentationTimeline');
  * @exportDoc
  */
 
+/**
+ * @event shaka.Player.AudioTrackChangedEvent
+ * @description Fired when the audio track changes at the playhead.
+ * That may be caused by an adaptation change or a DASH period transition.
+ * Separate events are emitted for audio and video contentTypes.
+ * This is supported for only DASH streams at this time.
+ * @property {string} type
+ *   'audiotrackchanged'
+ * @property {shaka.extern.MediaQualityInfo} mediaQuality
+ *   Information about media quality at the playhead position.
+ * @property {number} position
+ *   The playhead position.
+ * @exportDoc
+ */
+
 
 /**
  * @event shaka.Player.BufferingEvent
@@ -7316,10 +7331,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * @param {shaka.extern.MediaQualityInfo} mediaQuality
    * @param {number} position
+   * @param {boolean} audioTrackChanged This is to specify whether this should
+   * trigger a MediaQualityChangedEvent or an AudioTrackChangedEvent. Defaults
+   * to false to trigger MediaQualityChangedEvent.
    *
    * @private
    */
-  onMediaQualityChange_(mediaQuality, position) {
+  onMediaQualityChange_(mediaQuality, position, audioTrackChanged = false) {
     // Always make a copy to avoid exposing our internal data to the app.
     const clone = {
       bandwidth: mediaQuality.bandwidth,
@@ -7332,6 +7350,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       channelsCount: mediaQuality.channelsCount,
       pixelAspectRatio: mediaQuality.pixelAspectRatio,
       width: mediaQuality.width,
+      label: mediaQuality.label,
     };
 
     const data = new Map()
@@ -7339,7 +7358,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         .set('position', position);
 
     this.dispatchEvent(shaka.Player.makeEvent_(
-        shaka.util.FakeEvent.EventName.MediaQualityChanged, data));
+        audioTrackChanged ?
+          shaka.util.FakeEvent.EventName.AudioTrackChanged :
+          shaka.util.FakeEvent.EventName.MediaQualityChanged,
+        data));
   }
 
   /**

--- a/lib/util/fake_event.js
+++ b/lib/util/fake_event.js
@@ -155,6 +155,7 @@ shaka.util.FakeEvent = class {
 shaka.util.FakeEvent.EventName = {
   AbrStatusChanged: 'abrstatuschanged',
   Adaptation: 'adaptation',
+  AudioTrackChanged: 'audiotrackchanged',
   Buffering: 'buffering',
   Complete: 'complete',
   DownloadFailed: 'downloadfailed',

--- a/test/media/quality_observer_unit.js
+++ b/test/media/quality_observer_unit.js
@@ -23,6 +23,9 @@ describe('QualityObserver', () => {
       channelsCount: 2,
       pixelAspectRatio: '1:1',
       width: 1280,
+      label: null,
+      roles: null,
+      language: null,
     };
   };
   let emptyBuffer = true;
@@ -36,10 +39,12 @@ describe('QualityObserver', () => {
     if (emptyBuffer) {
       return {
         video: [],
+        audio: [],
       };
     }
     return {
       video: [{start: bufferStart, end: bufferEnd}],
+      audio: [{start: bufferStart, end: bufferEnd}],
     };
   };
 
@@ -135,4 +140,144 @@ describe('QualityObserver', () => {
         observer.poll(15, false);
         expect(onQualityChange).toHaveBeenCalledWith(quality2, 15);
       });
+
+  describe('audiotrackchange', () => {
+    /** @type {!jasmine.Spy} */
+    let onAudioTrackChange;
+
+    const createAudioQuality = (label, roles, language) => {
+      const qi = createQualityInfo('audio', 1);
+      qi.label = label;
+      qi.roles = roles;
+      qi.language = language;
+      return qi;
+    };
+
+    const audioQuality1 = createAudioQuality('Audio', ['main'], 'en');
+    const audioQuality2 = createAudioQuality('Audio', ['alternative'], 'en');
+    const audioQuality3 = createAudioQuality('English', ['main'], 'en');
+    const audioQuality4 = createAudioQuality('Audio', ['main'], 'jp');
+    const audioQuality5 = createAudioQuality('Audio', ['main'], 'en');
+    audioQuality5.bandwidth = 2;
+
+    beforeEach(() => {
+      onAudioTrackChange = jasmine.createSpy('onAudioTrackChange');
+      observer = new shaka.media.QualityObserver(getBufferedInfo);
+      observer.addEventListener('audiotrackchange', (event) => {
+        shaka.test.Util.spyFunc(onAudioTrackChange)(
+            event['quality'], event['position']);
+      });
+      emptyBuffer = true;
+      bufferStart = 0;
+      bufferEnd = 0;
+    });
+
+    it('does not call onAudioTrackChange when there are no quality changes',
+        () => {
+          observer.poll(10, false);
+          expect(onAudioTrackChange).not.toHaveBeenCalled();
+        });
+
+    it('does not call onAudioTrackChange after 1st quality change', () => {
+      observer.addMediaQualityChange(audioQuality1, 10);
+      emptyBuffer = false;
+      bufferStart = 10;
+      bufferEnd = 20;
+      observer.poll(10, false);
+      expect(onAudioTrackChange).not.toHaveBeenCalled();
+    });
+
+    it('does not call onAudioTrackChange when pos advances with no change',
+        () => {
+          observer.addMediaQualityChange(audioQuality1, 10);
+          emptyBuffer = false;
+          bufferStart = 10;
+          bufferEnd = 20;
+          observer.poll(10, false);
+          expect(onAudioTrackChange).not.toHaveBeenCalled();
+          observer.poll(11, false);
+          expect(onAudioTrackChange).not.toHaveBeenCalled();
+        });
+
+    it('calls onAudioTrackChange after 2nd quality change, if roles changed',
+        () => {
+          observer.addMediaQualityChange(audioQuality1, 10);
+          emptyBuffer = false;
+          bufferStart = 10;
+          bufferEnd = 20;
+          observer.poll(10, false);
+          expect(onAudioTrackChange).not.toHaveBeenCalled();
+          observer.addMediaQualityChange(audioQuality2, 20);
+          bufferStart = 10;
+          bufferEnd = 30;
+          observer.poll(20, false);
+          expect(onAudioTrackChange)
+              .toHaveBeenCalledOnceMoreWith([audioQuality2, 20]);
+        });
+
+    it('calls onAudioTrackChange after 2nd quality change, if label changed',
+        () => {
+          observer.addMediaQualityChange(audioQuality1, 10);
+          emptyBuffer = false;
+          bufferStart = 10;
+          bufferEnd = 20;
+          observer.poll(10, false);
+          expect(onAudioTrackChange).not.toHaveBeenCalled();
+          observer.addMediaQualityChange(audioQuality3, 20);
+          bufferStart = 10;
+          bufferEnd = 30;
+          observer.poll(20, false);
+          expect(onAudioTrackChange)
+              .toHaveBeenCalledOnceMoreWith([audioQuality3, 20]);
+        });
+
+    it('calls onAudioTrackChange after 2nd quality change, if language changed',
+        () => {
+          observer.addMediaQualityChange(audioQuality1, 10);
+          emptyBuffer = false;
+          bufferStart = 10;
+          bufferEnd = 20;
+          observer.poll(10, false);
+          expect(onAudioTrackChange).not.toHaveBeenCalled();
+          observer.addMediaQualityChange(audioQuality4, 20);
+          bufferStart = 10;
+          bufferEnd = 30;
+          observer.poll(20, false);
+          expect(onAudioTrackChange)
+              .toHaveBeenCalledOnceMoreWith([audioQuality4, 20]);
+        });
+    it('does not call onAudioTrackChange after 2nd quality change ' +
+        'when pos advances with no change',
+    () => {
+      observer.addMediaQualityChange(audioQuality1, 10);
+      emptyBuffer = false;
+      bufferStart = 10;
+      bufferEnd = 20;
+      observer.poll(10, false);
+      expect(onAudioTrackChange).not.toHaveBeenCalled();
+      observer.addMediaQualityChange(audioQuality2, 20);
+      bufferStart = 10;
+      bufferEnd = 30;
+      observer.poll(20, false);
+      expect(onAudioTrackChange).toHaveBeenCalledWith(audioQuality2, 20);
+      observer.poll(21, false);
+      expect(onAudioTrackChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not calls onAudioTrackChange after 2nd quality change, ' +
+        'if only bandwidth changed',
+    () => {
+      observer.addMediaQualityChange(audioQuality1, 10);
+      emptyBuffer = false;
+      bufferStart = 10;
+      bufferEnd = 20;
+      observer.poll(10, false);
+      expect(onAudioTrackChange).not.toHaveBeenCalled();
+      observer.addMediaQualityChange(audioQuality5, 20);
+      bufferStart = 10;
+      bufferEnd = 30;
+      observer.poll(20, false);
+      expect(onAudioTrackChange).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/test/media/segment_reference_unit.js
+++ b/test/media/segment_reference_unit.js
@@ -44,6 +44,8 @@ describe('InitSegmentReference', () => {
     height: 720,
     mimeType: 'mime type',
     label: null,
+    roles: null,
+    language: null,
     channelsCount: 2,
     pixelAspectRatio: '1:1',
     width: 1280,

--- a/test/media/segment_reference_unit.js
+++ b/test/media/segment_reference_unit.js
@@ -43,6 +43,7 @@ describe('InitSegmentReference', () => {
     frameRate: 30,
     height: 720,
     mimeType: 'mime type',
+    label: null,
     channelsCount: 2,
     pixelAspectRatio: '1:1',
     width: 1280,

--- a/test/test/util/test_scheme.js
+++ b/test/test/util/test_scheme.js
@@ -207,6 +207,8 @@ shaka.test.TestScheme = class {
         pixelAspectRatio: null,
         width: null,
         label: null,
+        roles: null,
+        language: null,
       };
       stream.mimeType = data[contentType].mimeType;
       stream.codecs = data[contentType].codecs;

--- a/test/test/util/test_scheme.js
+++ b/test/test/util/test_scheme.js
@@ -206,6 +206,7 @@ shaka.test.TestScheme = class {
         channelsCount: null,
         pixelAspectRatio: null,
         width: null,
+        label: null,
       };
       stream.mimeType = data[contentType].mimeType;
       stream.codecs = data[contentType].codecs;


### PR DESCRIPTION
This piggybacks on the media quality observer to also check whether the audio track changed and the change was in label, language, or role.

Currently, this new event is triggered is `observeQualityChanges` is set. This could be moved to a separate config.

I do play to add a test or two to the integration tests.

For verifying the role/label, I was testing against this public test stream https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-desc-aud.ism/.mpd (though, it does seem to error out every so often). There might be other test streams. Angel One is a great one for language.


Also, something that we noticed, but won't be part of this PR. The timing of this event is likely incorrect if the track was switched and safeMargin was set. We have some changes for this locally that we can PR, but there are some issues we found around devices for it, so, it isn't a straightforward change.