### PR TITLE
fix: calculations of channel count for DASH AudioChannelConfiguration elements.

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -2751,25 +2751,49 @@ shaka.dash.DashParser = class {
           return intValue;
         }
 
-        case 'tag:dolby.com,2014:dash:audio_channel_configuration:2011':
-        case 'urn:dolby:dash:audio_channel_configuration:2011': {
-          // A hex-encoded 16-bit integer, in which each bit represents a
-          // channel.
-          let hexValue = parseInt(value, 16);
+        case 'tag:dolby.com,2015:dash:audio_channel_configuration:2015': {
+          // ETSI TS 103 190-2 v1.2.1, Annex G.3
+          const channelCountMapping =
+            [2, 1, 2, 2, 2, 2, 1, 2, 2, 1, 1, 1, 1, 2, 1, 1, 2, 2];
+          const hexValue = parseInt(value, 16);
           if (!hexValue) {  // 0 or NaN
             shaka.log.warning('Channel parsing failure! ' +
                           'Ignoring scheme and value', scheme, value);
             continue;
           }
-          // Count the 1-bits in hexValue.
           let numBits = 0;
-          while (hexValue) {
-            if (hexValue & 1) {
-              ++numBits;
+          for (let i = 0; i < channelCountMapping.length; i++) {
+            if (hexValue & (1<<i)) {
+              numBits += channelCountMapping[i];
             }
-            hexValue >>= 1;
           }
-          return numBits;
+          if (numBits) {
+            return numBits;
+          }
+          continue;
+        }
+
+        case 'tag:dolby.com,2014:dash:audio_channel_configuration:2011':
+        case 'urn:dolby:dash:audio_channel_configuration:2011': {
+          // Defined by https://ott.dolby.com/OnDelKits/DDP/Dolby_Digital_Plus_Online_Delivery_Kit_v1.5/Documentation/Content_Creation/SDM/help_files/topics/ddp_mpeg_dash_c_mpd_auchlconfig.html
+          const channelCountMapping =
+            [1, 1, 1, 1, 1, 2, 2, 1, 1, 2, 2, 2, 1, 2, 1, 1].reverse();
+          const hexValue = parseInt(value, 16);
+          if (!hexValue) {  // 0 or NaN
+            shaka.log.warning('Channel parsing failure! ' +
+                          'Ignoring scheme and value', scheme, value);
+            continue;
+          }
+          let numBits = 0;
+          for (let i = 0; i < channelCountMapping.length; i++) {
+            if (hexValue & (1<<i)) {
+              numBits += channelCountMapping[i];
+            }
+          }
+          if (numBits) {
+            return numBits;
+          }
+          continue;
         }
 
         // Defined by https://dashif.org/identifiers/audio_source_metadata/ and clause 8.2, in ISO/IEC 23001-8.

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -2753,6 +2753,7 @@ shaka.dash.DashParser = class {
 
         case 'tag:dolby.com,2015:dash:audio_channel_configuration:2015': {
           // ETSI TS 103 190-2 v1.2.1, Annex G.3
+          // LSB-to-MSB order
           const channelCountMapping =
             [2, 1, 2, 2, 2, 2, 1, 2, 2, 1, 1, 1, 1, 2, 1, 1, 2, 2];
           const hexValue = parseInt(value, 16);
@@ -2776,6 +2777,7 @@ shaka.dash.DashParser = class {
         case 'tag:dolby.com,2014:dash:audio_channel_configuration:2011':
         case 'urn:dolby:dash:audio_channel_configuration:2011': {
           // Defined by https://ott.dolby.com/OnDelKits/DDP/Dolby_Digital_Plus_Online_Delivery_Kit_v1.5/Documentation/Content_Creation/SDM/help_files/topics/ddp_mpeg_dash_c_mpd_auchlconfig.html
+          // keep list in order of the spec; reverse for LSB-to-MSB order
           const channelCountMapping =
             [1, 1, 1, 1, 1, 2, 2, 1, 1, 2, 2, 2, 1, 2, 1, 1].reverse();
           const hexValue = parseInt(value, 16);

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -1530,17 +1530,17 @@ describe('DashParser Manifest', () => {
       // L,R,C,LFE,Ls,Rs (5.1)
       await testAudioChannelConfiguration(6,
           {'tag:dolby.com,2014:dash:audio_channel_configuration:2011':
-                'F801'});
+             'F801'});
 
       // L,R,C,LFE,Ls,Rs,Lrs,Rrs (7.1)
       await testAudioChannelConfiguration(8,
           {'tag:dolby.com,2014:dash:audio_channel_configuration:2011':
-                'FA01'});
+             'FA01'});
 
       // L,R,C,LFE,Ls,Rs,Ltm,Rtm (5.1.2)
       await testAudioChannelConfiguration(8,
           {'tag:dolby.com,2014:dash:audio_channel_configuration:2011':
-                'F805'});
+             'F805'});
 
       // L,R,C,LFE,Ls,Rs (5.1)
       await testAudioChannelConfiguration(6,
@@ -1560,15 +1560,18 @@ describe('DashParser Manifest', () => {
 
       // L,R,C,LFE,Ls,Rs (5.1)
       await testAudioChannelConfiguration(6,
-          {'tag:dolby.com,2015:dash:audio_channel_configuration:2015': '000047'});
+          {'tag:dolby.com,2015:dash:audio_channel_configuration:2015':
+             '000047'});
 
       // L,R,C,LFE,Ls,Rs,Lrs,Rrs (7.1)
       await testAudioChannelConfiguration(8,
-          {'tag:dolby.com,2015:dash:audio_channel_configuration:2015': '00004F'})
+          {'tag:dolby.com,2015:dash:audio_channel_configuration:2015':
+             '00004F'});
 
       // L,R,C,LFE,Ls,Rs,Ltm,Rtm (5.1.2)
       await testAudioChannelConfiguration(8,
-          {'tag:dolby.com,2015:dash:audio_channel_configuration:2015': '0000c7'});
+          {'tag:dolby.com,2015:dash:audio_channel_configuration:2015':
+             '0000c7'});
 
       // Results in null if the value is not a valid hex number.
       await testAudioChannelConfiguration(null,

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -1527,18 +1527,52 @@ describe('DashParser Manifest', () => {
     });
 
     it('parses dolby scheme', async () => {
-      // Parses a hex value in which each 1-bit is a channel.
+      // L,R,C,LFE,Ls,Rs (5.1)
       await testAudioChannelConfiguration(6,
           {'tag:dolby.com,2014:dash:audio_channel_configuration:2011':
                 'F801'});
 
-      // This scheme seems to use the same format.
+      // L,R,C,LFE,Ls,Rs,Lrs,Rrs (7.1)
       await testAudioChannelConfiguration(8,
-          {'urn:dolby:dash:audio_channel_configuration:2011': '7037'});
+          {'tag:dolby.com,2014:dash:audio_channel_configuration:2011':
+                'FA01'});
+
+      // L,R,C,LFE,Ls,Rs,Ltm,Rtm (5.1.2)
+      await testAudioChannelConfiguration(8,
+          {'tag:dolby.com,2014:dash:audio_channel_configuration:2011':
+                'F805'});
+
+      // L,R,C,LFE,Ls,Rs (5.1)
+      await testAudioChannelConfiguration(6,
+          {'urn:dolby:dash:audio_channel_configuration:2011': 'F801'});
+
+      // L,R,C,LFE,Ls,Rs,Lrs,Rrs (7.1)
+      await testAudioChannelConfiguration(8,
+          {'urn:dolby:dash:audio_channel_configuration:2011': 'FA01'});
+
+      // L,R,C,LFE,Ls,Rs,Ltm,Rtm (5.1.2)
+      await testAudioChannelConfiguration(8,
+          {'urn:dolby:dash:audio_channel_configuration:2011': 'F805'});
 
       // Results in null if the value is not a valid hex number.
       await testAudioChannelConfiguration(null,
           {'urn:dolby:dash:audio_channel_configuration:2011': 'x'});
+
+      // L,R,C,LFE,Ls,Rs (5.1)
+      await testAudioChannelConfiguration(6,
+          {'tag:dolby.com,2015:dash:audio_channel_configuration:2015': '000047'});
+
+      // L,R,C,LFE,Ls,Rs,Lrs,Rrs (7.1)
+      await testAudioChannelConfiguration(8,
+          {'tag:dolby.com,2015:dash:audio_channel_configuration:2015': '00004F'})
+
+      // L,R,C,LFE,Ls,Rs,Ltm,Rtm (5.1.2)
+      await testAudioChannelConfiguration(8,
+          {'tag:dolby.com,2015:dash:audio_channel_configuration:2015': '0000c7'});
+
+      // Results in null if the value is not a valid hex number.
+      await testAudioChannelConfiguration(null,
+          {'tag:dolby.com,2015:dash:audio_channel_configuration:2015': 'x'});
     });
 
     it('parses MPEG channel configuration scheme', async () => {


### PR DESCRIPTION
Fix tag:dolby.com,2014:dash:audio_channel_configuration:2011 scheme to correctly handle bits that represent channel pairs according to document at [dolby.com](https://ott.dolby.com/OnDelKits/DDP/Dolby_Digital_Plus_Online_Delivery_Kit_v1.5/Documentation/Content_Creation/SDM/help_files/topics/ddp_mpeg_dash_c_mpd_auchlconfig.html)

Add tag:dolby.com,2015:dash:audio_channel_configuration:2015 scheme according to ETSI TS 103 190-2 v1.2.1, Annex G.3

Test stream is available here: [manifest.mpd](https://content.media24.link/ac4_512/manifest.mpd)
