### PR TITLE
fix: Disable smooth codec switch on Tizen 8

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -642,19 +642,17 @@ shaka.util.Platform = class {
   /**
    * Returns if codec switching SMOOTH is known reliable device support.
    *
-   * Some devices are known not to support `MediaSource.changeType`
+   * Some devices are known not to support <code>SourceBuffer.changeType</code>
    * well. These devices should use the reload strategy. If a device
-   * reports that it supports `changeType` but support it unreliably
-   * it should be added to this list.
+   * reports that it supports <code<changeType</code> but supports it unreliably
+   * it should be disallowed in this method.
    *
    * @return {boolean}
    */
   static supportsSmoothCodecSwitching() {
     const Platform = shaka.util.Platform;
-    if (Platform.isTizen2() || Platform.isTizen3() || Platform.isTizen4() ||
-        Platform.isTizen5() || Platform.isTizen6() || Platform.isWebOS3() ||
-        Platform.isWebOS4() || Platform.isWebOS5() || Platform.isPS4() ||
-        Platform.isPS5()) {
+    // All Tizen versions (up to Tizen 8) do not support SMOOTH so far.
+    if (Platform.isTizen() || Platform.isPS4() || Platform.isPS5()) {
       return false;
     }
     // Older chromecasts without GoogleTV seem to not support SMOOTH properly.


### PR DESCRIPTION
It seems all Tizen versions do not support smooth codec switch for now.

Additionally I removed webOS versions listed here, as they don't have `SourceBuffer.changeType()` API anyway. They're available since Chrome 70, but webOS 5 uses Chrome 68.
And rephrased docs a bit.