### PR TITLE
feat(net): Add minimum bytes for progress events

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -469,6 +469,8 @@ shakaDemo.Config = class {
         .addBoolInput_('Auto Low Latency Mode', 'streaming.autoLowLatencyMode')
         .addBoolInput_('Force HTTP', 'streaming.forceHTTP')
         .addBoolInput_('Force HTTPS', 'streaming.forceHTTPS')
+        .addNumberInput_('Min bytes for progress events',
+            'streaming.minBytesForProgressEvents')
         .addBoolInput_('Prefer native HLS playback when available',
             'streaming.preferNativeHls')
         .addNumberInput_('Update interval seconds',

--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -169,7 +169,8 @@ shaka.extern.Response;
  *                     shaka.extern.Request,
  *                     shaka.net.NetworkingEngine.RequestType,
  *                     shaka.extern.ProgressUpdated,
- *                     shaka.extern.HeadersReceived):
+ *                     shaka.extern.HeadersReceived,
+ *                     shaka.extern.SchemePluginConfig):
  *     !shaka.extern.IAbortableOperation.<shaka.extern.Response>}
  * @description
  * Defines a plugin that handles a specific scheme.
@@ -183,6 +184,23 @@ shaka.extern.Response;
  * @exportDoc
  */
 shaka.extern.SchemePlugin;
+
+
+/**
+ * @typedef {{
+*   minBytesForProgressEvents: (number|undefined)
+* }}
+*
+* @description
+*   Defines configuration object to use by SchemePlugins.
+*
+* @property {(number|undefined)} minBytesForProgressEvents
+*   Defines minimum number of bytes that should be use to emit progress event,
+*   if possible.
+*
+* @exportDoc
+*/
+shaka.extern.SchemePluginConfig;
 
 
 /**

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1544,6 +1544,7 @@ shaka.extern.LiveSyncConfiguration;
  *   autoLowLatencyMode: boolean,
  *   forceHTTP: boolean,
  *   forceHTTPS: boolean,
+ *   minBytesForProgressEvents: number,
  *   preferNativeHls: boolean,
  *   updateIntervalSeconds: number,
  *   dispatchAllEmsgBoxes: boolean,
@@ -1702,6 +1703,11 @@ shaka.extern.LiveSyncConfiguration;
  *   If both forceHTTP and forceHTTPS are set, forceHTTPS wins.
  *   <br>
  *   Defaults to <code>false</code>.
+ * @property {number} minBytesForProgressEvents
+ *   Defines minimum number of bytes that should be used to emit progress event,
+ *   if possible. To avoid issues around feeding ABR with request history, this
+ *   value should be greater than or equal to `abr.advanced.minBytes`.
+ *   By default equals 16e3 (the same value as `abr.advanced.minBytes`).
  * @property {boolean} preferNativeHls
  *   If true, prefer native HLS playback when possible, regardless of platform.
  *   <br>

--- a/lib/net/http_fetch_plugin.js
+++ b/lib/net/http_fetch_plugin.js
@@ -29,10 +29,12 @@ shaka.net.HttpFetchPlugin = class {
    *   progress event happened.
    * @param {shaka.extern.HeadersReceived} headersReceived Called when the
    *   headers for the download are received, but before the body is.
+   * @param {shaka.extern.SchemePluginConfig} config
    * @return {!shaka.extern.IAbortableOperation.<shaka.extern.Response>}
    * @export
    */
-  static parse(uri, request, requestType, progressUpdated, headersReceived) {
+  static parse(uri, request, requestType, progressUpdated, headersReceived,
+      config) {
     const headers = new shaka.net.HttpFetchPlugin.Headers_();
     shaka.util.MapUtils.asMap(request.headers).forEach((value, key) => {
       headers.append(key, value);
@@ -56,9 +58,11 @@ shaka.net.HttpFetchPlugin = class {
       timedOut: false,
     };
 
+    const minBytes = config.minBytesForProgressEvents || 0;
+
     const pendingRequest = shaka.net.HttpFetchPlugin.request_(
         uri, requestType, init, abortStatus, progressUpdated, headersReceived,
-        request.streamDataCallback);
+        request.streamDataCallback, minBytes);
 
     /** @type {!shaka.util.AbortableOperation} */
     const op = new shaka.util.AbortableOperation(pendingRequest, () => {
@@ -96,11 +100,12 @@ shaka.net.HttpFetchPlugin = class {
    * @param {shaka.extern.ProgressUpdated} progressUpdated
    * @param {shaka.extern.HeadersReceived} headersReceived
    * @param {?function(BufferSource):!Promise} streamDataCallback
+   * @param {number} minBytes
    * @return {!Promise<!shaka.extern.Response>}
    * @private
    */
   static async request_(uri, requestType, init, abortStatus, progressUpdated,
-      headersReceived, streamDataCallback) {
+      headersReceived, streamDataCallback, minBytes) {
     const fetch = shaka.net.HttpFetchPlugin.fetch_;
     const ReadableStream = shaka.net.HttpFetchPlugin.ReadableStream_;
     let response;
@@ -163,13 +168,15 @@ shaka.net.HttpFetchPlugin = class {
             }
 
             const currentTime = Date.now();
+            const chunkSize = loaded - lastLoaded;
             // If the time between last time and this time we got progress event
             // is long enough, or if a whole segment is downloaded, call
             // progressUpdated().
-            if (currentTime - lastTime > 100 || readObj.done) {
+            if ((currentTime - lastTime > 100 && chunkSize >= minBytes) ||
+                readObj.done) {
               const numBytesRemaining =
                   readObj.done ? 0 : contentLength - loaded;
-              progressUpdated(currentTime - lastTime, loaded - lastLoaded,
+              progressUpdated(currentTime - lastTime, chunkSize,
                   numBytesRemaining);
               lastLoaded = loaded;
               lastTime = currentTime;

--- a/lib/net/http_xhr_plugin.js
+++ b/lib/net/http_xhr_plugin.js
@@ -26,10 +26,12 @@ shaka.net.HttpXHRPlugin = class {
    *   progress event happened.
    * @param {shaka.extern.HeadersReceived} headersReceived Called when the
    *   headers for the download are received, but before the body is.
+   * @param {shaka.extern.SchemePluginConfig} config
    * @return {!shaka.extern.IAbortableOperation.<shaka.extern.Response>}
    * @export
    */
-  static parse(uri, request, requestType, progressUpdated, headersReceived) {
+  static parse(uri, request, requestType, progressUpdated, headersReceived,
+      config) {
     const xhr = new shaka.net.HttpXHRPlugin.Xhr_();
 
     // Last time stamp when we got a progress event.
@@ -98,11 +100,13 @@ shaka.net.HttpXHRPlugin = class {
         // If the time between last time and this time we got progress event
         // is long enough, or if a whole segment is downloaded, call
         // progressUpdated().
-        if (currentTime - lastTime > 100 ||
+        const minBytes = config.minBytesForProgressEvents || 0;
+        const chunkSize = event.loaded - lastLoaded;
+        if ((currentTime - lastTime > 100 && chunkSize >= minBytes) ||
             (event.lengthComputable && event.loaded == event.total)) {
           const numBytesRemaining =
               xhr.readyState == 4 ? 0 : event.total - event.loaded;
-          progressUpdated(currentTime - lastTime, event.loaded - lastLoaded,
+          progressUpdated(currentTime - lastTime, chunkSize,
               numBytesRemaining);
           lastLoaded = event.loaded;
           lastTime = currentTime;

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -101,6 +101,9 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
 
     /** @private {boolean} */
     this.forceHTTPS_ = false;
+
+    /** @private {number} */
+    this.minBytesForProgressEvents_ = 16e3;
   }
 
   /**
@@ -117,6 +120,14 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
    */
   setForceHTTPS(forceHTTPS) {
     this.forceHTTPS_ = forceHTTPS;
+  }
+
+
+  /**
+   * @param {number} minBytes
+   */
+  setMinBytesForProgressEvents(minBytes) {
+    this.minBytesForProgressEvents_ = minBytes;
   }
 
   /**
@@ -575,7 +586,10 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
       request.requestStartTime = Date.now();
 
       const requestPlugin = plugin(
-          request.uris[index], request, type, progressUpdated, headersReceived);
+          request.uris[index], request, type, progressUpdated, headersReceived,
+          {
+            minBytesForProgressEvents: this.minBytesForProgressEvents_,
+          });
 
       if (!progressSupport) {
         return requestPlugin;

--- a/lib/player.js
+++ b/lib/player.js
@@ -804,6 +804,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.networkingEngine_ = this.createNetworkingEngine();
     this.networkingEngine_.setForceHTTP(this.config_.streaming.forceHTTP);
     this.networkingEngine_.setForceHTTPS(this.config_.streaming.forceHTTPS);
+    this.networkingEngine_.setMinBytesForProgressEvents(
+        this.config_.streaming.minBytesForProgressEvents);
 
     /** @private {shaka.extern.IAdManager} */
     this.adManager_ = null;
@@ -4029,6 +4031,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (this.networkingEngine_) {
       this.networkingEngine_.setForceHTTP(this.config_.streaming.forceHTTP);
       this.networkingEngine_.setForceHTTPS(this.config_.streaming.forceHTTPS);
+      this.networkingEngine_.setMinBytesForProgressEvents(
+          this.config_.streaming.minBytesForProgressEvents);
     }
 
     if (this.mediaSourceEngine_) {

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -32,6 +32,7 @@ shaka.util.PlayerConfiguration = class {
     // This is a relatively safe default in the absence of clues from the
     // browser.  For slower connections, the default estimate may be too high.
     const bandwidthEstimate = 1e6; // 1Mbps
+    const minBytes = 16e3;
 
     let abrMaxHeight = Infinity;
 
@@ -224,6 +225,7 @@ shaka.util.PlayerConfiguration = class {
       autoLowLatencyMode: false,
       forceHTTP: false,
       forceHTTPS: false,
+      minBytesForProgressEvents: minBytes,
       preferNativeHls: false,
       updateIntervalSeconds: 1,
       dispatchAllEmsgBoxes: false,
@@ -340,7 +342,7 @@ shaka.util.PlayerConfiguration = class {
       },
       advanced: {
         minTotalBytes: 128e3,
-        minBytes: 16e3,
+        minBytes,
         fastHalfLife: 2,
         slowHalfLife: 5,
       },

--- a/test/net/http_plugin_unit.js
+++ b/test/net/http_plugin_unit.js
@@ -163,7 +163,8 @@ function httpPluginTests(usingFetch) {
     request.headers['BAZ'] = '123';
 
     await plugin(
-        request.uris[0], request, requestType, progressUpdated, headersReceived)
+        request.uris[0], request, requestType, progressUpdated, headersReceived,
+        {})
         .promise;
 
     const actual = mostRecentRequest();
@@ -185,7 +186,7 @@ function httpPluginTests(usingFetch) {
       request.method = 'GET';
 
       await plugin(request.uris[0], request, requestType, progressUpdated,
-          headersReceived).promise;
+          headersReceived, {}).promise;
 
       const actual = jasmine.Fetch.requests.mostRecent();
       expect(actual).toBeTruthy();
@@ -201,7 +202,8 @@ function httpPluginTests(usingFetch) {
       const request = shaka.net.NetworkingEngine.makeRequest(
           [uri], retryParameters, Util.spyFunc(streamDataCallback));
       const response = await plugin(
-          uri, request, requestType, progressUpdated, headersReceived).promise;
+          uri, request, requestType, progressUpdated, headersReceived, {})
+          .promise;
 
       expect(mostRecentRequest().url).toBe(uri);
       expect(response).toBeTruthy();
@@ -293,7 +295,8 @@ function httpPluginTests(usingFetch) {
         ['https://foo.bar/cache'], retryParameters);
 
     const response = await plugin(
-        request.uris[0], request, requestType, progressUpdated, headersReceived)
+        request.uris[0], request, requestType, progressUpdated, headersReceived,
+        {})
         .promise;
     expect(response).toBeTruthy();
     expect(response.fromCache).toBe(true);
@@ -308,7 +311,7 @@ function httpPluginTests(usingFetch) {
       const request = shaka.net.NetworkingEngine.makeRequest(
           [uri], retryParameters);
       const operation = plugin(request.uris[0], request, requestType,
-          progressUpdated, headersReceived);
+          progressUpdated, headersReceived, {});
 
       /** @type {jasmine.Fetch.RequestStub} */
       const actual = jasmine.Fetch.requests.mostRecent();
@@ -350,7 +353,7 @@ function httpPluginTests(usingFetch) {
       const request = shaka.net.NetworkingEngine.makeRequest(
           [uri], retryParameters);
       operation = plugin(request.uris[0], request, requestType, progressUpdated,
-          headersReceived);
+          headersReceived, {});
       requestPromise = operation.promise;
     }
 
@@ -384,7 +387,8 @@ function httpPluginTests(usingFetch) {
     const request = shaka.net.NetworkingEngine.makeRequest(
         [uri], retryParameters);
     const response = await plugin(
-        uri, request, requestType, progressUpdated, headersReceived).promise;
+        uri, request, requestType, progressUpdated, headersReceived, {})
+        .promise;
 
     expect(mostRecentRequest().url).toBe(uri);
     expect(response).toBeTruthy();
@@ -406,7 +410,8 @@ function httpPluginTests(usingFetch) {
         [uri], retryParameters);
 
     const p = plugin(
-        uri, request, requestType, progressUpdated, headersReceived).promise;
+        uri, request, requestType, progressUpdated, headersReceived, {})
+        .promise;
     if (expected.code == shaka.util.Error.Code.TIMEOUT) {
       jasmine.clock().tick(5000);
     }

--- a/test/test/util/fake_networking_engine.js
+++ b/test/test/util/fake_networking_engine.js
@@ -52,6 +52,10 @@ shaka.test.FakeNetworkingEngine = class {
     /** @type {!jasmine.Spy} */
     this.setForceHTTPS = jasmine.createSpy('setForceHTTPS').and.stub();
 
+    /** @type {!jasmine.Spy} */
+    this.setMinBytesForProgressEvents =
+        jasmine.createSpy('setMinBytesForProgressEvents').and.stub();
+
     /** @private {number} */
     this.maxUris_ = 1;
 


### PR DESCRIPTION
By limiting progress events to only ones with minimal chunk size, we might end up with feeding better default ABR implementation, which should result in more accurate adaptation in case of network throttle.