### PR TITLE
fix: Reduce calls to EME by ignoring MIME type in MediaKeySystemAccess cache

### DIFF
--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -10,6 +10,7 @@ goog.require('shaka.log');
 goog.require('shaka.media.Capabilities');
 goog.require('shaka.polyfill');
 goog.require('shaka.util.DrmUtils');
+goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Platform');
 
 
@@ -222,6 +223,7 @@ shaka.polyfill.MediaCapabilities = class {
    * @private
    */
   static async checkDrmSupport_(videoConfig, audioConfig, mcapKeySystemConfig) {
+    const MimeUtils = shaka.util.MimeUtils;
     const audioCapabilities = [];
     const videoCapabilities = [];
 
@@ -277,8 +279,12 @@ shaka.polyfill.MediaCapabilities = class {
       mediaKeySystemConfig.videoCapabilities = videoCapabilities;
     }
 
-    const videoCodec = videoConfig ? videoConfig.contentType : '';
-    const audioCodec = audioConfig ? audioConfig.contentType : '';
+    const videoMimeType = videoConfig ? videoConfig.contentType : '';
+    const audioMimeType = audioConfig ? audioConfig.contentType : '';
+    const videoCodec = MimeUtils.getBasicType(videoMimeType) + ';' +
+        MimeUtils.getCodecBase(videoMimeType);
+    const audioCodec = MimeUtils.getBasicType(audioMimeType) + ';' +
+        MimeUtils.getCodecBase(audioMimeType);
     const keySystem = mcapKeySystemConfig.keySystem;
 
     /** @type {MediaKeySystemAccess} */


### PR DESCRIPTION
Fixes #7325 