### PR TITLE
fix: Do not disable streams on VOD

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1911,8 +1911,12 @@ shaka.media.StreamingEngine = class {
     });
 
     if (!waitingForAnotherStreamToRecover) {
+      const maxDisabledTime = this.getDisabledTime_(error);
+      if (maxDisabledTime) {
+        shaka.log.debug(logPrefix, 'Disabling stream due to quota exceeded');
+      }
       const handled = this.playerInterface_.disableStream(
-          mediaState.stream, this.config_.maxDisabledTime);
+          mediaState.stream, maxDisabledTime);
       if (handled) {
         return;
       }
@@ -2781,11 +2785,14 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   async handleStreamingError_(mediaState, error) {
+    const logPrefix = shaka.media.StreamingEngine.logPrefix_(mediaState);
+
     // If we invoke the callback right away, the application could trigger a
     // rapid retry cycle that could be very unkind to the server.  Instead,
     // use the backoff system to delay and backoff the error handling.
     await this.failureCallbackBackoff_.attempt();
     this.destroyer_.ensureNotDestroyed();
+
     // Try to recover from network errors
     if (error.category === shaka.util.Error.Category.NETWORK) {
       if (mediaState.restoreStreamAfterTrickPlay) {
@@ -2793,6 +2800,9 @@ shaka.media.StreamingEngine = class {
         return;
       }
       const maxDisabledTime = this.getDisabledTime_(error);
+      if (maxDisabledTime) {
+        shaka.log.debug(logPrefix, 'Disabling stream due to error', error);
+      }
       error.handled = this.playerInterface_.disableStream(
           mediaState.stream, maxDisabledTime);
 
@@ -2817,9 +2827,16 @@ shaka.media.StreamingEngine = class {
 
   /**
    * @param {!shaka.util.Error} error
+   * @return {number}
    * @private
    */
   getDisabledTime_(error) {
+    if (!this.manifest_.presentationTimeline.isLive()) {
+      // VOD streams are static.  They don't "recover", so this disabling
+      // feature doesn't make sense.
+      return 0;
+    }
+
     if (this.config_.maxDisabledTime === 0 &&
         error.code == shaka.util.Error.Code.SEGMENT_MISSING) {
       // Spec: https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-6.3.3


### PR DESCRIPTION
Disabling streams on VOD makes no sense, because they are static and they don't "recover".

This avoids an infinite loading loop (switching between streams) when VOD segments time out.

Closes #7368