### PR TITLE
fix(preload): Set manifest before initializing DRM

### DIFF
--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -718,11 +718,15 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
   }
 
   /**
-   * Waits for the manifest to be loaded.
+   * Waits for the manifest to be loaded (or to fail with an error).
    * @return {!Promise}
    */
   waitForManifest() {
-    return this.manifestPromise_;
+    const promises = [
+      this.manifestPromise_,
+      this.successPromise_,
+    ];
+    return Promise.race(promises);
   }
 
   /**

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -718,7 +718,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
   }
 
   /**
-   * Waits for the manifest to be loaded (or to fail with an error).
+   * Waits for the manifest to be loaded.
    * @return {!Promise}
    */
   waitForManifest() {

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -406,7 +406,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
         this.successPromise_.resolve();
       } catch (error) {
         this.successPromise_.reject(error);
-        this.manifestPromise_.reject(error);
       }
     })();
   }
@@ -431,7 +430,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     if (error.severity === shaka.util.Error.Severity.CRITICAL) {
       // Cancel the loading process.
       this.successPromise_.reject(error);
-      this.manifestPromise_.reject(error);
       this.destroy();
     }
 

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -128,6 +128,9 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     this.stats_ = new shaka.util.Stats();
 
     /** @private {!shaka.util.PublicPromise} */
+    this.manifestPromise_ = new shaka.util.PublicPromise();
+
+    /** @private {!shaka.util.PublicPromise} */
     this.successPromise_ = new shaka.util.PublicPromise();
 
     /** @private {?shaka.util.FakeEventTarget} */
@@ -392,6 +395,8 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
         await this.parseManifestInner_();
         this.throwIfDestroyed_();
 
+        this.manifestPromise_.resolve();
+
         await this.initializeDrmInner_();
         this.throwIfDestroyed_();
 
@@ -401,6 +406,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
         this.successPromise_.resolve();
       } catch (error) {
         this.successPromise_.reject(error);
+        this.manifestPromise_.reject(error);
       }
     })();
   }
@@ -425,6 +431,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     if (error.severity === shaka.util.Error.Severity.CRITICAL) {
       // Cancel the loading process.
       this.successPromise_.reject(error);
+      this.manifestPromise_.reject(error);
       this.destroy();
     }
 
@@ -710,6 +717,14 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
    */
   waitForFinish() {
     return this.successPromise_;
+  }
+
+  /**
+   * Waits for the manifest to be loaded (or to fail with an error).
+   * @return {!Promise}
+   */
+  waitForManifest() {
+    return this.manifestPromise_;
   }
 
   /**

--- a/lib/player.js
+++ b/lib/player.js
@@ -1698,6 +1698,17 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           await this.srcEqualsInner_(startTimeOfLoad, mimeType);
         }, 'srcEqualsInner_');
       } else {
+        // Wait for the manifest to be parsed.
+        await mutexWrapOperation(async () => {
+          await preloadManager.waitForManifest();
+        }, 'waitForFinish');
+
+        // Retrieve the manifest. This is specifically put before the media
+        // source engine is initialized, for the benefit of event handlers.
+        this.parserFactory_ = preloadManager.getParserFactory();
+        this.parser_ = preloadManager.receiveParser();
+        this.manifest_ = preloadManager.getManifest();
+
         if (!this.mediaSourceEngine_) {
           await mutexWrapOperation(async () => {
             await this.initializeMediaSourceEngineInner_();
@@ -1712,14 +1723,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         // Get manifest and associated values from preloader.
         this.config_ = preloadManager.getConfiguration();
         this.manifestFilterer_ = preloadManager.getManifestFilterer();
-        this.parserFactory_ = preloadManager.getParserFactory();
-        this.parser_ = preloadManager.receiveParser();
         if (this.parser_ && this.parser_.setMediaElement && this.video_) {
           this.parser_.setMediaElement(this.video_);
         }
         this.regionTimeline_ = preloadManager.receiveRegionTimeline();
         this.qualityObserver_ = preloadManager.getQualityObserver();
-        this.manifest_ = preloadManager.getManifest();
         const currentAdaptationSetCriteria =
             preloadManager.getCurrentAdaptationSetCriteria();
         if (currentAdaptationSetCriteria) {

--- a/lib/player.js
+++ b/lib/player.js
@@ -1700,7 +1700,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       } else {
         // Wait for the manifest to be parsed.
         await mutexWrapOperation(async () => {
-          await preloadManager.waitForManifest();
+          // Also wait for finish, so this stops on errors.
+          const promises = [
+            preloadManager.waitForFinish(),
+            preloadManager.waitForManifest(),
+          ];
+          await Promise.race(promises);
         }, 'waitForFinish');
 
         // Retrieve the manifest. This is specifically put before the media

--- a/lib/player.js
+++ b/lib/player.js
@@ -1700,12 +1700,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       } else {
         // Wait for the manifest to be parsed.
         await mutexWrapOperation(async () => {
-          // Also wait for finish, so this stops on errors.
-          const promises = [
-            preloadManager.waitForFinish(),
-            preloadManager.waitForManifest(),
-          ];
-          await Promise.race(promises);
+          await preloadManager.waitForManifest();
         }, 'waitForFinish');
 
         // Retrieve the manifest. This is specifically put before the media

--- a/test/player_load_graph_integration.js
+++ b/test/player_load_graph_integration.js
@@ -150,16 +150,16 @@ describe('Player Load Graph', () => {
       'unload',
       'manifest-parser',
       'manifest',
-      'media-source',
       'drm-engine',
+      'media-source',
       'load',
 
       // Load 3
       'unload',
       'manifest-parser',
       'manifest',
-      'media-source',
       'drm-engine',
+      'media-source',
       'load',
     ]);
   });


### PR DESCRIPTION
Previously, there were situations where, when handling `trackschanged` events, the manifest would not yet have been
copied from the preload manager to the player. This would prevent developers from properly handling those events.

This PR changes the order of operations slightly, such that the manifest is copied over earlier.