### PR TITLE
ci: Do not persist credentials after checkout

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Lint
         run: python build/check.py
@@ -104,6 +105,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       # Older versions of Safari can be installed, but not to the root, and it
       # can't replace the standard version, at least not on GitHub's VMs.  If
@@ -256,6 +258,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Docker
         run: |

--- a/.github/workflows/demo-version-index.yaml
+++ b/.github/workflows/demo-version-index.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           # We need a list of all tags for this, so fetch the entire history.
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -40,6 +40,10 @@ jobs:
           ref: main
           # Use a special shaka-bot access token for releases.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # We want to explicitly use these credentials to push a tag.
+          # The job is only one more step, so they don't leak.
+          persist-credentials: true
+
       - name: Tag the main branch
         run: |
           # Set missing git config for the tag.
@@ -189,6 +193,9 @@ jobs:
           fetch-depth: 0
           # Use a special shaka-bot access token for releases.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # We want to explicitly use these credentials to create the branch.
+          # The job is only one more step, so they don't leak.
+          persist-credentials: true
 
       - name: Create release branch
         run: |

--- a/.github/workflows/report-incremental-coverage.yaml
+++ b/.github/workflows/report-incremental-coverage.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Compute incremental code coverage
         id: compute

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -84,6 +84,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
+          persist-credentials: false
 
       - name: Install dependencies
         run: npm ci
@@ -154,6 +155,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
+          persist-credentials: false
 
       - name: Set commit status to pending
         if: ${{ inputs.skip_test_status == false }}
@@ -235,6 +237,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
+          persist-credentials: false
 
       - name: Set commit status to pending
         if: ${{ inputs.skip_commit_status == false }}

--- a/.github/workflows/talk-to-shaka-bot.yaml
+++ b/.github/workflows/talk-to-shaka-bot.yaml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Handle command
         shell: bash

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
+          persist-credentials: false
 
       - name: Set commit status to pending
         uses: shaka-project/shaka-github-tools/set-commit-status@main
@@ -61,6 +62,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
+          persist-credentials: false
 
       - name: Get artifacts
         uses: actions/download-artifact@v4
@@ -114,6 +116,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
+          persist-credentials: false
 
       - name: Compute final status
         id: compute


### PR DESCRIPTION
See https://github.com/actions/checkout/issues/485 and https://johnstawinski.com/2024/01/11/playing-with-fire-how-we-executed-a-critical-supply-chain-attack-on-pytorch/

In short, it is a terrible idea to persist even our default credentials after checkout.  There's no call for that, so we will now set `persist-credentials: false` on all checkout actions.

The only exceptions are for the release job, which wants to push a tag and create a branch, each of which explicitly persist credentials now and explain why in a comment.