### PR TITLE
fix(DASH): Evict empty indexes in MetaSegmentIndex

### DIFF
--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -700,6 +700,25 @@ shaka.media.MetaSegmentIndex = class extends shaka.media.SegmentIndex {
     this.indexes_ = [];
   }
 
+  /** Evicts all old SegmentIndexes in this MetaSegmentIndex that are empty. */
+  evictEmpty() {
+    // If we hypothetically have a segment index that is empty but comes after
+    // one that has references, assume it's new and leave it in.
+    const newIndexes = [];
+    let include = false;
+    for (const index of this.indexes_) {
+      if (!index.isEmpty()) {
+        include = true;
+      }
+      if (include) {
+        newIndexes.push(index);
+      } else {
+        index.release();
+      }
+    }
+    this.indexes_ = newIndexes;
+  }
+
   /**
    * Append a SegmentIndex to this MetaSegmentIndex.  This effectively stitches
    * the underlying Stream onto the end of the multi-Period Stream represented

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -622,6 +622,7 @@ shaka.util.PeriodCombiner = class {
           outputStream.segmentIndex.appendSegmentIndex(match.segmentIndex);
         }
       }
+      outputStream.segmentIndex.evictEmpty();
     }
   }
 


### PR DESCRIPTION
Issue #6239