### PR TITLE
feat: add support for multiple robustness levels in drm

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -140,7 +140,7 @@ shakaDemo.Config = class {
             'drm.ignoreDuplicateInitData');
     const advanced = shakaDemoMain.getConfiguration().drm.advanced || {};
     const addDRMAdvancedField = (name, valueName, suggestions,
-      arrayString = false) => {
+        arrayString = false) => {
       // All advanced fields of a given type are set at once.
       this.addDatalistInput_(name, suggestions, (input) => {
         // Add in any common drmSystem not currently in advanced.

--- a/demo/config.js
+++ b/demo/config.js
@@ -139,7 +139,8 @@ shakaDemo.Config = class {
         .addBoolInput_('Ignore duplicate init data',
             'drm.ignoreDuplicateInitData');
     const advanced = shakaDemoMain.getConfiguration().drm.advanced || {};
-    const addDRMAdvancedField = (name, valueName, suggestions) => {
+    const addDRMAdvancedField = (name, valueName, suggestions,
+      arrayString = false) => {
       // All advanced fields of a given type are set at once.
       this.addDatalistInput_(name, suggestions, (input) => {
         // Add in any common drmSystem not currently in advanced.
@@ -150,7 +151,9 @@ shakaDemo.Config = class {
         }
         // Set the robustness.
         for (const drmSystem in advanced) {
-          advanced[drmSystem][valueName] = input.value;
+          advanced[drmSystem][valueName] = arrayString ?
+              input.value.split(',').filter(Boolean) :
+              input.value;
         }
         shakaDemoMain.configure('drm.advanced', advanced);
         shakaDemoMain.remakeHash();
@@ -176,9 +179,11 @@ shakaDemo.Config = class {
     const sessionTypeSuggestions = ['temporary', 'persistent-license'];
 
     addDRMAdvancedField(
-        'Video Robustness', 'videoRobustness', robustnessSuggestions);
+        'Video Robustness', 'videoRobustness', robustnessSuggestions,
+        /* arrayString= */ true);
     addDRMAdvancedField(
-        'Audio Robustness', 'audioRobustness', robustnessSuggestions);
+        'Audio Robustness', 'audioRobustness', robustnessSuggestions,
+        /* arrayString= */ true);
     addDRMAdvancedField('Session Type', 'sessionType', sessionTypeSuggestions);
 
     this.addRetrySection_('drm', 'DRM Retry Parameters');

--- a/demo/main.js
+++ b/demo/main.js
@@ -949,12 +949,16 @@ shakaDemo.Main = class {
             advanced[drmSystem] = shakaDemo.Main.defaultAdvancedDrmConfig();
           }
           if ('videoRobustness' in params) {
-            advanced[drmSystem].videoRobustness = [params['videoRobustness']];
+            advanced[drmSystem].videoRobustness =
+                params['videoRobustness'].split(',');
           }
           if ('audioRobustness' in params) {
-            advanced[drmSystem].audioRobustness = [params['audioRobustness']];
+            advanced[drmSystem].audioRobustness =
+                params['audioRobustness'].split(',');
           }
         }
+
+        this.configure('drm.advanced', advanced);
       }
     }
     if ('lang' in params) {
@@ -1500,10 +1504,12 @@ shakaDemo.Main = class {
           const advancedFor = advanced[drmSystem];
           if (advancedFor) {
             if (advancedFor.videoRobustness) {
-              params.push('videoRobustness=' + advancedFor.videoRobustness);
+              params.push('videoRobustness=' +
+                  advancedFor.videoRobustness.join());
             }
             if (advancedFor.audioRobustness) {
-              params.push('audioRobustness=' + advancedFor.audioRobustness);
+              params.push('audioRobustness=' +
+                  advancedFor.audioRobustness.join());
             }
             break;
           }

--- a/demo/main.js
+++ b/demo/main.js
@@ -949,10 +949,10 @@ shakaDemo.Main = class {
             advanced[drmSystem] = shakaDemo.Main.defaultAdvancedDrmConfig();
           }
           if ('videoRobustness' in params) {
-            advanced[drmSystem].videoRobustness = params['videoRobustness'];
+            advanced[drmSystem].videoRobustness = [params['videoRobustness']];
           }
           if ('audioRobustness' in params) {
-            advanced[drmSystem].audioRobustness = params['audioRobustness'];
+            advanced[drmSystem].audioRobustness = [params['audioRobustness']];
           }
         }
       }
@@ -1933,8 +1933,8 @@ shakaDemo.Main = class {
     return {
       distinctiveIdentifierRequired: false,
       persistentStateRequired: false,
-      videoRobustness: '',
-      audioRobustness: '',
+      videoRobustness: [''],
+      audioRobustness: [''],
       sessionType: '',
       serverCertificate: new Uint8Array(0),
       serverCertificateUri: '',

--- a/demo/main.js
+++ b/demo/main.js
@@ -958,7 +958,9 @@ shakaDemo.Main = class {
           }
         }
 
-        this.configure('drm.advanced', advanced);
+        if ('audioRobustness' in params || 'videoRobustness' in params) {
+          this.configure('drm.advanced', advanced);
+        }
       }
     }
     if ('lang' in params) {
@@ -1503,11 +1505,13 @@ shakaDemo.Main = class {
         for (const drmSystem of shakaDemo.Main.commonDrmSystems) {
           const advancedFor = advanced[drmSystem];
           if (advancedFor) {
-            if (advancedFor.videoRobustness) {
+            if (advancedFor.videoRobustness &&
+              advancedFor.videoRobustness.length) {
               params.push('videoRobustness=' +
                   advancedFor.videoRobustness.join());
             }
-            if (advancedFor.audioRobustness) {
+            if (advancedFor.audioRobustness &&
+              advancedFor.audioRobustness.length) {
               params.push('audioRobustness=' +
                   advancedFor.audioRobustness.join());
             }
@@ -1939,8 +1943,8 @@ shakaDemo.Main = class {
     return {
       distinctiveIdentifierRequired: false,
       persistentStateRequired: false,
-      videoRobustness: [''],
-      audioRobustness: [''],
+      videoRobustness: [],
+      audioRobustness: [],
       sessionType: '',
       serverCertificate: new Uint8Array(0),
       serverCertificateUri: '',

--- a/docs/tutorials/upgrade.md
+++ b/docs/tutorials/upgrade.md
@@ -116,6 +116,7 @@ application:
       `panicThreshold`. (deprecated in v4.10.0)
     - `useSafariBehaviorForLive` has been removed.
     - `parsePrftBox` has been removed.
+    - `videoRobustness` and `audioRobustness` are now only an array of strings. (deprecated in v4.13.0)
 
   - Plugin changes:
     - `TextDisplayer` plugins must implement the `configure()` method.

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -829,13 +829,13 @@ shaka.extern.ProducerReferenceTime;
  *   Defaults to <code>false</code>.
  * @property {Array.<string>} videoRobustness
  *   A key-system-specific Array of strings that specifies a required security
- *   level for video. For multiple robustness leveles, list items in priority
+ *   level for video. For multiple robustness levels, list items in priority
  *   order.
  *   <br>
  *   Defaults to <code>[]</code>, i.e., no specific robustness required.
  * @property {Array.<string>} audioRobustness
  *   A key-system-specific Array of strings that specifies a required security
- *   level for audio. For multiple robustness leveles, list items in priority
+ *   level for audio. For multiple robustness levels, list items in priority
  *   order.
  *   <br>
  *   Defaults to <code>[]</code>, i.e., no specific robustness required.

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -808,8 +808,8 @@ shaka.extern.ProducerReferenceTime;
  * @typedef {{
  *   distinctiveIdentifierRequired: boolean,
  *   persistentStateRequired: boolean,
- *   videoRobustness: string,
- *   audioRobustness: string,
+ *   videoRobustness: string | Array.<string>,
+ *   audioRobustness: string | Array.<string>,
  *   serverCertificate: Uint8Array,
  *   serverCertificateUri: string,
  *   individualizationServer: string,
@@ -827,14 +827,14 @@ shaka.extern.ProducerReferenceTime;
  *   state, e.g., for persistent license storage.
  *   <br>
  *   Defaults to <code>false</code>.
- * @property {string} videoRobustness
+ * @property {string | Array.<string>} videoRobustness
  *   A key-system-specific string that specifies a required security level for
- *   video.
+ *   video. Can be an array of strings to represent multiple robustness.
  *   <br>
  *   Defaults to <code>''</code>, i.e., no specific robustness required.
- * @property {string} audioRobustness
+ * @property {string | Array.<string>} audioRobustness
  *   A key-system-specific string that specifies a required security level for
- *   audio.
+ *   audio. Can be an array of strings to represent multiple robustness.
  *   <br>
  *   Defaults to <code>''</code>, i.e., no specific robustness required.
  * @property {Uint8Array} serverCertificate

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -829,16 +829,16 @@ shaka.extern.ProducerReferenceTime;
  *   Defaults to <code>false</code>.
  * @property {Array.<string>} videoRobustness
  *   A key-system-specific Array of strings that specifies a required security
- *   level for video. Can be an array of strings to represent multiple
- *   robustness.
+ *   level for video. For multiple robustness leveles, list items in priority
+ *   order.
  *   <br>
- *   Defaults to <code>['']</code>, i.e., no specific robustness required.
+ *   Defaults to <code>[]</code>, i.e., no specific robustness required.
  * @property {Array.<string>} audioRobustness
  *   A key-system-specific Array of strings that specifies a required security
- *   level for audio. Can be an array of strings to represent multiple
- *   robustness.
+ *   level for audio. For multiple robustness leveles, list items in priority
+ *   order.
  *   <br>
- *   Defaults to <code>['']</code>, i.e., no specific robustness required.
+ *   Defaults to <code>[]</code>, i.e., no specific robustness required.
  * @property {Uint8Array} serverCertificate
  *   <i>An empty certificate (<code>byteLength==0</code>) will be treated as
  *   <code>null</code>.</i> <br>

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -808,8 +808,8 @@ shaka.extern.ProducerReferenceTime;
  * @typedef {{
  *   distinctiveIdentifierRequired: boolean,
  *   persistentStateRequired: boolean,
- *   videoRobustness: string | Array.<string>,
- *   audioRobustness: string | Array.<string>,
+ *   videoRobustness: Array.<string>,
+ *   audioRobustness: Array.<string>,
  *   serverCertificate: Uint8Array,
  *   serverCertificateUri: string,
  *   individualizationServer: string,
@@ -827,16 +827,18 @@ shaka.extern.ProducerReferenceTime;
  *   state, e.g., for persistent license storage.
  *   <br>
  *   Defaults to <code>false</code>.
- * @property {string | Array.<string>} videoRobustness
- *   A key-system-specific string that specifies a required security level for
- *   video. Can be an array of strings to represent multiple robustness.
+ * @property {Array.<string>} videoRobustness
+ *   A key-system-specific Array of strings that specifies a required security
+ *   level for video. Can be an array of strings to represent multiple
+ *   robustness.
  *   <br>
- *   Defaults to <code>''</code>, i.e., no specific robustness required.
- * @property {string | Array.<string>} audioRobustness
- *   A key-system-specific string that specifies a required security level for
- *   audio. Can be an array of strings to represent multiple robustness.
+ *   Defaults to <code>['']</code>, i.e., no specific robustness required.
+ * @property {Array.<string>} audioRobustness
+ *   A key-system-specific Array of strings that specifies a required security
+ *   level for audio. Can be an array of strings to represent multiple
+ *   robustness.
  *   <br>
- *   Defaults to <code>''</code>, i.e., no specific robustness required.
+ *   Defaults to <code>['']</code>, i.e., no specific robustness required.
  * @property {Uint8Array} serverCertificate
  *   <i>An empty certificate (<code>byteLength==0</code>) will be treated as
  *   <code>null</code>.</i> <br>

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -414,14 +414,25 @@ shaka.drm.DrmEngine = class {
     let configsByKeySystem;
 
     /**
-     * Expand robustness into multiple drm infos if multiple video robustness levels were provided.
+     * Expand robustness into multiple drm infos if multiple video robustness
+     * levels were provided.
      *
-     * robustness can be either a single item as a string or multiple items as an array of strings.
+     * robustness can be either a single item as a string or multiple items as
+     * an array of strings.
      */
     const expandRobustness = (drmInfos, robustnessType) => {
       const newDrmInfos = [];
       for (const drmInfo of drmInfos) {
-        const items = [].concat(drmInfo[robustnessType]);
+        let items = drmInfo[robustnessType] ||
+            this.config_.advanced &&
+            this.config_.advanced[drmInfo.keySystem] &&
+            this.config_.advanced[drmInfo.keySystem][robustnessType] || '';
+        if (typeof items === 'string') {
+          // if drmInfo's robustness has already been expanded,
+          // use the drmInfo directly directly
+          newDrmInfos.push(drmInfo);
+          continue;
+        }
         for (const item of items) {
           newDrmInfos.push(
               Object.assign({}, drmInfo, {[robustnessType]: item}),
@@ -2542,13 +2553,8 @@ shaka.drm.DrmEngine = class {
             advancedConfig.persistentStateRequired;
       }
 
-      if (!drmInfo.videoRobustness) {
-        drmInfo.videoRobustness = advancedConfig.videoRobustness;
-      }
-
-      if (!drmInfo.audioRobustness) {
-        drmInfo.audioRobustness = advancedConfig.audioRobustness;
-      }
+      // robustness will be filled in with defaults, if needed, in
+      // expandRobustness
 
       if (!drmInfo.serverCertificate) {
         drmInfo.serverCertificate = advancedConfig.serverCertificate;

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -423,10 +423,10 @@ shaka.drm.DrmEngine = class {
     const expandRobustness = (drmInfos, robustnessType) => {
       const newDrmInfos = [];
       for (const drmInfo of drmInfos) {
-        let items = drmInfo[robustnessType] ||
-            this.config_.advanced &&
+        const items = drmInfo[robustnessType] ||
+            (this.config_.advanced &&
             this.config_.advanced[drmInfo.keySystem] &&
-            this.config_.advanced[drmInfo.keySystem][robustnessType] || '';
+            this.config_.advanced[drmInfo.keySystem][robustnessType]) || '';
         if (typeof items === 'string') {
           // if drmInfo's robustness has already been expanded,
           // use the drmInfo directly directly

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -429,7 +429,7 @@ shaka.drm.DrmEngine = class {
             this.config_.advanced[drmInfo.keySystem][robustnessType]) || '';
         if (typeof items === 'string') {
           // if drmInfo's robustness has already been expanded,
-          // use the drmInfo directly directly
+          // use the drmInfo directly.
           newDrmInfos.push(drmInfo);
           continue;
         }

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -423,7 +423,7 @@ shaka.drm.DrmEngine = class {
     const expandRobustness = (drmInfos, robustnessType) => {
       const newDrmInfos = [];
       for (const drmInfo of drmInfos) {
-        const items = drmInfo[robustnessType] ||
+        let items = drmInfo[robustnessType] ||
             (this.config_.advanced &&
             this.config_.advanced[drmInfo.keySystem] &&
             this.config_.advanced[drmInfo.keySystem][robustnessType]) || '';
@@ -431,12 +431,15 @@ shaka.drm.DrmEngine = class {
           // if drmInfo's robustness has already been expanded,
           // use the drmInfo directly.
           newDrmInfos.push(drmInfo);
-          continue;
-        }
-        for (const item of items) {
-          newDrmInfos.push(
-              Object.assign({}, drmInfo, {[robustnessType]: item}),
-          );
+        } else if (Array.isArray(items)) {
+          if (items.length === 0) {
+            items = [''];
+          }
+          for (const item of items) {
+            newDrmInfos.push(
+                Object.assign({}, drmInfo, {[robustnessType]: item}),
+            );
+          }
         }
       }
       return newDrmInfos;

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -413,6 +413,43 @@ shaka.drm.DrmEngine = class {
     /** @type {!Map.<string, MediaKeySystemConfiguration>} */
     let configsByKeySystem;
 
+    /**
+     * Expand robustness into multiple drm infos if multiple video robustness levels were provided.
+     *
+     * robustness can be either a single item as a string or multiple items as an array of strings.
+     */
+    const expandRobustness = (drmInfos, robustnessType) => {
+      const newDrmInfos = [];
+      for (const drmInfo of drmInfos) {
+        const items = [].concat(drmInfo[robustnessType]);
+        for (const item of items) {
+          newDrmInfos.push(
+              Object.assign({}, drmInfo, {[robustnessType]: item}),
+          );
+        }
+      }
+      return newDrmInfos;
+    };
+
+    for (const variant of variants) {
+      if (variant.video) {
+        variant.video.drmInfos =
+            expandRobustness(variant.video.drmInfos,
+                'videoRobustness');
+        variant.video.drmInfos =
+            expandRobustness(variant.video.drmInfos,
+                'audioRobustness');
+      }
+      if (variant.audio) {
+        variant.audio.drmInfos =
+            expandRobustness(variant.audio.drmInfos,
+                'videoRobustness');
+        variant.audio.drmInfos =
+            expandRobustness(variant.audio.drmInfos,
+                'audioRobustness');
+      }
+    }
+
     // We should get the decodingInfo results for the variants after we filling
     // in the drm infos, and before queryMediaKeys_().
     await shaka.util.StreamUtils.getDecodingInfosForVariants(variants,

--- a/lib/player.js
+++ b/lib/player.js
@@ -4055,12 +4055,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       for (const keySystem in config['drm']['advanced']) {
         const {videoRobustness, audioRobustness} =
             config['drm']['advanced'][keySystem];
-        if ('videoRobustness' in keySystem &&
+        if ('videoRobustness' in config['drm']['advanced'][keySystem] &&
             !Array.isArray(keySystem['videoRobustness'])) {
           keySystem['videoRobustness'] = [videoRobustness];
           fixedUp = true;
         }
-        if ('audioRobustness' in keySystem &&
+        if ('audioRobustness' in config['drm']['advanced'][keySystem] &&
             !Array.isArray(keySystem['audioRobustness'])) {
           keySystem['audioRobustness'] = [audioRobustness];
           fixedUp = true;

--- a/lib/player.js
+++ b/lib/player.js
@@ -4047,6 +4047,34 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           config['streaming']['autoLowLatencyMode'];
       delete config['streaming']['autoLowLatencyMode'];
     }
+
+    // Deprecate AdvancedDrmConfiguration's videoRobustness and audioRobustness
+    // as a string. It's now an array of strings.
+    if (config['drm'] && config['drm']['advanced']) {
+      let fixedUp = false;
+      for (const keySystem in config['drm']['advanced']) {
+        const {videoRobustness, audioRobustness} =
+            config['drm']['advanced'][keySystem];
+        if ('videoRobustness' in keySystem &&
+            !Array.isArray(keySystem['videoRobustness'])) {
+          keySystem['videoRobustness'] = [videoRobustness];
+          fixedUp = true;
+        }
+        if ('audioRobustness' in keySystem &&
+            !Array.isArray(keySystem['audioRobustness'])) {
+          keySystem['audioRobustness'] = [audioRobustness];
+          fixedUp = true;
+        }
+      }
+
+      if (fixedUp) {
+        shaka.Deprecate.deprecateFeature(5,
+            'AdvancedDrmConfiguration\'s videoRobustness and audioRobustness',
+            'These propierties are no longer strings but array of strings, ' +
+            'please update your usage of these propeties.');
+      }
+    }
+
     const ret = shaka.util.PlayerConfiguration.mergeConfigObjects(
         this.config_, config, this.defaultConfig_());
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -4057,14 +4057,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             config['drm']['advanced'][keySystem];
         if ('videoRobustness' in config['drm']['advanced'][keySystem] &&
             !Array.isArray(
-              config['drm']['advanced'][keySystem]['videoRobustness'])) {
+                config['drm']['advanced'][keySystem]['videoRobustness'])) {
           config['drm']['advanced'][keySystem]['videoRobustness'] =
               [videoRobustness];
           fixedUp = true;
         }
         if ('audioRobustness' in config['drm']['advanced'][keySystem] &&
             !Array.isArray(
-              config['drm']['advanced'][keySystem]['audioRobustness'])) {
+                config['drm']['advanced'][keySystem]['audioRobustness'])) {
           config['drm']['advanced'][keySystem]['audioRobustness'] =
               [audioRobustness];
           fixedUp = true;

--- a/lib/player.js
+++ b/lib/player.js
@@ -4056,13 +4056,17 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         const {videoRobustness, audioRobustness} =
             config['drm']['advanced'][keySystem];
         if ('videoRobustness' in config['drm']['advanced'][keySystem] &&
-            !Array.isArray(keySystem['videoRobustness'])) {
-          keySystem['videoRobustness'] = [videoRobustness];
+            !Array.isArray(
+              config['drm']['advanced'][keySystem]['videoRobustness'])) {
+          config['drm']['advanced'][keySystem]['videoRobustness'] =
+              [videoRobustness];
           fixedUp = true;
         }
         if ('audioRobustness' in config['drm']['advanced'][keySystem] &&
-            !Array.isArray(keySystem['audioRobustness'])) {
-          keySystem['audioRobustness'] = [audioRobustness];
+            !Array.isArray(
+              config['drm']['advanced'][keySystem]['audioRobustness'])) {
+          config['drm']['advanced'][keySystem]['audioRobustness'] =
+              [audioRobustness];
           fixedUp = true;
         }
       }

--- a/lib/player.js
+++ b/lib/player.js
@@ -4070,8 +4070,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       if (fixedUp) {
         shaka.Deprecate.deprecateFeature(5,
             'AdvancedDrmConfiguration\'s videoRobustness and audioRobustness',
-            'These propierties are no longer strings but array of strings, ' +
-            'please update your usage of these propeties.');
+            'These properties are no longer strings but array of strings, ' +
+            'please update your usage of these properties.');
       }
     }
 

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -540,8 +540,8 @@ shaka.util.PlayerConfiguration = class {
       '.drm.advanced': {
         distinctiveIdentifierRequired: false,
         persistentStateRequired: false,
-        videoRobustness: '',
-        audioRobustness: '',
+        videoRobustness: [''],
+        audioRobustness: [''],
         sessionType: '',
         serverCertificate: new Uint8Array(0),
         serverCertificateUri: '',

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -540,8 +540,8 @@ shaka.util.PlayerConfiguration = class {
       '.drm.advanced': {
         distinctiveIdentifierRequired: false,
         persistentStateRequired: false,
-        videoRobustness: [''],
-        audioRobustness: [''],
+        videoRobustness: [],
+        audioRobustness: [],
         sessionType: '',
         serverCertificate: new Uint8Array(0),
         serverCertificateUri: '',

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -977,101 +977,109 @@ shaka.util.StreamUtils = class {
         usePersistentLicenses ? ['persistent-license'] : ['temporary'];
 
     for (const keySystem of drmInfoByKeySystems.keys()) {
-      const modifiedMediaDecodingConfigBatch = [];
-      for (const base of mediaDecodingConfigBatch) {
-        // Create a copy of the mediaDecodingConfig.
-        const config = /** @type {!MediaDecodingConfiguration} */
-            (Object.assign({}, base));
+      const drmInfos = drmInfoByKeySystems.get(keySystem);
 
-        const drmInfos = drmInfoByKeySystems.get(keySystem);
-
-        /** @type {!MediaCapabilitiesKeySystemConfiguration} */
-        const keySystemConfig = {
-          keySystem: keySystem,
-          initDataType: 'cenc',
-          persistentState: persistentState,
-          distinctiveIdentifier: 'optional',
-          sessionTypes: sessionTypes,
-        };
-
-        for (const info of drmInfos) {
-          if (info.initData && info.initData.length) {
-            const initDataTypes = new Set();
-            for (const initData of info.initData) {
-              initDataTypes.add(initData.initDataType);
-            }
-            if (initDataTypes.size > 1) {
-              shaka.log.v2('DrmInfo contains more than one initDataType,',
-                  'and we use the initDataType of the first initData.',
-                  info);
-            }
-            keySystemConfig.initDataType = info.initData[0].initDataType;
-          }
-
-          if (info.distinctiveIdentifierRequired) {
-            keySystemConfig.distinctiveIdentifier = 'required';
-          }
-          if (info.persistentStateRequired) {
-            keySystemConfig.persistentState = 'required';
-          }
-          if (info.sessionType) {
-            keySystemConfig.sessionTypes = [info.sessionType];
-          }
-
-          if (audio) {
-            if (!keySystemConfig.audio) {
-              // KeySystemTrackConfiguration
-              keySystemConfig.audio = {
-                robustness: info.audioRobustness,
-              };
-              if (info.encryptionScheme) {
-                keySystemConfig.audio.encryptionScheme = info.encryptionScheme;
-              }
-            } else {
-              if (info.encryptionScheme) {
-                keySystemConfig.audio.encryptionScheme =
-                    keySystemConfig.audio.encryptionScheme ||
-                    info.encryptionScheme;
-              }
-              keySystemConfig.audio.robustness =
-                  keySystemConfig.audio.robustness ||
-                  info.audioRobustness;
-            }
-            // See: https://github.com/shaka-project/shaka-player/issues/4659
-            if (keySystemConfig.audio.robustness == '') {
-              delete keySystemConfig.audio.robustness;
-            }
-          }
-
-          if (video) {
-            if (!keySystemConfig.video) {
-              // KeySystemTrackConfiguration
-              keySystemConfig.video = {
-                robustness: info.videoRobustness,
-              };
-              if (info.encryptionScheme) {
-                keySystemConfig.video.encryptionScheme = info.encryptionScheme;
-              }
-            } else {
-              if (info.encryptionScheme) {
-                keySystemConfig.video.encryptionScheme =
-                    keySystemConfig.video.encryptionScheme ||
-                    info.encryptionScheme;
-              }
-              keySystemConfig.video.robustness =
-                  keySystemConfig.video.robustness ||
-                  info.videoRobustness;
-            }
-            // See: https://github.com/shaka-project/shaka-player/issues/4659
-            if (keySystemConfig.video.robustness == '') {
-              delete keySystemConfig.video.robustness;
-            }
-          }
+      // Get all the robustness info so that we can avoid using nested
+      // loops when we just need the robustness.
+      const drmInfosByRobustness = new Map();
+      for (const info of drmInfos) {
+        const keyName = `${info.videoRobustness},${info.audioRobustness}`;
+        if (!drmInfosByRobustness.get(keyName)) {
+          drmInfosByRobustness.set(keyName, []);
         }
-        config.keySystemConfiguration = keySystemConfig;
-        modifiedMediaDecodingConfigBatch.push(config);
+        drmInfosByRobustness.get(keyName).push(info);
       }
-      configs.push(modifiedMediaDecodingConfigBatch);
+
+      for (const drmInfosRobustness of drmInfosByRobustness.values()) {
+        const modifiedMediaDecodingConfigBatch = [];
+        for (const base of mediaDecodingConfigBatch) {
+          // Create a copy of the mediaDecodingConfig.
+          const config = /** @type {!MediaDecodingConfiguration} */
+              (Object.assign({}, base));
+
+
+          /** @type {!MediaCapabilitiesKeySystemConfiguration} */
+          const keySystemConfig = {
+            keySystem: keySystem,
+            initDataType: 'cenc',
+            persistentState: persistentState,
+            distinctiveIdentifier: 'optional',
+            sessionTypes: sessionTypes,
+          };
+
+          for (const info of drmInfosRobustness) {
+            if (info.initData && info.initData.length) {
+              const initDataTypes = new Set();
+              for (const initData of info.initData) {
+                initDataTypes.add(initData.initDataType);
+              }
+              if (initDataTypes.size > 1) {
+                shaka.log.v2('DrmInfo contains more than one initDataType,',
+                    'and we use the initDataType of the first initData.',
+                    info);
+              }
+              keySystemConfig.initDataType = info.initData[0].initDataType;
+            }
+
+            if (info.distinctiveIdentifierRequired) {
+              keySystemConfig.distinctiveIdentifier = 'required';
+            }
+            if (info.persistentStateRequired) {
+              keySystemConfig.persistentState = 'required';
+            }
+            if (info.sessionType) {
+              keySystemConfig.sessionTypes = [info.sessionType];
+            }
+
+            if (audio) {
+              if (!keySystemConfig.audio) {
+                // KeySystemTrackConfiguration
+                keySystemConfig.audio = {
+                  robustness: info.audioRobustness,
+                };
+                if (info.encryptionScheme) {
+                  keySystemConfig.audio.encryptionScheme =
+                      info.encryptionScheme;
+                }
+              } else {
+                if (info.encryptionScheme) {
+                  keySystemConfig.audio.encryptionScheme =
+                      keySystemConfig.audio.encryptionScheme ||
+                      info.encryptionScheme;
+                }
+                keySystemConfig.audio.robustness =
+                    keySystemConfig.audio.robustness ||
+                    info.audioRobustness;
+              }
+            }
+
+            if (video) {
+              if (!keySystemConfig.video) {
+                // KeySystemTrackConfiguration
+                keySystemConfig.video = {
+                  robustness: info.videoRobustness,
+                };
+                if (info.encryptionScheme) {
+                  keySystemConfig.video.encryptionScheme =
+                      info.encryptionScheme;
+                }
+              } else {
+                if (info.encryptionScheme) {
+                  keySystemConfig.video.encryptionScheme =
+                      keySystemConfig.video.encryptionScheme ||
+                      info.encryptionScheme;
+                }
+                keySystemConfig.video.robustness =
+                    keySystemConfig.video.robustness ||
+                    info.videoRobustness;
+              }
+            }
+          }
+          config.keySystemConfiguration = keySystemConfig;
+          modifiedMediaDecodingConfigBatch.push(config);
+        }
+        configs.push(modifiedMediaDecodingConfigBatch);
+      }
     }
     return configs;
   }

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1051,6 +1051,10 @@ shaka.util.StreamUtils = class {
                     keySystemConfig.audio.robustness ||
                     info.audioRobustness;
               }
+              // See: https://github.com/shaka-project/shaka-player/issues/4659
+              if (keySystemConfig.audio.robustness == '') {
+                delete keySystemConfig.audio.robustness;
+              }
             }
 
             if (video) {
@@ -1072,6 +1076,10 @@ shaka.util.StreamUtils = class {
                 keySystemConfig.video.robustness =
                     keySystemConfig.video.robustness ||
                     info.videoRobustness;
+              }
+              // See: https://github.com/shaka-project/shaka-player/issues/4659
+              if (keySystemConfig.video.robustness == '') {
+                delete keySystemConfig.video.robustness;
               }
             }
           }

--- a/test/drm/drm_engine_unit.js
+++ b/test/drm/drm_engine_unit.js
@@ -528,8 +528,8 @@ describe('DrmEngine', () => {
           setDecodingInfoSpy([]);
 
           config.advanced['drm.abc'] = {
-            audioRobustness: 'good',
-            videoRobustness: 'really_really_ridiculously_good',
+            audioRobustness: ['good'],
+            videoRobustness: ['really_really_ridiculously_good'],
             serverCertificate: null,
             serverCertificateUri: '',
             sessionType: 'persistent-license',
@@ -583,9 +583,9 @@ describe('DrmEngine', () => {
           setDecodingInfoSpy([]);
 
           config.advanced['drm.abc'] = {
-            audioRobustness: 'good',
+            audioRobustness: ['good'],
             videoRobustness: [
-              'really_ridiculously_good','a_mid_one', 'another_worse_one'
+              'really_ridiculously_good', 'a_mid_one', 'another_worse_one',
             ],
             serverCertificate: null,
             serverCertificateUri: '',
@@ -671,9 +671,9 @@ describe('DrmEngine', () => {
 
           config.advanced['drm.abc'] = {
             audioRobustness: [
-              'really_ridiculously_good','a_mid_one', 'another_worse_one'
+              'really_ridiculously_good', 'a_mid_one', 'another_worse_one',
             ],
-            videoRobustness: 'good',
+            videoRobustness: ['good'],
             serverCertificate: null,
             serverCertificateUri: '',
             sessionType: 'persistent-license',
@@ -765,8 +765,8 @@ describe('DrmEngine', () => {
       });
 
       config.advanced['drm.abc'] = {
-        audioRobustness: 'bad',
-        videoRobustness: 'so_bad_it_hurts',
+        audioRobustness: ['bad'],
+        videoRobustness: ['so_bad_it_hurts'],
         serverCertificate: null,
         serverCertificateUri: '',
         sessionType: '',
@@ -2366,8 +2366,8 @@ describe('DrmEngine', () => {
       });
 
       config.advanced['drm.abc'] = {
-        audioRobustness: 'good',
-        videoRobustness: 'really_really_ridiculously_good',
+        audioRobustness: ['good'],
+        videoRobustness: ['really_really_ridiculously_good'],
         distinctiveIdentifierRequired: true,
         serverCertificate: null,
         serverCertificateUri: '',
@@ -2735,14 +2735,14 @@ describe('DrmEngine', () => {
    */
   function createAdvancedConfig(serverCert) {
     return {
-      audioRobustness: '',
+      audioRobustness: [''],
       distinctiveIdentifierRequired: false,
       persistentStateRequired: false,
       serverCertificate: serverCert,
       serverCertificateUri: '',
       individualizationServer: '',
       sessionType: '',
-      videoRobustness: '',
+      videoRobustness: [''],
       headers: {},
     };
   }

--- a/test/drm/drm_engine_unit.js
+++ b/test/drm/drm_engine_unit.js
@@ -2795,14 +2795,14 @@ describe('DrmEngine', () => {
    */
   function createAdvancedConfig(serverCert) {
     return {
-      audioRobustness: [''],
+      audioRobustness: [],
       distinctiveIdentifierRequired: false,
       persistentStateRequired: false,
       serverCertificate: serverCert,
       serverCertificateUri: '',
       individualizationServer: '',
       sessionType: '',
-      videoRobustness: [''],
+      videoRobustness: [],
       headers: {},
     };
   }

--- a/test/drm/drm_engine_unit.js
+++ b/test/drm/drm_engine_unit.js
@@ -509,59 +509,234 @@ describe('DrmEngine', () => {
       expect(variants[0].decodingInfos.length).toBe(1);
     });
 
-    it('uses advanced config to fill in DrmInfo', async () => {
-      // Leave only one drmInfo
-      manifest = shaka.test.ManifestGenerator.generate((manifest) => {
-        manifest.addVariant(0, (variant) => {
-          variant.addVideo(1, (stream) => {
-            stream.encrypted = true;
-            stream.addDrmInfo('drm.abc');
+    it('uses advanced config to fill in DrmInfo, single robustness',
+        async () => {
+          // Leave only one drmInfo
+          manifest = shaka.test.ManifestGenerator.generate((manifest) => {
+            manifest.addVariant(0, (variant) => {
+              variant.addVideo(1, (stream) => {
+                stream.encrypted = true;
+                stream.addDrmInfo('drm.abc');
+              });
+              variant.addAudio(2, (stream) => {
+                stream.encrypted = true;
+                stream.addDrmInfo('drm.abc');
+              });
+            });
           });
-          variant.addAudio(2, (stream) => {
-            stream.encrypted = true;
-            stream.addDrmInfo('drm.abc');
-          });
+
+          setDecodingInfoSpy([]);
+
+          config.advanced['drm.abc'] = {
+            audioRobustness: 'good',
+            videoRobustness: 'really_really_ridiculously_good',
+            serverCertificate: null,
+            serverCertificateUri: '',
+            sessionType: 'persistent-license',
+            individualizationServer: '',
+            distinctiveIdentifierRequired: true,
+            persistentStateRequired: true,
+            headers: {},
+          };
+          drmEngine.configure(config);
+
+          const variants = manifest.variants;
+          await expectAsync(
+              drmEngine.initForPlayback(variants, manifest.offlineSessionIds))
+              .toBeRejected();
+
+          expect(drmEngine.initialized()).toBe(false);
+          expect(decodingInfoSpy).toHaveBeenCalledTimes(1);
+          expect(decodingInfoSpy).toHaveBeenCalledWith(containing({
+            keySystemConfiguration: containing({
+              keySystem: 'drm.abc',
+              distinctiveIdentifier: 'required',
+              persistentState: 'required',
+              sessionTypes: ['persistent-license'],
+              initDataType: 'cenc',
+              audio: containing({
+                robustness: 'good',
+              }),
+              video: containing({
+                robustness: 'really_really_ridiculously_good',
+              }),
+            }),
+          }));
         });
-      });
 
-      setDecodingInfoSpy([]);
+    it('uses advanced config to fill in DrmInfo, multiple video robustness',
+        async () => {
+          // Leave only one drmInfo
+          manifest = shaka.test.ManifestGenerator.generate((manifest) => {
+            manifest.addVariant(0, (variant) => {
+              variant.addVideo(1, (stream) => {
+                stream.encrypted = true;
+                stream.addDrmInfo('drm.abc');
+              });
+              variant.addAudio(2, (stream) => {
+                stream.encrypted = true;
+                stream.addDrmInfo('drm.abc');
+              });
+            });
+          });
 
-      config.advanced['drm.abc'] = {
-        audioRobustness: 'good',
-        videoRobustness: 'really_really_ridiculously_good',
-        serverCertificate: null,
-        serverCertificateUri: '',
-        sessionType: 'persistent-license',
-        individualizationServer: '',
-        distinctiveIdentifierRequired: true,
-        persistentStateRequired: true,
-        headers: {},
-      };
-      drmEngine.configure(config);
+          setDecodingInfoSpy([]);
 
-      const variants = manifest.variants;
-      await expectAsync(
-          drmEngine.initForPlayback(variants, manifest.offlineSessionIds))
-          .toBeRejected();
+          config.advanced['drm.abc'] = {
+            audioRobustness: 'good',
+            videoRobustness: [
+              'really_ridiculously_good','a_mid_one', 'another_worse_one'
+            ],
+            serverCertificate: null,
+            serverCertificateUri: '',
+            sessionType: 'persistent-license',
+            individualizationServer: '',
+            distinctiveIdentifierRequired: true,
+            persistentStateRequired: true,
+            headers: {},
+          };
+          drmEngine.configure(config);
 
-      expect(drmEngine.initialized()).toBe(false);
-      expect(decodingInfoSpy).toHaveBeenCalledTimes(1);
-      expect(decodingInfoSpy).toHaveBeenCalledWith(containing({
-        keySystemConfiguration: containing({
-          keySystem: 'drm.abc',
-          distinctiveIdentifier: 'required',
-          persistentState: 'required',
-          sessionTypes: ['persistent-license'],
-          initDataType: 'cenc',
-          audio: containing({
-            robustness: 'good',
-          }),
-          video: containing({
-            robustness: 'really_really_ridiculously_good',
-          }),
-        }),
-      }));
-    });
+          const variants = manifest.variants;
+          await expectAsync(
+              drmEngine.initForPlayback(variants, manifest.offlineSessionIds))
+              .toBeRejected();
+
+          expect(drmEngine.initialized()).toBe(false);
+          expect(decodingInfoSpy).toHaveBeenCalledTimes(3);
+          expect(decodingInfoSpy).toHaveBeenCalledWith(containing({
+            keySystemConfiguration: containing({
+              keySystem: 'drm.abc',
+              distinctiveIdentifier: 'required',
+              persistentState: 'required',
+              sessionTypes: ['persistent-license'],
+              initDataType: 'cenc',
+              audio: containing({
+                robustness: 'good',
+              }),
+              video: containing({
+                robustness: 'really_ridiculously_good',
+              }),
+            }),
+          }));
+          expect(decodingInfoSpy).toHaveBeenCalledWith(containing({
+            keySystemConfiguration: containing({
+              keySystem: 'drm.abc',
+              distinctiveIdentifier: 'required',
+              persistentState: 'required',
+              sessionTypes: ['persistent-license'],
+              initDataType: 'cenc',
+              audio: containing({
+                robustness: 'good',
+              }),
+              video: containing({
+                robustness: 'a_mid_one',
+              }),
+            }),
+          }));
+          expect(decodingInfoSpy).toHaveBeenCalledWith(containing({
+            keySystemConfiguration: containing({
+              keySystem: 'drm.abc',
+              distinctiveIdentifier: 'required',
+              persistentState: 'required',
+              sessionTypes: ['persistent-license'],
+              initDataType: 'cenc',
+              audio: containing({
+                robustness: 'good',
+              }),
+              video: containing({
+                robustness: 'another_worse_one',
+              }),
+            }),
+          }));
+        });
+
+    it('uses advanced config to fill in DrmInfo, multiple audio robustness',
+        async () => {
+          // Leave only one drmInfo
+          manifest = shaka.test.ManifestGenerator.generate((manifest) => {
+            manifest.addVariant(0, (variant) => {
+              variant.addVideo(1, (stream) => {
+                stream.encrypted = true;
+                stream.addDrmInfo('drm.abc');
+              });
+              variant.addAudio(2, (stream) => {
+                stream.encrypted = true;
+                stream.addDrmInfo('drm.abc');
+              });
+            });
+          });
+
+          setDecodingInfoSpy([]);
+
+          config.advanced['drm.abc'] = {
+            audioRobustness: [
+              'really_ridiculously_good','a_mid_one', 'another_worse_one'
+            ],
+            videoRobustness: 'good',
+            serverCertificate: null,
+            serverCertificateUri: '',
+            sessionType: 'persistent-license',
+            individualizationServer: '',
+            distinctiveIdentifierRequired: true,
+            persistentStateRequired: true,
+            headers: {},
+          };
+          drmEngine.configure(config);
+
+          const variants = manifest.variants;
+          await expectAsync(
+              drmEngine.initForPlayback(variants, manifest.offlineSessionIds))
+              .toBeRejected();
+
+          expect(drmEngine.initialized()).toBe(false);
+          expect(decodingInfoSpy).toHaveBeenCalledTimes(3);
+          expect(decodingInfoSpy).toHaveBeenCalledWith(containing({
+            keySystemConfiguration: containing({
+              keySystem: 'drm.abc',
+              distinctiveIdentifier: 'required',
+              persistentState: 'required',
+              sessionTypes: ['persistent-license'],
+              initDataType: 'cenc',
+              audio: containing({
+                robustness: 'really_ridiculously_good',
+              }),
+              video: containing({
+                robustness: 'good',
+              }),
+            }),
+          }));
+          expect(decodingInfoSpy).toHaveBeenCalledWith(containing({
+            keySystemConfiguration: containing({
+              keySystem: 'drm.abc',
+              distinctiveIdentifier: 'required',
+              persistentState: 'required',
+              sessionTypes: ['persistent-license'],
+              initDataType: 'cenc',
+              audio: containing({
+                robustness: 'a_mid_one',
+              }),
+              video: containing({
+                robustness: 'good',
+              }),
+            }),
+          }));
+          expect(decodingInfoSpy).toHaveBeenCalledWith(containing({
+            keySystemConfiguration: containing({
+              keySystem: 'drm.abc',
+              distinctiveIdentifier: 'required',
+              persistentState: 'required',
+              sessionTypes: ['persistent-license'],
+              initDataType: 'cenc',
+              audio: containing({
+                robustness: 'another_worse_one',
+              }),
+              video: containing({
+                robustness: 'good',
+              }),
+            }),
+          }));
+        });
 
     it('prefers advanced config from manifest if present', async () => {
       // Leave only one drmInfo


### PR DESCRIPTION
This changes the `drm.advanced.videoRobustness` and `audioRobustness` config options from a string to an array of strings. Internally, in the drm engine, this gets expanded into an array of `DrmInfos` which have those values as strings.

Best way to review this change is with whitespace turned off in the diff options.