### PR TITLE
ci: Fix status reporting on PRs

### DIFF
--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -68,7 +68,7 @@ jobs:
           # If "sha" is given, it overrides PR.  If neither is given, we fall
           # back to testing "main".
           sha: ${{ inputs.sha }}
-          ref: ${{ inputs.pr && format('refs/pull/{0}/merge', inputs.pr) || 'refs/heads/main' }}
+          ref: ${{ inputs.pr && format('refs/pull/{0}/head', inputs.pr) || 'refs/heads/main' }}
 
   # Configure the build matrix based on our grid's YAML config.
   # The matrix contents will be computed by this first job and deserialized

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -23,7 +23,7 @@ jobs:
         id: compute
         uses: shaka-project/shaka-github-tools/compute-sha@main
         with:
-          ref: refs/pull/${{ inputs.pr }}/merge
+          ref: refs/pull/${{ inputs.pr }}/head
 
   set-pending-status:
     name: Set Pending Status


### PR DESCRIPTION
To report commit status on a PR, the head commit must be used, not the merge of that head back into the target (e.g. into main).

I would prefer to make status reporting special, so that we can run tests and other operations against the merge (for more realistic results and to avoid test failures that only show up after a merge).  But this is the quickest way for me to fix this critical feedback.