### PR TITLE
fix: Fix type passed to isTypeSupported in some cases

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -2114,17 +2114,6 @@ shaka.media.MediaSourceEngine = class {
 
     let newMimeType = shaka.util.MimeUtils.getFullType(refMimeType, refCodecs);
     let needTransmux = this.config_.forceTransmux;
-
-    // On Comcast platforms, calling isTypeSupported with a base codec
-    // string for 'avc' video codec causes a crash. This ensures 'avc'
-    // codec strings are always passed with a profile on these devices.
-    const isComcastPatchNeeded = shaka.util.Platform.isWPE() &&
-        refCodecs.startsWith('avc') && !refCodecs.includes('.');
-    if (isComcastPatchNeeded) {
-      const fullCodecs = stream.codecs || refCodecs;
-      newMimeType = shaka.util.MimeUtils.getFullType(refMimeType, fullCodecs);
-    }
-
     if (!shaka.media.Capabilities.isTypeSupported(newMimeType) ||
         (!this.sequenceMode_ &&
         shaka.util.MimeUtils.RAW_FORMATS.includes(newMimeType))) {

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -2114,6 +2114,17 @@ shaka.media.MediaSourceEngine = class {
 
     let newMimeType = shaka.util.MimeUtils.getFullType(refMimeType, refCodecs);
     let needTransmux = this.config_.forceTransmux;
+
+    // On Comcast platforms, calling isTypeSupported with a base codec
+    // string for 'avc' video codec causes a crash. This ensures 'avc'
+    // codec strings are always passed with a profile on these devices.
+    const isComcastPatchNeeded = shaka.util.Platform.isWPE() &&
+        refCodecs.startsWith('avc') && !refCodecs.includes('.');
+    if (isComcastPatchNeeded) {
+      const fullCodecs = stream.codecs || refCodecs;
+      newMimeType = shaka.util.MimeUtils.getFullType(refMimeType, fullCodecs);
+    }
+
     if (!shaka.media.Capabilities.isTypeSupported(newMimeType) ||
         (!this.sequenceMode_ &&
         shaka.util.MimeUtils.RAW_FORMATS.includes(newMimeType))) {

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1968,8 +1968,8 @@ shaka.media.StreamingEngine = class {
         reference.startTime <= appendWindowEnd,
         logPrefix + ' segment should start before append window end');
 
-    const fullCodecs = (reference.codecs || mediaState.stream.codecs);
-    const codecs = MimeUtils.getCodecBase(fullCodecs);
+    const codecs = MimeUtils.getCodecBase(
+        reference.codecs || mediaState.stream.codecs);
     const mimeType = MimeUtils.getBasicType(
         reference.mimeType || mediaState.stream.mimeType);
     const timestampOffset = reference.timestampOffset;
@@ -1987,7 +1987,7 @@ shaka.media.StreamingEngine = class {
       const isResetMediaSourceNecessary =
           mediaState.lastCodecs && mediaState.lastMimeType &&
           this.playerInterface_.mediaSourceEngine.isResetMediaSourceNecessary(
-              mediaState.type, mediaState.stream, mimeType, fullCodecs);
+              mediaState.type, mediaState.stream, mimeType, codecs);
       if (isResetMediaSourceNecessary) {
         let otherState = null;
         if (mediaState.type === ContentType.VIDEO) {

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1968,8 +1968,8 @@ shaka.media.StreamingEngine = class {
         reference.startTime <= appendWindowEnd,
         logPrefix + ' segment should start before append window end');
 
-    const codecs = MimeUtils.getCodecBase(
-        reference.codecs || mediaState.stream.codecs);
+    const fullCodecs = (reference.codecs || mediaState.stream.codecs);
+    const codecs = MimeUtils.getCodecBase(fullCodecs);
     const mimeType = MimeUtils.getBasicType(
         reference.mimeType || mediaState.stream.mimeType);
     const timestampOffset = reference.timestampOffset;
@@ -1987,7 +1987,7 @@ shaka.media.StreamingEngine = class {
       const isResetMediaSourceNecessary =
           mediaState.lastCodecs && mediaState.lastMimeType &&
           this.playerInterface_.mediaSourceEngine.isResetMediaSourceNecessary(
-              mediaState.type, mediaState.stream, mimeType, codecs);
+              mediaState.type, mediaState.stream, mimeType, fullCodecs);
       if (isResetMediaSourceNecessary) {
         let otherState = null;
         if (mediaState.type === ContentType.VIDEO) {

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -33,6 +33,7 @@ goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Mp4BoxParsers');
 goog.require('shaka.util.Mp4Parser');
 goog.require('shaka.util.Networking');
+goog.require('shaka.util.Platform');
 
 
 /**
@@ -1968,8 +1969,11 @@ shaka.media.StreamingEngine = class {
         reference.startTime <= appendWindowEnd,
         logPrefix + ' segment should start before append window end');
 
-    const codecs = MimeUtils.getCodecBase(
-        reference.codecs || mediaState.stream.codecs);
+    // On Comcast devices, calling isTypeSupported() with a base codec causes a
+    // critical crash. To prevent this, use full codec string on those devices.
+    const codecs = !shaka.util.Platform.isWPE() ?
+        MimeUtils.getCodecBase(reference.codecs || mediaState.stream.codecs) :
+        (reference.codecs || mediaState.stream.codecs);
     const mimeType = MimeUtils.getBasicType(
         reference.mimeType || mediaState.stream.mimeType);
     const timestampOffset = reference.timestampOffset;

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -33,7 +33,6 @@ goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Mp4BoxParsers');
 goog.require('shaka.util.Mp4Parser');
 goog.require('shaka.util.Networking');
-goog.require('shaka.util.Platform');
 
 
 /**
@@ -1969,11 +1968,8 @@ shaka.media.StreamingEngine = class {
         reference.startTime <= appendWindowEnd,
         logPrefix + ' segment should start before append window end');
 
-    // On Comcast devices, calling isTypeSupported() with a base codec causes a
-    // critical crash. To prevent this, use full codec string on those devices.
-    const codecs = !shaka.util.Platform.isWPE() ?
-        MimeUtils.getCodecBase(reference.codecs || mediaState.stream.codecs) :
-        (reference.codecs || mediaState.stream.codecs);
+    const fullCodecs = (reference.codecs || mediaState.stream.codecs);
+    const codecs = MimeUtils.getCodecBase(fullCodecs);
     const mimeType = MimeUtils.getBasicType(
         reference.mimeType || mediaState.stream.mimeType);
     const timestampOffset = reference.timestampOffset;
@@ -1991,7 +1987,7 @@ shaka.media.StreamingEngine = class {
       const isResetMediaSourceNecessary =
           mediaState.lastCodecs && mediaState.lastMimeType &&
           this.playerInterface_.mediaSourceEngine.isResetMediaSourceNecessary(
-              mediaState.type, mediaState.stream, mimeType, codecs);
+              mediaState.type, mediaState.stream, mimeType, fullCodecs);
       if (isResetMediaSourceNecessary) {
         let otherState = null;
         if (mediaState.type === ContentType.VIDEO) {


### PR DESCRIPTION
Fixes #7232

On some Comcast devices (Flex series) calling `isTypeSupported()` with base codec string results in video playback failure and an immediate application crash. 