### PR TITLE
fix: Follow the configured playRange, even for raw mp4

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -2470,7 +2470,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           duration > 0 ? this.video_.currentTime / duration : 0;
 
       if (!isNaN(completionRatio)) {
-        // Reset the current 'completionPercent'.
+        // Reset 'this.completionPercent_' to the current value.
         this.completionPercent_ = completionRatio * 100;
       }
     });
@@ -7054,8 +7054,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     const seekRange = this.seekRange();
     const duration = seekRange.end - seekRange.start;
-    const completionRatio =
-        duration > 0 ? this.video_.currentTime / duration : 0;
+    const completionRatio = duration > 0 ?
+        (this.video_.currentTime - seekRange.start) / duration :
+        0;
 
     if (isNaN(completionRatio)) {
       return;

--- a/lib/player.js
+++ b/lib/player.js
@@ -884,7 +884,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             this.preloadDueAdManagerTimer_.stop();
             if (!this.preloadDueAdManager_) {
               this.preloadDueAdManagerVideo_ = this.video_;
-              this.preloadDueAdManagerVideoEnded_ = this.video_.ended;
+              this.preloadDueAdManagerVideoEnded_ = this.isEnded();
               const saveLivePosition = /** @type {boolean} */(
                 e['saveLivePosition']) || false;
               this.preloadDueAdManager_ = await this.detachAndSavePreload(
@@ -2463,6 +2463,17 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   addBasicMediaListeners_(mediaElement, startTimeOfLoad) {
     const updateStateHistory = () => this.updateStateHistory_();
     const onRateChange = () => this.onRateChange_();
+    this.loadEventManager_.listen(mediaElement, 'play', () => {
+      const seekRange = this.seekRange();
+      const duration = seekRange.end - seekRange.start;
+      const completionRatio =
+          duration > 0 ? this.video_.currentTime / duration : 0;
+
+      if (!isNaN(completionRatio)) {
+        // Reset the current 'completionPercent'.
+        this.completionPercent_ = completionRatio * 100;
+      }
+    });
     this.loadEventManager_.listen(mediaElement, 'playing', updateStateHistory);
     this.loadEventManager_.listen(mediaElement, 'pause', updateStateHistory);
     this.loadEventManager_.listen(mediaElement, 'ended', updateStateHistory);
@@ -2774,7 +2785,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       if (this.manifest_.nextUrl) {
         if (this.config_.streaming.preloadNextUrlWindow > 0) {
           const onTimeUpdate = async () => {
-            const timeToEnd = this.video_.duration - this.video_.currentTime;
+            const timeToEnd = this.seekRange().end - this.video_.currentTime;
             if (!isNaN(timeToEnd)) {
               if (timeToEnd <= this.config_.streaming.preloadNextUrlWindow) {
                 this.loadEventManager_.unlisten(
@@ -4493,9 +4504,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (this.video_ && this.video_.src) {
       const seekable = this.video_.seekable;
       if (seekable.length) {
+        const start = Math.max(seekable.start(0), this.config_.playRangeStart);
+        const end = Math.min(
+            seekable.end(seekable.length - 1), this.config_.playRangeEnd);
         return {
-          'start': seekable.start(0),
-          'end': seekable.end(seekable.length - 1),
+          'start': start,
+          'end': end,
         };
       }
     }
@@ -6049,7 +6063,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
-    let duration = this.video_.duration;
+    const seekRange = this.seekRange();
+    let duration = seekRange.end - seekRange.start;
     if (this.manifest_) {
       duration = this.manifest_.presentationTimeline.getDuration();
     }
@@ -6822,7 +6837,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     let updateState = 'playing';
     if (this.bufferObserver_.getState() == State.STARVING) {
       updateState = 'buffering';
-    } else if (this.video_.ended) {
+    } else if (this.isEnded()) {
       updateState = 'ended';
     } else if (this.video_.paused) {
       updateState = 'paused';
@@ -7037,7 +7052,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return false;
     };
 
-    const completionRatio = this.video_.currentTime / this.video_.duration;
+    const seekRange = this.seekRange();
+    const duration = seekRange.end - seekRange.start;
+    const completionRatio =
+        duration > 0 ? this.video_.currentTime / duration : 0;
 
     if (isNaN(completionRatio)) {
       return;
@@ -7060,6 +7078,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     } else if (isQuartile(100, percent)) {
       event = shaka.Player.makeEvent_(
           shaka.util.FakeEvent.EventName.Complete);
+      // Make sure the video stops when we reach the end.
+      // This is required when there is a custom play range specified.
+      this.video_.pause();
     }
 
     if (event) {
@@ -8160,7 +8181,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // This is a strong guarantee that we are buffered to the end, because it
     // means the playhead is already at that end.
-    if (this.video_.ended) {
+    if (this.isEnded()) {
       return true;
     }
 
@@ -8200,7 +8221,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // This is a strong guarantee that we are buffered to the end, because it
     // means the playhead is already at that end.
-    if (this.video_.ended) {
+    if (this.isEnded()) {
       return true;
     }
 
@@ -8240,6 +8261,18 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return false;
     }
     return this.video_.remote.state != 'disconnected';
+  }
+
+  /**
+   * Indicate if the video has ended.
+   *
+   * @return {boolean}
+   * @export
+   */
+  isEnded() {
+    const seekRange = this.seekRange();
+    return !this.video_ || this.video_.ended ||
+        this.video_.currentTime >= seekRange.end;
   }
 };
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -2464,11 +2464,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const updateStateHistory = () => this.updateStateHistory_();
     const onRateChange = () => this.onRateChange_();
     this.loadEventManager_.listen(mediaElement, 'play', () => {
-      const seekRange = this.seekRange();
-      const duration = seekRange.end - seekRange.start;
-      const completionRatio =
-          duration > 0 ? this.video_.currentTime / duration : 0;
-
+      const completionRatio = this.getCurrentCompletionRatio_();
       if (!isNaN(completionRatio)) {
         // Reset 'this.completionPercent_' to the current value.
         this.completionPercent_ = completionRatio * 100;
@@ -7052,12 +7048,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return false;
     };
 
-    const seekRange = this.seekRange();
-    const duration = seekRange.end - seekRange.start;
-    const completionRatio = duration > 0 ?
-        (this.video_.currentTime - seekRange.start) / duration :
-        0;
-
+    const completionRatio = this.getCurrentCompletionRatio_();
     if (isNaN(completionRatio)) {
       return;
     }
@@ -7087,6 +7078,19 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (event) {
       this.dispatchEvent(event);
     }
+  }
+
+  /**
+   * Returns the current completion ratio.
+   *
+   * @private
+   */
+  getCurrentCompletionRatio_() {
+    const seekRange = this.seekRange();
+    const duration = seekRange.end - seekRange.start;
+    return duration > 0 ?
+        (this.video_.currentTime - seekRange.start) / duration :
+        0;
   }
 
   /**

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -869,6 +869,10 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
     }
 
     if (this.presentationIsPaused()) {
+      // If we are at the end, go back to the beginning.
+      if (this.player_.isEnded()) {
+        this.video_.currentTime = this.player_.seekRange().start;
+      }
       this.video_.play();
     } else {
       this.video_.pause();

--- a/ui/play_button.js
+++ b/ui/play_button.js
@@ -116,7 +116,7 @@ shaka.ui.PlayButton = class extends shaka.ui.Element {
       return false;
     }
 
-    return this.video.ended;
+    return this.player ? this.player.isEnded() : true;
   }
 
   /**


### PR DESCRIPTION
When 'playRangeStart' and/or 'playRangeEnd' is specified in the config,
limit the actual play range to this range.

In particular, this means stop the video after playRangeEnd. This
implies that 'video.ended' is no longer a good marker of the end of the
video.

Note that one change in functionnality is that 'completionPercent_' is
now reset when the video is restarted, which means the
FirstQuartile/Midpoint/ThirdQuartile/Complete events will trigger again.