### PR TITLE
ci: Fix auto-branch job

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -194,4 +194,4 @@ jobs:
         run: |
           TAG=${{ needs.release.outputs.tag_name }}
           BRANCH=$(echo "$TAG" | sed -e 's/\.0$/.x/')
-          git push origin HEAD:"$BRANCH"
+          git push origin refs/tags/"$TAG"^{commit}:refs/heads/"$BRANCH"


### PR DESCRIPTION
This uses very explicit ref names for both source and destination, to fix this error during branch creation:

>   TAG=v4.12.0
>   BRANCH=$(echo "$TAG" | sed -e 's/\.0$/.x/')
>   git push origin HEAD:"$BRANCH"
>
> error: The destination you provided is not a full refname (i.e.,
> starting with "refs/"). We tried to guess what you meant by:
>
> - Looking for a ref that matches 'v4.12.x' on the remote side.
> - Checking if the <src> being pushed ('HEAD')
>   is a ref in "refs/{heads,tags}/". If so we add a corresponding
>   refs/{heads,tags}/ prefix on the remote side.
>
> Neither worked, so we gave up. You must fully qualify the ref.
> hint: The <src> part of the refspec is a commit object.
> hint: Did you mean to create a new branch by pushing to
> hint: 'HEAD:refs/heads/v4.12.x'?
> error: failed to push some refs to 'https://github.com/shaka-project/shaka-player'
> Error: Process completed with exit code 1.