### PR TITLE
fix: Allow dispatch metadata event with cueTime equal to 0

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -3223,7 +3223,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    */
   processTimedMetadataMediaSrc_(metadata, offset, segmentEndTime) {
     for (const sample of metadata) {
-      if (sample.data && sample.cueTime && sample.frames) {
+      if (sample.data && typeof(sample.cueTime) == 'number' && sample.frames) {
         const start = sample.cueTime + offset;
         let end = segmentEndTime;
         // This can happen when the ID3 info arrives in a previous segment.


### PR DESCRIPTION
Related to https://github.com/shaka-project/shaka-player/issues/7097