### PR TITLE
fix: shaka.polyfill.MediaSource.rejectCodec_() incorrectly handles mime-type

### DIFF
--- a/lib/polyfill/mediasource.js
+++ b/lib/polyfill/mediasource.js
@@ -204,7 +204,8 @@ shaka.polyfill.MediaSource = class {
         MediaSource.isTypeSupported.bind(MediaSource);
 
     MediaSource.isTypeSupported = (mimeType) => {
-      const actualCodec = shaka.util.MimeUtils.getCodecBase(mimeType);
+      const codecs = shaka.util.MimeUtils.getCodecs(mimeType);
+      const actualCodec = shaka.util.MimeUtils.getCodecBase(codecs);
       return actualCodec != codec && isTypeSupported(mimeType);
     };
 

--- a/lib/polyfill/mediasource.js
+++ b/lib/polyfill/mediasource.js
@@ -215,7 +215,8 @@ shaka.polyfill.MediaSource = class {
           ManagedMediaSource.isTypeSupported.bind(ManagedMediaSource);
 
       window.ManagedMediaSource.isTypeSupported = (mimeType) => {
-        const actualCodec = shaka.util.MimeUtils.getCodecBase(mimeType);
+        const codecs = shaka.util.MimeUtils.getCodecs(mimeType);
+        const actualCodec = shaka.util.MimeUtils.getCodecBase(codecs);
         return actualCodec != codec && isTypeSupportedManaged(mimeType);
       };
     }

--- a/test/polyfill/media_source_unit.js
+++ b/test/polyfill/media_source_unit.js
@@ -25,13 +25,15 @@ describe('MediaSource', () => {
 
     it('dvh1 returns false', () => {
       reject('dvh1');
-      expect(window.MediaSource.isTypeSupported('video/mp4; codecs="dvh1.05.03"'))
+      expect(window.MediaSource
+          .isTypeSupported('video/mp4; codecs="dvh1.05.03"'))
           .toBe(false);
     });
 
     reject('dvhe');
     it('dvhe returns false', () => {
-      expect(window.MediaSource.isTypeSupported('video/mp4; codecs="dvhe.05.03"'))
+      expect(window.MediaSource
+          .isTypeSupported('video/mp4; codecs="dvhe.05.03"'))
           .toBe(false);
     });
   });

--- a/test/polyfill/media_source_unit.js
+++ b/test/polyfill/media_source_unit.js
@@ -1,0 +1,38 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('MediaSource', () => {
+  const originalMediaSource = window.MediaSource;
+
+  afterEach(() => {
+    window.MediaSource = originalMediaSource;
+  });
+
+  describe('rejectCodec_', () => {
+    /** @suppress {visibility} */
+    function reject(codec) {
+      shaka.polyfill.MediaSource.rejectCodec_('opus');
+    }
+
+    it('opus returns false', () => {
+      reject('opus');
+      expect(window.MediaSource.isTypeSupported('audio/mp4; codecs="opus"'))
+          .toBe(false);
+    });
+
+    it('dvh1 returns false', () => {
+      reject('dvh1');
+      expect(window.MediaSource.isTypeSupported('video/mp4; codecs="dvh1.05.03"'))
+          .toBe(false);
+    });
+
+    reject('dvhe');
+    it('dvhe returns false', () => {
+      expect(window.MediaSource.isTypeSupported('video/mp4; codecs="dvhe.05.03"'))
+          .toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
For example:

        shaka.polyfill.MediaSource.rejectCodec_('dvh1')

Useful to disable matching against broken codecs, even though it's supposed to be a private method.

This function is used in some conditional code, but I cannot see how it could be working correctly.

Notes:

1) shaka.util.MimeUtils.getCodecBase() does not take a mime-type as input.  It takes a codecs parameter.
2) add call to shaka.util.MimeUtils.getCodecs() to get the codecs parameter first                                                                                                           

Added some tests for this function, but difficult to run the test in isolation.