### PR TITLE
fix(PS4/5): Disable smooth codec switch on PS4/5

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -629,7 +629,7 @@ shaka.util.Platform = class {
    *
    * Some devices are known not to support `MediaSource.changeType`
    * well. These devices should use the reload strategy. If a device
-   * reports that it supports `changeType` but support it reliabley
+   * reports that it supports `changeType` but support it unreliably
    * it should be added to this list.
    *
    * @return {boolean}
@@ -638,7 +638,8 @@ shaka.util.Platform = class {
     const Platform = shaka.util.Platform;
     if (Platform.isTizen2() || Platform.isTizen3() || Platform.isTizen4() ||
         Platform.isTizen5() || Platform.isTizen6() || Platform.isWebOS3() ||
-        Platform.isWebOS4() || Platform.isWebOS5()) {
+        Platform.isWebOS4() || Platform.isWebOS5() || Platform.isPS4() ||
+        Platform.isPS5()) {
       return false;
     }
     // Older chromecasts without GoogleTV seem to not support SMOOTH properly.


### PR DESCRIPTION
Recent tests have shown that although `SourceBuffer.changeType()` exists on PS5, calling it when switching between AAC and EC3 always throws an exception. Disable smooth codec switch on that platform together with PS4.