### PR TITLE
test: Don't fail tests when cast property can't be deleted

### DIFF
--- a/test/polyfill/media_capabilities_unit.js
+++ b/test/polyfill/media_capabilities_unit.js
@@ -183,7 +183,15 @@ describe('MediaCapabilities', () => {
         async () => {
           // Temporarily remove window.cast to trigger error. It's restored
           // after every test.
-          delete window['cast'];
+          try {
+            delete window['cast'];
+            // eslint-disable-next-line no-restricted-syntax
+          } catch (error) {
+            // This may fail on some Cast devices where you can't delete the
+            // cast API.  The test should still be valid on non-Cast devices,
+            // since we're mocking everything including the platform.
+            pending('Unable to delete window.cast');
+          }
 
           const isChromecastSpy =
               spyOn(shaka['util']['Platform'],


### PR DESCRIPTION
On some real Cast devices, you can't delete window.cast.  This is fine, and shouldn't cause the test to fail.  If this happens, skip the test instead.  The test, which mocks everything including the platform detection and the Cast API, is still valid on platforms where we can get away with those mocks.