### PR TITLE
revert: Revert "perf(DASH): Do not check is index instance of MetaSegmentIndex (#7295)"

### DIFF
--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -614,15 +614,14 @@ shaka.util.PeriodCombiner = class {
     // Satisfy the compiler about the type.
     // Also checks if the segmentIndex is still valid after the async
     // operations, to make sure we stop if the active stream has changed.
-    goog.asserts.assert(
-        outputStream.segmentIndex instanceof shaka.media.MetaSegmentIndex,
-        'wrong segmentIndex type');
-    for (let i = firstNewPeriodIndex; i < streams.length; i++) {
-      const match = streams[i];
-      goog.asserts.assert(match.segmentIndex,
-          'stream should have a segmentIndex.');
-      if (match.segmentIndex) {
-        outputStream.segmentIndex.appendSegmentIndex(match.segmentIndex);
+    if (outputStream.segmentIndex instanceof shaka.media.MetaSegmentIndex) {
+      for (let i = firstNewPeriodIndex; i < streams.length; i++) {
+        const match = streams[i];
+        goog.asserts.assert(match.segmentIndex,
+            'stream should have a segmentIndex.');
+        if (match.segmentIndex) {
+          outputStream.segmentIndex.appendSegmentIndex(match.segmentIndex);
+        }
       }
     }
   }


### PR DESCRIPTION
This reverts commit a32043864a3f8c642f44c333fe9350a6f84e70de.

MetaSegmentIndex may be closed during an async operation and we must take this into account.

BEGIN_COMMIT_OVERRIDE
chore: Ignore this in the changelog; it was reverted
END_COMMIT_OVERRIDE