### PR TITLE
fix(HLS): Expose tilesLayout properly for live

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1163,7 +1163,8 @@ shaka.hls.HlsParser = class {
         if (streamInfo.type != 'audio' && streamInfo.type != 'video') {
           continue;
         }
-        const firstReference = streamInfo.stream.segmentIndex.get(0);
+        const firstReference =
+            streamInfo.stream.segmentIndex.earliestReference();
         if (firstReference && firstReference.syncTime) {
           const syncTime = firstReference.syncTime;
           this.presentationTimeline_.setInitialProgramDateTime(syncTime);
@@ -2222,7 +2223,7 @@ shaka.hls.HlsParser = class {
       // lazy-load in this situation.
       await streamInfo.stream.createSegmentIndex();
 
-      const reference = streamInfo.stream.segmentIndex.get(0);
+      const reference = streamInfo.stream.segmentIndex.earliestReference();
       const layout = reference.getTilesLayout();
       if (layout) {
         streamInfo.stream.width =
@@ -2536,7 +2537,7 @@ shaka.hls.HlsParser = class {
         }
 
         if (type == ContentType.TEXT) {
-          const firstSegment = realStream.segmentIndex.get(0);
+          const firstSegment = realStream.segmentIndex.earliestReference();
           if (firstSegment && firstSegment.initSegmentReference) {
             stream.mimeType = 'application/mp4';
             this.setFullTypeForStream_(stream);

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -675,7 +675,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     if (!prefetchSegment) {
       // If we can't get a segment at the desired spot, at least get a segment,
       // so we can get the init segment.
-      prefetchSegment = stream.segmentIndex.get(0);
+      prefetchSegment = stream.segmentIndex.earliestReference();
     }
     if (prefetchSegment) {
       if (isLive) {

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1434,7 +1434,7 @@ shaka.util.StreamUtils = class {
     // in DASH this information comes at the stream level and not at the
     // segment level.
     if (stream.segmentIndex) {
-      reference = stream.segmentIndex.get(0);
+      reference = stream.segmentIndex.earliestReference();
     }
     let layout = stream.tilesLayout;
     if (reference) {


### PR DESCRIPTION
If any segment gets evicted in live scenario, `segmentIndex.get(0)` will return `null`. Due to that, image tracks have `tilesLayout` set to `null` if we call `player.getImageTracks()` after segments have been evicted.
Additionally to main fix, I've replaced all other appearances of `segmentIndex.get(0)` with `segmentIndex.earliestReference()` to prevent similar bugs.