### PR TITLE
test: Fix uncaught errors while testing on Cast

### DIFF
--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -347,9 +347,13 @@ function configureJasmineEnvironment() {
     shaka.log.setLevel(shaka.log.Level.INFO);
   }
 
-  // Ensure node modules are loaded before any tests execute.
   beforeAll(async () => {
+    // Ensure node modules are loaded before any tests execute.
     await loadNodeModules();
+
+    // Replace jasmine's global error handler, since we have our own more
+    // nuanced version.
+    window.onerror = null;
   });
 
   const originalSetTimeout = window.setTimeout;


### PR DESCRIPTION
We get strange uncaught errors sometimes on Cast devices.  These are unreadable "script error" events that have nothing to do with our tests (see https://sentry.io/answers/script-error/), and we intend to ignore them.

However, our existing logic to ignore those is not sufficient, because in addition to our own error handler (via window.addEventListener("error")), Jasmine has its own unconditional error handler (via window.onerror).

To take complete control over how these are handled, we need to remove Jasmine's handler.

Jasmine's handler is installed at the top of its execute() function, so our top-level beforeAll() is the best place to remove it.