### PR TITLE
fix(Prefetch): Use the same references time for evict and prefetchSegmentsByTime

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1400,7 +1400,7 @@ shaka.media.StreamingEngine = class {
 
     if (mediaState.segmentPrefetch && mediaState.segmentIterator &&
         !this.audioPrefetchMap_.has(mediaState.stream)) {
-      mediaState.segmentPrefetch.evict(presentationTime);
+      mediaState.segmentPrefetch.evict(reference.startTime);
       mediaState.segmentPrefetch.prefetchSegmentsByTime(reference.startTime);
     }
 


### PR DESCRIPTION
Using different time bases can result in duplicate or unnecessary segments being downloaded in HLS LL