### PR TITLE
chore: Disable line-length checking on player version line

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -8085,7 +8085,7 @@ shaka.Player.TYPICAL_BUFFERING_THRESHOLD_ = 0.5;
  * @define {string} A version number taken from git at compile time.
  * @export
  */
-// eslint-disable-next-line no-useless-concat
+// eslint-disable-next-line no-useless-concat, max-len
 shaka.Player.version = 'v4.11.0' + '-uncompiled';  // x-release-please-version
 
 // Initialize the deprecation system using the version string we just set


### PR DESCRIPTION
The max line length of 80 characters was exceeded by a release PR in the newly-created v4.9.2-caf branch, for release tagged as v4.9.2-caf1.

This disables the line length check for this robot-maintained line.