### PR TITLE
ci: Do not cancel other Selenium jobs

### DIFF
--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -211,8 +211,9 @@ jobs:
 
     # Only one run of this job is allowed at a time, since it uses physical
     # resources in our lab.
-    concurrency: selenium-lab-${{ matrix.browser }}
-    cancel-in-progress: false
+    concurrency:
+      group: selenium-lab-${{ matrix.browser }}
+      cancel-in-progress: false
 
     needs: [compute-sha, build-shaka, matrix-config]
     strategy:


### PR DESCRIPTION
Documentation: https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs