### PR TITLE
fix: Fix rendering of image subs when using SimpleTextDisplayer

### DIFF
--- a/lib/text/simple_text_displayer.js
+++ b/lib/text/simple_text_displayer.js
@@ -112,7 +112,7 @@ shaka.text.SimpleTextDisplayer = class {
         return false;
       });
 
-      if (!containsCue) {
+      if (!containsCue && inCue.payload) {
         const cue =
             shaka.text.Utils.mapShakaCueToNativeCue(inCue);
         if (cue) {

--- a/lib/text/text_utils.js
+++ b/lib/text/text_utils.js
@@ -32,6 +32,10 @@ shaka.text.Utils = class {
       }).join('');
     }
 
+    if (!cue.payload) {
+      return cue.payload;
+    }
+
     // Handle bold, italics and underline
     const openStyleTags = [];
     const bold = cue.fontWeight >= shaka.text.Cue.fontWeight.BOLD;


### PR DESCRIPTION
This change prevents cues from being created without payload, as is the case with subtitles in image format.