### PR TITLE
feat: Add support for PlayReady in HLS

### DIFF
--- a/build/types/core
+++ b/build/types/core
@@ -111,6 +111,7 @@
 +../../lib/util/periods.js
 +../../lib/util/platform.js
 +../../lib/util/player_configuration.js
++../../lib/util/playready.js
 +../../lib/util/pssh.js
 +../../lib/util/public_promise.js
 +../../lib/util/state_history.js

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -8,7 +8,6 @@ goog.provide('shaka.dash.ContentProtection');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
-goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.Platform');

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -12,6 +12,7 @@ goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.Platform');
+goog.require('shaka.util.PlayReady');
 goog.require('shaka.util.Pssh');
 goog.require('shaka.util.StringUtils');
 goog.require('shaka.util.TXml');
@@ -286,107 +287,6 @@ shaka.dash.ContentProtection = class {
   }
 
   /**
-   * Parses an Array buffer starting at byteOffset for PlayReady Object Records.
-   * Each PRO Record is preceded by its PlayReady Record type and length in
-   * bytes.
-   *
-   * PlayReady Object Record format: https://goo.gl/FTcu46
-   *
-   * @param {!DataView} view
-   * @param {number} byteOffset
-   * @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
-   * @private
-   */
-  static parseMsProRecords_(view, byteOffset) {
-    const records = [];
-
-    while (byteOffset < view.byteLength - 1) {
-      const type = view.getUint16(byteOffset, true);
-      byteOffset += 2;
-
-      const byteLength = view.getUint16(byteOffset, true);
-      byteOffset += 2;
-
-      if ((byteLength & 1) != 0 || byteLength + byteOffset > view.byteLength) {
-        shaka.log.warning('Malformed MS PRO object');
-        return [];
-      }
-
-      const recordValue = shaka.util.BufferUtils.toUint8(
-          view, byteOffset, byteLength);
-      records.push({
-        type: type,
-        value: recordValue,
-      });
-
-      byteOffset += byteLength;
-    }
-
-    return records;
-  }
-
-  /**
-   * Parses a buffer for PlayReady Objects.  The data
-   * should contain a 32-bit integer indicating the length of
-   * the PRO in bytes.  Following that, a 16-bit integer for
-   * the number of PlayReady Object Records in the PRO.  Lastly,
-   * a byte array of the PRO Records themselves.
-   *
-   * PlayReady Object format: https://goo.gl/W8yAN4
-   *
-   * @param {BufferSource} data
-   * @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
-   * @private
-   */
-  static parseMsPro_(data) {
-    let byteOffset = 0;
-    const view = shaka.util.BufferUtils.toDataView(data);
-
-    // First 4 bytes is the PRO length (DWORD)
-    const byteLength = view.getUint32(byteOffset, /* littleEndian= */ true);
-    byteOffset += 4;
-
-    if (byteLength != data.byteLength) {
-      // Malformed PRO
-      shaka.log.warning('PlayReady Object with invalid length encountered.');
-      return [];
-    }
-
-    // Skip PRO Record count (WORD)
-    byteOffset += 2;
-
-    // Rest of the data contains the PRO Records
-    const ContentProtection = shaka.dash.ContentProtection;
-    return ContentProtection.parseMsProRecords_(view, byteOffset);
-  }
-
-  /**
-   * PlayReady Header format: https://goo.gl/dBzxNA
-   *
-   * @param {!shaka.extern.xml.Node} xml
-   * @return {string}
-   * @private
-   */
-  static getLaurl_(xml) {
-    const TXml = shaka.util.TXml;
-    // LA_URL element is optional and no more than one is
-    // allowed inside the DATA element. Only absolute URLs are allowed.
-    // If the LA_URL element exists, it must not be empty.
-    for (const elem of TXml.getElementsByTagName(xml, 'DATA')) {
-      if (elem.children) {
-        for (const child of elem.children) {
-          if (child.tagName == 'LA_URL') {
-            return /** @type{string} */(shaka.util.TXml.getTextContents(child));
-          }
-        }
-      }
-    }
-
-    // Not found
-    return '';
-  }
-
-  /**
    * Gets a PlayReady license URL from a content protection element
    * containing a PlayReady Header Object
    *
@@ -412,28 +312,11 @@ shaka.dash.ContentProtection = class {
       return '';
     }
 
-    const ContentProtection = shaka.dash.ContentProtection;
-    const PLAYREADY_RECORD_TYPES = ContentProtection.PLAYREADY_RECORD_TYPES;
-
     const textContent =
     /** @type {string} */ (shaka.util.TXml.getTextContents(proNode));
     const bytes = shaka.util.Uint8ArrayUtils.fromBase64(textContent);
-    const records = ContentProtection.parseMsPro_(bytes);
-    const record = records.filter((record) => {
-      return record.type === PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT;
-    })[0];
 
-    if (!record) {
-      return '';
-    }
-
-    const xml = shaka.util.StringUtils.fromUTF16(record.value, true);
-    const rootElement = shaka.util.TXml.parseXmlString(xml, 'WRMHEADER');
-    if (!rootElement) {
-      return '';
-    }
-
-    return ContentProtection.getLaurl_(rootElement);
+    return shaka.util.PlayReady.getLicenseUrl(bytes);
   }
 
   /**
@@ -713,32 +596,6 @@ shaka.dash.ContentProtection = class {
       iv,
     };
   }
-};
-
-/**
- * @typedef {{
- *   type: number,
- *   value: !Uint8Array
- * }}
- *
- * @description
- * The parsed result of a PlayReady object record.
- *
- * @property {number} type
- *   Type of data stored in the record.
- * @property {!Uint8Array} value
- *   Record content.
- */
-shaka.dash.ContentProtection.PlayReadyRecord;
-
-/**
- * Enum for PlayReady record types.
- * @enum {number}
- */
-shaka.dash.ContentProtection.PLAYREADY_RECORD_TYPES = {
-  RIGHTS_MANAGEMENT: 0x001,
-  RESERVED: 0x002,
-  EMBEDDED_LICENSE: 0x003,
 };
 
 /**

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -4876,7 +4876,7 @@ shaka.hls.HlsParser = class {
           {initDataType: 'cenc', initData: pssh},
         ]);
 
-    drmInfo.licenseServerUri = shaka.util.PlayReady.getPlayReadyLicenseUrl(data);
+    drmInfo.licenseServerUri = shaka.util.PlayReady.getLicenseUrl(data);
 
     return drmInfo;
   }

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -44,6 +44,7 @@ goog.require('shaka.util.Timer');
 goog.require('shaka.util.TsParser');
 goog.require('shaka.util.TXml');
 goog.require('shaka.util.Platform');
+goog.require('shaka.util.PlayReady');
 goog.require('shaka.util.StreamUtils');
 goog.require('shaka.util.Uint8ArrayUtils');
 goog.requireType('shaka.hls.Segment');
@@ -4874,6 +4875,8 @@ shaka.hls.HlsParser = class {
         'com.microsoft.playready', encryptionScheme, [
           {initDataType: 'cenc', initData: pssh},
         ]);
+
+    drmInfo.licenseServerUri = shaka.util.PlayReady.getPlayReadyLicenseUrl(data);
 
     return drmInfo;
   }

--- a/lib/util/playready.js
+++ b/lib/util/playready.js
@@ -1,0 +1,201 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.provide('shaka.util.PlayReady');
+
+goog.require('goog.asserts');
+goog.require('shaka.log');
+goog.require('shaka.util.BufferUtils');
+goog.require('shaka.util.Error');
+goog.require('shaka.util.Pssh');
+goog.require('shaka.util.StringUtils');
+goog.require('shaka.util.TXml');
+goog.require('shaka.util.Uint8ArrayUtils');
+
+
+/**
+ * @summary A set of functions for parsing Microsoft Playready Objects.
+ */
+shaka.util.PlayReady = class {
+
+  /**
+   * Parses an Array buffer starting at byteOffset for PlayReady Object Records.
+   * Each PRO Record is preceded by its PlayReady Record type and length in
+   * bytes.
+   *
+   * PlayReady Object Record format: https://goo.gl/FTcu46
+   *
+   * @param {!DataView} view
+   * @param {number} byteOffset
+   * @return {!Array.<shaka.util.PlayReady.PlayReadyRecord>}
+   * @private
+   */
+  static parseMsProRecords_(view, byteOffset) {
+    const records = [];
+
+    while (byteOffset < view.byteLength - 1) {
+      const type = view.getUint16(byteOffset, true);
+      byteOffset += 2;
+
+      const byteLength = view.getUint16(byteOffset, true);
+      byteOffset += 2;
+
+      if ((byteLength & 1) != 0 || byteLength + byteOffset > view.byteLength) {
+        shaka.log.warning('Malformed MS PRO object');
+        return [];
+      }
+
+      const recordValue = shaka.util.BufferUtils.toUint8(
+          view, byteOffset, byteLength);
+      records.push({
+        type: type,
+        value: recordValue,
+      });
+
+      byteOffset += byteLength;
+    }
+
+    return records;
+  }
+
+  /**
+   * Parses a buffer for PlayReady Objects.  The data
+   * should contain a 32-bit integer indicating the length of
+   * the PRO in bytes.  Following that, a 16-bit integer for
+   * the number of PlayReady Object Records in the PRO.  Lastly,
+   * a byte array of the PRO Records themselves.
+   *
+   * PlayReady Object format: https://goo.gl/W8yAN4
+   *
+   * @param {BufferSource} data
+   * @return {!Array.<shaka.util.PlayReady.PlayReadyRecord>}
+   * @private
+   */
+  static parseMsPro_(data) {
+    let byteOffset = 0;
+    const view = shaka.util.BufferUtils.toDataView(data);
+
+    // First 4 bytes is the PRO length (DWORD)
+    const byteLength = view.getUint32(byteOffset, /* littleEndian= */ true);
+    byteOffset += 4;
+
+    if (byteLength != data.byteLength) {
+      // Malformed PRO
+      shaka.log.warning('PlayReady Object with invalid length encountered.');
+      return [];
+    }
+
+    // Skip PRO Record count (WORD)
+    byteOffset += 2;
+
+    // Rest of the data contains the PRO Records
+    return shaka.util.PlayReady.parseMsProRecords_(view, byteOffset);
+  }
+
+  /**
+   * PlayReady Header format: https://goo.gl/dBzxNA
+   *
+   * @param {!shaka.extern.xml.Node} xml
+   * @return {string}
+   * @private
+   */
+  static getLaurl_(xml) {
+    const TXml = shaka.util.TXml;
+    // LA_URL element is optional and no more than one is
+    // allowed inside the DATA element. Only absolute URLs are allowed.
+    // If the LA_URL element exists, it must not be empty.
+    for (const elem of TXml.getElementsByTagName(xml, 'DATA')) {
+      if (elem.children) {
+        for (const child of elem.children) {
+          if (child.tagName == 'LA_URL') {
+            return /** @type{string} */(shaka.util.TXml.getTextContents(child));
+          }
+        }
+      }
+    }
+
+    // Not found
+    return '';
+  }
+
+
+  /**
+   * Gets a PlayReady license URL from a PlayReady Header Object
+   *
+   * @param {Uint8Array} element
+   * @return {string}
+   */
+  static getPlayReadyLicenseUrl(bytes) {
+    const records = shaka.util.PlayReady.parseMsPro_(bytes);
+    const record = records.filter((record) => {
+      return record.type === shaka.util.PlayReady.PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT;
+    })[0];
+
+    if (!record) {
+      return '';
+    }
+
+    const xml = shaka.util.StringUtils.fromUTF16(record.value, true);
+    const rootElement = shaka.util.TXml.parseXmlString(xml, 'WRMHEADER');
+    if (!rootElement) {
+      return '';
+    }
+
+    return shaka.util.PlayReady.getLaurl_(rootElement);
+  }
+
+  /**
+   * Gets a PlayReady initData from a PlayReady Pro Object
+   *
+   * @param {Uint8Array} element
+   * @return {?Array.<shaka.extern.InitDataOverride>}
+   * @private
+   */
+  static getInitDataFromPro_(data) {
+    const systemId = new Uint8Array([
+      0x9a, 0x04, 0xf0, 0x79, 0x98, 0x40, 0x42, 0x86,
+      0xab, 0x92, 0xe6, 0x5b, 0xe0, 0x88, 0x5f, 0x95,
+    ]);
+    const keyIds = new Set();
+    const psshVersion = 0;
+    const pssh =
+        shaka.util.Pssh.createPssh(data, systemId, keyIds, psshVersion);
+    return [
+      {
+        initData: pssh,
+        initDataType: 'cenc',
+        keyId: element.keyId,
+      },
+    ];
+  }
+
+};
+
+/**
+ * @typedef {{
+ *   type: number,
+ *   value: !Uint8Array
+ * }}
+ *
+ * @description
+ * The parsed result of a PlayReady object record.
+ *
+ * @property {number} type
+ *   Type of data stored in the record.
+ * @property {!Uint8Array} value
+ *   Record content.
+ */
+shaka.util.PlayReady.PlayReadyRecord;
+
+/**
+ * Enum for PlayReady record types.
+ * @enum {number}
+ */
+shaka.util.PlayReady.PLAYREADY_RECORD_TYPES = {
+  RIGHTS_MANAGEMENT: 0x001,
+  RESERVED: 0x002,
+  EMBEDDED_LICENSE: 0x003,
+};

--- a/lib/util/playready.js
+++ b/lib/util/playready.js
@@ -128,7 +128,7 @@ shaka.util.PlayReady = class {
    * @param {Uint8Array} element
    * @return {string}
    */
-  static getPlayReadyLicenseUrl(bytes) {
+  static getLicenseUrl(bytes) {
     const records = shaka.util.PlayReady.parseMsPro_(bytes);
     const record = records.filter((record) => {
       return record.type === shaka.util.PlayReady.PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT;

--- a/lib/util/playready.js
+++ b/lib/util/playready.js
@@ -6,21 +6,16 @@
 
 goog.provide('shaka.util.PlayReady');
 
-goog.require('goog.asserts');
 goog.require('shaka.log');
 goog.require('shaka.util.BufferUtils');
-goog.require('shaka.util.Error');
-goog.require('shaka.util.Pssh');
 goog.require('shaka.util.StringUtils');
 goog.require('shaka.util.TXml');
-goog.require('shaka.util.Uint8ArrayUtils');
 
 
 /**
  * @summary A set of functions for parsing Microsoft Playready Objects.
  */
 shaka.util.PlayReady = class {
-
   /**
    * Parses an Array buffer starting at byteOffset for PlayReady Object Records.
    * Each PRO Record is preceded by its PlayReady Record type and length in
@@ -121,17 +116,17 @@ shaka.util.PlayReady = class {
     return '';
   }
 
-
   /**
    * Gets a PlayReady license URL from a PlayReady Header Object
    *
-   * @param {Uint8Array} element
+   * @param {BufferSource} data
    * @return {string}
    */
-  static getLicenseUrl(bytes) {
-    const records = shaka.util.PlayReady.parseMsPro_(bytes);
+  static getLicenseUrl(data) {
+    const records = shaka.util.PlayReady.parseMsPro_(data);
     const record = records.filter((record) => {
-      return record.type === shaka.util.PlayReady.PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT;
+      return record.type ===
+         shaka.util.PlayReady.PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT;
     })[0];
 
     if (!record) {
@@ -146,32 +141,6 @@ shaka.util.PlayReady = class {
 
     return shaka.util.PlayReady.getLaurl_(rootElement);
   }
-
-  /**
-   * Gets a PlayReady initData from a PlayReady Pro Object
-   *
-   * @param {Uint8Array} element
-   * @return {?Array.<shaka.extern.InitDataOverride>}
-   * @private
-   */
-  static getInitDataFromPro_(data) {
-    const systemId = new Uint8Array([
-      0x9a, 0x04, 0xf0, 0x79, 0x98, 0x40, 0x42, 0x86,
-      0xab, 0x92, 0xe6, 0x5b, 0xe0, 0x88, 0x5f, 0x95,
-    ]);
-    const keyIds = new Set();
-    const psshVersion = 0;
-    const pssh =
-        shaka.util.Pssh.createPssh(data, systemId, keyIds, psshVersion);
-    return [
-      {
-        initData: pssh,
-        initDataType: 'cenc',
-        keyId: element.keyId,
-      },
-    ];
-  }
-
 };
 
 /**

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -1005,7 +1005,7 @@ describe('DashParser ContentProtection', () => {
         // record count
         1,
         // type
-        ContentProtection.PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT,
+        1,
         // record size (in num bytes)
         laurl.length * 2,
         // value

--- a/test/util/playready_unit.js
+++ b/test/util/playready_unit.js
@@ -1,0 +1,34 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('PlayReady', () => {
+  it('getLicenseURL', () => {
+    const laurl = [
+      '<WRMHEADER>',
+      '  <DATA>',
+      '    <LA_URL>www.example.com</LA_URL>',
+      '  </DATA>',
+      '</WRMHEADER>',
+    ].join('\n');
+    const laurlCodes = laurl.split('').map((c) => {
+      return c.charCodeAt();
+    });
+    const prBytes = new Uint16Array([
+      // pr object size (in num bytes).
+      // + 10 for PRO size, count, and type
+      laurl.length * 2 + 10, 0,
+      // record count
+      1,
+      // type
+      shaka.util.PlayReady.PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT,
+      // record size (in num bytes)
+      laurl.length * 2,
+      // value
+    ].concat(laurlCodes));
+    const actual = shaka.util.PlayReady.getLicenseUrl(prBytes);
+    expect(actual).toBe('www.example.com');
+  });
+});


### PR DESCRIPTION
Example HLS manifest is: https://content.media24.link/hls/flicker84/playready/master.m3u8

(note: the example HLS manifest uses the SUPPLEMENTAL-CODECS attribute and requires PR#7775 to work properly)

This patch:

* factor-out parsing of the PlayReady Object from the dash parser into the util collection
* modify the HLS parser to retrieve the LA_URL from the URI attribute in #EXT-X-KEY

Playback tested on Microsoft Edge.  Tests pass on Safari and Edge.