### PR TITLE
fix: Do not reuse the same tsParser for different contentType

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -164,8 +164,9 @@ shaka.media.MediaSourceEngine = class {
     /** @private {?number} */
     this.lastDuration_ = null;
 
-    /** @private {?shaka.util.TsParser} */
-    this.tsParser_ = null;
+    /** @private {!Object.<shaka.util.ManifestParserUtils.ContentType,
+                           !shaka.util.TsParser>} */
+    this.tsParser_ = {};
 
     /** @private {?number} */
     this.firstVideoTimestamp_ = null;
@@ -508,7 +509,7 @@ shaka.media.MediaSourceEngine = class {
     // This object is owned by Player
     this.lcevcDec_ = null;
 
-    this.tsParser_ = null;
+    this.tsParser_ = {};
     this.playerInterface_ = null;
   }
 
@@ -560,7 +561,7 @@ shaka.media.MediaSourceEngine = class {
         this.manifestType_ == shaka.media.ManifestParser.HLS &&
         !this.ignoreManifestTimestampsInSegmentsMode_;
 
-    this.tsParser_ = null;
+    this.tsParser_ = {};
     this.firstVideoTimestamp_ = null;
     this.firstVideoReferenceStartTime_ = null;
     this.firstAudioTimestamp_ = null;
@@ -921,12 +922,12 @@ shaka.media.MediaSourceEngine = class {
       }
     } else if (!mimeType.includes('/mp4') && !mimeType.includes('/webm') &&
         shaka.util.TsParser.probe(uint8ArrayData)) {
-      if (!this.tsParser_) {
-        this.tsParser_ = new shaka.util.TsParser();
+      if (!this.tsParser_[contentType]) {
+        this.tsParser_[contentType] = new shaka.util.TsParser();
       } else {
-        this.tsParser_.clearData();
+        this.tsParser_[contentType].clearData();
       }
-      const tsParser = this.tsParser_.parse(uint8ArrayData);
+      const tsParser = this.tsParser_[contentType].parse(uint8ArrayData);
       const startTime = tsParser.getStartTime(contentType);
       if (startTime != null) {
         timestamp = startTime;

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -166,7 +166,7 @@ shaka.media.MediaSourceEngine = class {
 
     /** @private {!Object.<shaka.util.ManifestParserUtils.ContentType,
                            !shaka.util.TsParser>} */
-    this.tsParser_ = {};
+    this.tsParsers_ = {};
 
     /** @private {?number} */
     this.firstVideoTimestamp_ = null;
@@ -509,7 +509,7 @@ shaka.media.MediaSourceEngine = class {
     // This object is owned by Player
     this.lcevcDec_ = null;
 
-    this.tsParser_ = {};
+    this.tsParsers_ = {};
     this.playerInterface_ = null;
   }
 
@@ -561,7 +561,7 @@ shaka.media.MediaSourceEngine = class {
         this.manifestType_ == shaka.media.ManifestParser.HLS &&
         !this.ignoreManifestTimestampsInSegmentsMode_;
 
-    this.tsParser_ = {};
+    this.tsParsers_ = {};
     this.firstVideoTimestamp_ = null;
     this.firstVideoReferenceStartTime_ = null;
     this.firstAudioTimestamp_ = null;
@@ -922,12 +922,12 @@ shaka.media.MediaSourceEngine = class {
       }
     } else if (!mimeType.includes('/mp4') && !mimeType.includes('/webm') &&
         shaka.util.TsParser.probe(uint8ArrayData)) {
-      if (!this.tsParser_[contentType]) {
-        this.tsParser_[contentType] = new shaka.util.TsParser();
+      if (!this.tsParsers_[contentType]) {
+        this.tsParsers_[contentType] = new shaka.util.TsParser();
       } else {
-        this.tsParser_[contentType].clearData();
+        this.tsParsers_[contentType].clearData();
       }
-      const tsParser = this.tsParser_[contentType].parse(uint8ArrayData);
+      const tsParser = this.tsParsers_[contentType].parse(uint8ArrayData);
       const startTime = tsParser.getStartTime(contentType);
       if (startTime != null) {
         timestamp = startTime;


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/7399

This PR resolves issue https://github.com/shaka-project/shaka-player/issues/7399 which has the same pid for audio and video, but they are different segments.