### PR TITLE
fix(MSS): Fix playback of some MSS streams

### DIFF
--- a/lib/util/mp4_generator.js
+++ b/lib/util/mp4_generator.js
@@ -765,7 +765,7 @@ shaka.util.Mp4Generator = class {
       0x00, 0x00, 0x00, 0x01, // default_sample_description_index
       0x00, 0x00, 0x00, 0x00, // default_sample_duration
       0x00, 0x00, 0x00, 0x00, // default_sample_size
-      0x00, 0x01, 0x00, 0x01, // default_sample_flags
+      0x00, 0x00, 0x00, 0x00, // default_sample_flags
     ]);
     return Mp4Generator.box('trex', bytes);
   }


### PR DESCRIPTION
With this change, no default flags are used. It seems that when a sample has to use the default flags, in Safari, it can cause problems with MSS. With HLS this does not happen.

Fixes https://github.com/shaka-project/shaka-player/issues/7509