### PR TITLE
chore: Forbid using instanceof on arrays

### DIFF
--- a/build/eslint-plugin-shaka-rules/array-no-instanceof.js
+++ b/build/eslint-plugin-shaka-rules/array-no-instanceof.js
@@ -1,3 +1,9 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/build/eslint-plugin-shaka-rules/array-no-instanceof.js
+++ b/build/eslint-plugin-shaka-rules/array-no-instanceof.js
@@ -1,0 +1,29 @@
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Usage of Array.isArray() instead of instanceof Array',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    fixable: 'code',
+    schema: [],
+  },
+  create: (ctx) => ({
+    BinaryExpression: (node) => {
+      if (node.operator === 'instanceof' &&
+          node.right.type === 'Identifier' && node.right.name === 'Array') {
+        ctx.report({
+          node,
+          message: 'Do not use instanceof Array',
+          fix: (fixer) => {
+            const source = ctx.sourceCode;
+            const text = source.getText();
+            const leftSide = text.slice(node.left.start, node.left.end);
+            return fixer.replaceText(node, `Array.isArray(${leftSide})`);
+          },
+        });
+      }
+    },
+  }),
+};

--- a/build/eslint-plugin-shaka-rules/index.js
+++ b/build/eslint-plugin-shaka-rules/index.js
@@ -16,6 +16,7 @@ module.exports = {
 
 const RULES = [
   'arg-comment-spacing',
+  'array-no-instanceof',
   'private',
 ];
 for (const rule of RULES) {

--- a/test/test/util/manifest_parser_util.js
+++ b/test/test/util/manifest_parser_util.js
@@ -59,7 +59,7 @@ shaka.test.ManifestParser = class {
       partialReferences = [], tilesLayout = '', syncTime = null) {
     const getUris = () => {
       const uris = [];
-      if (uri instanceof Array) {
+      if (Array.isArray(uri)) {
         for (const url of uri) {
           if (url.length) {
             uris.push(baseUri + url);

--- a/test/test/util/ttml_utils.js
+++ b/test/test/util/ttml_utils.js
@@ -17,7 +17,7 @@ shaka.test.TtmlUtils = class {
         cue.region = jasmine.objectContaining(cue.region);
       }
 
-      if (cue.nestedCues && (cue.nestedCues instanceof Array)) {
+      if (Array.isArray(cue.nestedCues)) {
         cue.nestedCues = cue.nestedCues.map(mapExpected);
       }
 


### PR DESCRIPTION
Roughly related to #6279.
Whenever possible, we should limit usage of `instanceof` operator for the sake of `documentPip` mode.