### PR TITLE
fix: Disable Encryption Scheme Polyfil On Some Devices

### DIFF
--- a/lib/polyfill/encryption_scheme.js
+++ b/lib/polyfill/encryption_scheme.js
@@ -7,6 +7,7 @@
 goog.provide('shaka.polyfill.EncryptionScheme');
 
 goog.require('shaka.polyfill');
+goog.require('shaka.util.Platform');
 
 /**
  * @summary A polyfill to add support for EncryptionScheme queries in EME.
@@ -23,6 +24,14 @@ shaka.polyfill.EncryptionScheme = class {
    * @export
    */
   static install() {
+    // Skip polyfill for PlayStation 4 and SkyQ devices due to known crashes
+    // caused by unsupported encryptionScheme handling. These platforms do not
+    // require the polyfill, and forcing encryptionScheme processing can result
+    // in playback crashes.
+    if (shaka.util.Platform.isPS4() || shaka.util.Platform.isSkyQ()) {
+      return;
+    }
+
     EncryptionSchemePolyfills.install();
   }
 };

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -347,6 +347,13 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is SkyQ STB.
+   */
+  static isSkyQ() {
+    return shaka.util.Platform.userAgentContains_('Sky_STB');
+  }
+
+  /**
    * Check if the current platform is Amazon Fire TV.
    * https://developer.amazon.com/docs/fire-tv/identify-amazon-fire-tv-devices.html
    *


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/7354
These platforms don't support `encryptionScheme`, so there is no need to install this polyfil.