### PR TITLE
fix(offline): Text segments are downloaded before audio&video

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2242,7 +2242,8 @@ shaka.extern.LcevcConfiguration;
  *   <br>
  *   Defaults to <code>true</code>.
  * @property {number} numberOfParallelDownloads
- *   Number of parallel downloads.
+ *   Number of parallel downloads. If the value is 0, downloads will be
+ *   sequential for each stream.
  *   Note: normally browsers limit to 5 request in parallel, so putting a
  *   number higher than this will not help it download faster.
  *   <br>

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -1613,7 +1613,7 @@ shaka.offline.Storage = class {
         manifest.presentationTimeline.getSegmentAvailabilityStart();
 
     const numberOfParallelDownloads = config.offline.numberOfParallelDownloads;
-    let groupId = 0;
+    let groupId = numberOfParallelDownloads === 0 ? stream.id : 0;
 
     shaka.offline.Storage.forEachSegment_(stream, startTime, (segment) => {
       const pendingSegmentRefId =
@@ -1666,7 +1666,9 @@ shaka.offline.Storage = class {
         thumbnailSprite: segment.thumbnailSprite,
       };
       streamDb.segments.push(segmentDB);
-      groupId = (groupId + 1) % numberOfParallelDownloads;
+      if (numberOfParallelDownloads !== 0) {
+        groupId = (groupId + 1) % numberOfParallelDownloads;
+      }
     });
 
     return streamDb;
@@ -1861,14 +1863,6 @@ shaka.offline.Storage = class {
     /** @type {!Set.<shaka.extern.Stream>} */
     const set = new Set();
 
-    for (const text of manifest.textStreams) {
-      set.add(text);
-    }
-
-    for (const image of manifest.imageStreams) {
-      set.add(image);
-    }
-
     for (const variant of manifest.variants) {
       if (variant.audio) {
         set.add(variant.audio);
@@ -1876,6 +1870,14 @@ shaka.offline.Storage = class {
       if (variant.video) {
         set.add(variant.video);
       }
+    }
+
+    for (const text of manifest.textStreams) {
+      set.add(text);
+    }
+
+    for (const image of manifest.imageStreams) {
+      set.add(image);
     }
 
     return set;


### PR DESCRIPTION
Support for using the old parallel download mechanism is also added.

Fixes: https://github.com/shaka-project/shaka-player/issues/4878