### PR TITLE
fix(ABR): Add a guard when variant is null

### DIFF
--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -193,7 +193,7 @@ shaka.abr.SimpleAbrManager = class {
     }
 
     let normalVariants = this.variants_.filter((variant) => {
-      return !shaka.util.StreamUtils.isFastSwitching(variant);
+      return variant && !shaka.util.StreamUtils.isFastSwitching(variant);
     });
     if (!normalVariants.length) {
       normalVariants = this.variants_;
@@ -203,7 +203,7 @@ shaka.abr.SimpleAbrManager = class {
     if (preferFastSwitching &&
         normalVariants.length != this.variants_.length) {
       variants = this.variants_.filter((variant) => {
-        return shaka.util.StreamUtils.isFastSwitching(variant);
+        return variant && shaka.util.StreamUtils.isFastSwitching(variant);
       });
     }
 


### PR DESCRIPTION
This rare case can occur when a stream is disabled and this stream disables the entire variant.