### PR TITLE
fix: Only request initialization segment when it's necessary

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -2652,7 +2652,6 @@ shaka.media.StreamingEngine = class {
     mediaState.clearBufferSafeMargin = 0;
     mediaState.clearingBuffer = true;
     mediaState.lastSegmentReference = null;
-    mediaState.lastInitSegmentReference = null;
     mediaState.segmentIterator = null;
 
     shaka.log.debug(logPrefix, 'clearing buffer');

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -1180,12 +1180,13 @@ describe('StreamingEngine', () => {
 
       const segmentType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
       const segmentContext = {
-        type: shaka.net.NetworkingEngine.AdvancedRequestType.INIT_SEGMENT,
+        type: shaka.net.NetworkingEngine.AdvancedRequestType.MEDIA_SEGMENT,
       };
 
-      // Quickly switching back to text1, and text init segment should be
+      // Quickly switching back to text1, and text init segment shouldn't be
       // fetched again.
-      netEngine.expectRequest('text-20-init', segmentType, segmentContext);
+      netEngine.expectRequest('text-20-0.mp4', segmentType, segmentContext);
+      netEngine.expectNoRequest('text-20-init', segmentType, segmentContext);
       netEngine.expectNoRequest('text-21-init', segmentType, segmentContext);
       // TODO: huh?
     });


### PR DESCRIPTION
According to https://w3c.github.io/media-source/#dom-sourcebuffer-remove

Deleting a range from the source buffer does not delete the initialization segment, so this change will prevent the initialization segment from being requested when it is not needed.