### PR TITLE
feat: Support Fairplay DRM in DASH manifest.

### DIFF
--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -195,6 +195,27 @@ shaka.dash.ContentProtection = class {
   }
 
   /**
+   * Gets a FairPlay license URL from a content protection element
+   * containing a 'dashif:Laurl' element
+   *
+   * @param {shaka.dash.ContentProtection.Element} element
+   * @return {string}
+   */
+  static getFairPlayLicenseUrl(element) {
+    const dashIfLaurlNode = shaka.util.TXml.findChildNS(
+        element.node, shaka.dash.ContentProtection.DashIfNamespaceUri_,
+        'Laurl',
+    );
+    if (dashIfLaurlNode) {
+      const textContents = shaka.util.TXml.getTextContents(dashIfLaurlNode);
+      if (textContents) {
+        return textContents;
+      }
+    }
+    return '';
+  }
+
+  /**
    * Gets a Widevine license URL from a content protection element
    * containing a custom `ms:laurl` or 'dashif:Laurl' elements
    *
@@ -793,6 +814,8 @@ shaka.dash.ContentProtection.Element;
  * @private
  */
 shaka.dash.ContentProtection.licenseUrlParsers_ = new Map()
+    .set('com.apple.fps',
+        shaka.dash.ContentProtection.getFairPlayLicenseUrl)
     .set('com.widevine.alpha',
         shaka.dash.ContentProtection.getWidevineLicenseUrl)
     .set('com.microsoft.playready',

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -11,6 +11,7 @@ goog.require('shaka.log');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.ManifestParserUtils');
+goog.require('shaka.util.Platform');
 goog.require('shaka.util.Pssh');
 goog.require('shaka.util.StringUtils');
 goog.require('shaka.util.TXml');
@@ -202,6 +203,13 @@ shaka.dash.ContentProtection = class {
    * @return {string}
    */
   static getFairPlayLicenseUrl(element) {
+    if (shaka.util.Platform.isMediaKeysPolyfilled()) {
+      throw new shaka.util.Error(
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.MANIFEST,
+          shaka.util.Error.Code
+              .DASH_MSE_ENCRYPTED_LEGACY_APPLE_MEDIA_KEYS_NOT_SUPPORTED);
+    }
     const dashIfLaurlNode = shaka.util.TXml.findChildNS(
         element.node, shaka.dash.ContentProtection.DashIfNamespaceUri_,
         'Laurl',

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -784,6 +784,11 @@ shaka.util.Error.Code = {
    */
   'HLS_EMPTY_MEDIA_PLAYLIST': 4053,
 
+  /**
+   * We do not support playing encrypted content with MSE
+   * and legacy Apple MediaKeys API.
+   */
+  'DASH_MSE_ENCRYPTED_LEGACY_APPLE_MEDIA_KEYS_NOT_SUPPORTED': 4054,
 
   // RETIRED: 'INCONSISTENT_BUFFER_STATE': 5000,
   // RETIRED: 'INVALID_SEGMENT_INDEX': 5001,

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -145,6 +145,8 @@ shaka.util.PlayerConfiguration = class {
             'com.microsoft.playready',
           'urn:uuid:79f0049a-4098-8642-ab92-e65be0885f95':
             'com.microsoft.playready',
+          'urn:uuid:94ce86fb-07ff-4f43-adb8-93d2fa968ca2':
+            'com.apple.fps',
         },
         manifestPreprocessor:
             shaka.util.PlayerConfiguration.defaultManifestPreprocessor,

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -228,23 +228,29 @@ describe('DashParser ContentProtection', () => {
         ['9a04f079-9840-4286-ab92-e65be0885f95'], ['com.microsoft.playready']);
     testKeySystemMappings('for old PlayReady',
         ['79f0049a-4098-8642-ab92-e65be0885f95'], ['com.microsoft.playready']);
+    testKeySystemMappings('for FairPlay',
+        ['94ce86fb-07ff-4f43-adb8-93d2fa968ca2'], ['com.apple.fps']);
 
     testKeySystemMappings('for multiple DRMs in the specified order',
         [
           'edef8ba9-79d6-4ace-a3c8-27dcd51d21ed',
           '9a04f079-9840-4286-ab92-e65be0885f95',
+          '94ce86fb-07ff-4f43-adb8-93d2fa968ca2',
         ], [
           'com.widevine.alpha',
           'com.microsoft.playready',
+          'com.apple.fps',
         ]);
 
     testKeySystemMappings('in a case-insensitive way',
         [
           'EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED',
           '9A04F079-9840-4286-AB92-E65BE0885F95',
+          '94CE86FB-07FF-4F43-ADB8-93D2FA968CA2',
         ], [
           'com.widevine.alpha',
           'com.microsoft.playready',
+          'com.apple.fps',
         ]);
   });
 
@@ -337,6 +343,10 @@ describe('DashParser ContentProtection', () => {
       '  schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95">',
       '  <cenc:pssh>bm8gaHVtYW4gY2FuIHJlYWQgYmFzZTY0IGRpcmVjdGx5</cenc:pssh>',
       '</ContentProtection>',
+      '<ContentProtection',
+      '  schemeIdUri="urn:uuid:94ce86fb-07ff-4f43-adb8-93d2fa968ca2">',
+      '  <cenc:pssh>ZmFrZSBGYWlyUGxheSBQU1NI</cenc:pssh>',
+      '</ContentProtection>',
     ], [], []);
     const expected = buildExpectedManifest([
       buildDrmInfo('com.widevine.alpha',
@@ -345,6 +355,9 @@ describe('DashParser ContentProtection', () => {
       buildDrmInfo('com.microsoft.playready',
           [], // key IDs
           buildInitData(['bm8gaHVtYW4gY2FuIHJlYWQgYmFzZTY0IGRpcmVjdGx5'])),
+      buildDrmInfo('com.apple.fps',
+          [], // key IDs
+          buildInitData(['ZmFrZSBGYWlyUGxheSBQU1NI'])),
     ]);
     await testDashParser(source, expected);
   });
@@ -395,6 +408,7 @@ describe('DashParser ContentProtection', () => {
     const drmInfos = jasmine.arrayContaining([
       buildDrmInfo('com.widevine.alpha'),
       buildDrmInfo('com.microsoft.playready'),
+      buildDrmInfo('com.apple.fps'),
     ]);
     const expected = buildExpectedManifest(
         /** @type {!Array.<shaka.extern.DrmInfo>} */(drmInfos),
@@ -414,6 +428,7 @@ describe('DashParser ContentProtection', () => {
     const drmInfos = jasmine.arrayContaining([
       buildDrmInfo('com.widevine.alpha', [], [], 'cbcs'),
       buildDrmInfo('com.microsoft.playready', [], [], 'cbcs'),
+      buildDrmInfo('com.apple.fps', [], [], 'cbcs'),
     ]);
     const expected = buildExpectedManifest(
         /** @type {!Array.<shaka.extern.DrmInfo>} */(drmInfos),
@@ -433,6 +448,9 @@ describe('DashParser ContentProtection', () => {
       '  schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95">',
       '  <cenc:pssh>bm8gaHVtYW4gY2FuIHJlYWQgYmFzZTY0IGRpcm</cenc:pssh>',
       '</ContentProtection>',
+      '<ContentProtection',
+      '  schemeIdUri="urn:uuid:94ce86fb-07ff-4f43-adb8-93d2fa968ca2">',
+      '</ContentProtection>',
     ], [], []);
 
     // The order does not matter here, so use arrayContaining.
@@ -440,6 +458,7 @@ describe('DashParser ContentProtection', () => {
     const drmInfos = jasmine.arrayContaining([
       buildDrmInfo('com.widevine.alpha'),
       buildDrmInfo('com.microsoft.playready'),
+      buildDrmInfo('com.apple.fps'),
     ]);
     const expected = buildExpectedManifest(
         /** @type {!Array.<shaka.extern.DrmInfo>} */(drmInfos),
@@ -455,6 +474,9 @@ describe('DashParser ContentProtection', () => {
       '  cenc:default_KID="DEADBEEF-FEED-BAAD-F00D-000008675309" />',
       '<ContentProtection',
       '  schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"',
+      '  cenc:default_KID="DEADBEEF-FEED-BAAD-F00D-000008675309" />',
+      '<ContentProtection',
+      '  schemeIdUri="urn:uuid:94ce86fb-07ff-4f43-adb8-93d2fa968ca2"',
       '  cenc:default_KID="DEADBEEF-FEED-BAAD-F00D-000008675309" />',
     ], [], []);
     const keyIds = [
@@ -473,6 +495,7 @@ describe('DashParser ContentProtection', () => {
       // PlayReady has two associated UUIDs, so it appears twice.
       buildDrmInfo('com.microsoft.playready', keyIds),
       buildDrmInfo('com.microsoft.playready', keyIds),
+      buildDrmInfo('com.apple.fps', keyIds),
     ], variantKeyIds);
     await testDashParser(source, expected, /* ignoreDrmInfo= */ true);
   });
@@ -488,12 +511,17 @@ describe('DashParser ContentProtection', () => {
       '  schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed" />',
       '<ContentProtection',
       '  schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" />',
+      '<ContentProtection',
+      '  schemeIdUri="urn:uuid:94ce86fb-07ff-4f43-adb8-93d2fa968ca2" />',
     ], [], []);
     const expected = buildExpectedManifest([
       buildDrmInfo('com.widevine.alpha',
           [], // key IDs
           buildInitData(['b25lIGhlYWRlciB0byBydWxlIHRoZW0gYWxs'])),
       buildDrmInfo('com.microsoft.playready',
+          [], // key IDs
+          buildInitData(['b25lIGhlYWRlciB0byBydWxlIHRoZW0gYWxs'])),
+      buildDrmInfo('com.apple.fps',
           [], // key IDs
           buildInitData(['b25lIGhlYWRlciB0byBydWxlIHRoZW0gYWxs'])),
     ]);
@@ -515,6 +543,10 @@ describe('DashParser ContentProtection', () => {
       '</ContentProtection>',
       '<ContentProtection',
       '  schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" />',
+      '<ContentProtection',
+      '  schemeIdUri="urn:uuid:94ce86fb-07ff-4f43-adb8-93d2fa968ca2">',
+      '  <cenc:pssh>ZmFpcnBsYXkgb3ZlcnJpZGU=</cenc:pssh>',
+      '</ContentProtection>',
     ], [], []);
     const expected = buildExpectedManifest([
       buildDrmInfo('com.widevine.alpha',
@@ -524,6 +556,9 @@ describe('DashParser ContentProtection', () => {
       buildDrmInfo('com.microsoft.playready',
           [], // key IDs
           buildInitData(['b25lIGhlYWRlciB0byBydWxlIHRoZW0gYWxs'])),
+      buildDrmInfo('com.apple.fps',
+          [], // key IDs
+          buildInitData(['ZmFpcnBsYXkgb3ZlcnJpZGU='])),
     ]);
     await testDashParser(source, expected);
   });
@@ -629,6 +664,9 @@ describe('DashParser ContentProtection', () => {
       '<ContentProtection',
       '  schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"',
       '  cenc:default_KID="DEADBEEF-FEED-BAAD-F00D-000008675309" />',
+      '<ContentProtection',
+      '  schemeIdUri="urn:uuid:94ce86fb-07ff-4f43-adb8-93d2fa968ca2"',
+      '  cenc:default_KID="DEADBEEF-FEED-BAAD-F00D-000008675309" />',
     ], [
       // Representation 2 lines
       '<ContentProtection',
@@ -636,6 +674,9 @@ describe('DashParser ContentProtection', () => {
       '  cenc:default_KID="BAADF00D-FEED-DEAF-BEEF-000004390116" />',
       '<ContentProtection',
       '  schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"',
+      '  cenc:default_KID="BAADF00D-FEED-DEAF-BEEF-000004390116" />',
+      '<ContentProtection',
+      '  schemeIdUri="urn:uuid:94ce86fb-07ff-4f43-adb8-93d2fa968ca2"',
       '  cenc:default_KID="BAADF00D-FEED-DEAF-BEEF-000004390116" />',
     ]);
     const keyIds = [
@@ -647,6 +688,7 @@ describe('DashParser ContentProtection', () => {
     const expected = buildExpectedManifest([
       buildDrmInfo('com.microsoft.playready', keyIds),
       buildDrmInfo('com.widevine.alpha', keyIds),
+      buildDrmInfo('com.apple.fps', keyIds),
     ]);
     await testDashParser(source, expected);
   });
@@ -659,6 +701,9 @@ describe('DashParser ContentProtection', () => {
       '  cenc:default_KID="DEADBEEF-FEED-BAAD-F00D-000008675309" />',
       '<ContentProtection',
       '  schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"',
+      '  cenc:default_KID="DEADBEEF-FEED-BAAD-F00D-000008675309" />',
+      '<ContentProtection',
+      '  schemeIdUri="urn:uuid:94ce86fb-07ff-4f43-adb8-93d2fa968ca2"',
       '  cenc:default_KID="DEADBEEF-FEED-BAAD-F00D-000008675309" />',
     ], [], []);
     const keyIds = [
@@ -674,6 +719,7 @@ describe('DashParser ContentProtection', () => {
     const expected = buildExpectedManifest([
       buildDrmInfo('com.microsoft.playready', keyIds),
       buildDrmInfo('com.widevine.alpha', keyIds),
+      buildDrmInfo('com.apple.fps', keyIds),
     ], variantKeyIds);
     await testDashParser(source, expected);
   });
@@ -1023,6 +1069,52 @@ describe('DashParser ContentProtection', () => {
         node: strToXml('<test></test>'),
       };
       const actual = ContentProtection.getPlayReadyLicenseUrl(input);
+      expect(actual).toBe('');
+    });
+  });
+
+  describe('getFairPlayLicenseUrl', () => {
+    it('valid dashif:Laurl node', () => {
+      const input = {
+        init: null,
+        keyId: null,
+        schemeUri: '',
+        encryptionScheme: null,
+        node: strToXml([
+          '<test xmlns:dashif="https://dashif.org/CPS">',
+          '  <dashif:Laurl>www.example.com</dashif:Laurl>',
+          '</test>',
+        ].join('\n')),
+      };
+      const actual = ContentProtection.getFairPlayLicenseUrl(input);
+      expect(actual).toBe('www.example.com');
+    });
+
+    it('dashif:Laurl without license url', () => {
+      const input = {
+        init: null,
+        keyId: null,
+        schemeUri: '',
+        encryptionScheme: null,
+        node: strToXml([
+          '<test xmlns:dashif="https://dashif.org/CPS">',
+          '  <dashif:Laurl></dashif:Laurl>',
+          '</test>',
+        ].join('\n')),
+      };
+      const actual = ContentProtection.getFairPlayLicenseUrl(input);
+      expect(actual).toBe('');
+    });
+
+    it('no dashif:Laurl node', () => {
+      const input = {
+        init: null,
+        keyId: null,
+        schemeUri: '',
+        encryptionScheme: null,
+        node: strToXml('<test></test>'),
+      };
+      const actual = ContentProtection.getFairPlayLicenseUrl(input);
       expect(actual).toBe('');
     });
   });


### PR DESCRIPTION
Support Fairplay DRM for DASH, specifying the license server in the manifest using dashif:Laurl.

For example, multi-drm manifest is here: https://content.media24.link/drm/manifest.mpd
