### PR TITLE
chore(Demo): Change manifest.dash.clockSyncUri in the Demo

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -414,8 +414,7 @@ shakaDemo.Main = class {
     // default values assigned to UI config elements as well as the decision
     // about what values to place in the URL hash.
     this.player_.configure(
-        'manifest.dash.clockSyncUri',
-        'https://shaka-player-demo.appspot.com/time.txt');
+        'manifest.dash.clockSyncUri', 'https://time.akamai.com/?ms&iso');
 
     // Get default config.
     this.defaultConfig_ = this.player_.getConfiguration();


### PR DESCRIPTION
When testing from different parts of the world, the Akamai server always has a better response time, so it is changed to this one by default.