### PR TITLE
fix: Multivariant HLS manifests don't work with DRM

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1061,7 +1061,7 @@ shaka.hls.HlsParser = class {
 
     this.playerInterface_.makeTextStreamsForClosedCaptions(this.manifest_);
 
-    if (variants.length == 1) {
+    if (variants.length) {
       const createSegmentIndexPromises = [];
       const variant = variants[0];
       for (const stream of [variant.video, variant.audio]) {


### PR DESCRIPTION
For Reference, DASH manifest is: https://content.media24.link/hls/flicker84/playready/manifest.mpd

Problematic HLS manifests:

PlayReady: https://content.media24.link/hls/flicker84/playready/master.m3u8
FairPlay: https://content.media24.link/hls/flicker84/fairplay/master.m3u8

This specifically happened with a test for supplemental codecs, because the implementation of HLS SUPPLEMENTAL-CODECS duplicates the variant for all the supplemental codecs.  But the same behaviour could be done by explicitly providing multiple variants in the manifest.

The problematic code is in lib/hls/hls_parser.js, method parseManifest_():

```
    if (variants.length == 1) {
      const createSegmentIndexPromises = [];
      const variant = variants[0];
      for (const stream of [variant.video, variant.audio]) {
        if (stream && !stream.segmentIndex) {
          createSegmentIndexPromises.push(stream.createSegmentIndex());
        }
      }
      if (createSegmentIndexPromises.length > 0) {
        await Promise.all(createSegmentIndexPromises);
      }
    }
```

This code will only invoke stream.createSegmentIndex() when one variant is available.  If it isn't invoked, then the download of the media manifest is deferred, the EXT-X-KEY in the media manifest is not parsed and the code in shaka.media.PreloadManager.initializeDrmInner() never detects any DrmInfos.

Not sure why this code is only invoked if one variant is available. Maybe an optimisation in the common case, which is now a required code path.