### PR TITLE
fix: skip when moveTo currentTime

### DIFF
--- a/lib/media/video_wrapper.js
+++ b/lib/media/video_wrapper.js
@@ -248,6 +248,11 @@ shaka.media.VideoWrapper.PlayheadMover = class {
    * @param {number} timeInSeconds
    */
   moveTo(timeInSeconds) {
+    // Skip if the time has not changed.
+    if (this.mediaElement_.currentTime == timeInSeconds) {
+      return;
+    }
+
     this.originTime_ = this.mediaElement_.currentTime;
     this.targetTime_ = timeInSeconds;
 


### PR DESCRIPTION
When `targetTime` equals `currentTime`, the onTick method always fails and exhausts all retry attempts.
To prevent this, we may skip in such cases.