### PR TITLE
feat: Use source tags instead of src attribute

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -184,7 +184,7 @@ shaka.media.DrmEngine = class {
       // Webkit EME implementation requires the src to be defined to clear
       // the MediaKeys.
       if (!shaka.util.Platform.isMediaKeysPolyfilled('webkit')) {
-        goog.asserts.assert(!this.video_.src,
+        goog.asserts.assert(!this.video_.getElementsByTagName('source').length,
             'video src must be removed first!');
       }
 

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -184,7 +184,9 @@ shaka.media.DrmEngine = class {
       // Webkit EME implementation requires the src to be defined to clear
       // the MediaKeys.
       if (!shaka.util.Platform.isMediaKeysPolyfilled('webkit')) {
-        goog.asserts.assert(!this.video_.getElementsByTagName('source').length,
+        goog.asserts.assert(
+            !this.video_.src &&
+            !this.video_.getElementsByTagName('source').length,
             'video src must be removed first!');
       }
 

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -20,6 +20,7 @@ goog.require('shaka.text.TextEngine');
 goog.require('shaka.transmuxer.TransmuxerEngine');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Destroyer');
+goog.require('shaka.util.Dom');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.EventManager');
 goog.require('shaka.util.FakeEvent');
@@ -116,6 +117,9 @@ shaka.media.MediaSourceEngine = class {
 
     /** @private {boolean} */
     this.playbackHasBegun_ = false;
+
+    /** @private {HTMLSourceElement} */
+    this.source_ = null;
 
     /** @private {MediaSource} */
     this.mediaSource_ = this.createMediaSource(this.mediaSourceOpen_);
@@ -215,7 +219,12 @@ shaka.media.MediaSourceEngine = class {
     // Store the object URL for releasing it later.
     this.url_ = shaka.media.MediaSourceEngine.createObjectURL(mediaSource);
 
-    this.video_.src = this.url_;
+    if (this.source_) {
+      this.video_.removeChild(this.source_);
+    }
+    this.source_ = shaka.util.Dom.createSourceElement(this.url_);
+    this.video_.appendChild(this.source_);
+    this.video_.load();
 
     return mediaSource;
   }
@@ -412,11 +421,13 @@ shaka.media.MediaSourceEngine = class {
       this.eventManager_ = null;
     }
 
-    if (this.video_) {
+    if (this.video_ && this.source_) {
       // "unload" the video element.
-      this.video_.removeAttribute('src');
+      this.video_.removeChild(this.source_);
       this.video_.load();
+      this.video_.disableRemotePlayback = false;
       this.video_ = null;
+      this.source_ = null;
     }
 
     this.config_ = null;

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -219,6 +219,7 @@ shaka.media.MediaSourceEngine = class {
     // Store the object URL for releasing it later.
     this.url_ = shaka.media.MediaSourceEngine.createObjectURL(mediaSource);
 
+    this.video_.removeAttribute('src');
     if (this.source_) {
       this.video_.removeChild(this.source_);
     }

--- a/lib/player.js
+++ b/lib/player.js
@@ -1446,16 +1446,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       if (this.video_) {
         // Remove all track nodes
         shaka.util.Dom.removeAllChildren(this.video_);
-      }
 
-      // In order to unload a media element, we need to remove the src attribute
-      // and then load again. When we destroy media source engine, this will be
-      // done for us, but for src=, we need to do it here.
-      //
-      // DrmEngine requires this to be done before we destroy DrmEngine itself.
-      if (this.video_ && this.video_.src) {
-        this.video_.removeAttribute('src');
-        this.video_.load();
+        // In order to unload a media element, we need to remove the src
+        // attribute and then load again. When we destroy media source engine,
+        // this will be done for us, but for src=, we need to do it here.
+        //
+        // DrmEngine requires this to be done before we destroy DrmEngine
+        // itself.
+        if (this.video_.currentSrc) {
+          this.video_.load();
+        }
       }
 
       if (this.drmEngine_) {
@@ -2394,6 +2394,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     this.makeStateChangeEvent_('media-source');
 
+    // Remove children if we had any, i.e. from previously used src= mode.
+    shaka.util.Dom.removeAllChildren(this.video_);
+
     this.createTextDisplayer_();
     goog.asserts.assert(this.textDisplayer_,
         'Text displayer should be created already');
@@ -2979,12 +2982,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         playbackUri += ',' + this.config_.playRangeEnd;
       }
     }
-    mediaElement.src = playbackUri;
-    // If ManagedMediaSource exists, we've disabled remote playback on our own.
-    // Reenable it so AirPlay can be used via RemotePlayback API.
-    if (this.mediaSourceEngine_ && window.ManagedMediaSource) {
-      mediaElement.disableRemotePlayback = false;
+
+    if (this.mediaSourceEngine_ ) {
+      await this.mediaSourceEngine_.destroy();
+      this.mediaSourceEngine_ = null;
     }
+    shaka.util.Dom.removeAllChildren(mediaElement);
+
+    const source = shaka.util.Dom.createSourceElement(playbackUri, mimeType);
+    mediaElement.appendChild(source);
 
     // Tizen 3 / WebOS won't load anything unless you call load() explicitly,
     // no matter the value of the preload attribute.  This is harmful on some
@@ -4346,7 +4352,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     // For native HLS, the duration for live streams seems to be Infinity.
-    if (this.video_ && this.video_.src) {
+    if (this.video_ && this.video_.currentSrc) {
       return this.video_.duration == Infinity;
     }
 
@@ -4390,7 +4396,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // Therefore if the first variant has no video, that's sufficient to say
       // it is audio-only content.
       return !variants[0].video;
-    } else if (this.video_ && this.video_.src) {
+    } else if (this.video_ && this.video_.currentSrc) {
       // If we have video track info, use that.  It will be the least
       // error-prone way with native HLS.  In contrast, videoHeight might be
       // unset until the first frame is loaded.  Since isAudioOnly is queried
@@ -4439,7 +4445,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // If we have loaded content with src=, we ask the video element for its
     // seekable range.  This covers both plain mp4s and native HLS playbacks.
-    if (this.video_ && this.video_.src) {
+    if (this.video_ && this.video_.currentSrc) {
       const seekable = this.video_.seekable;
       if (seekable.length) {
         return {
@@ -4748,7 +4754,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
 
       return tracks;
-    } else if (this.video_ && this.video_.src && this.video_.textTracks) {
+    } else if (this.video_ && this.video_.currentSrc &&
+        this.video_.textTracks) {
       const textTracks = this.getFilteredTextTracks_();
       const StreamUtils = shaka.util.StreamUtils;
       return textTracks.map((text) => StreamUtils.html5TextTrackToTrack(text));
@@ -4972,7 +4979,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // When track is selected, back-propagate the language to
       // currentTextLanguage_.
       this.currentTextLanguage_ = stream.language;
-    } else if (this.video_ && this.video_.src && this.video_.textTracks) {
+    } else if (this.video_ && this.video_.currentSrc &&
+        this.video_.textTracks) {
       const textTracks = this.getFilteredTextTracks_();
       const oldTrack = textTracks.find((textTrack) =>
         textTrack.mode !== 'disabled');
@@ -5348,7 +5356,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @export
    */
   getChaptersTracks() {
-    if (this.video_ && this.video_.src && this.video_.textTracks) {
+    if (this.video_ && this.video_.currentSrc && this.video_.textTracks) {
       const textTracks = this.getChaptersTracks_();
       const StreamUtils = shaka.util.StreamUtils;
       return textTracks.map((text) => StreamUtils.html5TextTrackToTrack(text));
@@ -5365,7 +5373,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @export
    */
   getChapters(language) {
-    if (!this.video_ || !this.video_.src || !this.video_.textTracks) {
+    if (!this.video_ || !this.video_.currentSrc || !this.video_.textTracks) {
       return [];
     }
     const LanguageUtils = shaka.util.LanguageUtils;
@@ -5494,7 +5502,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           this.streamingEngine_.unloadTextStream();
         }
       }
-    } else if (this.video_ && this.video_.src && this.video_.textTracks) {
+    } else if (this.video_ && this.video_.currentSrc &&
+        this.video_.textTracks) {
       this.textDisplayer_.setTextVisibility(newVisibility);
     }
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -1453,7 +1453,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         //
         // DrmEngine requires this to be done before we destroy DrmEngine
         // itself.
-        if (this.video_.currentSrc) {
+        if (this.video_.src) {
+          this.video_.removeAttribute('src');
           this.video_.load();
         }
       }
@@ -2395,6 +2396,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.makeStateChangeEvent_('media-source');
 
     // Remove children if we had any, i.e. from previously used src= mode.
+    this.video_.removeAttribute('src');
     shaka.util.Dom.removeAllChildren(this.video_);
 
     this.createTextDisplayer_();
@@ -2989,8 +2991,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
     shaka.util.Dom.removeAllChildren(mediaElement);
 
-    const source = shaka.util.Dom.createSourceElement(playbackUri, mimeType);
-    mediaElement.appendChild(source);
+    mediaElement.src = playbackUri;
 
     // Tizen 3 / WebOS won't load anything unless you call load() explicitly,
     // no matter the value of the preload attribute.  This is harmful on some
@@ -4352,7 +4353,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     // For native HLS, the duration for live streams seems to be Infinity.
-    if (this.video_ && this.video_.currentSrc) {
+    if (this.video_ && this.video_.src) {
       return this.video_.duration == Infinity;
     }
 
@@ -4396,7 +4397,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // Therefore if the first variant has no video, that's sufficient to say
       // it is audio-only content.
       return !variants[0].video;
-    } else if (this.video_ && this.video_.currentSrc) {
+    } else if (this.video_ && this.video_.src) {
       // If we have video track info, use that.  It will be the least
       // error-prone way with native HLS.  In contrast, videoHeight might be
       // unset until the first frame is loaded.  Since isAudioOnly is queried
@@ -4445,7 +4446,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // If we have loaded content with src=, we ask the video element for its
     // seekable range.  This covers both plain mp4s and native HLS playbacks.
-    if (this.video_ && this.video_.currentSrc) {
+    if (this.video_ && this.video_.src) {
       const seekable = this.video_.seekable;
       if (seekable.length) {
         return {
@@ -4754,8 +4755,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
 
       return tracks;
-    } else if (this.video_ && this.video_.currentSrc &&
-        this.video_.textTracks) {
+    } else if (this.video_ && this.video_.src && this.video_.textTracks) {
       const textTracks = this.getFilteredTextTracks_();
       const StreamUtils = shaka.util.StreamUtils;
       return textTracks.map((text) => StreamUtils.html5TextTrackToTrack(text));
@@ -4979,8 +4979,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // When track is selected, back-propagate the language to
       // currentTextLanguage_.
       this.currentTextLanguage_ = stream.language;
-    } else if (this.video_ && this.video_.currentSrc &&
-        this.video_.textTracks) {
+    } else if (this.video_ && this.video_.src && this.video_.textTracks) {
       const textTracks = this.getFilteredTextTracks_();
       const oldTrack = textTracks.find((textTrack) =>
         textTrack.mode !== 'disabled');
@@ -5502,8 +5501,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           this.streamingEngine_.unloadTextStream();
         }
       }
-    } else if (this.video_ && this.video_.currentSrc &&
-        this.video_.textTracks) {
+    } else if (this.video_ && this.video_.src && this.video_.textTracks) {
       this.textDisplayer_.setTextVisibility(newVisibility);
     }
 

--- a/lib/util/dom_utils.js
+++ b/lib/util/dom_utils.js
@@ -43,6 +43,20 @@ shaka.util.Dom = class {
 
 
   /**
+   * @param {string} url
+   * @param {string=} mimeType
+   * @return {!HTMLSourceElement}
+   */
+  static createSourceElement(url, mimeType = '') {
+    const source =
+      /** @type {HTMLSourceElement} */ (document.createElement('source'));
+    source.src = url;
+    source.type = mimeType;
+    return source;
+  }
+
+
+  /**
    * Cast a Node/Element to an HTMLElement
    *
    * @param {!Node|!Element} original

--- a/test/media/media_source_engine_integration.js
+++ b/test/media/media_source_engine_integration.js
@@ -179,7 +179,7 @@ describe('MediaSourceEngine', () => {
     mediaSourceEngine.configure(config);
 
     mediaSource = /** @type {?} */(mediaSourceEngine)['mediaSource_'];
-    expect(video.src).toBeTruthy();
+    expect(video.getElementsByTagName('source').length).toBe(1);
     await mediaSourceEngine.init(new Map(), false);
   });
 

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -218,24 +218,21 @@ describe('MediaSourceEngine', () => {
     //  - seek to flush the pipeline on some platforms
     //  - check buffered.length to assert that flushing the pipeline is okay
     mockVideo = {
-      src: '',
+      firstElementChild: undefined,
       error: null,
       currentTime: 0,
       buffered: {
         length: 0,
       },
-      removeAttribute: /** @this {HTMLVideoElement} */ (attr) => {
-        // Only called with attr == 'src'.
-        // This assertion alerts us if the requirements for this mock change.
-        goog.asserts.assert(attr == 'src', 'Unexpected removeAttribute() call');
-        mockVideo.src = '';
+      appendChild: (element) => {
+        mockVideo.firstElementChild = element;
+      },
+      removeChild: () => {
+        mockVideo.firstElementChild = undefined;
       },
       addEventListener: jasmine.createSpy('addVideoEventListener'),
       removeEventListener: jasmine.createSpy('removeVideoEventListener'),
-      load: /** @this {HTMLVideoElement} */ () => {
-        // This assertion alerts us if the requirements for this mock change.
-        goog.asserts.assert(mockVideo.src == '', 'Unexpected load() call');
-      },
+      load: jasmine.createSpy('load'),
       play: jasmine.createSpy('play'),
       paused: true,
       autoplay: false,
@@ -329,7 +326,7 @@ describe('MediaSourceEngine', () => {
 
       expect(createMediaSourceSpy).toHaveBeenCalled();
       expect(createObjectURLSpy).toHaveBeenCalled();
-      expect(mockVideo.src).toBe('blob:foo');
+      expect(mockVideo.firstElementChild.src).toBe('blob:foo');
     });
 
     it('revokes object URL after MediaSource opens', () => {

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -230,6 +230,7 @@ describe('MediaSourceEngine', () => {
       removeChild: () => {
         mockVideo.firstElementChild = undefined;
       },
+      removeAttribute: jasmine.createSpy('removeAttribute'),
       addEventListener: jasmine.createSpy('addVideoEventListener'),
       removeEventListener: jasmine.createSpy('removeVideoEventListener'),
       load: jasmine.createSpy('load'),

--- a/test/player_load_graph_integration.js
+++ b/test/player_load_graph_integration.js
@@ -58,18 +58,18 @@ describe('Player Load Graph', () => {
       async () => {
         createPlayer();
 
-        expect(video.src).toBeFalsy();
+        expect(video.getElementsByTagName('source').length).toBeFalsy();
         await player.attach(video, /* initializeMediaSource= */ true);
-        expect(video.src).toBeTruthy();
+        expect(video.getElementsByTagName('source').length).toBeTruthy();
       });
 
   it('attach + initializeMediaSource=false will not intialize media source',
       async () => {
         createPlayer();
 
-        expect(video.src).toBeFalsy();
+        expect(video.getElementsByTagName('source').length).toBeFalsy();
         await player.attach(video, /* initializeMediaSource= */ false);
-        expect(video.src).toBeFalsy();
+        expect(video.getElementsByTagName('source').length).toBeFalsy();
       });
 
   it('unload + initializeMediaSource=false does not initialize media source',
@@ -80,7 +80,7 @@ describe('Player Load Graph', () => {
         await player.load('test:sintel');
 
         await player.unload(/* initializeMediaSource= */ false);
-        expect(video.src).toBeFalsy();
+        expect(video.getElementsByTagName('source').length).toBeFalsy();
       });
 
   it('unload + initializeMediaSource=true initializes media source',
@@ -91,7 +91,7 @@ describe('Player Load Graph', () => {
         await player.load('test:sintel');
 
         await player.unload(/* initializeMediaSource= */ true);
-        expect(video.src).toBeTruthy();
+        expect(video.getElementsByTagName('source').length).toBeTruthy();
       });
 
   it('load and unload can be called multiple times', async () => {

--- a/test/player_src_equals_integration.js
+++ b/test/player_src_equals_integration.js
@@ -255,19 +255,25 @@ describe('Player Src Equals', () => {
   it('configures play and seek range for VOD with start', async () => {
     player.configure({playRangeStart: 3});
     await loadWithSrcEquals(SMALL_MP4_CONTENT_URI, /* startTime= */ null);
-    expect(video.src.includes('#t=3')).toBeTruthy();
+    const source = /** @type {HTMLSourceElement} */ (
+      video.getElementsByTagName('source')[0]);
+    expect(source.src).toContain('#t=3');
   });
 
   it('configures play and seek range for VOD with end', async () => {
     player.configure({playRangeEnd: 8});
     await loadWithSrcEquals(SMALL_MP4_CONTENT_URI, /* startTime= */ null);
-    expect(video.src.includes('#t=,8')).toBeTruthy();
+    const source = /** @type {HTMLSourceElement} */ (
+      video.getElementsByTagName('source')[0]);
+    expect(source.src).toContain('#t=,8');
   });
 
   it('configures play and seek range for VOD with start and end', async () => {
     player.configure({playRangeStart: 3, playRangeEnd: 8});
     await loadWithSrcEquals(SMALL_MP4_CONTENT_URI, /* startTime= */ null);
-    expect(video.src.includes('#t=3,8')).toBeTruthy();
+    const source = /** @type {HTMLSourceElement} */ (
+      video.getElementsByTagName('source')[0]);
+    expect(source.src).toContain('#t=3,8');
   });
 
   // TODO: test HLS on platforms with native HLS

--- a/test/player_src_equals_integration.js
+++ b/test/player_src_equals_integration.js
@@ -255,25 +255,19 @@ describe('Player Src Equals', () => {
   it('configures play and seek range for VOD with start', async () => {
     player.configure({playRangeStart: 3});
     await loadWithSrcEquals(SMALL_MP4_CONTENT_URI, /* startTime= */ null);
-    const source = /** @type {HTMLSourceElement} */ (
-      video.getElementsByTagName('source')[0]);
-    expect(source.src).toContain('#t=3');
+    expect(video.src).toContain('#t=3');
   });
 
   it('configures play and seek range for VOD with end', async () => {
     player.configure({playRangeEnd: 8});
     await loadWithSrcEquals(SMALL_MP4_CONTENT_URI, /* startTime= */ null);
-    const source = /** @type {HTMLSourceElement} */ (
-      video.getElementsByTagName('source')[0]);
-    expect(source.src).toContain('#t=,8');
+    expect(video.src).toContain('#t=,8');
   });
 
   it('configures play and seek range for VOD with start and end', async () => {
     player.configure({playRangeStart: 3, playRangeEnd: 8});
     await loadWithSrcEquals(SMALL_MP4_CONTENT_URI, /* startTime= */ null);
-    const source = /** @type {HTMLSourceElement} */ (
-      video.getElementsByTagName('source')[0]);
-    expect(source.src).toContain('#t=3,8');
+    expect(video.src).toContain('#t=3,8');
   });
 
   // TODO: test HLS on platforms with native HLS

--- a/test/test/util/simple_fakes.js
+++ b/test/test/util/simple_fakes.js
@@ -188,9 +188,10 @@ shaka.test.FakeVideo = class {
     this.autoplay = false;
     this.paused = false;
     this.buffered = createFakeBuffered([]);
-    this.src = '';
     this.offsetWidth = 1000;
     this.offsetHeight = 1000;
+    /** @private {!Array<!Element>} */
+    this.children_ = [];
 
     /** @type {!jasmine.Spy} */
     this.addTextTrack =
@@ -234,6 +235,19 @@ shaka.test.FakeVideo = class {
 
     /** @type {!jasmine.Spy} */
     this.canPlayType = jasmine.createSpy('canPlayType');
+
+    /** @type {!jasmine.Spy} */
+    this.appendChild =
+      jasmine.createSpy('appendChild').and.callFake((element) => {
+        this.children_.push(element);
+      });
+
+    /** @type {!jasmine.Spy} */
+    this.getElementsByTagName =
+      jasmine.createSpy('getElementsByTagName').and.callFake((tagName) => {
+        tagName = tagName.toUpperCase();
+        return this.children_.filter((tag) => tag.tagName === tagName);
+      });
   }
 };
 

--- a/ui/ui.js
+++ b/ui/ui.js
@@ -485,17 +485,21 @@ shaka.ui.Overlay = class {
     //    <source src='foo.m2u8'/>
     //  </video>
     // It should not be specified on both.
+    const urls = [];
     const src = video.getAttribute('src');
     if (src) {
-      const sourceElem = document.createElement('source');
-      sourceElem.setAttribute('src', src);
-      video.appendChild(sourceElem);
+      urls.push(src);
       video.removeAttribute('src');
     }
+    for (const source of /** @type {!NodeList<!HTMLSourceElement>}*/(
+      video.getElementsByTagName('source'))) {
+      urls.push(source.src);
+      video.removeChild(source);
+    }
 
-    for (const elem of video.querySelectorAll('source')) {
+    for (const url of urls) {
       try { // eslint-disable-next-line no-await-in-loop
-        await ui.getControls().getPlayer().load(elem.getAttribute('src'));
+        await ui.getControls().getPlayer().load(url);
         break;
       } catch (e) {
         shaka.log.error('Error auto-loading asset', e);

--- a/ui/ui.js
+++ b/ui/ui.js
@@ -491,9 +491,9 @@ shaka.ui.Overlay = class {
       urls.push(src);
       video.removeAttribute('src');
     }
-    for (const source of /** @type {!NodeList<!HTMLSourceElement>}*/(
-      video.getElementsByTagName('source'))) {
-      urls.push(source.src);
+
+    for (const source of video.getElementsByTagName('source')) {
+      urls.push(/** @type {!HTMLSourceElement} */ (source).src);
       video.removeChild(source);
     }
 


### PR DESCRIPTION
Needed for #5022 

This PR does not enable AirPlay on MSE yet, but moves shaka from using `src` attribute to `source` tags. With this change we will be able to enable it more easily, as `src` and `source` should not be used together.