### PR TITLE
test: Fix secondary error thrown from unhandled errors

### DIFF
--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -352,8 +352,10 @@ function configureJasmineEnvironment() {
     await loadNodeModules();
 
     // Replace jasmine's global error handler, since we have our own more
-    // nuanced version.
-    window.onerror = null;
+    // nuanced version.  You can't set this to null, since jasmine still tries
+    // to call it.  Note also that our handler uses window.addEventListener
+    // instead of window.onerror.
+    window.onerror = function() {};
   });
 
   const originalSetTimeout = window.setTimeout;

--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -355,7 +355,7 @@ function configureJasmineEnvironment() {
     // nuanced version.  You can't set this to null, since jasmine still tries
     // to call it.  Note also that our handler uses window.addEventListener
     // instead of window.onerror.
-    window.onerror = function() {};
+    window.onerror = () => {};
   });
 
   const originalSetTimeout = window.setTimeout;


### PR DESCRIPTION
In #7345, we disabled Jasmine's global error handler.  However, jasmine still tries to call this.  So instead of replacing it with null, replace it with a stub.

Also add comments about why we are able to do this and still handle global errors in our own way.