### PR TITLE
fix: Do not minify CodecSwitchingStrategy enum keys

### DIFF
--- a/lib/config/codec_switching_strategy.js
+++ b/lib/config/codec_switching_strategy.js
@@ -11,14 +11,18 @@ goog.provide('shaka.config.CodecSwitchingStrategy');
  * @export
  */
 shaka.config.CodecSwitchingStrategy = {
-  // Allow codec switching which will always involve reloading the
-  // `MediaSource`.
-  RELOAD: 'reload',
-  // Allow codec switching; determine if `SourceBuffer.changeType` is available
-  // and attempt to use this first, but fall back to reloading `MediaSource` if
-  // not available.
-  //
-  // Note: Some devices that support `SourceBuffer.changeType` can become stuck
-  // in a pause state.
-  SMOOTH: 'smooth',
+  /**
+   * Allow codec switching which will always involve reloading
+   * the <code<MediaSource</code>.
+   */
+  'RELOAD': 'reload',
+  /**
+   * Allow codec switching; determine if <code>SourceBuffer.changeType</code>
+   * is available and attempt to use this first, but fall back to reloading
+   * <code>MediaSource</code> if not available.
+   * <br>
+   * Note: Some devices that support <code>SourceBuffer.changeType</code> can
+   * become stuck in a pause state.
+   */
+  'SMOOTH': 'smooth',
 };


### PR DESCRIPTION
Enum keys has been minified in release build.
As comments were using wrong syntax, they weren't displayed in documentation.