### PR TITLE
fix: Disable smooth codec switch on webOS 6

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -663,6 +663,7 @@ shaka.util.Platform = class {
   static supportsSmoothCodecSwitching() {
     const Platform = shaka.util.Platform;
     // All Tizen versions (up to Tizen 8) do not support SMOOTH so far.
+    // webOS seems to support SMOOTH from webOS 22.
     if (Platform.isTizen() || Platform.isPS4() || Platform.isPS5() ||
         Platform.isWebOS6()) {
       return false;

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -206,6 +206,17 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is a WebOS 6.
+   *
+   * @return {boolean}
+   */
+  static isWebOS6() {
+    // See: https://webostv.developer.lge.com/develop/specifications/web-api-and-web-engine#useragent-string
+    return shaka.util.Platform.isWebOS() &&
+        shaka.util.Platform.chromeVersion() === 79;
+  }
+
+  /**
    * Check if the current platform is a Google Chromecast.
    *
    * @return {boolean}
@@ -652,7 +663,8 @@ shaka.util.Platform = class {
   static supportsSmoothCodecSwitching() {
     const Platform = shaka.util.Platform;
     // All Tizen versions (up to Tizen 8) do not support SMOOTH so far.
-    if (Platform.isTizen() || Platform.isPS4() || Platform.isPS5()) {
+    if (Platform.isTizen() || Platform.isPS4() || Platform.isPS5() ||
+        Platform.isWebOS6()) {
       return false;
     }
     // Older chromecasts without GoogleTV seem to not support SMOOTH properly.

--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -19,6 +19,7 @@ describe('Platform', () => {
   const webOs3 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.2.1 Chrome/38.0.2125.122 Safari/537.36 WebAppManager';
   const webOs4 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.34 Safari/537.36 WebAppManager';
   const webOs5 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 WebAppManager';
+  const webOs6 = 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36 WebAppManager';
   /* eslint-enable max-len */
 
   afterEach(() => {
@@ -79,6 +80,8 @@ describe('Platform', () => {
     expect(shaka.util.Platform.isWebOS3()).toBe(false);
     setUserAgent(webOs5);
     expect(shaka.util.Platform.isWebOS3()).toBe(false);
+    setUserAgent(webOs6);
+    expect(shaka.util.Platform.isWebOS3()).toBe(false);
   });
 
   it('checks is webOS 4', () => {
@@ -89,6 +92,8 @@ describe('Platform', () => {
     setUserAgent(webOs4);
     expect(shaka.util.Platform.isWebOS4()).toBe(true);
     setUserAgent(webOs5);
+    expect(shaka.util.Platform.isWebOS4()).toBe(false);
+    setUserAgent(webOs6);
     expect(shaka.util.Platform.isWebOS4()).toBe(false);
   });
 
@@ -101,6 +106,21 @@ describe('Platform', () => {
     expect(shaka.util.Platform.isWebOS5()).toBe(false);
     setUserAgent(webOs5);
     expect(shaka.util.Platform.isWebOS5()).toBe(true);
+    setUserAgent(webOs6);
+    expect(shaka.util.Platform.isWebOS5()).toBe(false);
+  });
+
+  it('checks is webOS 6', () => {
+    setUserAgent(tizen50);
+    expect(shaka.util.Platform.isWebOS6()).toBe(false);
+    setUserAgent(webOs3);
+    expect(shaka.util.Platform.isWebOS6()).toBe(false);
+    setUserAgent(webOs4);
+    expect(shaka.util.Platform.isWebOS6()).toBe(false);
+    setUserAgent(webOs5);
+    expect(shaka.util.Platform.isWebOS6()).toBe(false);
+    setUserAgent(webOs6);
+    expect(shaka.util.Platform.isWebOS6()).toBe(true);
   });
 
   describe('isMediaKeysPolyfilled', () => {


### PR DESCRIPTION
In our preliminary tests webOS 6 does not support smooth codec switch, but webOS 22 (so the next one) does, so hopefully this will be the last adjustment in this method.