### PR TITLE
feat: Add config to ignore hardware resolution

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2295,6 +2295,7 @@ shaka.extern.TextDisplayerConfiguration;
  *   cmsd: shaka.extern.CmsdConfiguration,
  *   lcevc: shaka.extern.LcevcConfiguration,
  *   offline: shaka.extern.OfflineConfiguration,
+ *   ignoreHardwareResolution: boolean,
  *   preferredAudioLanguage: string,
  *   preferredAudioLabel: string,
  *   preferredTextLanguage: string,
@@ -2345,6 +2346,11 @@ shaka.extern.TextDisplayerConfiguration;
  *   (Low Complexity Enhancement Video Codec)
  * @property {shaka.extern.OfflineConfiguration} offline
  *   Offline configuration and settings.
+ * @property {boolean} ignoreHardwareResolution
+ *   Do not detect the hardware resolution.  For some niche cases where content
+ *   is only available at resolutions beyond the device's native resolution,
+ *   and you are confident it can be decoded and downscaled, this flag can
+ *   allow playback when it would otherwise fail.
  * @property {string} preferredAudioLanguage
  *   The preferred language to use for audio tracks.  If not given it will use
  *   the <code>'main'</code> track.

--- a/lib/player.js
+++ b/lib/player.js
@@ -2077,7 +2077,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // Avoid having to detect the resolution again if it has already been
     // detected or set
     if (this.maxHwRes_.width == Infinity &&
-        this.maxHwRes_.height == Infinity) {
+        this.maxHwRes_.height == Infinity &&
+        !this.config_.ignoreHardwareResolution) {
       const maxResolution =
           await shaka.util.Platform.detectMaxHardwareResolution();
       this.maxHwRes_.width = maxResolution.width;

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -474,6 +474,7 @@ shaka.util.PlayerConfiguration = class {
       cmsd: cmsd,
       lcevc: lcevc,
       ads: ads,
+      ignoreHardwareResolution: false,
     };
 
     // Add this callback so that we can reference the preferred audio language

--- a/test/demo/demo_unit.js
+++ b/test/demo/demo_unit.js
@@ -79,6 +79,7 @@ describe('Demo', () => {
     function checkConfig(checkValueNameFn) {
       const configPrimitives = new Set(['number', 'string', 'boolean']);
       const exceptions = new Set()
+          .add('ignoreHardwareResolution')
           .add('playRangeStart')
           .add('playRangeEnd')
           .add('manifest.dash.keySystemsByURI')


### PR DESCRIPTION
For some niche cases where content is only available at resolutions beyond the device's native resolution, and you are confident it can be decoded and downscaled, this flag can allow playback when it would otherwise fail.