### PR TITLE
fix: Active track state on variantchanged and adaptation events

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -7094,6 +7094,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       oldTrack = shaka.util.StreamUtils.variantToTrack(currentVariant);
     }
     const newTrack = shaka.util.StreamUtils.variantToTrack(variant);
+    newTrack.active = true;
 
     if (fromAdaptation) {
       // Dispatch an 'adaptation' event

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -384,11 +384,11 @@ describe('Player', () => {
         });
 
         // Produce next 'adaptation' event
-        const activeTrack = player.getVariantTracks().find((t) => !t.active);
-        expect(activeTrack).toBeDefined();
+        const inactiveTrack = player.getVariantTracks().find((t) => !t.active);
+        expect(inactiveTrack).toBeDefined();
 
         const newTrack = abrManager.variants.filter((t) => {
-          return t.id == activeTrack.id;
+          return t.id == inactiveTrack.id;
         })[0];
         expect(newTrack).toBeDefined();
 

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -352,6 +352,51 @@ describe('Player', () => {
       });
     });
 
+    describe('adaptation event', () => {
+      /** @type {jasmine.Spy} */
+      let onAdaptation;
+
+      beforeEach(() => {
+        onAdaptation = jasmine.createSpy('onAdaptation');
+        player.addEventListener('adaptation', Util.spyFunc(onAdaptation));
+        player.configure({abr: {enabled: true}});
+      });
+
+      it('fires with correct payload and tracks active state', async () => {
+        expect(onAdaptation).not.toHaveBeenCalled();
+        await player.load(fakeManifestUri, 0, fakeMimeType);
+        expect(abrManager.chooseVariant).toHaveBeenCalled();
+        expect(onAdaptation).toHaveBeenCalled();
+
+        // First event
+        /** @type {{oldTrack?:{active:boolean}, newTrack:{active:boolean}}} */
+        const event = onAdaptation.calls.first().args[0];
+        expect(event.oldTrack).toBe(null);
+        expect(event.newTrack).toBeDefined();
+        expect(event.newTrack.active).toBe(true);
+
+        // In subsequent events both |oldTrack| and |newTrack| shall be defined
+        onAdaptation.and.callFake((e) => {
+          expect(e.oldTrack).toBeDefined();
+          expect(e.oldTrack.active).toBe(false);
+          expect(e.newTrack).toBeDefined();
+          expect(e.newTrack.active).toBe(true);
+        });
+
+        // Produce next 'adaptation' event
+        const activeTrack = player.getVariantTracks().find((t) => !t.active);
+        expect(activeTrack).toBeDefined();
+
+        const newTrack = abrManager.variants.filter((t) => {
+          return t.id == activeTrack.id;
+        })[0];
+        expect(newTrack).toBeDefined();
+
+        abrManager.switchCallback(newTrack, true);
+        expect(streamingEngine.switchVariant).toHaveBeenCalledTimes(2);
+      });
+    });
+
     describe('disableStream', () => {
       /** @type {number} */
       let disableTimeInSeconds;
@@ -2583,6 +2628,12 @@ describe('Player', () => {
         player.addEventListener('textchanged', Util.spyFunc(textChanged));
 
         variantChanged = jasmine.createSpy('variantChanged');
+        variantChanged.and.callFake((e) => {
+          expect(e.oldTrack).toBeDefined();
+          expect(e.oldTrack.active).toBe(false);
+          expect(e.newTrack).toBeDefined();
+          expect(e.newTrack.active).toBe(true);
+        });
         player.addEventListener('variantchanged', Util.spyFunc(variantChanged));
       });
 


### PR DESCRIPTION
This change ensures that the active states of tracks for "variantchanged" and "adaptation" events are accurate.