### PR TITLE
fix(preload): Resolve manifest promise sooner

### DIFF
--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -395,8 +395,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
         await this.parseManifestInner_();
         this.throwIfDestroyed_();
 
-        this.manifestPromise_.resolve();
-
         await this.initializeDrmInner_();
         this.throwIfDestroyed_();
 
@@ -506,10 +504,15 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
           this.assetUri_, this.manifestPlayerInterface_);
     }
 
+    this.manifestPromise_.resolve();
+
     // This event is fired after the manifest is parsed, but before any
     // filtering takes place.
     const event =
           this.makeEvent_(shaka.util.FakeEvent.EventName.ManifestParsed);
+    // Delay event to ensure manifest has been properly propagated
+    // to the player.
+    await Promise.resolve();
     this.dispatchEvent(event);
 
     // We require all manifests to have at least one variant.

--- a/lib/player.js
+++ b/lib/player.js
@@ -1694,13 +1694,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         // Wait for the manifest to be parsed.
         await mutexWrapOperation(async () => {
           await preloadManager.waitForManifest();
+          // Retrieve the manifest. This is specifically put before the media
+          // source engine is initialized, for the benefit of event handlers.
+          this.parserFactory_ = preloadManager.getParserFactory();
+          this.parser_ = preloadManager.receiveParser();
+          this.manifest_ = preloadManager.getManifest();
         }, 'waitForFinish');
-
-        // Retrieve the manifest. This is specifically put before the media
-        // source engine is initialized, for the benefit of event handlers.
-        this.parserFactory_ = preloadManager.getParserFactory();
-        this.parser_ = preloadManager.receiveParser();
-        this.manifest_ = preloadManager.getManifest();
 
         if (!this.mediaSourceEngine_) {
           await mutexWrapOperation(async () => {


### PR DESCRIPTION
Resolve manifest promise a bit sooner to ensure `player.getManifest()` returns correct value on `manifestparsed` event.