### PR TITLE
perf(HLS): do not loop twice when processing nalus

### DIFF
--- a/lib/util/ts_parser.js
+++ b/lib/util/ts_parser.js
@@ -726,7 +726,7 @@ shaka.util.TsParser = class {
   }
 
   /**
-   * Return the audio data
+   * Return the video data
    *
    * @param {boolean=} naluProcessing
    * @return {!Array.<shaka.extern.MPEG_PES>}
@@ -760,15 +760,15 @@ shaka.util.TsParser = class {
       if (naluProcessing) {
         let lastNalu;
         let lastState;
+        const pesWithLength = [];
         for (const pes of this.videoPes_) {
           pes.nalus = this.parseNalus(pes, lastNalu, lastState);
           if (pes.nalus.length) {
+            pesWithLength.push(pes);
             lastNalu = pes.nalus[pes.nalus.length - 1];
           }
         }
-        this.videoPes_ = this.videoPes_.filter((pes) => {
-          return pes.nalus.length;
-        });
+        this.videoPes_ = pesWithLength;
       }
       if (sort) {
         this.videoPes_ = this.videoPes_.sort((a, b) => {


### PR DESCRIPTION
PES arrays can get pretty big so it would be prudent to avoid looping over them more than needed