### PR TITLE
fix(UI): Fix the position of save video frame in the overflow menu

### DIFF
--- a/ui/ui.js
+++ b/ui/ui.js
@@ -193,7 +193,6 @@ shaka.ui.Overlay = class {
         'playback_rate',
         'recenter_vr',
         'toggle_stereoscopic',
-        'save_video_frame',
       ],
       statisticsList: [
         'width',
@@ -291,6 +290,9 @@ shaka.ui.Overlay = class {
       config.controlPanelElements = config.controlPanelElements.filter(
           (name) => name != 'play_pause' && name != 'volume');
     }
+
+    // Set this button here to push it at the end.
+    config.overflowMenuButtons.push('save_video_frame');
 
     return config;
   }


### PR DESCRIPTION
This change is necessary because the remote playback button is not in the initial list, and this causes it to be positioned in last place when we do not want this to happen.