### PR TITLE
feat(DASH): Disable xlink processing by default

### DIFF
--- a/demo/common/assets.js
+++ b/demo/common/assets.js
@@ -578,7 +578,14 @@ shakaAssets.testAssets = [
       .addFeature(shakaAssets.Feature.MP4)
       .addFeature(shakaAssets.Feature.WEBM)
       .addFeature(shakaAssets.Feature.XLINK)
-      .addFeature(shakaAssets.Feature.OFFLINE),
+      .addFeature(shakaAssets.Feature.OFFLINE)
+      .setExtraConfig({
+        manifest: {
+          dash: {
+            disableXlinkProcessing: false,
+          },
+        },
+      }),
   // From: http://dig.ccmixter.org/files/JeffSpeed68/53327
   // Licensed under Creative Commons BY-NC 3.0.
   // Free for non-commercial use with attribution.

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1096,7 +1096,7 @@ shaka.extern.xml.Node;
  * @property {boolean} disableXlinkProcessing
  *   If true, xlink-related processing will be disabled.
  *   <br>
- *   Defaults to <code>false</code>.
+ *   Defaults to <code>true</code>.
  * @property {boolean} xlinkFailGracefully
  *   If true, xlink-related errors will result in a fallback to the tag's
  *   existing contents. If false, xlink-related errors will be propagated

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -124,7 +124,7 @@ shaka.util.PlayerConfiguration = class {
       dash: {
         clockSyncUri: '',
         ignoreDrmInfo: false,
-        disableXlinkProcessing: false,
+        disableXlinkProcessing: true,
         xlinkFailGracefully: false,
         ignoreMinBufferTime: false,
         autoCorrectDrift: true,

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -934,7 +934,11 @@ describe('DashParser Manifest', () => {
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MANIFEST,
           shaka.util.Error.Code.DASH_UNSUPPORTED_XLINK_ACTUATE);
-      await Dash.testFails(source, error);
+
+      const config = shaka.util.PlayerConfiguration.createDefault().manifest;
+      config.dash.disableXlinkProcessing = false;
+
+      await Dash.testFails(source, error, config);
     });
 
     it('failed network requests', async () => {

--- a/test/test/util/dash_parser_util.js
+++ b/test/test/util/dash_parser_util.js
@@ -67,11 +67,16 @@ shaka.test.Dash = class {
    *
    * @param {string} manifestText
    * @param {!shaka.util.Error} expectedError
+   * @param {?shaka.extern.ManifestConfiguration=} config
    * @return {!Promise}
    */
-  static async testFails(manifestText, expectedError) {
+  static async testFails(manifestText, expectedError, config) {
     const manifestData = shaka.util.StringUtils.toUTF8(manifestText);
     const dashParser = shaka.test.Dash.makeDashParser();
+
+    if (config) {
+      dashParser.configure(config);
+    }
 
     const networkingEngine = new shaka.test.FakeNetworkingEngine()
         .setResponseValue('dummy://foo', manifestData);


### PR DESCRIPTION
Since xlink processing is slow and very few streams use it, it is best to disable this functionality by default to improve performance especially on STB or SmartTV devices.