### PR TITLE
ci: Do not cancel other Selenium jobs

### DIFF
--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -212,6 +212,7 @@ jobs:
     # Only one run of this job is allowed at a time, since it uses physical
     # resources in our lab.
     concurrency: selenium-lab-${{ matrix.browser }}
+    cancel-in-progress: false
 
     needs: [compute-sha, build-shaka, matrix-config]
     strategy:


### PR DESCRIPTION
When we have two jobs queued for FirefoxWindows, for example, we want one of them to wait, not cancel each other.  The only time you would cancel one is if the other is from the same branch/PR after an update.  Right now, only the browser name is used in the key, so we should never cancel another job with the same key.

This fix lets us start tests for multiple release PRs at once.