### PR TITLE
fix: Fix video progress events accuracy

### DIFF
--- a/build/types/core
+++ b/build/types/core
@@ -105,6 +105,7 @@
 +../../lib/util/multi_map.js
 +../../lib/util/mutex.js
 +../../lib/util/networking.js
++../../lib/util/number_utils.js
 +../../lib/util/object_utils.js
 +../../lib/util/operation_manager.js
 +../../lib/util/periods.js

--- a/lib/player.js
+++ b/lib/player.js
@@ -2762,6 +2762,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.loadEventManager_.listen(
           mediaElement, 'timeupdate', onVideoProgress);
       this.loadEventManager_.listen(
+          mediaElement, 'playing', onVideoProgress);
+      this.loadEventManager_.listen(
           mediaElement, 'ended', onVideoProgress);
       this.onVideoProgress_();
       if (this.manifest_.nextUrl) {
@@ -3159,6 +3161,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const onVideoProgress = () => this.onVideoProgress_();
       this.loadEventManager_.listen(
           mediaElement, 'timeupdate', onVideoProgress);
+      this.loadEventManager_.listen(
+          mediaElement, 'playing', onVideoProgress);
       this.loadEventManager_.listen(
           mediaElement, 'ended', onVideoProgress);
       this.onVideoProgress_();

--- a/lib/player.js
+++ b/lib/player.js
@@ -2762,8 +2762,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.loadEventManager_.listen(
           mediaElement, 'timeupdate', onVideoProgress);
       this.loadEventManager_.listen(
-          mediaElement, 'playing', onVideoProgress);
-      this.loadEventManager_.listen(
           mediaElement, 'ended', onVideoProgress);
       this.onVideoProgress_();
       if (this.manifest_.nextUrl) {
@@ -3161,8 +3159,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const onVideoProgress = () => this.onVideoProgress_();
       this.loadEventManager_.listen(
           mediaElement, 'timeupdate', onVideoProgress);
-      this.loadEventManager_.listen(
-          mediaElement, 'playing', onVideoProgress);
       this.loadEventManager_.listen(
           mediaElement, 'ended', onVideoProgress);
       this.onVideoProgress_();

--- a/lib/player.js
+++ b/lib/player.js
@@ -58,6 +58,7 @@ goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.MediaReadyState');
 goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Mutex');
+goog.require('shaka.util.NumberUtils');
 goog.require('shaka.util.ObjectUtils');
 goog.require('shaka.util.Platform');
 goog.require('shaka.util.PlayerConfiguration');
@@ -2760,6 +2761,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const onVideoProgress = () => this.onVideoProgress_();
       this.loadEventManager_.listen(
           mediaElement, 'timeupdate', onVideoProgress);
+      this.loadEventManager_.listen(
+          mediaElement, 'ended', onVideoProgress);
       this.onVideoProgress_();
       if (this.manifest_.nextUrl) {
         if (this.config_.streaming.preloadNextUrlWindow > 0) {
@@ -3156,6 +3159,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const onVideoProgress = () => this.onVideoProgress_();
       this.loadEventManager_.listen(
           mediaElement, 'timeupdate', onVideoProgress);
+      this.loadEventManager_.listen(
+          mediaElement, 'ended', onVideoProgress);
       this.onVideoProgress_();
     }
 
@@ -7033,21 +7038,24 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return;
     }
 
-    const isCloseEnough = (n1, n2) => {
-      const epsilon = 0.1;
-      return Math.abs(n1 - n2) < epsilon;
-    }
-
     const isQuartile = (quartilePercent, currentPercent) => {
+      const NumberUtils = shaka.util.NumberUtils;
+      /**
+       * According to MDN, depending on system load, the |timeupdate| event will
+       * be thrown with a frequency between about 4Hz and 66Hz. A tolerance
+       * margin of 0.3 should be good enough to not miss any quartile point.
+       */
+      const tolerance = 0.3;
+
       if (
-        isCloseEnough(quartilePercent, currentPercent) &&
+        NumberUtils.isFloatEqual(quartilePercent, currentPercent, tolerance) &&
         this.completionPercent_ < quartilePercent
       ) {
         this.completionPercent_ = quartilePercent;
         return true;
       }
       return false;
-    }
+    };
 
     const completionRatio = this.video_.currentTime / this.video_.duration;
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -7045,11 +7045,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const isQuartile = (quartilePercent, currentPercent) => {
       const NumberUtils = shaka.util.NumberUtils;
 
-      if (
-        (NumberUtils.isFloatEqual(quartilePercent, currentPercent) ||
+      if ((NumberUtils.isFloatEqual(quartilePercent, currentPercent) ||
           currentPercent > quartilePercent) &&
-        this.completionPercent_ < quartilePercent
-      ) {
+          this.completionPercent_ < quartilePercent) {
         this.completionPercent_ = quartilePercent;
         return true;
       }

--- a/lib/player.js
+++ b/lib/player.js
@@ -2761,8 +2761,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const onVideoProgress = () => this.onVideoProgress_();
       this.loadEventManager_.listen(
           mediaElement, 'timeupdate', onVideoProgress);
-      this.loadEventManager_.listen(
-          mediaElement, 'ended', onVideoProgress);
       this.onVideoProgress_();
       if (this.manifest_.nextUrl) {
         if (this.config_.streaming.preloadNextUrlWindow > 0) {
@@ -3159,8 +3157,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const onVideoProgress = () => this.onVideoProgress_();
       this.loadEventManager_.listen(
           mediaElement, 'timeupdate', onVideoProgress);
-      this.loadEventManager_.listen(
-          mediaElement, 'ended', onVideoProgress);
       this.onVideoProgress_();
     }
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -1526,7 +1526,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
       this.externalSrcEqualsThumbnailsStreams_ = [];
 
-      this.completionPercent_ = NaN;
+      this.completionPercent_ = -1;
 
       // Make sure that the app knows of the new buffering state.
       this.updateBufferState_();
@@ -7040,15 +7040,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     const isQuartile = (quartilePercent, currentPercent) => {
       const NumberUtils = shaka.util.NumberUtils;
-      /**
-       * According to MDN, depending on system load, the |timeupdate| event will
-       * be thrown with a frequency between about 4Hz and 66Hz. A tolerance
-       * margin of 0.3 should be good enough to not miss any quartile point.
-       */
-      const tolerance = 0.3;
 
       if (
-        NumberUtils.isFloatEqual(quartilePercent, currentPercent, tolerance) &&
+        (NumberUtils.isFloatEqual(quartilePercent, currentPercent) ||
+          currentPercent > quartilePercent) &&
         this.completionPercent_ < quartilePercent
       ) {
         this.completionPercent_ = quartilePercent;

--- a/lib/player.js
+++ b/lib/player.js
@@ -763,7 +763,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.externalSrcEqualsThumbnailsStreams_ = [];
 
     /** @private {number} */
-    this.completionPercent_ = NaN;
+    this.completionPercent_ = -1;
 
     /** @private {?shaka.extern.PlayerConfiguration} */
     this.config_ = this.defaultConfig_();
@@ -7032,42 +7032,87 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!this.video_) {
       return;
     }
+
+    const isCloseEnough = (n1, n2) => {
+      const epsilon = 0.01 || Number.EPSILON || 2.220446049250313e-16;
+      return Math.abs(n1 - n2) < epsilon;
+    }
+
+    const isQuartile = (quartilePercent, currentPercent) => {
+      if (
+        isCloseEnough(quartilePercent, currentPercent) &&
+        this.completionPercent_ < quartilePercent
+      ) {
+        this.completionPercent_ = quartilePercent;
+        return true;
+      }
+      return false;
+    }
+
     let hasNewCompletionPercent = false;
     const completionRatio = this.video_.currentTime / this.video_.duration;
-    if (!isNaN(completionRatio)) {
-      const percent = Math.round(100 * completionRatio);
-      if (isNaN(this.completionPercent_)) {
-        this.completionPercent_ = percent;
-        hasNewCompletionPercent = true;
-      } else {
-        const newCompletionPercent = Math.max(this.completionPercent_, percent);
-        if (this.completionPercent_ != newCompletionPercent) {
-          this.completionPercent_ = newCompletionPercent;
-          hasNewCompletionPercent = true;
-        }
-      }
+
+    if (isNaN(completionRatio)) {
+      return;
     }
-    if (hasNewCompletionPercent) {
-      let event;
-      if (this.completionPercent_ == 0) {
-        event = shaka.Player.makeEvent_(shaka.util.FakeEvent.EventName.Started);
-      } else if (this.completionPercent_ == 25) {
-        event = shaka.Player.makeEvent_(
-            shaka.util.FakeEvent.EventName.FirstQuartile);
-      } else if (this.completionPercent_ == 50) {
-        event = shaka.Player.makeEvent_(
-            shaka.util.FakeEvent.EventName.Midpoint);
-      } else if (this.completionPercent_ == 75) {
-        event = shaka.Player.makeEvent_(
-            shaka.util.FakeEvent.EventName.ThirdQuartile);
-      } else if (this.completionPercent_ == 100) {
-        event = shaka.Player.makeEvent_(
-            shaka.util.FakeEvent.EventName.Complete);
-      }
-      if (event) {
-        this.dispatchEvent(event);
-      }
+
+    let event;
+    const percent = completionRatio * 100;
+
+    if (isQuartile(0, percent)) {
+      event = shaka.Player.makeEvent_(shaka.util.FakeEvent.EventName.Started);
+    } else if (isQuartile(25, percent)) {
+      event = shaka.Player.makeEvent_(
+          shaka.util.FakeEvent.EventName.FirstQuartile);
+    } else if (isQuartile(50, percent)) {
+      event = shaka.Player.makeEvent_(
+          shaka.util.FakeEvent.EventName.Midpoint);
+    } else if (isQuartile(75, percent)) {
+      event = shaka.Player.makeEvent_(
+          shaka.util.FakeEvent.EventName.ThirdQuartile);
+    } else if (isQuartile(100, percent)) {
+      event = shaka.Player.makeEvent_(
+          shaka.util.FakeEvent.EventName.Complete);
     }
+
+    if (event) {
+      this.dispatchEvent(event);
+    }
+
+    // if (!isNaN(completionRatio)) {
+    //   const percent = Math.round(100 * completionRatio);
+    //   if (isNaN(this.completionPercent_)) {
+    //     this.completionPercent_ = percent;
+    //     hasNewCompletionPercent = true;
+    //   } else {
+    //     const newCompletionPercent = Math.max(this.completionPercent_, percent);
+    //     if (this.completionPercent_ != newCompletionPercent) {
+    //       this.completionPercent_ = newCompletionPercent;
+    //       hasNewCompletionPercent = true;
+    //     }
+    //   }
+    // }
+    // if (hasNewCompletionPercent) {
+    //   let event;
+    //   if (this.completionPercent_ == 0) {
+    //     event = shaka.Player.makeEvent_(shaka.util.FakeEvent.EventName.Started);
+    //   } else if (this.completionPercent_ == 25) {
+    //     event = shaka.Player.makeEvent_(
+    //         shaka.util.FakeEvent.EventName.FirstQuartile);
+    //   } else if (this.completionPercent_ == 50) {
+    //     event = shaka.Player.makeEvent_(
+    //         shaka.util.FakeEvent.EventName.Midpoint);
+    //   } else if (this.completionPercent_ == 75) {
+    //     event = shaka.Player.makeEvent_(
+    //         shaka.util.FakeEvent.EventName.ThirdQuartile);
+    //   } else if (this.completionPercent_ == 100) {
+    //     event = shaka.Player.makeEvent_(
+    //         shaka.util.FakeEvent.EventName.Complete);
+    //   }
+    //   if (event) {
+    //     this.dispatchEvent(event);
+    //   }
+    // }
   }
 
   /**

--- a/lib/player.js
+++ b/lib/player.js
@@ -7034,7 +7034,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     const isCloseEnough = (n1, n2) => {
-      const epsilon = 0.01 || Number.EPSILON || 2.220446049250313e-16;
+      const epsilon = 0.1;
       return Math.abs(n1 - n2) < epsilon;
     }
 
@@ -7049,16 +7049,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return false;
     }
 
-    let hasNewCompletionPercent = false;
     const completionRatio = this.video_.currentTime / this.video_.duration;
 
     if (isNaN(completionRatio)) {
       return;
     }
 
-    let event;
     const percent = completionRatio * 100;
 
+    let event;
     if (isQuartile(0, percent)) {
       event = shaka.Player.makeEvent_(shaka.util.FakeEvent.EventName.Started);
     } else if (isQuartile(25, percent)) {
@@ -7078,41 +7077,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (event) {
       this.dispatchEvent(event);
     }
-
-    // if (!isNaN(completionRatio)) {
-    //   const percent = Math.round(100 * completionRatio);
-    //   if (isNaN(this.completionPercent_)) {
-    //     this.completionPercent_ = percent;
-    //     hasNewCompletionPercent = true;
-    //   } else {
-    //     const newCompletionPercent = Math.max(this.completionPercent_, percent);
-    //     if (this.completionPercent_ != newCompletionPercent) {
-    //       this.completionPercent_ = newCompletionPercent;
-    //       hasNewCompletionPercent = true;
-    //     }
-    //   }
-    // }
-    // if (hasNewCompletionPercent) {
-    //   let event;
-    //   if (this.completionPercent_ == 0) {
-    //     event = shaka.Player.makeEvent_(shaka.util.FakeEvent.EventName.Started);
-    //   } else if (this.completionPercent_ == 25) {
-    //     event = shaka.Player.makeEvent_(
-    //         shaka.util.FakeEvent.EventName.FirstQuartile);
-    //   } else if (this.completionPercent_ == 50) {
-    //     event = shaka.Player.makeEvent_(
-    //         shaka.util.FakeEvent.EventName.Midpoint);
-    //   } else if (this.completionPercent_ == 75) {
-    //     event = shaka.Player.makeEvent_(
-    //         shaka.util.FakeEvent.EventName.ThirdQuartile);
-    //   } else if (this.completionPercent_ == 100) {
-    //     event = shaka.Player.makeEvent_(
-    //         shaka.util.FakeEvent.EventName.Complete);
-    //   }
-    //   if (event) {
-    //     this.dispatchEvent(event);
-    //   }
-    // }
   }
 
   /**

--- a/lib/util/number_utils.js
+++ b/lib/util/number_utils.js
@@ -1,0 +1,37 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.provide('shaka.util.NumberUtils');
+
+
+shaka.util.NumberUtils = class {
+  /**
+   * Compare two float numbers, taking a configurable tolerance margin into
+   * account.
+   *
+   * @param {number} a
+   * @param {number} b
+   * @param {number=} tolerance
+   * @return {boolean}
+   */
+  static isFloatEqual(a, b, tolerance = Number.EPSILON) {
+    if (a === b) {
+      return true;
+    }
+
+    const error = Math.abs(a - b);
+
+    if (error <= tolerance) {
+      return true;
+    }
+
+    if (tolerance !== Number.EPSILON) {
+      return Math.abs(error - tolerance) <= Number.EPSILON;
+    }
+
+    return false;
+  }
+};

--- a/test/util/number_utils_unit.js
+++ b/test/util/number_utils_unit.js
@@ -1,0 +1,20 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('NumberUtils', () => {
+  const NumberUtils = shaka.util.NumberUtils;
+
+  it('compares float', () => {
+    expect(NumberUtils.isFloatEqual(0.1 + 0.2, 0.3)).toBe(true);
+    expect(NumberUtils.isFloatEqual(0.4 - 0.1, 0.3)).toBe(true);
+    expect(NumberUtils.isFloatEqual(0.0004, 0.0003)).toBe(false);
+  });
+
+  it('respects provided tolerance margin', () => {
+    expect(NumberUtils.isFloatEqual(1.5, 1.4)).toBe(false);
+    expect(NumberUtils.isFloatEqual(1.5, 1.4, 0.1)).toBe(true);
+  });
+});


### PR DESCRIPTION
Due do rounding errors the progress events were fired way too early (especially the complete event on longer videos). This changes use float comparison to mitigate the issue.
Further improvements (video with start time, seek handling) will be added in follow up PRs.