### PR TITLE
fix(Widevine): Add default audio/video robustness for Widevine

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -123,6 +123,14 @@ shakaDemo.Config = class {
 
   /** @private */
   addDrmSection_() {
+    const widevineRobustnessLevels = {
+      '': '',
+      'SW_SECURE_CRYPTO': 'SW_SECURE_CRYPTO',
+      'SW_SECURE_DECODE': 'SW_SECURE_DECODE',
+      'HW_SECURE_CRYPTO': 'HW_SECURE_CRYPTO',
+      'HW_SECURE_DECODE': 'HW_SECURE_DECODE',
+      'HW_SECURE_ALL': 'HW_SECURE_ALL',
+    };
     const docLink = this.resolveExternLink_('.DrmConfiguration');
     this.addSection_('DRM', docLink)
         .addBoolInput_('Delay License Request Until Played',
@@ -137,7 +145,13 @@ shakaDemo.Config = class {
             'drm.parseInbandPsshEnabled')
         .addTextInput_('Min HDCP version', 'drm.minHdcpVersion')
         .addBoolInput_('Ignore duplicate init data',
-            'drm.ignoreDuplicateInitData');
+            'drm.ignoreDuplicateInitData')
+        .addSelectInput_('Default audio robustness for Widevine',
+            'drm.defaultAudioRobustnessForWidevine',
+            widevineRobustnessLevels, widevineRobustnessLevels)
+        .addSelectInput_('Default video robustness for Widevine',
+            'drm.defaultVideoRobustnessForWidevine',
+            widevineRobustnessLevels, widevineRobustnessLevels);
     const advanced = shakaDemoMain.getConfiguration().drm.advanced || {};
     const addDRMAdvancedField = (name, valueName, suggestions,
         arrayString = false) => {

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -936,7 +936,9 @@ shaka.extern.PersistentSessionMetadata;
  *   keySystemsMapping: !Object.<string, string>,
  *   parseInbandPsshEnabled: boolean,
  *   minHdcpVersion: string,
- *   ignoreDuplicateInitData: boolean
+ *   ignoreDuplicateInitData: boolean,
+ *   defaultAudioRobustnessForWidevine: string,
+ *   defaultVideoRobustnessForWidevine: string
  * }}
  *
  * @property {shaka.extern.RetryParameters} retryParameters
@@ -1020,6 +1022,16 @@ shaka.extern.PersistentSessionMetadata;
  *   <br>
  *   Defaults to <code>false</code> on Tizen 2, and <code>true</code> for all
  *   other browsers.
+ * @property {string} defaultAudioRobustnessForWidevine
+ *   Specify the default audio security level for Widevine when audio robustness
+ *   is not specified.
+ *   <br>
+ *   Defaults to <code>'SW_SECURE_CRYPTO'</code>.
+ * @property {string} defaultVideoRobustnessForWidevine
+ *   Specify the default video security level for Widevine when video robustness
+ *   is not specified.
+ *   <br>
+ *   Defaults to <code>'SW_SECURE_DECODE'</code>.
  * @exportDoc
  */
 shaka.extern.DrmConfiguration;

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -419,6 +419,10 @@ shaka.drm.DrmEngine = class {
      *
      * robustness can be either a single item as a string or multiple items as
      * an array of strings.
+     *
+     * @param {!Array.<shaka.extern.DrmInfo>} drmInfos
+     * @param {string} robustnessType
+     * @return {!Array.<shaka.extern.DrmInfo>}
      */
     const expandRobustness = (drmInfos, robustnessType) => {
       const newDrmInfos = [];

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -427,6 +427,14 @@ shaka.drm.DrmEngine = class {
             (this.config_.advanced &&
             this.config_.advanced[drmInfo.keySystem] &&
             this.config_.advanced[drmInfo.keySystem][robustnessType]) || '';
+        if (items == '' &&
+            shaka.drm.DrmUtils.isWidevineKeySystem(drmInfo.keySystem)) {
+          if (robustnessType == 'audioRobustness') {
+            items = [this.config_.defaultAudioRobustnessForWidevine];
+          } else if (robustnessType == 'videoRobustness') {
+            items = [this.config_.defaultVideoRobustnessForWidevine];
+          }
+        }
         if (typeof items === 'string') {
           // if drmInfo's robustness has already been expanded,
           // use the drmInfo directly.

--- a/lib/drm/drm_utils.js
+++ b/lib/drm/drm_utils.js
@@ -117,6 +117,18 @@ shaka.drm.DrmUtils = class {
    * @param {?string} keySystem
    * @return {boolean}
    */
+  static isWidevineKeySystem(keySystem) {
+    if (keySystem) {
+      return !!keySystem.match(/^com\.widevine\.alpha/);
+    }
+
+    return false;
+  }
+
+  /**
+   * @param {?string} keySystem
+   * @return {boolean}
+   */
   static isPlayReadyKeySystem(keySystem) {
     if (keySystem) {
       return !!keySystem.match(/^com\.(microsoft|chromecast)\.playready/);

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -94,6 +94,8 @@ shaka.util.PlayerConfiguration = class {
       parseInbandPsshEnabled: shaka.util.Platform.isXboxOne(),
       minHdcpVersion: '',
       ignoreDuplicateInitData: !shaka.util.Platform.isTizen2(),
+      defaultAudioRobustnessForWidevine: 'SW_SECURE_CRYPTO',
+      defaultVideoRobustnessForWidevine: 'SW_SECURE_DECODE',
     };
 
     // The Xbox One and PS4 only support the Playready DRM, so they should

--- a/test/drm/drm_utils_unit.js
+++ b/test/drm/drm_utils_unit.js
@@ -145,6 +145,22 @@ describe('DrmUtils', () => {
     });
   }); // describe('getCommonDrmInfos')
 
+  describe('isWidevineKeySystem', () => {
+    it('should return true for Widevine', () => {
+      expect(shaka.drm.DrmUtils.isWidevineKeySystem(
+          'com.widevine.alpha')).toBe(true);
+      expect(shaka.drm.DrmUtils.isWidevineKeySystem(
+          'com.widevine.alpha.anything')).toBe(true);
+    });
+
+    it('should return false for non-Widevine key systems', () => {
+      expect(shaka.drm.DrmUtils.isWidevineKeySystem(
+          'com.microsoft.playready')).toBe(false);
+      expect(shaka.drm.DrmUtils.isWidevineKeySystem(
+          'com.apple.fps')).toBe(false);
+    });
+  });
+
   describe('isPlayReadyKeySystem', () => {
     it('should return true for MS & Chromecast PlayReady', () => {
       expect(shaka.drm.DrmUtils.isPlayReadyKeySystem(


### PR DESCRIPTION
The following bug is avoided in Chromium: `It is recommended that a robustness level be specified. Not specifying the robustness level could result in unexpected behavior.Understand this warningAI`

It also prevents errors when initializing EME on Android.

Fixes https://github.com/shaka-project/shaka-player/issues/7760