### PR TITLE
perf: Improve performance when parsing EMSG

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -487,8 +487,6 @@ shakaDemo.Config = class {
         .addNumberInput_('Update interval seconds',
             'streaming.updateIntervalSeconds',
             /* canBeDecimal= */ true)
-        .addBoolInput_('Dispatch all emsg boxes',
-            'streaming.dispatchAllEmsgBoxes')
         .addBoolInput_('Observe media quality changes',
             'streaming.observeQualityChanges')
         .addNumberInput_('Max Variant Disabled Time',
@@ -645,7 +643,9 @@ shakaDemo.Config = class {
             'Codec Switching Strategy',
             'mediaSource.codecSwitchingStrategy',
             strategyOptions,
-            strategyOptionsNames);
+            strategyOptionsNames)
+        .addBoolInput_('Dispatch all emsg boxes',
+            'mediaSource.dispatchAllEmsgBoxes');
   }
 
   /** @private */

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1557,7 +1557,6 @@ shaka.extern.LiveSyncConfiguration;
  *   minBytesForProgressEvents: number,
  *   preferNativeHls: boolean,
  *   updateIntervalSeconds: number,
- *   dispatchAllEmsgBoxes: boolean,
  *   observeQualityChanges: boolean,
  *   maxDisabledTime: number,
  *   segmentPrefetchLimit: number,
@@ -1739,10 +1738,6 @@ shaka.extern.LiveSyncConfiguration;
  *   The minimum number of seconds to see if the manifest has changes.
  *   <br>
  *   Defaults to <code>1</code>.
- * @property {boolean} dispatchAllEmsgBoxes
- *   If true, all emsg boxes are parsed and dispatched.
- *   <br>
- *   Defaults to <code>false</code>.
  * @property {boolean} observeQualityChanges
  *   If true, monitor media quality changes and emit
  *   <code>shaka.Player.MediaQualityChangedEvent</code>.
@@ -1850,7 +1845,8 @@ shaka.extern.StreamingConfiguration;
  *   addExtraFeaturesToSourceBuffer: function(string): string,
  *   forceTransmux: boolean,
  *   insertFakeEncryptionInInit: boolean,
- *   modifyCueCallback: shaka.extern.TextParser.ModifyCueCallback
+ *   modifyCueCallback: shaka.extern.TextParser.ModifyCueCallback,
+ *   dispatchAllEmsgBoxes: boolean
  * }}
  *
  * @description
@@ -1889,6 +1885,10 @@ shaka.extern.StreamingConfiguration;
  *    A callback called for each cue after it is parsed, but right before it
  *    is appended to the presentation.
  *    Gives a chance for client-side editing of cue text, cue timing, etc.
+ * @property {boolean} dispatchAllEmsgBoxes
+ *   If true, all emsg boxes are parsed and dispatched.
+ *   <br>
+ *   Defaults to <code>false</code>.
  * @exportDoc
  */
 shaka.extern.MediaSourceConfiguration;

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -858,15 +858,18 @@ shaka.media.MediaSourceEngine = class {
   }
 
   /**
+   * This method is only public for testing.
+   *
    * @param {shaka.util.ManifestParserUtils.ContentType} contentType
    * @param {!BufferSource} data
-   * @param {?shaka.media.SegmentReference} reference The segment reference
-   *   we are appending, or null for init segments
+   * @param {!shaka.media.SegmentReference} reference The segment reference
+   *   we are appending
+   * @param {shaka.extern.Stream} stream
    * @param {!string} mimeType
    * @return {{timestamp: ?number, metadata: !Array.<shaka.extern.ID3Metadata>}}
-   * @private
    */
-  getTimestampAndDispatchMetadata_(contentType, data, reference, mimeType) {
+  getTimestampAndDispatchMetadata(contentType, data, reference, stream,
+      mimeType) {
     let timestamp = null;
     let metadata = [];
 
@@ -893,16 +896,23 @@ shaka.media.MediaSourceEngine = class {
             [id3Metadata], /* offset= */ 0, reference.endTime);
       }
     } else if (mimeType.includes('/mp4') &&
-        reference && reference.timestampOffset == 0 &&
+        reference &&
         reference.initSegmentReference &&
         reference.initSegmentReference.timescale) {
       const timescale = reference.initSegmentReference.timescale;
       if (!isNaN(timescale)) {
+        const hasEmsg = ((stream.emsgSchemeIdUris != null &&
+            stream.emsgSchemeIdUris.length > 0) ||
+            this.config_.dispatchAllEmsgBoxes);
         const Mp4Parser = shaka.util.Mp4Parser;
         let startTime = 0;
         let parsedMedia = false;
-        new Mp4Parser()
-            .fullBox('prft', (box) => this.parsePrft_(timescale, box))
+        const parser = new Mp4Parser();
+        if (hasEmsg) {
+          parser.fullBox('emsg', (box) =>
+            this.parseEMSG_(reference, stream.emsgSchemeIdUris, box));
+        }
+        parser.fullBox('prft', (box) => this.parsePrft_(timescale, box))
             .box('moof', Mp4Parser.children)
             .box('traf', Mp4Parser.children)
             .fullBox('tfdt', (box) => {
@@ -915,7 +925,7 @@ shaka.media.MediaSourceEngine = class {
               parsedMedia = true;
               box.parser.stop();
             }).parse(data, /* partialOkay= */ true);
-        if (parsedMedia) {
+        if (parsedMedia && reference.timestampOffset == 0) {
           timestamp = startTime;
         }
       }
@@ -934,6 +944,130 @@ shaka.media.MediaSourceEngine = class {
       metadata = tsParser.getMetadata();
     }
     return {timestamp, metadata};
+  }
+
+
+  /**
+   * Parse the EMSG box from a MP4 container.
+   *
+   * @param {!shaka.media.SegmentReference} reference
+   * @param {?Array.<string>} emsgSchemeIdUris Array of emsg
+   *     scheme_id_uri for which emsg boxes should be parsed.
+   * @param {!shaka.extern.ParsedBox} box
+   * @private
+   * https://dashif-documents.azurewebsites.net/Events/master/event.html#emsg-format
+   * aligned(8) class DASHEventMessageBox
+   *    extends FullBox(‘emsg’, version, flags = 0){
+   * if (version==0) {
+   *   string scheme_id_uri;
+   *   string value;
+   *   unsigned int(32) timescale;
+   *   unsigned int(32) presentation_time_delta;
+   *   unsigned int(32) event_duration;
+   *   unsigned int(32) id;
+   * } else if (version==1) {
+   *   unsigned int(32) timescale;
+   *   unsigned int(64) presentation_time;
+   *   unsigned int(32) event_duration;
+   *   unsigned int(32) id;
+   *   string scheme_id_uri;
+   *   string value;
+   * }
+   * unsigned int(8) message_data[];
+   */
+  parseEMSG_(reference, emsgSchemeIdUris, box) {
+    let timescale;
+    let id;
+    let eventDuration;
+    let schemeId;
+    let startTime;
+    let presentationTimeDelta;
+    let value;
+
+    if (box.version === 0) {
+      schemeId = box.reader.readTerminatedString();
+      value = box.reader.readTerminatedString();
+      timescale = box.reader.readUint32();
+      presentationTimeDelta = box.reader.readUint32();
+      eventDuration = box.reader.readUint32();
+      id = box.reader.readUint32();
+      startTime = reference.startTime + (presentationTimeDelta / timescale);
+    } else {
+      timescale = box.reader.readUint32();
+      const pts = box.reader.readUint64();
+      startTime = (pts / timescale) + reference.timestampOffset;
+      presentationTimeDelta = startTime - reference.startTime;
+      eventDuration = box.reader.readUint32();
+      id = box.reader.readUint32();
+      schemeId = box.reader.readTerminatedString();
+      value = box.reader.readTerminatedString();
+    }
+    const messageData = box.reader.readBytes(
+        box.reader.getLength() - box.reader.getPosition());
+
+    // See DASH sec. 5.10.3.3.1
+    // If a DASH client detects an event message box with a scheme that is not
+    // defined in MPD, the client is expected to ignore it.
+    if ((emsgSchemeIdUris && emsgSchemeIdUris.includes(schemeId)) ||
+        this.config_.dispatchAllEmsgBoxes) {
+      // See DASH sec. 5.10.4.1
+      // A special scheme in DASH used to signal manifest updates.
+      if (schemeId == 'urn:mpeg:dash:event:2012') {
+        this.playerInterface_.onManifestUpdate();
+      } else {
+        // All other schemes are dispatched as a general 'emsg' event.
+        const endTime = startTime + (eventDuration / timescale);
+        /** @type {shaka.extern.EmsgInfo} */
+        const emsg = {
+          startTime: startTime,
+          endTime: endTime,
+          schemeIdUri: schemeId,
+          value: value,
+          timescale: timescale,
+          presentationTimeDelta: presentationTimeDelta,
+          eventDuration: eventDuration,
+          id: id,
+          messageData: messageData,
+        };
+
+        // Dispatch an event to notify the application about the emsg box.
+        const eventName = shaka.util.FakeEvent.EventName.Emsg;
+        const data = (new Map()).set('detail', emsg);
+        const event = new shaka.util.FakeEvent(eventName, data);
+        // A user can call preventDefault() on a cancelable event.
+        event.cancelable = true;
+
+        this.playerInterface_.onEvent(event);
+
+        if (event.defaultPrevented) {
+          // If the caller uses preventDefault() on the 'emsg' event, don't
+          // process any further, and don't generate an ID3 'metadata' event
+          // for the same data.
+          return;
+        }
+
+        // Additionally, ID3 events generate a 'metadata' event.  This is a
+        // pre-parsed version of the metadata blob already dispatched in the
+        // 'emsg' event.
+        if (schemeId == 'https://aomedia.org/emsg/ID3' ||
+            schemeId == 'https://developer.apple.com/streaming/emsg-id3') {
+          // See https://aomediacodec.github.io/id3-emsg/
+          const frames = shaka.util.Id3Utils.getID3Frames(messageData);
+          if (frames.length) {
+            /** @private {shaka.extern.ID3Metadata} */
+            const metadata = {
+              cueTime: startTime,
+              data: messageData,
+              frames: frames,
+              dts: startTime,
+              pts: startTime,
+            };
+            this.playerInterface_.onMetadata(
+                [metadata], /* offset= */ 0, endTime);
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -1039,8 +1173,8 @@ shaka.media.MediaSourceEngine = class {
       mimeType = this.transmuxers_[contentType].getOriginalMimeType();
     }
     if (reference) {
-      const {timestamp, metadata} = this.getTimestampAndDispatchMetadata_(
-          contentType, data, reference, mimeType);
+      const {timestamp, metadata} = this.getTimestampAndDispatchMetadata(
+          contentType, data, reference, stream, mimeType);
       if (timestamp != null) {
         if (this.firstVideoTimestamp_ == null &&
             contentType == ContentType.VIDEO) {
@@ -2341,7 +2475,8 @@ shaka.media.MediaSourceEngine.SourceBufferMode_ = {
  * @typedef {{
  *   getKeySystem: function():?string,
  *   onMetadata: function(!Array<shaka.extern.ID3Metadata>, number, ?number),
- *   onEvent: function(!Event)
+ *   onEvent: function(!Event),
+ *   onManifestUpdate: function()
  * }}
  *
  * @summary Player interface
@@ -2352,5 +2487,7 @@ shaka.media.MediaSourceEngine.SourceBufferMode_ = {
  *   Callback to use when metadata arrives.
  * @property {function(!Event)} onEvent
  *   Called when an event occurs that should be sent to the app.
+ * @property {function()} onManifestUpdate
+ *   Called when an embedded 'emsg' box should trigger a manifest update.
  */
 shaka.media.MediaSourceEngine.PlayerInterface;

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -27,7 +27,6 @@ goog.require('shaka.util.Destroyer');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.IDestroyable');
-goog.require('shaka.util.Id3Utils');
 goog.require('shaka.util.LanguageUtils');
 goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.MimeUtils');
@@ -2250,74 +2249,64 @@ shaka.media.StreamingEngine = class {
     const hasClosedCaptions = stream.closedCaptions &&
         stream.closedCaptions.size > 0;
 
-    let parser;
-    const hasEmsg = ((stream.emsgSchemeIdUris != null &&
-      stream.emsgSchemeIdUris.length > 0) ||
-      this.config_.dispatchAllEmsgBoxes);
+    if (this.config_.shouldFixTimestampOffset) {
+      let parser;
 
-    const isMP4 = stream.mimeType == 'video/mp4' ||
-            stream.mimeType == 'audio/mp4';
-    let timescale = null;
-    if (reference.initSegmentReference) {
-      timescale = reference.initSegmentReference.timescale;
-    }
-    const shouldFixTimestampOffset = isMP4 && timescale &&
-        stream.type === shaka.util.ManifestParserUtils.ContentType.VIDEO &&
-        this.manifest_.type == shaka.media.ManifestParser.DASH &&
-        this.config_.shouldFixTimestampOffset;
+      const isMP4 = stream.mimeType == 'video/mp4' ||
+              stream.mimeType == 'audio/mp4';
+      let timescale = null;
+      if (reference.initSegmentReference) {
+        timescale = reference.initSegmentReference.timescale;
+      }
+      const shouldFixTimestampOffset = isMP4 && timescale &&
+          stream.type === shaka.util.ManifestParserUtils.ContentType.VIDEO &&
+          this.manifest_.type == shaka.media.ManifestParser.DASH;
 
-    if (hasEmsg || shouldFixTimestampOffset) {
-      parser = new shaka.util.Mp4Parser();
-    }
+      if (shouldFixTimestampOffset) {
+        parser = new shaka.util.Mp4Parser();
+      }
 
-    if (hasEmsg) {
-      parser
-          .fullBox(
-              'emsg',
-              (box) => this.parseEMSG_(
-                  reference, stream.emsgSchemeIdUris, box));
-    }
+      if (shouldFixTimestampOffset) {
+        parser
+            .box('moof', shaka.util.Mp4Parser.children)
+            .box('traf', shaka.util.Mp4Parser.children)
+            .fullBox('tfdt', async (box) => {
+              goog.asserts.assert(
+                  box.version != null,
+                  'TFDT is a full box and should have a valid version.');
 
-    if (shouldFixTimestampOffset) {
-      parser
-          .box('moof', shaka.util.Mp4Parser.children)
-          .box('traf', shaka.util.Mp4Parser.children)
-          .fullBox('tfdt', async (box) => {
-            goog.asserts.assert(
-                box.version != null,
-                'TFDT is a full box and should have a valid version.');
+              const parsedTFDT = shaka.util.Mp4BoxParsers.parseTFDTInaccurate(
+                  box.reader, box.version);
 
-            const parsedTFDT = shaka.util.Mp4BoxParsers.parseTFDTInaccurate(
-                box.reader, box.version);
+              const baseMediaDecodeTime = parsedTFDT.baseMediaDecodeTime;
 
-            const baseMediaDecodeTime = parsedTFDT.baseMediaDecodeTime;
-
-            // In case the time is 0, it is not updated
-            if (!baseMediaDecodeTime) {
-              return;
-            }
-            goog.asserts.assert(typeof(timescale) == 'number',
-                'Should be an number!');
-
-            const scaledMediaDecodeTime = -baseMediaDecodeTime / timescale;
-
-            const comparison1 = Number(mediaState.lastTimestampOffset) || 0;
-
-            if (comparison1 < scaledMediaDecodeTime) {
-              const lastAppendWindowStart = mediaState.lastAppendWindowStart;
-              const lastAppendWindowEnd = mediaState.lastAppendWindowEnd;
-              goog.asserts.assert(typeof(lastAppendWindowStart) == 'number',
+              // In case the time is 0, it is not updated
+              if (!baseMediaDecodeTime) {
+                return;
+              }
+              goog.asserts.assert(typeof(timescale) == 'number',
                   'Should be an number!');
-              goog.asserts.assert(typeof(lastAppendWindowEnd) == 'number',
-                  'Should be an number!');
-              await this.setProperties_(mediaState, scaledMediaDecodeTime,
-                  lastAppendWindowStart, lastAppendWindowEnd, reference);
-            }
-          });
-    }
 
-    if (hasEmsg || shouldFixTimestampOffset) {
-      parser.parse(segment, /* partialOkay= */ false, isChunkedData);
+              const scaledMediaDecodeTime = -baseMediaDecodeTime / timescale;
+
+              const comparison1 = Number(mediaState.lastTimestampOffset) || 0;
+
+              if (comparison1 < scaledMediaDecodeTime) {
+                const lastAppendWindowStart = mediaState.lastAppendWindowStart;
+                const lastAppendWindowEnd = mediaState.lastAppendWindowEnd;
+                goog.asserts.assert(typeof(lastAppendWindowStart) == 'number',
+                    'Should be an number!');
+                goog.asserts.assert(typeof(lastAppendWindowEnd) == 'number',
+                    'Should be an number!');
+                await this.setProperties_(mediaState, scaledMediaDecodeTime,
+                    lastAppendWindowStart, lastAppendWindowEnd, reference);
+              }
+            });
+      }
+
+      if (shouldFixTimestampOffset) {
+        parser.parse(segment, /* partialOkay= */ false, isChunkedData);
+      }
     }
 
     await this.evict_(mediaState, presentationTime);
@@ -2340,130 +2329,6 @@ shaka.media.StreamingEngine = class {
         isChunkedData);
     this.destroyer_.ensureNotDestroyed();
     shaka.log.v2(logPrefix, 'appended media segment');
-  }
-
-
-  /**
-   * Parse the EMSG box from a MP4 container.
-   *
-   * @param {!shaka.media.SegmentReference} reference
-   * @param {?Array.<string>} emsgSchemeIdUris Array of emsg
-   *     scheme_id_uri for which emsg boxes should be parsed.
-   * @param {!shaka.extern.ParsedBox} box
-   * @private
-   * https://dashif-documents.azurewebsites.net/Events/master/event.html#emsg-format
-   * aligned(8) class DASHEventMessageBox
-   *    extends FullBox(‘emsg’, version, flags = 0){
-   * if (version==0) {
-   *   string scheme_id_uri;
-   *   string value;
-   *   unsigned int(32) timescale;
-   *   unsigned int(32) presentation_time_delta;
-   *   unsigned int(32) event_duration;
-   *   unsigned int(32) id;
-   * } else if (version==1) {
-   *   unsigned int(32) timescale;
-   *   unsigned int(64) presentation_time;
-   *   unsigned int(32) event_duration;
-   *   unsigned int(32) id;
-   *   string scheme_id_uri;
-   *   string value;
-   * }
-   * unsigned int(8) message_data[];
-   */
-  parseEMSG_(reference, emsgSchemeIdUris, box) {
-    let timescale;
-    let id;
-    let eventDuration;
-    let schemeId;
-    let startTime;
-    let presentationTimeDelta;
-    let value;
-
-    if (box.version === 0) {
-      schemeId = box.reader.readTerminatedString();
-      value = box.reader.readTerminatedString();
-      timescale = box.reader.readUint32();
-      presentationTimeDelta = box.reader.readUint32();
-      eventDuration = box.reader.readUint32();
-      id = box.reader.readUint32();
-      startTime = reference.startTime + (presentationTimeDelta / timescale);
-    } else {
-      timescale = box.reader.readUint32();
-      const pts = box.reader.readUint64();
-      startTime = (pts / timescale) + reference.timestampOffset;
-      presentationTimeDelta = startTime - reference.startTime;
-      eventDuration = box.reader.readUint32();
-      id = box.reader.readUint32();
-      schemeId = box.reader.readTerminatedString();
-      value = box.reader.readTerminatedString();
-    }
-    const messageData = box.reader.readBytes(
-        box.reader.getLength() - box.reader.getPosition());
-
-    // See DASH sec. 5.10.3.3.1
-    // If a DASH client detects an event message box with a scheme that is not
-    // defined in MPD, the client is expected to ignore it.
-    if ((emsgSchemeIdUris && emsgSchemeIdUris.includes(schemeId)) ||
-        this.config_.dispatchAllEmsgBoxes) {
-      // See DASH sec. 5.10.4.1
-      // A special scheme in DASH used to signal manifest updates.
-      if (schemeId == 'urn:mpeg:dash:event:2012') {
-        this.playerInterface_.onManifestUpdate();
-      } else {
-        // All other schemes are dispatched as a general 'emsg' event.
-        const endTime = startTime + (eventDuration / timescale);
-        /** @type {shaka.extern.EmsgInfo} */
-        const emsg = {
-          startTime: startTime,
-          endTime: endTime,
-          schemeIdUri: schemeId,
-          value: value,
-          timescale: timescale,
-          presentationTimeDelta: presentationTimeDelta,
-          eventDuration: eventDuration,
-          id: id,
-          messageData: messageData,
-        };
-
-        // Dispatch an event to notify the application about the emsg box.
-        const eventName = shaka.util.FakeEvent.EventName.Emsg;
-        const data = (new Map()).set('detail', emsg);
-        const event = new shaka.util.FakeEvent(eventName, data);
-        // A user can call preventDefault() on a cancelable event.
-        event.cancelable = true;
-
-        this.playerInterface_.onEvent(event);
-
-        if (event.defaultPrevented) {
-          // If the caller uses preventDefault() on the 'emsg' event, don't
-          // process any further, and don't generate an ID3 'metadata' event
-          // for the same data.
-          return;
-        }
-
-        // Additionally, ID3 events generate a 'metadata' event.  This is a
-        // pre-parsed version of the metadata blob already dispatched in the
-        // 'emsg' event.
-        if (schemeId == 'https://aomedia.org/emsg/ID3' ||
-            schemeId == 'https://developer.apple.com/streaming/emsg-id3') {
-          // See https://aomediacodec.github.io/id3-emsg/
-          const frames = shaka.util.Id3Utils.getID3Frames(messageData);
-          if (frames.length) {
-            /** @private {shaka.extern.ID3Metadata} */
-            const metadata = {
-              cueTime: startTime,
-              data: messageData,
-              frames: frames,
-              dts: startTime,
-              pts: startTime,
-            };
-            this.playerInterface_.onMetadata(
-                [metadata], /* offset= */ 0, endTime);
-          }
-        }
-      }
-    }
   }
 
   /**
@@ -2974,13 +2839,11 @@ shaka.media.StreamingEngine = class {
  *   netEngine: shaka.net.NetworkingEngine,
  *   onError: function(!shaka.util.Error),
  *   onEvent: function(!Event),
- *   onManifestUpdate: function(),
  *   onSegmentAppended: function(!shaka.media.SegmentReference,
  *     !shaka.extern.Stream),
  *   onInitSegmentAppended: function(!number,!shaka.media.InitSegmentReference),
  *   beforeAppendSegment: function(
  *     shaka.util.ManifestParserUtils.ContentType,!BufferSource):Promise,
- *   onMetadata: !function(!Array.<shaka.extern.ID3Metadata>, number, ?number),
  *   disableStream: function(!shaka.extern.Stream, number):boolean
  * }}
  *
@@ -3001,8 +2864,6 @@ shaka.media.StreamingEngine = class {
  *   StreamingEngine.switch*() or StreamingEngine.seeked() to attempt recovery.
  * @property {function(!Event)} onEvent
  *   Called when an event occurs that should be sent to the app.
- * @property {function()} onManifestUpdate
- *   Called when an embedded 'emsg' box should trigger a manifest update.
  * @property {function(!shaka.media.SegmentReference,
  *     !shaka.extern.Stream)} onSegmentAppended
  *   Called after a segment is successfully appended to a MediaSource.
@@ -3012,9 +2873,6 @@ shaka.media.StreamingEngine = class {
  * @property {!function(shaka.util.ManifestParserUtils.ContentType,
  *   !BufferSource):Promise} beforeAppendSegment
  *   A function called just before appending to the source buffer.
- * @property
- *  {!function(!Array.<shaka.extern.ID3Metadata>, number, ?number)} onMetadata
- *   Called when an ID3 is found in a EMSG.
  * @property {function(!shaka.extern.Stream, number):boolean} disableStream
  *   Called to temporarily disable a stream i.e. disabling all variant
  *   containing said stream.

--- a/lib/player.js
+++ b/lib/player.js
@@ -2429,6 +2429,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             this.processTimedMetadataMediaSrc_(metadata, offset, endTime);
           },
           onEvent: (event) => this.dispatchEvent(event),
+          onManifestUpdate: () => this.onManifestUpdate_(),
         },
         this.lcevcDec_);
     mediaSourceEngine.configure(this.config_.mediaSource);
@@ -3767,7 +3768,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       netEngine: this.networkingEngine_,
       onError: (error) => this.onError_(error),
       onEvent: (event) => this.dispatchEvent(event),
-      onManifestUpdate: () => this.onManifestUpdate_(),
       onSegmentAppended: (reference, stream) => {
         this.onSegmentAppended_(
             reference.startTime, reference.endTime, stream.type,
@@ -3781,9 +3781,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       },
       beforeAppendSegment: (contentType, segment) => {
         return this.drmEngine_.parseInbandPssh(contentType, segment);
-      },
-      onMetadata: (metadata, offset, endTime) => {
-        this.processTimedMetadataMediaSrc_(metadata, offset, endTime);
       },
       disableStream: (stream, time) => this.disableStream(stream, time),
     };
@@ -4012,6 +4009,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           'manifest.dash.enableAudioGroups configuration',
           'It is now enabled by default and cannot be disabled.');
       delete config['manifest']['dash']['enableAudioGroups'];
+    }
+
+    // Deprecate 'streaming.dispatchAllEmsgBoxes' configuration.
+    if (config['streaming'] && 'dispatchAllEmsgBoxes' in config['streaming']) {
+      shaka.Deprecate.deprecateFeature(5,
+          'streaming.dispatchAllEmsgBoxes configuration',
+          'Please Use mediaSource.dispatchAllEmsgBoxes instead.');
+      config['mediaSource']['dispatchAllEmsgBoxes'] =
+          config['streaming']['dispatchAllEmsgBoxes'];
+      delete config['streaming']['dispatchAllEmsgBoxes'];
     }
 
     // If lowLatencyMode is enabled, and inaccurateManifestTolerance and

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -235,7 +235,6 @@ shaka.util.PlayerConfiguration = class {
       minBytesForProgressEvents: minBytes,
       preferNativeHls: false,
       updateIntervalSeconds: 1,
-      dispatchAllEmsgBoxes: false,
       observeQualityChanges: false,
       maxDisabledTime: 30,
       // When low latency streaming is enabled, segmentPrefetchLimit will
@@ -402,6 +401,7 @@ shaka.util.PlayerConfiguration = class {
             [cue, uri],
             undefined);
       },
+      dispatchAllEmsgBoxes: false,
     };
 
     let customPlayheadTracker = false;

--- a/test/cast/cast_utils_unit.js
+++ b/test/cast/cast_utils_unit.js
@@ -229,6 +229,7 @@ describe('CastUtils', () => {
               getKeySystem: () => null,
               onMetadata: () => {},
               onEvent: () => {},
+              onManifestUpdate: () => {},
             });
         const config =
             shaka.util.PlayerConfiguration.createDefault().mediaSource;

--- a/test/media/drm_engine_integration.js
+++ b/test/media/drm_engine_integration.js
@@ -119,6 +119,7 @@ describe('DrmEngine', () => {
           getKeySystem: () => null,
           onMetadata: () => {},
           onEvent: () => {},
+          onManifestUpdate: () => {},
         });
     const mediaSourceConfig =
         shaka.util.PlayerConfiguration.createDefault().mediaSource;

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -248,6 +248,7 @@ describe('MediaSourceEngine', () => {
           getKeySystem: () => null,
           onMetadata: () => {},
           onEvent: () => {},
+          onManifestUpdate: () => {},
         });
     mediaSourceEngine.getCaptionParser = () => {
       return mockClosedCaptionParser;
@@ -323,6 +324,7 @@ describe('MediaSourceEngine', () => {
             getKeySystem: () => null,
             onMetadata: () => {},
             onEvent: () => {},
+            onManifestUpdate: () => {},
           });
 
       expect(createMediaSourceSpy).toHaveBeenCalled();
@@ -346,6 +348,7 @@ describe('MediaSourceEngine', () => {
             getKeySystem: () => null,
             onMetadata: () => {},
             onEvent: () => {},
+            onManifestUpdate: () => {},
           });
 
       if (window.ManagedMediaSource) {

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -74,6 +74,7 @@ describe('StreamingEngine', () => {
           getKeySystem: () => null,
           onMetadata: () => {},
           onEvent: () => {},
+          onManifestUpdate: () => {},
         });
     const mediaSourceConfig =
         shaka.util.PlayerConfiguration.createDefault().mediaSource;
@@ -267,11 +268,9 @@ describe('StreamingEngine', () => {
       netEngine: /** @type {!shaka.net.NetworkingEngine} */(netEngine),
       onError: Util.spyFunc(onError),
       onEvent: Util.spyFunc(onEvent),
-      onManifestUpdate: () => {},
       onSegmentAppended: () => playhead.notifyOfBufferingChange(),
       onInitSegmentAppended: () => {},
       beforeAppendSegment: () => Promise.resolve(),
-      onMetadata: () => {},
       disableStream: (stream, time) => false,
     };
     streamingEngine = new shaka.media.StreamingEngine(


### PR DESCRIPTION
With the change, we reuse MediaSource's MP4 parsing code to avoid parsing everything twice.
It will also help with the implementation of https://github.com/shaka-project/shaka-player/issues/7556 in the future.