### PR TITLE
ci: Update release-please-action

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -15,7 +15,7 @@ jobs:
       patch: ${{ steps.release.outputs.patch }}
     steps:
       # Create/update release PR
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           # Make sure we create the PR against the correct branch.


### PR DESCRIPTION
google-github-actions/release-please-action has been deprecated and replaced with googleapis/release-please-action.