### PR TITLE
fix(DASH): Live DASH allows segment overlap in the updated manifest for first new segments

### DIFF
--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -860,7 +860,7 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
       if (currentTimeline.length) {
         const lastCurrentEntry = currentTimeline[currentTimeline.length - 1];
         newEntries = info.timeline.filter((entry) => {
-          return entry.start >= lastCurrentEntry.end;
+          return entry.end > lastCurrentEntry.end;
         });
       } else {
         newEntries = info.timeline.slice();


### PR DESCRIPTION
fix(DASH): Live DASH allows segment overlap in the updated manifest for first new segments to avoid creating GAP with ms inaccurate manifest vs Segment duration and start time

Fixes https://github.com/shaka-project/shaka-player/issues/7397