### PR TITLE
test: Deduplicate platform support check

### DIFF
--- a/test/cast/cast_receiver_integration.js
+++ b/test/cast/cast_receiver_integration.js
@@ -243,8 +243,7 @@ filterDescribe('CastReceiver', castReceiverIntegrationSupport, () => {
     });
   });
 
-  const widevineSupport =
-      () => window['shakaSupport'].drm['com.widevine.alpha'];
+  const widevineSupport = () => shakaSupport.drm['com.widevine.alpha'];
   filterDescribe('with drm', widevineSupport, () => {
     drmIt('sends reasonably-sized updates', async () => {
       // Use an encrypted asset, to make sure DRM info doesn't balloon the size.

--- a/test/dash/dash_parser_integration.js
+++ b/test/dash/dash_parser_integration.js
@@ -23,7 +23,7 @@ describe('DashParser', () => {
   let waiter;
 
   function checkClearKeySupport() {
-    const clearKeySupport = window['shakaSupport'].drm['org.w3.clearkey'];
+    const clearKeySupport = shakaSupport.drm['org.w3.clearkey'];
     if (!clearKeySupport) {
       return false;
     }

--- a/test/hls/hls_parser_integration.js
+++ b/test/hls/hls_parser_integration.js
@@ -23,7 +23,7 @@ describe('HlsParser', () => {
   let waiter;
 
   function checkClearKeySupport() {
-    const clearKeySupport = window['shakaSupport'].drm['org.w3.clearkey'];
+    const clearKeySupport = shakaSupport.drm['org.w3.clearkey'];
     if (!clearKeySupport) {
       return false;
     }

--- a/test/media/drm_engine_integration.js
+++ b/test/media/drm_engine_integration.js
@@ -151,12 +151,12 @@ describe('DrmEngine', () => {
       // https://testweb.playready.microsoft.com/Server/ServiceQueryStringSyntax
       return false;
     }
-    return window['shakaSupport'].drm['com.widevine.alpha'] ||
-        window['shakaSupport'].drm['com.microsoft.playready'];
+    return shakaSupport.drm['com.widevine.alpha'] ||
+        shakaSupport.drm['com.microsoft.playready'];
   }
 
   function checkClearKeySupport() {
-    return window['shakaSupport'].drm['org.w3.clearkey'];
+    return shakaSupport.drm['org.w3.clearkey'];
   }
 
   filterDescribe('basic flow', checkTrueDrmSupport, () => {

--- a/test/mss/mss_player_integration.js
+++ b/test/mss/mss_player_integration.js
@@ -33,8 +33,8 @@ describe('MSS Player', () => {
 
   function checkPlayReadySupport() {
     const playReadySupport =
-        window['shakaSupport'].drm['com.microsoft.playready'] ||
-        window['shakaSupport'].drm['com.chromecast.playready'];
+        shakaSupport.drm['com.microsoft.playready'] ||
+        shakaSupport.drm['com.chromecast.playready'];
     if (!playReadySupport) {
       return false;
     }

--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -28,9 +28,9 @@ filterDescribe('Offline', supportsStorage, () => {
     video = shaka.test.UiUtils.createVideoElement();
     document.body.appendChild(video);
 
-    widevineSupport = window['shakaSupport'].drm['com.widevine.alpha'];
-    playreadySupport = window['shakaSupport'].drm['com.microsoft.playready'] ||
-        window['shakaSupport'].drm['com.chromecast.playready'];
+    widevineSupport = shakaSupport.drm['com.widevine.alpha'];
+    playreadySupport = shakaSupport.drm['com.microsoft.playready'] ||
+        shakaSupport.drm['com.chromecast.playready'];
   });
 
   afterAll(() => {

--- a/test/offline/storage_integration.js
+++ b/test/offline/storage_integration.js
@@ -15,7 +15,7 @@ function drmStorageSupport() {
     return false;
   }
 
-  const widevineSupport = window['shakaSupport'].drm['com.widevine.alpha'];
+  const widevineSupport = shakaSupport.drm['com.widevine.alpha'];
   return !!(widevineSupport && widevineSupport.persistentState);
 }
 

--- a/test/player_external.js
+++ b/test/player_external.js
@@ -100,8 +100,8 @@ describe('Player', () => {
             !asset.drm.some((keySystem) => {
               // Demo assets use an enum here, which we look up in idFor.
               // Command-line assets use a direct key system ID.
-              return window['shakaSupport'].drm[idFor(keySystem)] ||
-                 window['shakaSupport'].drm[keySystem];
+              return shakaSupport.drm[idFor(keySystem)] ||
+                 shakaSupport.drm[keySystem];
             })) {
           pending('None of the required key systems are supported.');
         }
@@ -124,7 +124,7 @@ describe('Player', () => {
             mimeTypes.push('video/mp4; codecs="dvh1.20.01"');
           }
           if (mimeTypes.length &&
-              !mimeTypes.some((type) => window['shakaSupport'].media[type])) {
+              !mimeTypes.some((type) => shakaSupport.media[type])) {
             pending('None of the required MIME types are supported.');
           }
         }

--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -1242,10 +1242,9 @@ describe('Player', () => {
   /** Regression test for Issue #2741 */
   describe('unloading', () => {
     drmIt('unloads properly after DRM error', async () => {
-      const drmSupport = await shaka.media.DrmEngine.probeSupport();
-      if (!drmSupport['com.widevine.alpha'] &&
-          !drmSupport['com.microsoft.playready'] &&
-          !drmSupport['com.chromecast.playready']) {
+      if (!shakaSupport.drm['com.widevine.alpha'] &&
+          !shakaSupport.drm['com.microsoft.playready'] &&
+          !shakaSupport.drm['com.chromecast.playready']) {
         pending('Skipping DRM error test, only runs on Widevine and PlayReady');
       }
 

--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -460,12 +460,14 @@ async function loadDaiScript() {
   });
 }
 
-async function logSupport() {
+async function checkSupport() {
   try {
-    const support = await shaka.Player.probeSupport();
+    const startMs = Date.now();
+    window.shakaSupport = await shaka.Player.probeSupport();
+    const endMs = Date.now();
     // Bypass Karma's log settings and dump this to the console.
-    window.dump('Platform support: ' + JSON.stringify(support, null, 2));
-    window['shakaSupport'] = support;
+    window.dump('Platform support: ' + JSON.stringify(shakaSupport, null, 2));
+    window.dump(`Platform support check took ${endMs - startMs} ms.`);
     // eslint-disable-next-line no-restricted-syntax
   } catch (error) {
     window.dump('Support check failed at boot: ' + error);
@@ -491,7 +493,7 @@ async function setupTestEnvironment() {
   // detected.
   shaka.polyfill.installAll();
 
-  await logSupport();
+  await checkSupport();
 
   configureJasmineEnvironment();
 }

--- a/test/test/externs/support.js
+++ b/test/test/externs/support.js
@@ -1,0 +1,16 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Externs for a global map of platform support used in tests.
+ * @externs
+ */
+
+
+/**
+ * @type {shaka.extern.SupportType}
+ */
+var shakaSupport;


### PR DESCRIPTION
This deduplicates a platform support check that was run in player_integration.js, and declares the pre-existing central support map in an extern so we can clean up its use.

This stops a DRM integration test from timing out on FirefoxWindows.  It still gets skipped, though, due to a failing Widevine check, so there will be follow-on work for that.

Issue #7449