### PR TITLE
fix(DASH): Fix EventStream Elements creation

### DIFF
--- a/lib/util/tXml.js
+++ b/lib/util/tXml.js
@@ -874,7 +874,7 @@ shaka.util.TXml = class {
    * @param {boolean=} doChildren
    * @return {!Element}
    */
-  static txmlNodeToDomElement(node, doParents = false, doChildren = true) {
+  static txmlNodeToDomElement(node) {
     const TXml = shaka.util.TXml;
     const element = document.createElementNS('', node.tagName);
 
@@ -883,23 +883,14 @@ shaka.util.TXml = class {
       element.setAttribute(k, v);
     }
 
-    if (doParents && node.parent && node.parent.tagName != '?xml') {
-      const parentElement = TXml.txmlNodeToDomElement(
-          node.parent, /* doParents= */ true, /* doChildren= */ false);
-      parentElement.appendChild(element);
-    }
-
-    if (doChildren) {
-      for (const child of node.children) {
-        let childElement;
-        if (typeof child == 'string') {
-          childElement = new Text(child);
-        } else {
-          childElement = TXml.txmlNodeToDomElement(
-              child, /* doParents= */ false, /* doChildren= */ true);
-        }
-        element.appendChild(childElement);
+    for (const child of node.children) {
+      let childElement;
+      if (typeof child == 'string') {
+        childElement = new Text(child);
+      } else {
+        childElement = TXml.txmlNodeToDomElement(child);
       }
+      element.appendChild(childElement);
     }
 
     return element;

--- a/lib/util/tXml.js
+++ b/lib/util/tXml.js
@@ -870,8 +870,6 @@ shaka.util.TXml = class {
   /**
    * Converts a tXml node to DOM element.
    * @param {shaka.extern.xml.Node} node
-   * @param {boolean=} doParents
-   * @param {boolean=} doChildren
    * @return {!Element}
    */
   static txmlNodeToDomElement(node) {

--- a/lib/util/tXml.js
+++ b/lib/util/tXml.js
@@ -874,9 +874,9 @@ shaka.util.TXml = class {
    * @param {boolean=} doChildren
    * @return {!Element}
    */
-  static txmlNodeToDomElement(node, doParents = true, doChildren = true) {
+  static txmlNodeToDomElement(node, doParents = false, doChildren = true) {
     const TXml = shaka.util.TXml;
-    const element = document.createElement(node.tagName);
+    const element = document.createElementNS('', node.tagName);
 
     for (const k in node.attributes) {
       const v = node.attributes[k];


### PR DESCRIPTION
Related to #7148 
Does not create parent elements anymore to reduce memory consumption.
Starts to use `createElementNS()` so created elements will keep proper cases for tag names and they won't be anymore of type `HTMLElement`, but `Element`, which should be more lightweight and suitable for our needs.
