### PR TITLE
chore: Improve logging around test setup failures

### DIFF
--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -458,11 +458,11 @@ async function logSupport() {
   try {
     const support = await shaka.Player.probeSupport();
     // Bypass Karma's log settings and dump this to the console.
-    window.dump('Platform support:' + JSON.stringify(support, null, 2));
+    window.dump('Platform support: ' + JSON.stringify(support, null, 2));
     window['shakaSupport'] = support;
     // eslint-disable-next-line no-restricted-syntax
   } catch (error) {
-    window.dump('Support check failed at boot!', error);
+    window.dump('Support check failed at boot: ' + error);
   }
 }
 
@@ -553,7 +553,7 @@ window.__karma__.start = async () => {
 
     // eslint-disable-next-line no-restricted-syntax
   } catch (error) {
-    window.dump('Error during setup:', error);
+    window.dump('Error during setup: ' + error);
     window.__karma__.error(error);
     return;
   }

--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -462,7 +462,7 @@ async function logSupport() {
     window['shakaSupport'] = support;
     // eslint-disable-next-line no-restricted-syntax
   } catch (error) {
-    console.error('Support check failed at boot!', error);
+    window.dump('Support check failed at boot!', error);
   }
 }
 
@@ -553,7 +553,7 @@ window.__karma__.start = async () => {
 
     // eslint-disable-next-line no-restricted-syntax
   } catch (error) {
-    console.error('Error during setup:', error);
+    window.dump('Error during setup:', error);
     window.__karma__.error(error);
     return;
   }

--- a/test/test/cast-boot.js
+++ b/test/test/cast-boot.js
@@ -37,7 +37,7 @@ if (navigator.userAgent.indexOf('CrKey') != -1) {
   // functions, for compatibility with the oldest devices and runtimes.
   // eslint-disable-next-line no-restricted-syntax
   script.onerror = function(error) {
-    window.dump('Unable to load Cast SDK!', error);
+    window.dump('Unable to load Cast SDK: ' + error);
   };
 
   document.head.appendChild(script);

--- a/test/test/cast-boot.js
+++ b/test/test/cast-boot.js
@@ -33,5 +33,9 @@ if (navigator.userAgent.indexOf('CrKey') != -1) {
     console.log('Cast SDK loaded');
   };
 
+  script.onerror = function(error) {
+    window.dump('Unable to load Cast SDK!', error);
+  };
+
   document.head.appendChild(script);
 }

--- a/test/test/cast-boot.js
+++ b/test/test/cast-boot.js
@@ -33,6 +33,9 @@ if (navigator.userAgent.indexOf('CrKey') != -1) {
     console.log('Cast SDK loaded');
   };
 
+  // Use an anonymous function here, normally banned in favor of arrow
+  // functions, for compatibility with the oldest devices and runtimes.
+  // eslint-disable-next-line no-restricted-syntax
   script.onerror = function(error) {
     window.dump('Unable to load Cast SDK!', error);
   };


### PR DESCRIPTION
If we fail certain actions during test setup, we should log those unconditionally through Karma's dump() function, and not just when browser console logs are enabled with --enable-logging.