### PR TITLE
fix(HLS): Omit daterange without START-DATE in order to avoid errors

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -4016,7 +4016,9 @@ shaka.hls.HlsParser = class {
     }
     let dateRangeTags =
         shaka.hls.Utils.filterTagsByName(tags, 'EXT-X-DATERANGE');
-    dateRangeTags = dateRangeTags.sort((a, b) => {
+    dateRangeTags = dateRangeTags.filter((tag) => {
+      return tag.getAttribute('START-DATE') != null;
+    }).sort((a, b) => {
       const aStartDateValue = a.getRequiredAttrValue('START-DATE');
       const bStartDateValue = b.getRequiredAttrValue('START-DATE');
       if (aStartDateValue < bStartDateValue) {


### PR DESCRIPTION
Per the HLS spec, we require a START-DATE for SCTE35-IN 
However, unlike for SCTE35-OUT and SCTE35-CMD, it’s not clear what that value should be – and the HLS spec example does not include it.