### PR TITLE
ci: Allow concurrent lab runs that use different devices

### DIFF
--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -53,10 +53,6 @@ on:
     # Runs every night at 2am PST / 10am UTC, testing against the main branch.
     - cron: '0 10 * * *'
 
-# Only one run of this workflow is allowed at a time, since it uses physical
-# resources in our lab.
-concurrency: selenium-lab
-
 jobs:
   compute-sha:
     name: Compute SHA
@@ -212,6 +208,11 @@ jobs:
     # This is a self-hosted runner in a Docker container, with access to our
     # lab's Selenium grid on port 4444.
     runs-on: self-hosted-selenium
+
+    # Only one run of this job is allowed at a time, since it uses physical
+    # resources in our lab.
+    concurrency: selenium-lab-${{ matrix.browser }}
+
     needs: [compute-sha, build-shaka, matrix-config]
     strategy:
       fail-fast: false


### PR DESCRIPTION
Using the branch this PR is based on, I was able to start two concurrent lab runs on different sets of browsers:

https://github.com/shaka-project/shaka-player/actions/runs/10836501320
 - FirefoxLinux
 - FirefoxWindows
 - FirefoxMac

![Screenshot 2024-09-12 11 33 20](https://github.com/user-attachments/assets/0d75efe7-729a-40b0-9e03-348830a1f418)

https://github.com/shaka-project/shaka-player/actions/runs/10836507170
 - ChromeLinux
 - ChromeWindows
 - ChromeMac
 - ChromeAndroid

![Screenshot 2024-09-12 11 33 26](https://github.com/user-attachments/assets/cbd3bea9-791e-4808-884f-02a1aa5ee36d)

The early jobs (Compute SHA, Matrix config, Pre-build Player) were all able to run simultaneously since they only use Actions VMs.  The later jobs under the matrix "lab-tests" were also able to run at the same time across workflow runs because they used disjoint sets of browsers.

I started a third run 5 minutes later with some overlap in browsers with the first two runs:

https://github.com/shaka-project/shaka-player/actions/runs/10836571930
 - Safari
 - ChromeLinux

![Screenshot 2024-09-12 11 33 30](https://github.com/user-attachments/assets/c2713266-c0da-4b11-8ade-d2a1dcdaf93a)

Here the ChromeLinux job had to wait for the other ChromeLinux job to complete.  Meanwhile, the Safari job was able to proceed.