### PR TITLE
fix: Calculate timeToFirstByte before fire the event 'downloadheadersreceived'

### DIFF
--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -576,12 +576,12 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
         }
       };
       const headersReceived = (headers) => {
-        if (this.onHeadersReceived_) {
-          this.onHeadersReceived_(headers, request, type);
-        }
         headersReceivedCalled = true;
         request.timeToFirstByte = Date.now() -
         /** @type {number} */ (request.requestStartTime);
+        if (this.onHeadersReceived_) {
+          this.onHeadersReceived_(headers, request, type);
+        }
       };
       request.requestStartTime = Date.now();
 


### PR DESCRIPTION
Fixes #7604