### PR TITLE
fix: Avoid reset iterator when seek into the buffer

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -769,25 +769,16 @@ shaka.media.StreamingEngine = class {
       const mediaState = this.mediaStates_.get(type);
       const logPrefix = shaka.media.StreamingEngine.logPrefix_(mediaState);
 
-      let segment = null;
-      if (mediaState.segmentIterator) {
-        segment = mediaState.segmentIterator.current();
-      }
-      if (mediaState.segmentPrefetch) {
-        mediaState.segmentPrefetch.resetPosition();
-      }
-      if (mediaState.type === ContentType.AUDIO) {
-        for (const prefetch of this.audioPrefetchMap_.values()) {
-          prefetch.resetPosition();
-        }
-      }
-      // Only reset the iterator if we seek outside the current segment.
-      if (!segment || segment.startTime > presentationTime ||
-          segment.endTime < presentationTime) {
-        mediaState.segmentIterator = null;
-      }
-
       if (!newTimeIsBuffered(type)) {
+        if (mediaState.segmentPrefetch) {
+          mediaState.segmentPrefetch.resetPosition();
+        }
+        if (mediaState.type === ContentType.AUDIO) {
+          for (const prefetch of this.audioPrefetchMap_.values()) {
+            prefetch.resetPosition();
+          }
+        }
+        mediaState.segmentIterator = null;
         const bufferEnd =
             this.playerInterface_.mediaSourceEngine.bufferEnd(type);
         const somethingBuffered = bufferEnd != null;


### PR DESCRIPTION
When using HLS LL and making seek small this produces overlaps