### PR TITLE
fix: only use lastSegmentReference for knowing if variant changed

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1975,8 +1975,7 @@ shaka.media.StreamingEngine = class {
     const MimeUtils = shaka.util.MimeUtils;
     const StreamingEngine = shaka.media.StreamingEngine;
     const logPrefix = StreamingEngine.logPrefix_(mediaState);
-    const nullLastReferences = mediaState.lastSegmentReference == null &&
-      mediaState.lastInitSegmentReference == null;
+    const nullLastReferences = mediaState.lastSegmentReference == null;
 
     /** @type {!Array.<!Promise>} */
     const operations = [];


### PR DESCRIPTION

Instead of checking for both lastSegmentReference and lastInitSegmentReference, we shoould only check lastSegmentReference.

As of shaka-project/shaka-player#6929, init segment references aren't cleared on clearBuffer, this onInitSegmentAppended not account for the safe margin properly.