### PR TITLE
ci: Fix SHA1 selection in lab run

### DIFF
--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sha: ${{ needs.compute-sha.outputs.SHA }}
+          ref: ${{ needs.compute-sha.outputs.SHA }}
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
In #6811, I introduced a bug into the lab workflow.  This came to my attention through the GitHub Actions warning: "Unexpected input(s) 'sha', valid inputs are ...".  This came from the "actions/checkout" step of the "matrix config" job.  The correct input is "ref", not "sha".

This bug meant that any changes to the matrix config were not being properly tested.  It's likely we haven't had any PRs that touched the matrix config since the bug was introduced in June.