### PR TITLE
fix: Don't ignore the license server in manifest when another key-system has license server in configuration

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -2512,26 +2512,24 @@ shaka.drm.DrmEngine = class {
     // The order of preference for drmInfo:
     // 1. Clear Key config, used for debugging, should override everything else.
     //    (The application can still specify a clearkey license server.)
-    // 2. Application-configured servers, if any are present, should override
-    //    anything from the manifest.  Nuance: if key system A is in the
-    //    manifest and key system B is in the player config, only B will be
-    //    used, not A.
+    // 2. Application-configured servers, if present, override
+    //    anything from the manifest.
     // 3. Manifest-provided license servers are only used if nothing else is
     //    specified.
     // This is important because it allows the application a clear way to
-    // indicate which DRM systems should be used on platforms with multiple DRM
-    // systems.
-    // The only way to get license servers from the manifest is not to specify
-    // any in your player config.
+    // indicate which DRM systems should be ignored on platforms with multiple
+    // DRM systems.
+    // Alternatively, use config.preferredKeySystems to specify the preferred
+    // key system.
 
     if (originalKeySystem == 'org.w3.clearkey' && drmInfo.licenseServerUri) {
       // Preference 1: Clear Key with pre-configured keys will have a data URI
       // assigned as its license server.  Don't change anything.
       return;
-    } else if (servers.size) {
-      // Preference 2: If anything is configured at the application level,
-      // override whatever was in the manifest.
-      const server = servers.get(originalKeySystem) || '';
+    } else if (servers.size && servers.get(originalKeySystem)) {
+      // Preference 2: If a license server for this keySystem is configured at
+      // the application level, override whatever was in the manifest.
+      const server = servers.get(originalKeySystem);
 
       drmInfo.licenseServerUri = server;
     } else {

--- a/test/drm/drm_engine_unit.js
+++ b/test/drm/drm_engine_unit.js
@@ -223,7 +223,7 @@ describe('DrmEngine', () => {
       // Accept both drm.abc and drm.def.  Only one can be chosen.
       setDecodingInfoSpy(['drm.abc', 'drm.def']);
 
-      // Remove the server URI for drm.abc, which appears first in the manifest.
+      // Remove the server URI for drm.abc.
       delete config.servers['drm.abc'];
       drmEngine.configure(config);
       // Ignore error logs, which we expect to occur due to the missing server.
@@ -237,7 +237,7 @@ describe('DrmEngine', () => {
           .toBe('drm.def');
     });
 
-    it('overrides manifest with configured license servers', async () => {
+    it('overrides manifest with configured license server', async () => {
       // Accept both drm.abc and drm.def.  Only one can be chosen.
       setDecodingInfoSpy(['drm.abc', 'drm.def']);
 
@@ -257,9 +257,8 @@ describe('DrmEngine', () => {
         }
       });
 
-      // Remove the server URI for drm.abc from the config, so that only drm.def
-      // could be used, in spite of the manifest-supplied license server URI.
-      delete config.servers['drm.abc'];
+      // Override the server URI for drm.abc from config.
+      config.servers['drm.abc'] = 'override.drm.abc';
       drmEngine.configure(config);
 
       // Ignore error logs, which we expect to occur due to the missing server.
@@ -271,8 +270,8 @@ describe('DrmEngine', () => {
       expect(variants[0].decodingInfos.length).toBe(2);
       const selectedDrmInfo = drmEngine.getDrmInfo();
       expect(selectedDrmInfo).not.toBe(null);
-      expect(selectedDrmInfo.keySystem).toBe('drm.def');
-      expect(selectedDrmInfo.licenseServerUri).toBe(config.servers['drm.def']);
+      expect(selectedDrmInfo.keySystem).toBe('drm.abc');
+      expect(selectedDrmInfo.licenseServerUri).toBe(config.servers['drm.abc']);
     });
 
     it('fails to initialize if no key systems are available', async () => {


### PR DESCRIPTION
Related to https://github.com/shaka-project/shaka-player/pull/7453

Thanks @gmcgarry !