### PR TITLE
fix: Fix support for scte214:supplementalCodecs and SUPPLEMENTAL-CODECS

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -1967,8 +1967,23 @@ shaka.dash.DashParser = class {
 
     const label = context.adaptationSet.label;
 
+    // Duplicate representations with their supplementalCodecs
+    let representations = TXml.findChildren(elem, 'Representation');
+    let supplementalRepresentations = representations.filter((rep) => {
+      return TXml.getAttributeNS(
+          rep, shaka.dash.DashParser.SCTE214_, 'supplementalCodecs') != null;
+    });
+    supplementalRepresentations = supplementalRepresentations.map((rep) => {
+      const supplementalCodecs =
+          TXml.getAttributeNS(
+              rep, shaka.dash.DashParser.SCTE214_, 'supplementalCodecs');
+      const obj = shaka.util.ObjectUtils.cloneObject(rep);
+      obj.attributes['codecs'] = supplementalCodecs.split(' ').join(',');
+      return obj;
+    });
+    representations = [...representations, ...supplementalRepresentations];
+
     // Parse Representations into Streams.
-    const representations = TXml.findChildren(elem, 'Representation');
     const streams = representations.map((representation) => {
       const parsedRepresentation = this.parseRepresentation_(context,
           contentProtection, kind, language, label, main, roleValues,
@@ -2539,7 +2554,6 @@ shaka.dash.DashParser = class {
   createFrame_(elem, parent, getBaseUris) {
     goog.asserts.assert(parent || getBaseUris,
         'Must provide either parent or getBaseUris');
-    const SCTE214 = shaka.dash.DashParser.SCTE214_;
     const SegmentUtils = shaka.media.SegmentUtils;
     const ManifestParserUtils = shaka.util.ManifestParserUtils;
     const TXml = shaka.util.TXml;
@@ -2597,11 +2611,7 @@ shaka.dash.DashParser = class {
     const allCodecs = [
       elem.attributes['codecs'] || parent.codecs,
     ];
-    const supplementalCodecs =
-        TXml.getAttributeNS(elem, SCTE214, 'supplementalCodecs');
-    if (supplementalCodecs) {
-      allCodecs.push(supplementalCodecs);
-    }
+
     const codecs = SegmentUtils.codecsFiltering(allCodecs).join(',');
     const frameRate =
         TXml.parseAttr(elem, 'frameRate', evalDivision) || parent.frameRate;

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -977,7 +977,6 @@ shaka.hls.HlsParser = class {
         for (const v of newVariantTags) {
           variantTags.push(v);
         }
-      }
 
       this.parseCodecs_(variantTags);
 

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -951,32 +951,31 @@ shaka.hls.HlsParser = class {
       await this.processContentSteering_(contentSteeringTags);
 
       /* duplicate variant tags with supplementalCodecs */
-      if (!this.config_.hls.ignoreSupplementalCodecs) {
-        const newVariantTags = [];
-        for (const tag of variantTags) {
-          const supplementalCodecsString =
-              tag.getAttributeValue('SUPPLEMENTAL-CODECS');
-          if (!supplementalCodecsString) {
-            continue;
+      const newVariantTags = [];
+      for (const tag of variantTags) {
+        const supplementalCodecsString =
+            tag.getAttributeValue('SUPPLEMENTAL-CODECS');
+        if (!supplementalCodecsString) {
+          continue;
+        }
+        const supplementalCodecs = supplementalCodecsString.split(/\s*,\s*/)
+            .map((codec) => {
+              return codec.split('/')[0];
+            });
+        const newAttributes = tag.attributes.map((attr) => {
+          const name = attr.name;
+          let value = attr.value;
+          if (name == 'CODECS') {
+            value = supplementalCodecs.join(',');
           }
-          const supplementalCodecs = supplementalCodecsString.split(/\s*,\s*/)
-              .map((codec) => {
-                return codec.split('/')[0];
-              });
-          const newAttributes = tag.attributes.map((attr) => {
-            const name = attr.name;
-            let value = attr.value;
-            if (name == 'CODECS') {
-              value = supplementalCodecs.join(',');
-            }
-            return new shaka.hls.Attribute(name, value);
-          });
-          newVariantTags.push(
-              new shaka.hls.Tag(tag.id, tag.name, newAttributes, null));
-        }
-        for (const v of newVariantTags) {
-          variantTags.push(v);
-        }
+          return new shaka.hls.Attribute(name, value);
+        });
+        newVariantTags.push(
+            new shaka.hls.Tag(tag.id, tag.name, newAttributes, null));
+      }
+      for (const v of newVariantTags) {
+        variantTags.push(v);
+      }
 
       this.parseCodecs_(variantTags);
 

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -10,6 +10,7 @@ goog.provide('shaka.hls.HlsParser');
 goog.require('goog.Uri');
 goog.require('goog.asserts');
 goog.require('shaka.abr.Ewma');
+goog.require('shaka.hls.Attribute');
 goog.require('shaka.hls.ManifestTextParser');
 goog.require('shaka.hls.Playlist');
 goog.require('shaka.hls.PlaylistType');
@@ -949,6 +950,35 @@ shaka.hls.HlsParser = class {
       this.processSessionData_(sessionDataTags);
       await this.processContentSteering_(contentSteeringTags);
 
+      /* duplicate variant tags with supplementalCodecs */
+      if (!this.config_.hls.ignoreSupplementalCodecs) {
+        const newVariantTags = [];
+        for (const tag of variantTags) {
+          const supplementalCodecsString =
+              tag.getAttributeValue('SUPPLEMENTAL-CODECS');
+          if (!supplementalCodecsString) {
+            continue;
+          }
+          const supplementalCodecs = supplementalCodecsString.split(/\s*,\s*/)
+              .map((codec) => {
+                return codec.split('/')[0];
+              });
+          const newAttributes = tag.attributes.map((attr) => {
+            const name = attr.name;
+            let value = attr.value;
+            if (name == 'CODECS') {
+              value = supplementalCodecs.join(',');
+            }
+            return new shaka.hls.Attribute(name, value);
+          });
+          newVariantTags.push(
+              new shaka.hls.Tag(tag.id, tag.name, newAttributes, null));
+        }
+        for (const v of newVariantTags) {
+          variantTags.push(v);
+        }
+      }
+
       this.parseCodecs_(variantTags);
 
       this.parseClosedCaptions_(mediaTags);
@@ -1806,9 +1836,6 @@ shaka.hls.HlsParser = class {
   getCodecsForVariantTag_(tag) {
     let codecsString = tag.getAttributeValue('CODECS') || '';
 
-    const supplementalCodecsString =
-        tag.getAttributeValue('SUPPLEMENTAL-CODECS');
-
     this.codecInfoInManifest_ = codecsString.length > 0;
 
     if (!this.codecInfoInManifest_ && !this.config_.hls.disableCodecGuessing) {
@@ -1828,14 +1855,6 @@ shaka.hls.HlsParser = class {
     // Strip out internal whitespace while splitting on commas:
     /** @type {!Array.<string>} */
     const codecs = codecsString.split(/\s*,\s*/);
-
-    if (supplementalCodecsString) {
-      const supplementalCodecs = supplementalCodecsString.split(/\s*,\s*/)
-          .map((codec) => {
-            return codec.split('/')[0];
-          });
-      codecs.push(...supplementalCodecs);
-    }
 
     return shaka.media.SegmentUtils.codecsFiltering(codecs);
   }


### PR DESCRIPTION
Currently the codec adds supplemental codecs to the list of allCodecs and has an implicit priority order to select a codec.  Support for the codec is tested with MediaSource.isTypeSupported().

There are multiple issues with this approach:

* the priority is implicit
* MediaSource.isTypeSupported() decision is effectively overriding platform-specific MediaCapabilities logic
* MediaSource.isTypeSupported() is frequently wrong depending on whether the content is encrypted

Speaking in DASH parlance, this patch considers that scte214:supplementalCodecs is effectively a short-hand mechanism to specify an alternate variant.  In fact, shaka-packager implements the mechanism of supplementalCodecs by duplicating the AdaptationSet with a different @codecs attribute.

This patch duplicates the variant with each supplemental codec and defers codec priority and codec selection until after MediaCapabilities.decodingInfo().

This fixes support for DolbyVision Profile 8, which is otherwise broken because the latest browsers always return false from MediaSource.isTypeSupported(), and DolbyVision is commonly only available in a secure hardware decode pipeline.