### PR TITLE
fix(HLS): Fix uncaught error in slow network scenario

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1519,9 +1519,11 @@ shaka.media.StreamingEngine = class {
           logPrefix, 'looking up segment from new stream endTime:', time);
 
       const reverse = this.playerInterface_.getPlaybackRate() < 0;
-      mediaState.segmentIterator =
-          mediaState.stream.segmentIndex.getIteratorForTime(
-              time, /* allowNonIndepedent= */ false, reverse);
+      if (mediaState.stream.segmentIndex) {
+        mediaState.segmentIterator =
+            mediaState.stream.segmentIndex.getIteratorForTime(
+                time, /* allowNonIndepedent= */ false, reverse);
+      }
       const ref = mediaState.segmentIterator &&
           mediaState.segmentIterator.next().value;
       if (ref == null) {
@@ -1545,18 +1547,22 @@ shaka.media.StreamingEngine = class {
       const reverse = this.playerInterface_.getPlaybackRate() < 0;
       let ref = null;
       if (inaccurateTolerance) {
-        mediaState.segmentIterator =
-            mediaState.stream.segmentIndex.getIteratorForTime(
-                lookupTime, /* allowNonIndepedent= */ false, reverse);
+        if (mediaState.stream.segmentIndex) {
+          mediaState.segmentIterator =
+              mediaState.stream.segmentIndex.getIteratorForTime(
+                  lookupTime, /* allowNonIndepedent= */ false, reverse);
+        }
         ref = mediaState.segmentIterator &&
             mediaState.segmentIterator.next().value;
       }
       if (!ref) {
         // If we can't find a valid segment with the drifted time, look for a
         // segment with the presentation time.
-        mediaState.segmentIterator =
-            mediaState.stream.segmentIndex.getIteratorForTime(
-                presentationTime, /* allowNonIndepedent= */ false, reverse);
+        if (mediaState.stream.segmentIndex) {
+          mediaState.segmentIterator =
+              mediaState.stream.segmentIndex.getIteratorForTime(
+                  presentationTime, /* allowNonIndepedent= */ false, reverse);
+        }
         ref = mediaState.segmentIterator &&
             mediaState.segmentIterator.next().value;
       }


### PR DESCRIPTION
This case can occur with a live HLS in which the playlist timeout errors and that playlist is deactivated and changed to another one and this other one takes a long time to be received.