### PR TITLE
fix(Ads): Always fire CUEPOINTS_CHANGED when not using multi video elements

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -623,6 +623,8 @@ shaka.ads.InterstitialAdManager = class {
           if (!this.baseVideo_.ended) {
             this.baseVideo_.play();
           }
+        } else {
+          this.cuepointsChanged_();
         }
         this.determineIfUsingBaseVideo_();
       }


### PR DESCRIPTION
This is necessary because in our UI when reusing the same video element the unloading event is launched and we clear the cuepoints with that event.