### PR TITLE
feat: Add configuration to ignore SCTE214 supplemental codecs

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1078,7 +1078,8 @@ shaka.extern.xml.Node;
  *   multiTypeVariantsAllowed: boolean,
  *   useStreamOnceInPeriodFlattening: boolean,
  *   updatePeriod: number,
- *   enableFastSwitching: boolean
+ *   enableFastSwitching: boolean,
+ *   ignoreSupplementalCodecs: boolean
  * }}
  *
  * @property {string} clockSyncUri
@@ -1189,6 +1190,10 @@ shaka.extern.xml.Node;
  *   If false, disables fast switching track recognition.
  *   <br>
  *   Defaults to <code>true</code>.
+ * @property {boolean} ignoreSupplementalCodecs
+ *   If false, ignores supplemental codecs
+ *   <br>
+ *   Defaults to <code>false</code>.
  * @exportDoc
  */
 shaka.extern.DashManifestConfiguration;
@@ -1208,7 +1213,8 @@ shaka.extern.DashManifestConfiguration;
  *   ignoreManifestTimestampsInSegmentsMode: boolean,
  *   disableCodecGuessing: boolean,
  *   disableClosedCaptionsDetection: boolean,
- *   allowLowLatencyByteRangeOptimization: boolean
+ *   allowLowLatencyByteRangeOptimization: boolean,
+ *   ignoreSupplementalCodecs: boolean
  * }}
  *
  * @property {boolean} ignoreTextStreamFailures
@@ -1294,6 +1300,10 @@ shaka.extern.DashManifestConfiguration;
  *   https://www.akamai.com/blog/performance/-using-ll-hls-with-byte-range-addressing-to-achieve-interoperabi
  *   <br>
  *   Defaults to <code>true</code>.
+ * @property {boolean} ignoreSupplementalCodecs
+ *   If false, ignores supplemental codecs
+ *   <br>
+ *   Defaults to <code>false</code>.
  * @exportDoc
  */
 shaka.extern.HlsManifestConfiguration;

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -2597,10 +2597,13 @@ shaka.dash.DashParser = class {
     const allCodecs = [
       elem.attributes['codecs'] || parent.codecs,
     ];
-    const supplementalCodecs =
+
+    if (!this.config_.dash.ignoreSupplementalCodecs) {
+      const supplementalCodecs =
         TXml.getAttributeNS(elem, SCTE214, 'supplementalCodecs');
-    if (supplementalCodecs) {
-      allCodecs.push(supplementalCodecs);
+      if (supplementalCodecs) {
+        allCodecs.push(supplementalCodecs);
+      }
     }
     const codecs = SegmentUtils.codecsFiltering(allCodecs).join(',');
     const frameRate =

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1829,7 +1829,8 @@ shaka.hls.HlsParser = class {
     /** @type {!Array.<string>} */
     const codecs = codecsString.split(/\s*,\s*/);
 
-    if (supplementalCodecsString) {
+    if (!this.config_.hls.ignoreSupplementalCodecs
+        && supplementalCodecsString) {
       const supplementalCodecs = supplementalCodecsString.split(/\s*,\s*/)
           .map((codec) => {
             return codec.split('/')[0];

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -156,6 +156,7 @@ shaka.util.PlayerConfiguration = class {
         useStreamOnceInPeriodFlattening: false,
         updatePeriod: -1,
         enableFastSwitching: true,
+        ignoreSupplementalCodecs: false,
       },
       hls: {
         ignoreTextStreamFailures: false,
@@ -172,6 +173,7 @@ shaka.util.PlayerConfiguration = class {
         disableCodecGuessing: false,
         disableClosedCaptionsDetection: false,
         allowLowLatencyByteRangeOptimization: true,
+        ignoreSupplementalCodecs: false,
       },
       mss: {
         manifestPreprocessor:


### PR DESCRIPTION
SCTE214 Supplemental codecs defines an attribute to AdaptationSet and Representation in the DASH manifest, to define alternative names of the media codec.  These attributes are recommended to be used for codec extensions such as Dolby Vision Profile 8.
 
There are some issues with the ecosystem:

- MediaSource.isTypeSupported() == true is not guaranteed to always decode the media
- Browsers may behave differently depending on hardware DRM or software DRM or clear content
- Necessary to force the base codec for testing and/or work-around platform bugs

For these reasons, having a configuration parameter to disable support for supplementalCodecs is useful.