### PR TITLE
fix: Do not seek to first subtitle

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -7241,11 +7241,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.playhead_.notifyOfBufferingChange();
       // Skip the initial buffer gap
       const startTime = this.mediaSourceEngine_.bufferStart(contentType);
+      const ContentType = shaka.util.ManifestParserUtils.ContentType;
       if (
         !this.isLive() &&
         // If not paused then GapJumpingController will handle this gap.
         this.video_.paused &&
         startTime != null &&
+        contentType != ContentType.TEXT &&
         startTime > 0 &&
         this.playhead_.getTime() < startTime
       ) {


### PR DESCRIPTION
The bug was introduced in #6340, and affects v4.6.16-18, v4.7.12-15, v4.8.0-20, v4.9.0-26, v4.10.0-16, and v4.11.0.

Closes #7310