### PR TITLE
test: Remove some flaky integration test covered with unit tests

### DIFF
--- a/test/ads_integration.js
+++ b/test/ads_integration.js
@@ -29,20 +29,6 @@ describe('Ads', () => {
   /** @type {!shaka.test.Waiter} */
   let waiter;
 
-  /** @type {string} */
-  const vastUri = 'https://pubads.g.doubleclick.net/gampad/ads?' +
-      'sz=640x480&iu=/124319096/external/single_ad_samples&' +
-      'ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&' +
-      'unviewed_position_start=1&' +
-      'cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator=';
-
-  /** @type {string} */
-  const vmapUri = 'https://pubads.g.doubleclick.net/gampad/ads?' +
-      'iu=/21775744923/external/vmap_ad_samples&sz=640x480&' +
-      'cust_params=sample_ar%3Dpreonly&ciu_szs=300x250%2C728x90&gdfp_req=1&' +
-      'ad_rule=1&output=vmap&unviewed_position_start=1&' +
-      'env=vp&impl=s&correlator=';
-
   beforeAll(async () => {
     video = shaka.test.UiUtils.createVideoElement();
     document.body.appendChild(video);
@@ -198,70 +184,6 @@ describe('Ads', () => {
       // Play for 10 seconds, but stop early if the video ends.  If it takes
       // longer than 30 seconds, fail the test.
       await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 10, 30);
-
-      await player.unload();
-    });
-  });
-
-  describe('support VAST using Interstitials API', () => {
-    /** @type {string} */
-    const streamUri = '/base/test/test/assets/dash-multi-codec/dash.mpd';
-
-    it('without support for multiple media elements', async () => {
-      player.configure('ads.supportsMultipleMediaElements', false);
-
-      adManager.initInterstitial(adContainer, player, video);
-
-      await player.load(streamUri);
-      await video.play();
-      expect(player.isLive()).toBe(false);
-
-      adManager.addAdUrlInterstitial(vastUri);
-
-      // Wait a maximum of 10 seconds before the ad starts playing.
-      await waiter.timeoutAfter(10)
-          .waitForEvent(adManager, shaka.ads.Utils.AD_STARTED);
-      await waiter.timeoutAfter(20)
-          .waitForEvent(adManager, shaka.ads.Utils.AD_STOPPED);
-
-      await shaka.test.Util.delay(1);
-      expect(video.currentTime).toBeLessThanOrEqual(3);
-
-      // Play for 5 seconds, but stop early if the video ends.  If it takes
-      // longer than 30 seconds, fail the test.
-      await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 5, 30);
-
-      await player.unload();
-    });
-  });
-
-  describe('support VMAP using Interstitials API', () => {
-    /** @type {string} */
-    const streamUri = '/base/test/test/assets/dash-multi-codec/dash.mpd';
-
-    it('without support for multiple media elements', async () => {
-      player.configure('ads.supportsMultipleMediaElements', false);
-
-      adManager.initInterstitial(adContainer, player, video);
-
-      await player.load(streamUri);
-      await video.play();
-      expect(player.isLive()).toBe(false);
-
-      adManager.addAdUrlInterstitial(vmapUri);
-
-      // Wait a maximum of 10 seconds before the ad starts playing.
-      await waiter.timeoutAfter(10)
-          .waitForEvent(adManager, shaka.ads.Utils.AD_STARTED);
-      await waiter.timeoutAfter(20)
-          .waitForEvent(adManager, shaka.ads.Utils.AD_STOPPED);
-
-      await shaka.test.Util.delay(1);
-      expect(video.currentTime).toBeLessThanOrEqual(3);
-
-      // Play for 5 seconds, but stop early if the video ends.  If it takes
-      // longer than 30 seconds, fail the test.
-      await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 5, 30);
 
       await player.unload();
     });


### PR DESCRIPTION
VAST and VMAP parsing are now covered by unit tests, and ad playing is already covered by the other HLS and DASH tests since the same code is used internally. There is no change in coverage.