### PR TITLE
fix(UI): Remove not loaded font

### DIFF
--- a/demo/demo.less
+++ b/demo/demo.less
@@ -79,7 +79,7 @@ main.mdl-layout__content {
 
 html, body {
   /* Ensure everything has a consistent font. */
-  font-family: Roboto-Regular, Roboto, sans-serif, TengwarTelcontar;
+  font-family: Roboto, sans-serif, TengwarTelcontar;
 }
 
 // This font supports the Sindarin (sjn) translation.

--- a/ui/less/containers.less
+++ b/ui/less/containers.less
@@ -23,7 +23,7 @@
 
   /* Set the fonts for all other content. */
   * {
-    font-family: Roboto-Regular, Roboto, sans-serif, TengwarTelcontar;
+    font-family: Roboto, sans-serif, TengwarTelcontar;
     -webkit-font-smoothing: antialiased;
   }
 }

--- a/ui/less/tooltip.less
+++ b/ui/less/tooltip.less
@@ -47,7 +47,7 @@
       content: attr(aria-label);
 
       /* Override .material-icons-round text styling */
-      font-family: Roboto-Regular, Roboto, sans-serif;
+      font-family: Roboto, sans-serif;
       line-height: calc(@material-icons-width / 2);
       white-space: nowrap;
       font-size: 13px;


### PR DESCRIPTION
font-family settings always started with "Roboto-Regular" before "Roboto", but we don't load "Roboto-Regular". It may exist already on some systems, but we don't explicitly load it. We do explicitly load "Roboto", so that should be the only Roboto-family font in the list.  This issue has been present since the very first introduction of our UI.