### PR TITLE
perf(DASH): Create segment indexes only on new periods

### DIFF
--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -600,7 +600,8 @@ shaka.util.PeriodCombiner = class {
     const streams = outputStream.matchedStreams;
     goog.asserts.assert(streams, 'matched streams should be valid');
 
-    for (const stream of streams) {
+    for (let i = firstNewPeriodIndex; i < streams.length; i++) {
+      const stream = streams[i];
       operations.push(stream.createSegmentIndex());
       if (stream.trickModeVideo && !stream.trickModeVideo.segmentIndex) {
         operations.push(stream.trickModeVideo.createSegmentIndex());


### PR DESCRIPTION
Old references to segment index are already stored in meta segment index, so there's no reason to recreate them.