### PR TITLE
feat(CMCD): Implement new streaming format from CMCDv2

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -2545,6 +2545,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           'https://bit.ly/3clctcj for details.');
     }
 
+    if (this.cmcdManager_) {
+      this.cmcdManager_.setLowLatency(
+          this.manifest_.isLowLatency && this.config_.streaming.lowLatencyMode);
+    }
+
     shaka.Player.applyPlayRange_(this.manifest_.presentationTimeline,
         this.config_.playRangeStart,
         this.config_.playRangeEnd);

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -51,6 +51,11 @@ shaka.util.CmcdManager = class {
      * @private {boolean}
      */
     this.starved_ = false;
+
+    /**
+     * @private {boolean}
+     */
+    this.lowLatency_ = false;
   }
 
   /**
@@ -71,6 +76,7 @@ shaka.util.CmcdManager = class {
     this.playbackStarted_ = false;
     this.buffering_ = true;
     this.starved_ = false;
+    this.lowLatency_ = false;
   }
 
   /**
@@ -88,6 +94,30 @@ shaka.util.CmcdManager = class {
     }
 
     this.buffering_ = buffering;
+  }
+
+  /**
+   * Set the low latency
+   *
+   * @param {boolean} lowLatency
+   */
+  setLowLatency(lowLatency) {
+    this.lowLatency_ = lowLatency;
+
+    const StreamingFormat = shaka.util.CmcdManager.StreamingFormat;
+    if (this.lowLatency_) {
+      if (this.sf_ == StreamingFormat.DASH) {
+        this.sf_ = StreamingFormat.LOW_LATENCY_DASH;
+      } else if (this.sf_ == StreamingFormat.HLS) {
+        this.sf_ = StreamingFormat.LOW_LATENCY_HLS;
+      }
+    } else {
+      if (this.sf_ == StreamingFormat.LOW_LATENCY_DASH) {
+        this.sf_ = StreamingFormat.DASH;
+      } else if (this.sf_ == StreamingFormat.LOW_LATENCY_HLS) {
+        this.sf_ = StreamingFormat.HLS;
+      }
+    }
   }
 
   /**
@@ -624,10 +654,16 @@ shaka.util.CmcdManager = class {
 
     switch (type) {
       case AdvancedRequestType.MPD:
+        if (this.lowLatency_) {
+          return shaka.util.CmcdManager.StreamingFormat.LOW_LATENCY_DASH;
+        }
         return shaka.util.CmcdManager.StreamingFormat.DASH;
 
       case AdvancedRequestType.MASTER_PLAYLIST:
       case AdvancedRequestType.MEDIA_PLAYLIST:
+        if (this.lowLatency_) {
+          return shaka.util.CmcdManager.StreamingFormat.LOW_LATENCY_HLS;
+        }
         return shaka.util.CmcdManager.StreamingFormat.HLS;
 
       case AdvancedRequestType.MSS:
@@ -887,7 +923,9 @@ shaka.util.CmcdManager.StreamType = {
  */
 shaka.util.CmcdManager.StreamingFormat = {
   DASH: 'd',
+  LOW_LATENCY_DASH: 'ld',
   HLS: 'h',
+  LOW_LATENCY_HLS: 'lh',
   SMOOTH: 's',
   OTHER: 'o',
 };


### PR DESCRIPTION
This aligns Shaka's implementation with what Apple's native player will return when CMCD is enabled, see: https://developer.apple.com/streaming/Whats-new-HLS.pdf