### PR TITLE
fix: Fix error thrown after catching null error

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -1773,7 +1773,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.dispatchEvent(shaka.Player.makeEvent_(
           shaka.util.FakeEvent.EventName.Loaded));
     } catch (error) {
-      if (error.code != shaka.util.Error.Code.LOAD_INTERRUPTED) {
+      if (error && error.code != shaka.util.Error.Code.LOAD_INTERRUPTED) {
         await this.unload(/* initializeMediaSource= */ false);
       }
       throw error;


### PR DESCRIPTION
Sometimes, this catches a "null" error.  This shouldn't happen, but if it does, we shouldn't throw yet another exception while handling it.