### PR TITLE
perf: Reduce calls to isTypeSupported

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -489,6 +489,23 @@ shaka.util.StreamUtils = class {
    * @private
    */
   static checkVariantSupported_(variant, keySystem) {
+    const variantSupported = variant.decodingInfos.some((decodingInfo) => {
+      if (!decodingInfo.supported) {
+        return false;
+      }
+      if (keySystem) {
+        const keySystemAccess = decodingInfo.keySystemAccess;
+        if (keySystemAccess) {
+          if (keySystemAccess.keySystem != keySystem) {
+            return false;
+          }
+        }
+      }
+      return true;
+    });
+    if (!variantSupported) {
+      return false;
+    }
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
     const Capabilities = shaka.media.Capabilities;
     const ManifestParserUtils = shaka.util.ManifestParserUtils;
@@ -537,15 +554,17 @@ shaka.util.StreamUtils = class {
         videoCodecs = [videoCodecs, audioCodecs].join(',');
       }
 
-      const fullType = MimeUtils.getFullOrConvertedType(
-          video.mimeType, videoCodecs, ContentType.VIDEO);
+      if (video.codecs != videoCodecs) {
+        const fullType = MimeUtils.getFullOrConvertedType(
+            video.mimeType, videoCodecs, ContentType.VIDEO);
 
-      if (!Capabilities.isTypeSupported(fullType)) {
-        return false;
+        if (!Capabilities.isTypeSupported(fullType)) {
+          return false;
+        }
+
+        // Update the codec string with the (possibly) converted codecs.
+        video.codecs = videoCodecs;
       }
-
-      // Update the codec string with the (possibly) converted codecs.
-      video.codecs = videoCodecs;
     }
 
     const audio = variant.audio;
@@ -562,31 +581,20 @@ shaka.util.StreamUtils = class {
     if (audio) {
       const codecs = StreamUtils.getCorrectAudioCodecs(
           audio.codecs, audio.mimeType);
-      const fullType = MimeUtils.getFullOrConvertedType(
-          audio.mimeType, codecs, ContentType.AUDIO);
+      if (audio.codecs != codecs) {
+        const fullType = MimeUtils.getFullOrConvertedType(
+            audio.mimeType, codecs, ContentType.AUDIO);
 
-      if (!Capabilities.isTypeSupported(fullType)) {
-        return false;
+        if (!Capabilities.isTypeSupported(fullType)) {
+          return false;
+        }
+
+        // Update the codec string with the (possibly) converted codecs.
+        audio.codecs = codecs;
       }
-
-      // Update the codec string with the (possibly) converted codecs.
-      audio.codecs = codecs;
     }
 
-    return variant.decodingInfos.some((decodingInfo) => {
-      if (!decodingInfo.supported) {
-        return false;
-      }
-      if (keySystem) {
-        const keySystemAccess = decodingInfo.keySystemAccess;
-        if (keySystemAccess) {
-          if (keySystemAccess.keySystem != keySystem) {
-            return false;
-          }
-        }
-      }
-      return true;
-    });
+    return true;
   }
 
 

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -3712,6 +3712,8 @@ describe('Player', () => {
             stream.mimeType = 'video';
             stream.codecs = 'unsupported';
             stream.addDrmInfo('foo.bar');
+            stream.fullMimeTypes = new Set([shaka.util.MimeUtils.getFullType(
+                stream.mimeType, stream.codecs)]);
           });
         });
         manifest.addVariant(1, (variant) => {


### PR DESCRIPTION
There should not be any call to isTypeSupported if we have already used Mcap with the same codecs/mimeType