### PR TITLE
fix(TTML): Fix font styles parsing

### DIFF
--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -630,7 +630,9 @@ shaka.text.TtmlTextParser = class {
           cue.fontFamily = 'serif';
           break;
         default:
-          cue.fontFamily = fontFamily;
+          cue.fontFamily = fontFamily.split(',').filter((font) => {
+            return font != 'default';
+          }).join(',');
           break;
       }
     }
@@ -1300,9 +1302,9 @@ shaka.text.TtmlTextParser.percentValues_ =
 /**
  * @const
  * @private {!RegExp}
- * @example 0.6% 90%
+ * @example 0.6% 90% 300% 1000%
  */
-shaka.text.TtmlTextParser.percentValue_ = /^(\d{1,2}(?:\.\d+)?|100)%$/;
+shaka.text.TtmlTextParser.percentValue_ = /^(\d{1,4}(?:\.\d+)?|100)%$/;
 
 /**
  * @const


### PR DESCRIPTION
Exclude default fontFamily (not supported in Chromium browsers)
Allow fontSize with 3 and 4 digits, for example 300% or 1000%