### PR TITLE
fix(DASH): Fix Dolby Atmos detection when there is not SupplementalProperty

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -2291,8 +2291,12 @@ shaka.dash.DashParser = class {
       return element.attributes['schemeIdUri'] == expectedUri &&
           element.attributes['value'] == expectedValue;
     });
+    const codecs = context.representation.codecs;
+    // Detect the presence of Dolby Atmos audio content based on the codec and
+    // bandwidth. Bandwidth above 384 kbps is a good indicator of Atmos content.
+    const isAtmos = codecs.includes('ec-3') && context.bandwidth >= 384000;
     let spatialAudio = false;
-    if (hasJoc) {
+    if (hasJoc || isAtmos) {
       spatialAudio = true;
     }
 
@@ -2324,7 +2328,6 @@ shaka.dash.DashParser = class {
 
     let hdr;
     const profiles = context.profiles;
-    const codecs = context.representation.codecs;
 
     const hevcHDR = 'http://dashif.org/guidelines/dash-if-uhd#hevc-hdr-pq10';
     if (profiles.includes(hevcHDR) && (codecs.includes('hvc1.2.4.L153.B0') ||

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -540,6 +540,28 @@ describe('DashParser Manifest', () => {
     expect(stream.spatialAudio).toBe(true);
   });
 
+  it('Detects spatial audio by codec and bandwidth', async () => {
+    const source = [
+      '<MPD>',
+      '  <Period duration="PT30M">',
+      '    <AdaptationSet mimeType="audio/mp4" lang="\u2603">',
+      '      <Representation bandwidth="384000" codecs="ec-3">',
+      '        <BaseURL>http://example.com</BaseURL>',
+      '        <SegmentTemplate media="2.mp4" duration="1" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '  </Period>',
+      '</MPD>',
+    ].join('\n');
+
+    fakeNetEngine.setResponseText('dummy://foo', source);
+
+    /** @type {shaka.extern.Manifest} */
+    const manifest = await parser.start('dummy://foo', playerInterface);
+    const stream = manifest.variants[0].audio;
+    expect(stream.spatialAudio).toBe(true);
+  });
+
   it('correctly parses CEA-608 closed caption tags without channel numbers',
       async () => {
         const source = [


### PR DESCRIPTION
The correct way is to use JOC, but some packagers do not use it.