### PR TITLE
ci: Fix test deflake

### DIFF
--- a/.github/workflows/deflake.yaml
+++ b/.github/workflows/deflake.yaml
@@ -8,7 +8,7 @@ on:
   workflow_run:
     workflows:
       - Selenium Lab Tests
-      - Build and Test PR
+      - Build and Test
     types: [completed]
 
 jobs:


### PR DESCRIPTION
Deflaking tests depends on an exact workflow name, but #7535 renamed the test workflow.  This syncs the name in the deflake workflow.