### PR TITLE
feat(DASH): Add subtitle support for role attribute and kind='subtitle'

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -2300,6 +2300,13 @@ shaka.dash.DashParser = class {
           roles.includes('forced-subtitle');
     }
 
+    // If there are no roles, and we have defaulted to the subtitle "kind" for
+    // this track, add the implied subtitle role.
+    if (!roles.length &&
+        kind === shaka.util.ManifestParserUtils.TextStreamKind.SUBTITLE) {
+      roles.push(shaka.util.ManifestParserUtils.TextStreamKind.SUBTITLE);
+    }
+
     let tilesLayout;
     if (isImage) {
       const thumbnailTileElem = essentialPropertyElems.find((element) => {


### PR DESCRIPTION
Add dash subtitle for player

For stream with roles with empty subtitle, we do not get subtitle.
But this is not expected behaviour. 

So, add role='subtitle' if kind of stream is subtitle. 

Screenshot after change.

<img width="756" alt="Screenshot 2024-11-22 at 2 47 14 PM" src="https://github.com/user-attachments/assets/d9ac3fbb-c6dd-4e5a-ae6a-c3c0f5ea744e">

