### PR TITLE
perf(DASH): Do not check is index instance of MetaSegmentIndex

### DIFF
--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -614,14 +614,15 @@ shaka.util.PeriodCombiner = class {
     // Satisfy the compiler about the type.
     // Also checks if the segmentIndex is still valid after the async
     // operations, to make sure we stop if the active stream has changed.
-    if (outputStream.segmentIndex instanceof shaka.media.MetaSegmentIndex) {
-      for (let i = firstNewPeriodIndex; i < streams.length; i++) {
-        const match = streams[i];
-        goog.asserts.assert(match.segmentIndex,
-            'stream should have a segmentIndex.');
-        if (match.segmentIndex) {
-          outputStream.segmentIndex.appendSegmentIndex(match.segmentIndex);
-        }
+    goog.asserts.assert(
+        outputStream.segmentIndex instanceof shaka.media.MetaSegmentIndex,
+        'wrong segmentIndex type');
+    for (let i = firstNewPeriodIndex; i < streams.length; i++) {
+      const match = streams[i];
+      goog.asserts.assert(match.segmentIndex,
+          'stream should have a segmentIndex.');
+      if (match.segmentIndex) {
+        outputStream.segmentIndex.appendSegmentIndex(match.segmentIndex);
       }
     }
   }


### PR DESCRIPTION
It should always be MetaSegmentIndex, so handle it via assertion instead of an `if()`. This way we will satisfy compiler, avoid unnecessary `if()` check and potentially find errors quicker thanks to assertion.