### PR TITLE
ci: Update workflow permissions

### DIFF
--- a/.github/workflows/deflake.yaml
+++ b/.github/workflows/deflake.yaml
@@ -16,6 +16,10 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
 
+    permissions:
+      # "Write" to Actions to enable rerun command.
+      actions: write
+
     steps:
       - name: Check run count and re-run workflow
         env:

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -145,6 +145,11 @@ jobs:
     name: Pre-build Player
     needs: compute-sha
     runs-on: ubuntu-latest
+
+    permissions:
+      # "Write" to statuses to update commit status
+      statuses: write
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -208,6 +213,10 @@ jobs:
     # This is a self-hosted runner in a Docker container, with access to our
     # lab's Selenium grid on port 4444.
     runs-on: self-hosted-selenium
+
+    permissions:
+      # "Write" to statuses to update commit status
+      statuses: write
 
     # Only one run of this job is allowed at a time, since it uses physical
     # resources in our lab.

--- a/.github/workflows/update-issues.yaml
+++ b/.github/workflows/update-issues.yaml
@@ -8,10 +8,6 @@ on:
     # Run every 30 minutes
     - cron: '*/30 * * * *'
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   update-issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now that default permissions are read-only, we must enable specific permissions for certain workflow jobs.

This fixes every job except "update screenshots", which has unresolved permissions issues.