### PR TITLE
fix: Fix SEGMENT HEAD requests, compatibility with Cast SDK

### DIFF
--- a/lib/net/http_fetch_plugin.js
+++ b/lib/net/http_fetch_plugin.js
@@ -109,7 +109,7 @@ shaka.net.HttpFetchPlugin = class {
     const fetch = shaka.net.HttpFetchPlugin.fetch_;
     const ReadableStream = shaka.net.HttpFetchPlugin.ReadableStream_;
     let response;
-    let arrayBuffer;
+    let arrayBuffer = new ArrayBuffer(0);
     let loaded = 0;
     let lastLoaded = 0;
 

--- a/lib/net/http_plugin_utils.js
+++ b/lib/net/http_plugin_utils.js
@@ -6,6 +6,7 @@
 
 goog.provide('shaka.net.HttpPluginUtils');
 
+goog.require('goog.asserts');
 goog.require('shaka.log');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.StringUtils');
@@ -27,6 +28,8 @@ shaka.net.HttpPluginUtils = class {
    * @return {!shaka.extern.Response}
    */
   static makeResponse(headers, data, status, uri, responseURL, requestType) {
+    goog.asserts.assert(data, 'Data should be non-null!');
+
     if (status >= 200 && status <= 299 && status != 202) {
       // Most 2xx HTTP codes are success cases.
       /** @type {shaka.extern.Response} */


### PR DESCRIPTION
The Cast SDK currently assumes that SEGMENT response objects always have data, however this stopped being true for HEAD requests in v4.3.6.

This PR fixes the behavior of the Fetch plugin so that HEAD requests will at least have an empty ArrayBuffer for data, as they did in v4.3.5 and earlier.

The Cast SDK will also receive a fix to stop assuming this, fixing compatibility with v4.3.6+ - v4.12.6.

This incompatibility between the current Cast SDK and these versions of Shaka Player is only triggered by HLS content whose segment URLs have no recognizable extension.

Affected Shaka Player versions:
 - v4.3.6 - v4.3.16
 - v4.4.x - v4.8.x
 - v4.9.0 - v4.9.34
 - v4.9.2-caf - v4.9.2-caf4
 - v4.10.x
 - v4.11.0 - v4.11.18
 - v4.12.0 - v4.12.6

Affected Cast Web Receiver SDK versions:
 - <= 3.0.0137

Fixes will be in:
 - v4.9.35+
 - v4.9.2-caf5+
 - v4.11.19+
 - v4.12.7+
 - v4.13.0+

Closes #7600