### PR TITLE
fix(Ads): Limit interstitial duration to actual duration if available when using src=

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -666,6 +666,13 @@ shaka.ads.InterstitialAdManager = class {
           new shaka.util.FakeEvent(shaka.ads.Utils.AD_RESUMED));
     });
     this.adEventManager_.listen(this.video_, 'pause', () => {
+      // playRangeEnd in src= causes the ended event not to be fired when that
+      // position is reached, instead pause event is fired.
+      const currentConfig = this.player_.getConfiguration();
+      if (this.video_.currentTime >= currentConfig.playRangeEnd) {
+        complete();
+        return;
+      }
       this.onEvent_(
           new shaka.util.FakeEvent(shaka.ads.Utils.AD_PAUSED));
     });
@@ -680,12 +687,7 @@ shaka.ads.InterstitialAdManager = class {
     });
     try {
       this.updatePlayerConfig_();
-      // playRangeEnd in src= causes the ended event not to be fired when that
-      // position is reached. So we don't use it because we would never go back
-      // to the main stream.
-      const loadMode = this.basePlayer_.getLoadMode();
-      if (loadMode == shaka.Player.LoadMode.MEDIA_SOURCE &&
-          interstitial.startTime && interstitial.endTime &&
+      if (interstitial.startTime && interstitial.endTime &&
           interstitial.endTime != Infinity &&
           interstitial.startTime != interstitial.endTime) {
         const duration = interstitial.endTime - interstitial.startTime;
@@ -697,9 +699,7 @@ shaka.ads.InterstitialAdManager = class {
         playoutLimitTimer = new shaka.util.Timer(() => {
           ad.skip();
         }).tickAfter(interstitial.playoutLimit);
-        if (loadMode == shaka.Player.LoadMode.MEDIA_SOURCE) {
-          this.player_.configure('playRangeEnd', interstitial.playoutLimit);
-        }
+        this.player_.configure('playRangeEnd', interstitial.playoutLimit);
       }
       await this.player_.attach(this.video_);
       if (this.preloadManagerInterstitials_.has(interstitial)) {


### PR DESCRIPTION
Currently, if the interstitial lasts 30 and we have a stream that lasts 31 seconds, we would go back to live after the interstitial, but with 1 extra second of latency. This PR solves this by limiting the play range to 30.

Related to https://github.com/shaka-project/shaka-player/pull/7480