### PR TITLE
fix(DASH): Fix period combining when roles are equal

### DIFF
--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -1242,7 +1242,7 @@ shaka.util.PeriodCombiner = class {
         return true;
       } else if (candidateRoleMatches.length < bestRoleMatches.length) {
         return false;
-      } else {
+      } else if (candidate.roles.length !== best.roles.length) {
         // Both streams have the same role overlap with the outputStream
         // If this is the case, choose the stream with the fewer roles overall.
         // Streams that match best together tend to be streams with the same


### PR DESCRIPTION
When roles exist and are equal between tracks and periods, period combiner matches based on that instead of looking for other similarities. This PR addresses it & adds regression test.