### PR TITLE
chore(DRM): Move util methods from DrmEngine to DrmUtils

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -16,7 +16,6 @@ goog.require('shaka.hls.PlaylistType');
 goog.require('shaka.hls.Tag');
 goog.require('shaka.hls.Utils');
 goog.require('shaka.log');
-goog.require('shaka.media.DrmEngine');
 goog.require('shaka.media.InitSegmentReference');
 goog.require('shaka.media.ManifestParser');
 goog.require('shaka.media.PresentationTimeline');
@@ -27,6 +26,7 @@ goog.require('shaka.net.DataUriPlugin');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.BufferUtils');
+goog.require('shaka.util.DrmUtils');
 goog.require('shaka.util.ContentSteeringManager');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.EventManager');
@@ -1936,7 +1936,7 @@ shaka.hls.HlsParser = class {
       audioInfos, videoInfos, bandwidth, width, height, frameRate, videoRange,
       videoLayout, drmInfos, keyIds) {
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
-    const DrmEngine = shaka.media.DrmEngine;
+    const DrmUtils = shaka.util.DrmUtils;
 
     for (const info of videoInfos) {
       this.addVideoAttributes_(
@@ -1979,7 +1979,7 @@ shaka.hls.HlsParser = class {
         const variantUriKey = videoStreamUri + ' - ' + audioStreamUri;
 
         if (audioStream && videoStream) {
-          if (!DrmEngine.areDrmCompatible(audioDrmInfos, videoDrmInfos)) {
+          if (!DrmUtils.areDrmCompatible(audioDrmInfos, videoDrmInfos)) {
             shaka.log.warning(
                 'Incompatible DRM info in HLS variant.  Skipping.');
             continue;

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -18,7 +18,6 @@ goog.require('shaka.util.EventManager');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.IDestroyable');
 goog.require('shaka.util.Iterables');
-goog.require('shaka.util.Lazy');
 goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.MapUtils');
 goog.require('shaka.util.MimeUtils');
@@ -760,13 +759,6 @@ shaka.media.DrmEngine = class {
   /** @return {boolean} */
   initialized() {
     return this.initialized_;
-  }
-
-  /**
-   * @param {?shaka.extern.DrmInfo} drmInfo
-   * @return {string} */
-  static keySystem(drmInfo) {
-    return drmInfo ? drmInfo.keySystem : '';
   }
 
   /**
@@ -1764,29 +1756,12 @@ shaka.media.DrmEngine = class {
   }
 
   /**
-   * Returns true if the browser has recent EME APIs.
-   *
-   * @return {boolean}
-   */
-  static isBrowserSupported() {
-    const basic =
-        !!window.MediaKeys &&
-        !!window.navigator &&
-        !!window.navigator.requestMediaKeySystemAccess &&
-        !!window.MediaKeySystemAccess &&
-        // eslint-disable-next-line no-restricted-syntax
-        !!window.MediaKeySystemAccess.prototype.getConfiguration;
-
-    return basic;
-  }
-
-  /**
    * Returns a Promise to a map of EME support for well-known key systems.
    *
    * @return {!Promise.<!Object.<string, ?shaka.extern.DrmSupportType>>}
    */
   static async probeSupport() {
-    goog.asserts.assert(shaka.media.DrmEngine.isBrowserSupported(),
+    goog.asserts.assert(shaka.util.DrmUtils.isBrowserSupported(),
         'Must have basic EME support');
 
     const testKeySystems = [
@@ -2115,89 +2090,11 @@ shaka.media.DrmEngine = class {
       }
     }
 
-    const keySystem = shaka.media.DrmEngine.keySystem(this.currentDrmInfo_);
+    const keySystem = shaka.util.DrmUtils.keySystem(this.currentDrmInfo_);
     const drmInfos = this.getVariantDrmInfos_(variant);
 
     return drmInfos.length == 0 ||
         drmInfos.some((drmInfo) => drmInfo.keySystem == keySystem);
-  }
-
-  /**
-   * Checks if two DrmInfos can be decrypted using the same key system.
-   * Clear content is considered compatible with every key system.
-   *
-   * @param {!Array.<!shaka.extern.DrmInfo>} drms1
-   * @param {!Array.<!shaka.extern.DrmInfo>} drms2
-   * @return {boolean}
-   */
-  static areDrmCompatible(drms1, drms2) {
-    if (!drms1.length || !drms2.length) {
-      return true;
-    }
-
-    if (drms1 === drms2) {
-      return true;
-    }
-
-    return shaka.media.DrmEngine.getCommonDrmInfos(
-        drms1, drms2).length > 0;
-  }
-
-  /**
-   * Returns an array of drm infos that are present in both input arrays.
-   * If one of the arrays is empty, returns the other one since clear
-   * content is considered compatible with every drm info.
-   *
-   * @param {!Array.<!shaka.extern.DrmInfo>} drms1
-   * @param {!Array.<!shaka.extern.DrmInfo>} drms2
-   * @return {!Array.<!shaka.extern.DrmInfo>}
-   */
-  static getCommonDrmInfos(drms1, drms2) {
-    if (!drms1.length) {
-      return drms2;
-    }
-    if (!drms2.length) {
-      return drms1;
-    }
-
-    const commonDrms = [];
-
-    for (const drm1 of drms1) {
-      for (const drm2 of drms2) {
-        if (drm1.keySystem == drm2.keySystem) {
-          const initDataMap = new Map();
-          const bothInitDatas = (drm1.initData || [])
-              .concat(drm2.initData || []);
-          for (const d of bothInitDatas) {
-            initDataMap.set(d.keyId, d);
-          }
-          const initData = Array.from(initDataMap.values());
-
-          const keyIds = drm1.keyIds && drm2.keyIds ?
-              new Set([...drm1.keyIds, ...drm2.keyIds]) :
-              drm1.keyIds || drm2.keyIds;
-          const mergedDrm = {
-            keySystem: drm1.keySystem,
-            licenseServerUri: drm1.licenseServerUri || drm2.licenseServerUri,
-            distinctiveIdentifierRequired: drm1.distinctiveIdentifierRequired ||
-                drm2.distinctiveIdentifierRequired,
-            persistentStateRequired: drm1.persistentStateRequired ||
-                drm2.persistentStateRequired,
-            videoRobustness: drm1.videoRobustness || drm2.videoRobustness,
-            audioRobustness: drm1.audioRobustness || drm2.audioRobustness,
-            serverCertificate: drm1.serverCertificate || drm2.serverCertificate,
-            serverCertificateUri: drm1.serverCertificateUri ||
-                drm2.serverCertificateUri,
-            initData,
-            keyIds,
-          };
-          commonDrms.push(mergedDrm);
-          break;
-        }
-      }
-    }
-
-    return commonDrms;
   }
 
   /**
@@ -2717,73 +2614,6 @@ shaka.media.DrmEngine = class {
     this.newInitData('cenc', combinedData);
     return this.allSessionsLoaded_;
   }
-
-  /**
-   * A method for generating a key for the MediaKeySystemAccessRequests cache.
-   *
-   * @param {string} videoCodec
-   * @param {string} audioCodec
-   * @param {string} keySystem
-   * @return {string}
-   * @private
-   */
-  static generateKeySystemCacheKey_(videoCodec, audioCodec, keySystem) {
-    return `${videoCodec}#${audioCodec}#${keySystem}`;
-  }
-
-  /**
-   * Check does MediaKeySystemAccess cache contains something for following
-   * attributes.
-   *
-   * @param {string} videoCodec
-   * @param {string} audioCodec
-   * @param {string} keySystem
-   * @return {boolean}
-   */
-  static hasMediaKeySystemAccess(videoCodec, audioCodec, keySystem) {
-    const DrmEngine = shaka.media.DrmEngine;
-    const key = DrmEngine.generateKeySystemCacheKey_(
-        videoCodec, audioCodec, keySystem);
-    return DrmEngine.memoizedMediaKeySystemAccessRequests_.has(key);
-  }
-
-  /**
-   * Get MediaKeySystemAccess object for following attributes.
-   *
-   * @param {string} videoCodec
-   * @param {string} audioCodec
-   * @param {string} keySystem
-   * @return {?MediaKeySystemAccess}
-   */
-  static getMediaKeySystemAccess(videoCodec, audioCodec, keySystem) {
-    const DrmEngine = shaka.media.DrmEngine;
-    const key = DrmEngine.generateKeySystemCacheKey_(
-        videoCodec, audioCodec, keySystem);
-    return DrmEngine.memoizedMediaKeySystemAccessRequests_.get(key) || null;
-  }
-
-  /**
-   * Store MediaKeySystemAccess object associated with specified attributes.
-   *
-   * @param {string} videoCodec
-   * @param {string} audioCodec
-   * @param {string} keySystem
-   * @param {!MediaKeySystemAccess} mksa
-   */
-  static setMediaKeySystemAccess(videoCodec, audioCodec, keySystem, mksa) {
-    const DrmEngine = shaka.media.DrmEngine;
-    const key = DrmEngine.generateKeySystemCacheKey_(
-        videoCodec, audioCodec, keySystem);
-    return DrmEngine.memoizedMediaKeySystemAccessRequests_.set(key, mksa);
-  }
-
-  /**
-   * Clears underlying cache.
-   */
-  static clearMediaKeySystemAccessMap() {
-    const DrmEngine = shaka.media.DrmEngine;
-    DrmEngine.memoizedMediaKeySystemAccessRequests_.clear();
-  }
 };
 
 
@@ -2868,22 +2698,3 @@ shaka.media.DrmEngine.SESSION_LOAD_TIMEOUT_ = 5;
  * @type {number}
  */
 shaka.media.DrmEngine.KEY_STATUS_BATCH_TIME = 0.5;
-
-
-/**
- * Contains the suggested "default" key ID used by EME polyfills that do not
- * have a per-key key status. See w3c/encrypted-media#32.
- * @type {!shaka.util.Lazy.<!ArrayBuffer>}
- */
-shaka.media.DrmEngine.DUMMY_KEY_ID = new shaka.util.Lazy(
-    () => shaka.util.BufferUtils.toArrayBuffer(new Uint8Array([0])));
-
-
-/**
- * A cache that stores the MediaKeySystemAccess result of calling
- * `navigator.requestMediaKeySystemAccess` by a key combination of
- * video/audio codec and key system string.
- *
- * @private {!Map<string, !MediaKeySystemAccess>}
- */
-shaka.media.DrmEngine.memoizedMediaKeySystemAccessRequests_ = new Map();

--- a/lib/player.js
+++ b/lib/player.js
@@ -45,6 +45,7 @@ goog.require('shaka.util.CmcdManager');
 goog.require('shaka.util.CmsdManager');
 goog.require('shaka.util.ConfigUtils');
 goog.require('shaka.util.Dom');
+goog.require('shaka.util.DrmUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.EventManager');
 goog.require('shaka.util.FakeEvent');
@@ -1072,7 +1073,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // DRM support is not strictly necessary, but the APIs at least need to be
     // there.  Our no-op DRM polyfill should handle that.
     // TODO(#1017): Consider making even DrmEngine optional.
-    const drmSupport = shaka.media.DrmEngine.isBrowserSupported();
+    const drmSupport = shaka.util.DrmUtils.isBrowserSupported();
     if (!drmSupport) {
       return false;
     }
@@ -1469,7 +1470,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // each playback.
       if (this.config_.streaming.clearDecodingCache) {
         shaka.util.StreamUtils.clearDecodingConfigCache();
-        shaka.media.DrmEngine.clearMediaKeySystemAccessMap();
+        shaka.util.DrmUtils.clearMediaKeySystemAccessMap();
       }
 
       this.manifest_ = null;
@@ -4330,7 +4331,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @export
    */
   keySystem() {
-    return shaka.media.DrmEngine.keySystem(this.drmInfo());
+    return shaka.util.DrmUtils.keySystem(this.drmInfo());
   }
 
   /**

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -8,8 +8,8 @@ goog.provide('shaka.polyfill.MediaCapabilities');
 
 goog.require('shaka.log');
 goog.require('shaka.media.Capabilities');
-goog.require('shaka.media.DrmEngine');
 goog.require('shaka.polyfill');
+goog.require('shaka.util.DrmUtils');
 goog.require('shaka.util.Platform');
 
 
@@ -284,14 +284,14 @@ shaka.polyfill.MediaCapabilities = class {
     /** @type {MediaKeySystemAccess} */
     let keySystemAccess = null;
     try {
-      if (shaka.media.DrmEngine.hasMediaKeySystemAccess(
+      if (shaka.util.DrmUtils.hasMediaKeySystemAccess(
           videoCodec, audioCodec, keySystem)) {
-        keySystemAccess = shaka.media.DrmEngine.getMediaKeySystemAccess(
+        keySystemAccess = shaka.util.DrmUtils.getMediaKeySystemAccess(
             videoCodec, audioCodec, keySystem);
       } else {
         keySystemAccess = await navigator.requestMediaKeySystemAccess(
             mcapKeySystemConfig.keySystem, [mediaKeySystemConfig]);
-        shaka.media.DrmEngine.setMediaKeySystemAccess(
+        shaka.util.DrmUtils.setMediaKeySystemAccess(
             videoCodec, audioCodec, keySystem, keySystemAccess);
       }
     } catch (e) {

--- a/lib/polyfill/patchedmediakeys_apple.js
+++ b/lib/polyfill/patchedmediakeys_apple.js
@@ -8,9 +8,9 @@ goog.provide('shaka.polyfill.PatchedMediaKeysApple');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
-goog.require('shaka.media.DrmEngine');
 goog.require('shaka.polyfill');
 goog.require('shaka.util.BufferUtils');
+goog.require('shaka.util.DrmUtils');
 goog.require('shaka.util.EventManager');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.FakeEventTarget');
@@ -746,7 +746,7 @@ shaka.polyfill.PatchedMediaKeysApple.MediaKeyStatusMap = class {
   /** @override */
   forEach(fn) {
     if (this.status_) {
-      fn(this.status_, shaka.media.DrmEngine.DUMMY_KEY_ID.value());
+      fn(this.status_, shaka.util.DrmUtils.DUMMY_KEY_ID.value());
     }
   }
 
@@ -760,7 +760,7 @@ shaka.polyfill.PatchedMediaKeysApple.MediaKeyStatusMap = class {
 
   /** @override */
   has(keyId) {
-    const fakeKeyId = shaka.media.DrmEngine.DUMMY_KEY_ID.value();
+    const fakeKeyId = shaka.util.DrmUtils.DUMMY_KEY_ID.value();
     if (this.status_ && shaka.util.BufferUtils.equal(keyId, fakeKeyId)) {
       return true;
     }

--- a/lib/polyfill/patchedmediakeys_webkit.js
+++ b/lib/polyfill/patchedmediakeys_webkit.js
@@ -8,9 +8,9 @@ goog.provide('shaka.polyfill.PatchedMediaKeysWebkit');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
-goog.require('shaka.media.DrmEngine');
 goog.require('shaka.polyfill');
 goog.require('shaka.util.BufferUtils');
+goog.require('shaka.util.DrmUtils');
 goog.require('shaka.util.EventManager');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.FakeEventTarget');
@@ -924,7 +924,7 @@ shaka.polyfill.PatchedMediaKeysWebkit.MediaKeyStatusMap = class {
   /** @override */
   forEach(fn) {
     if (this.status_) {
-      fn(this.status_, shaka.media.DrmEngine.DUMMY_KEY_ID.value());
+      fn(this.status_, shaka.util.DrmUtils.DUMMY_KEY_ID.value());
     }
   }
 
@@ -938,7 +938,7 @@ shaka.polyfill.PatchedMediaKeysWebkit.MediaKeyStatusMap = class {
 
   /** @override */
   has(keyId) {
-    const fakeKeyId = shaka.media.DrmEngine.DUMMY_KEY_ID.value();
+    const fakeKeyId = shaka.util.DrmUtils.DUMMY_KEY_ID.value();
     if (this.status_ && shaka.util.BufferUtils.equal(keyId, fakeKeyId)) {
       return true;
     }

--- a/lib/util/drm_utils.js
+++ b/lib/util/drm_utils.js
@@ -6,8 +6,113 @@
 
 goog.provide('shaka.util.DrmUtils');
 
+goog.require('shaka.util.BufferUtils');
+goog.require('shaka.util.Lazy');
+
 
 shaka.util.DrmUtils = class {
+  /**
+   * Returns true if the browser has recent EME APIs.
+   *
+   * @return {boolean}
+   */
+  static isBrowserSupported() {
+    const basic =
+        !!window.MediaKeys &&
+        !!window.navigator &&
+        !!window.navigator.requestMediaKeySystemAccess &&
+        !!window.MediaKeySystemAccess &&
+        // eslint-disable-next-line no-restricted-syntax
+        !!window.MediaKeySystemAccess.prototype.getConfiguration;
+
+    return basic;
+  }
+
+  /**
+   * Checks if two DrmInfos can be decrypted using the same key system.
+   * Clear content is considered compatible with every key system.
+   *
+   * @param {!Array<!shaka.extern.DrmInfo>} drms1
+   * @param {!Array<!shaka.extern.DrmInfo>} drms2
+   * @return {boolean}
+   */
+  static areDrmCompatible(drms1, drms2) {
+    if (!drms1.length || !drms2.length) {
+      return true;
+    }
+
+    if (drms1 === drms2) {
+      return true;
+    }
+
+    return shaka.util.DrmUtils.getCommonDrmInfos(
+        drms1, drms2).length > 0;
+  }
+
+  /**
+   * Returns an array of drm infos that are present in both input arrays.
+   * If one of the arrays is empty, returns the other one since clear
+   * content is considered compatible with every drm info.
+   *
+   * @param {!Array<!shaka.extern.DrmInfo>} drms1
+   * @param {!Array<!shaka.extern.DrmInfo>} drms2
+   * @return {!Array<!shaka.extern.DrmInfo>}
+   */
+  static getCommonDrmInfos(drms1, drms2) {
+    if (!drms1.length) {
+      return drms2;
+    }
+    if (!drms2.length) {
+      return drms1;
+    }
+
+    const commonDrms = [];
+
+    for (const drm1 of drms1) {
+      for (const drm2 of drms2) {
+        if (drm1.keySystem == drm2.keySystem) {
+          const initDataMap = new Map();
+          const bothInitDatas = (drm1.initData || [])
+              .concat(drm2.initData || []);
+          for (const d of bothInitDatas) {
+            initDataMap.set(d.keyId, d);
+          }
+          const initData = Array.from(initDataMap.values());
+
+          const keyIds = drm1.keyIds && drm2.keyIds ?
+              new Set([...drm1.keyIds, ...drm2.keyIds]) :
+              drm1.keyIds || drm2.keyIds;
+          const mergedDrm = {
+            keySystem: drm1.keySystem,
+            licenseServerUri: drm1.licenseServerUri || drm2.licenseServerUri,
+            distinctiveIdentifierRequired: drm1.distinctiveIdentifierRequired ||
+                drm2.distinctiveIdentifierRequired,
+            persistentStateRequired: drm1.persistentStateRequired ||
+                drm2.persistentStateRequired,
+            videoRobustness: drm1.videoRobustness || drm2.videoRobustness,
+            audioRobustness: drm1.audioRobustness || drm2.audioRobustness,
+            serverCertificate: drm1.serverCertificate || drm2.serverCertificate,
+            serverCertificateUri: drm1.serverCertificateUri ||
+                drm2.serverCertificateUri,
+            initData,
+            keyIds,
+          };
+          commonDrms.push(mergedDrm);
+          break;
+        }
+      }
+    }
+
+    return commonDrms;
+  }
+
+  /**
+   * @param {?shaka.extern.DrmInfo} drmInfo
+   * @return {string} */
+  static keySystem(drmInfo) {
+    return drmInfo ? drmInfo.keySystem : '';
+  }
+
   /**
    * @param {?string} keySystem
    * @return {boolean}
@@ -31,4 +136,90 @@ shaka.util.DrmUtils = class {
 
     return false;
   }
+
+  /**
+   * A method for generating a key for the MediaKeySystemAccessRequests cache.
+   *
+   * @param {string} videoCodec
+   * @param {string} audioCodec
+   * @param {string} keySystem
+   * @return {string}
+   * @private
+   */
+  static generateKeySystemCacheKey_(videoCodec, audioCodec, keySystem) {
+    return `${videoCodec}#${audioCodec}#${keySystem}`;
+  }
+
+  /**
+   * Check does MediaKeySystemAccess cache contains something for following
+   * attributes.
+   *
+   * @param {string} videoCodec
+   * @param {string} audioCodec
+   * @param {string} keySystem
+   * @return {boolean}
+   */
+  static hasMediaKeySystemAccess(videoCodec, audioCodec, keySystem) {
+    const DrmUtils = shaka.util.DrmUtils;
+    const key = DrmUtils.generateKeySystemCacheKey_(
+        videoCodec, audioCodec, keySystem);
+    return DrmUtils.memoizedMediaKeySystemAccessRequests_.has(key);
+  }
+
+  /**
+   * Get MediaKeySystemAccess object for following attributes.
+   *
+   * @param {string} videoCodec
+   * @param {string} audioCodec
+   * @param {string} keySystem
+   * @return {?MediaKeySystemAccess}
+   */
+  static getMediaKeySystemAccess(videoCodec, audioCodec, keySystem) {
+    const DrmUtils = shaka.util.DrmUtils;
+    const key = DrmUtils.generateKeySystemCacheKey_(
+        videoCodec, audioCodec, keySystem);
+    return DrmUtils.memoizedMediaKeySystemAccessRequests_.get(key) || null;
+  }
+
+  /**
+   * Store MediaKeySystemAccess object associated with specified attributes.
+   *
+   * @param {string} videoCodec
+   * @param {string} audioCodec
+   * @param {string} keySystem
+   * @param {!MediaKeySystemAccess} mksa
+   */
+  static setMediaKeySystemAccess(videoCodec, audioCodec, keySystem, mksa) {
+    const DrmUtils = shaka.util.DrmUtils;
+    const key = DrmUtils.generateKeySystemCacheKey_(
+        videoCodec, audioCodec, keySystem);
+    return DrmUtils.memoizedMediaKeySystemAccessRequests_.set(key, mksa);
+  }
+
+  /**
+   * Clears underlying cache.
+   */
+  static clearMediaKeySystemAccessMap() {
+    const DrmUtils = shaka.util.DrmUtils;
+    DrmUtils.memoizedMediaKeySystemAccessRequests_.clear();
+  }
 };
+
+
+/**
+ * Contains the suggested "default" key ID used by EME polyfills that do not
+ * have a per-key key status. See w3c/encrypted-media#32.
+ * @type {!shaka.util.Lazy<!ArrayBuffer>}
+ */
+shaka.util.DrmUtils.DUMMY_KEY_ID = new shaka.util.Lazy(
+    () => shaka.util.BufferUtils.toArrayBuffer(new Uint8Array([0])));
+
+
+/**
+ * A cache that stores the MediaKeySystemAccess result of calling
+ * `navigator.requestMediaKeySystemAccess` by a key combination of
+ * video/audio codec and key system string.
+ *
+ * @private {!Map<string, !MediaKeySystemAccess>}
+ */
+shaka.util.DrmUtils.memoizedMediaKeySystemAccessRequests_ = new Map();

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -8,9 +8,9 @@ goog.provide('shaka.util.PeriodCombiner');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
-goog.require('shaka.media.DrmEngine');
 goog.require('shaka.media.MetaSegmentIndex');
 goog.require('shaka.media.SegmentIndex');
+goog.require('shaka.util.DrmUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.IReleasable');
 goog.require('shaka.util.LanguageUtils');
@@ -282,7 +282,7 @@ shaka.util.PeriodCombiner = class {
     } else {
       for (const audio of this.audioStreams_) {
         for (const video of this.videoStreams_) {
-          const commonDrmInfos = shaka.media.DrmEngine.getCommonDrmInfos(
+          const commonDrmInfos = shaka.util.DrmUtils.getCommonDrmInfos(
               audio.drmInfos, video.drmInfos);
 
           if (audio.drmInfos.length && video.drmInfos.length &&
@@ -855,7 +855,7 @@ shaka.util.PeriodCombiner = class {
       output.originalId += ',' + (input.originalId || '');
     }
 
-    const commonDrmInfos = shaka.media.DrmEngine.getCommonDrmInfos(
+    const commonDrmInfos = shaka.util.DrmUtils.getCommonDrmInfos(
         output.drmInfos, input.drmInfos);
     if (input.drmInfos.length && output.drmInfos.length &&
         !commonDrmInfos.length) {
@@ -1115,7 +1115,7 @@ shaka.util.PeriodCombiner = class {
     if (outputStream.drmInfos) {
       // Check for compatible DRM systems.  Note that clear streams are
       // implicitly compatible with any DRM and with each other.
-      if (!shaka.media.DrmEngine.areDrmCompatible(outputStream.drmInfos,
+      if (!shaka.util.DrmUtils.areDrmCompatible(outputStream.drmInfos,
           candidate.drmInfos)) {
         return false;
       }

--- a/test/polyfill/media_capabilities_unit.js
+++ b/test/polyfill/media_capabilities_unit.js
@@ -68,7 +68,7 @@ describe('MediaCapabilities', () => {
         width: 512,
       },
     };
-    shaka.media.DrmEngine.clearMediaKeySystemAccessMap();
+    shaka.util.DrmUtils.clearMediaKeySystemAccessMap();
     supportMap.clear();
 
     mockCanDisplayType = jasmine.createSpy('canDisplayType');

--- a/test/util/drm_utils_unit.js
+++ b/test/util/drm_utils_unit.js
@@ -5,6 +5,144 @@
  */
 
 describe('DrmUtils', () => {
+  describe('getCommonDrmInfos', () => {
+    it('returns one array if the other is empty', () => {
+      const drmInfo = {
+        keySystem: 'drm.abc',
+        licenseServerUri: 'http://abc.drm/license',
+        distinctiveIdentifierRequired: true,
+        persistentStateRequired: true,
+        audioRobustness: 'good',
+        videoRobustness: 'really_really_ridiculously_good',
+        serverCertificate: undefined,
+        serverCertificateUri: '',
+        initData: [],
+        keyIds: new Set(['deadbeefdeadbeefdeadbeefdeadbeef']),
+      };
+      const returnedOne =
+          shaka.util.DrmUtils.getCommonDrmInfos([drmInfo], []);
+      const returnedTwo =
+          shaka.util.DrmUtils.getCommonDrmInfos([], [drmInfo]);
+      expect(returnedOne).toEqual([drmInfo]);
+      expect(returnedTwo).toEqual([drmInfo]);
+    });
+
+    it('merges drmInfos if two exist', () => {
+      const serverCert = new Uint8Array(0);
+      const drmInfoVideo = {
+        keySystem: 'drm.abc',
+        licenseServerUri: 'http://abc.drm/license',
+        distinctiveIdentifierRequired: false,
+        persistentStateRequired: true,
+        videoRobustness: 'really_really_ridiculously_good',
+        serverCertificate: serverCert,
+        serverCertificateUri: '',
+        initData: [{keyId: 'a'}],
+        keyIds: new Set(['deadbeefdeadbeefdeadbeefdeadbeef']),
+      };
+      const drmInfoAudio = {
+        keySystem: 'drm.abc',
+        licenseServerUri: undefined,
+        distinctiveIdentifierRequired: true,
+        persistentStateRequired: false,
+        audioRobustness: 'good',
+        serverCertificate: undefined,
+        serverCertificateUri: '',
+        initData: [{keyId: 'b'}],
+        keyIds: new Set(['eadbeefdeadbeefdeadbeefdeadbeefd']),
+      };
+      const drmInfoDesired = {
+        keySystem: 'drm.abc',
+        licenseServerUri: 'http://abc.drm/license',
+        distinctiveIdentifierRequired: true,
+        persistentStateRequired: true,
+        audioRobustness: 'good',
+        videoRobustness: 'really_really_ridiculously_good',
+        serverCertificate: serverCert,
+        serverCertificateUri: '',
+        initData: [{keyId: 'a'}, {keyId: 'b'}],
+        keyIds: new Set([
+          'deadbeefdeadbeefdeadbeefdeadbeef',
+          'eadbeefdeadbeefdeadbeefdeadbeefd',
+        ]),
+      };
+      const returned = shaka.util.DrmUtils.getCommonDrmInfos([drmInfoVideo],
+          [drmInfoAudio]);
+      expect(returned).toEqual([drmInfoDesired]);
+    });
+
+    it('dedupes the merged init data based on keyId matching', () => {
+      const serverCert = new Uint8Array(0);
+      const drmInfoVideo = {
+        keySystem: 'drm.abc',
+        licenseServerUri: 'http://abc.drm/license',
+        distinctiveIdentifierRequired: false,
+        persistentStateRequired: true,
+        videoRobustness: 'really_really_ridiculously_good',
+        serverCertificate: serverCert,
+        serverCertificateUri: '',
+        initData: [{keyId: 'v-init'}],
+        keyIds: new Set(['deadbeefdeadbeefdeadbeefdeadbeef']),
+      };
+      const drmInfoAudio = {
+        keySystem: 'drm.abc',
+        licenseServerUri: undefined,
+        distinctiveIdentifierRequired: true,
+        persistentStateRequired: false,
+        audioRobustness: 'good',
+        serverCertificate: undefined,
+        serverCertificateUri: '',
+        initData: [{keyId: 'v-init'}, {keyId: 'a-init'}],
+        keyIds: new Set(['eadbeefdeadbeefdeadbeefdeadbeefd']),
+      };
+      const drmInfoDesired = {
+        keySystem: 'drm.abc',
+        licenseServerUri: 'http://abc.drm/license',
+        distinctiveIdentifierRequired: true,
+        persistentStateRequired: true,
+        audioRobustness: 'good',
+        videoRobustness: 'really_really_ridiculously_good',
+        serverCertificate: serverCert,
+        serverCertificateUri: '',
+        initData: [{keyId: 'v-init'}, {keyId: 'a-init'}],
+        keyIds: new Set([
+          'deadbeefdeadbeefdeadbeefdeadbeef',
+          'eadbeefdeadbeefdeadbeefdeadbeefd',
+        ]),
+      };
+      const returned = shaka.util.DrmUtils.getCommonDrmInfos([drmInfoVideo],
+          [drmInfoAudio]);
+      expect(returned).toEqual([drmInfoDesired]);
+    });
+
+    it('does not match incompatible drmInfos', () => {
+      // Different key systems do not match.
+      const drmInfo1 = {
+        keySystem: 'drm.abc',
+        licenseServerUri: undefined,
+        distinctiveIdentifierRequired: false,
+        persistentStateRequired: false,
+        serverCertificate: undefined,
+        serverCertificateUri: '',
+        initData: [],
+        keyIds: new Set(),
+      };
+      const drmInfo2 = {
+        keySystem: 'drm.foobar',
+        licenseServerUri: undefined,
+        distinctiveIdentifierRequired: false,
+        persistentStateRequired: false,
+        serverCertificate: undefined,
+        serverCertificateUri: '',
+        initData: [],
+        keyIds: new Set(),
+      };
+      const returned1 = shaka.util.DrmUtils.getCommonDrmInfos(
+          [drmInfo1], [drmInfo2]);
+      expect(returned1).toEqual([]);
+    });
+  }); // describe('getCommonDrmInfos')
+
   describe('isPlayReadyKeySystem', () => {
     it('should return true for MS & Chromecast PlayReady', () => {
       expect(shaka.util.DrmUtils.isPlayReadyKeySystem(


### PR DESCRIPTION
As we already have `DrmUtils`, try to cut few lines from `DrmEngine`.