### PR TITLE
feat: Add streaming.preferNativeDash config

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -488,6 +488,8 @@ shakaDemo.Config = class {
         .addBoolInput_('Force HTTPS', 'streaming.forceHTTPS')
         .addNumberInput_('Min bytes for progress events',
             'streaming.minBytesForProgressEvents')
+        .addBoolInput_('Prefer native DASH playback when available',
+            'streaming.preferNativeDash')
         .addBoolInput_('Prefer native HLS playback when available',
             'streaming.preferNativeHls')
         .addNumberInput_('Update interval seconds',

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1564,6 +1564,7 @@ shaka.extern.LiveSyncConfiguration;
  *   forceHTTP: boolean,
  *   forceHTTPS: boolean,
  *   minBytesForProgressEvents: number,
+ *   preferNativeDash: boolean,
  *   preferNativeHls: boolean,
  *   updateIntervalSeconds: number,
  *   observeQualityChanges: boolean,
@@ -1740,6 +1741,10 @@ shaka.extern.LiveSyncConfiguration;
  *   if possible. To avoid issues around feeding ABR with request history, this
  *   value should be greater than or equal to `abr.advanced.minBytes`.
  *   By default equals 16e3 (the same value as `abr.advanced.minBytes`).
+ * @property {boolean} preferNativeDash
+ *   If true, prefer native DASH playback when possible, regardless of platform.
+ *   <br>
+ *   Defaults to <code>false</code>.
  * @property {boolean} preferNativeHls
  *   If true, prefer native HLS playback when possible, regardless of platform.
  *   <br>

--- a/lib/player.js
+++ b/lib/player.js
@@ -2371,6 +2371,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         return this.config_.streaming.preferNativeHls;
       }
 
+      if (MimeUtils.isDashType(mimeType)) {
+        // Native DASH can be preferred on any platform via this flag:
+        return this.config_.streaming.preferNativeDash;
+      }
+
       // In all other cases, we prefer MediaSource.
       return false;
     }

--- a/lib/util/mime_utils.js
+++ b/lib/util/mime_utils.js
@@ -252,6 +252,17 @@ shaka.util.MimeUtils = class {
   }
 
   /**
+   * Checks if the given MIME type is DASH MIME type.
+   *
+   * @param {string} mimeType
+   * @return {boolean}
+   */
+  static isDashType(mimeType) {
+    return mimeType === 'application/dash+xml' ||
+        mimeType === 'video/vnd.mpeg.dash.mpd';
+  }
+
+  /**
    * Get the base and profile of a codec string. Where [0] will be the codec
    * base and [1] will be the profile.
    * @param {string} codecString

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -233,6 +233,7 @@ shaka.util.PlayerConfiguration = class {
       forceHTTP: false,
       forceHTTPS: false,
       minBytesForProgressEvents: minBytes,
+      preferNativeDash: false,
       preferNativeHls: false,
       updateIntervalSeconds: 1,
       observeQualityChanges: false,


### PR DESCRIPTION
This is useful for WebOS, because in MSE there is no support for VVC but there is support for src=