### PR TITLE
fix(PS5): Prevent uncaught promise rejections when requests are aborted

### DIFF
--- a/lib/util/abortable_operation.js
+++ b/lib/util/abortable_operation.js
@@ -166,6 +166,9 @@ shaka.util.AbortableOperation = class {
    */
   chain(onSuccess, onError) {
     const newPromise = new shaka.util.PublicPromise();
+    // Silence uncaught rejection errors, which may otherwise occur any place
+    // we don't explicitly handle aborted operations.
+    newPromise.catch(() => {});
     const abortError = shaka.util.AbortableOperation.abortError();
 
     // If called before "this" completes, just abort "this".


### PR DESCRIPTION
On PS5 we are seeing following uncaught exceptions when requests are aborted:
```
[Error] Fetch is aborted – PromiseRejectionEvent {isTrusted: false, promise: Promise, reason: AbortError: Fetch is aborted, …}
PromiseRejectionEvent {isTrusted: false, promise: Promise, reason: AbortError: Fetch is aborted, type: "unhandledrejection", target: Window, …}PromiseRejectionEvent
	(anonymous function) (Anonymous Script 1 (line 429))
[Error] Unhandled Promise Rejection: AbortError: Fetch is aborted
	promiseEmptyOnRejected
	promiseReactionJob
```