### PR TITLE
test: Fix DOM autosetup test flake

### DIFF
--- a/test/ui/ui_unit.js
+++ b/test/ui/ui_unit.js
@@ -90,8 +90,12 @@ describe('UI', () => {
       });
 
       it('has loaded the video', () => {
-        expect(video.duration).not.toBeNaN();
-        expect(video.duration).not.toBe(0);
+        // The above promise for DOMAutoSetup() doesn't guarantee that load()
+        // is complete, only that we started it.  So don't check duration or
+        // other things that require load() to complete.
+        const overlay = /** @type {!shaka.ui.Overlay} */(video['ui']);
+        const player = overlay.getControls().getPlayer();
+        expect(player.getAssetUri()).toBeTruthy();
       });
     });
 
@@ -118,8 +122,12 @@ describe('UI', () => {
       });
 
       it('has loaded the video', () => {
-        expect(video.duration).not.toBeNaN();
-        expect(video.duration).not.toBe(0);
+        // The above promise for DOMAutoSetup() doesn't guarantee that load()
+        // is complete, only that we started it.  So don't check duration or
+        // other things that require load() to complete.
+        const overlay = /** @type {!shaka.ui.Overlay} */(video['ui']);
+        const player = overlay.getControls().getPlayer();
+        expect(player.getAssetUri()).toBeTruthy();
       });
     });
 


### PR DESCRIPTION
The promise for DOM auto setup tests doesn't guarantee that load() is complete, only that we started it.  So checking video duration causes flake, in particular on slow devices like Tizen.  Instead, check for the player to have an asset URI.