### PR TITLE
ci: Fix screenshot upload

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -240,7 +240,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: screenshots-${{ matrix.browser }}
+          name: screenshots-${{ matrix.browser }}-${{ matrix.os }}
           path: |
             test/test/assets/screenshots/*/*.png-new
             test/test/assets/screenshots/*/*.png-diff


### PR DESCRIPTION
This is meant to fix errors like "Failed request: (409) Conflict: an artifact with this name already exists on the workflow run" which occur when more than one instance of a browser fails tests in the same run.

The change in behavior that led to the error likely began after updating actions/upload-artifact.