### PR TITLE
feat: Add adaptation set criteria factory configuration

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2369,6 +2369,9 @@ shaka.extern.TextDisplayerConfiguration;
  *   Media source configuration and settings.
  * @property {shaka.extern.AbrManager.Factory} abrFactory
  *   A factory to construct an abr manager.
+ * @property {shaka.media.AdaptationSetCriteria.Factory}
+ *     adaptationSetCriteriaFactory
+ *   A factory to construct an adaptation set criteria.
  * @property {shaka.extern.AbrConfiguration} abr
  *   ABR configuration and settings.
  * @property {shaka.extern.CmcdConfiguration} cmcd

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2323,6 +2323,7 @@ shaka.extern.TextDisplayerConfiguration;
  *   streaming: shaka.extern.StreamingConfiguration,
  *   mediaSource: shaka.extern.MediaSourceConfiguration,
  *   abrFactory: shaka.extern.AbrManager.Factory,
+ *   adaptationSetCriteriaFactory: shaka.media.AdaptationSetCriteria.Factory,
  *   abr: shaka.extern.AbrConfiguration,
  *   cmcd: shaka.extern.CmcdConfiguration,
  *   cmsd: shaka.extern.CmsdConfiguration,

--- a/lib/media/adaptation_set.js
+++ b/lib/media/adaptation_set.js
@@ -15,6 +15,7 @@ goog.require('shaka.util.MimeUtils');
  * A set of variants that we want to adapt between.
  *
  * @final
+ * @export
  */
 shaka.media.AdaptationSet = class {
   /**

--- a/lib/media/adaptation_set_criteria.js
+++ b/lib/media/adaptation_set_criteria.js
@@ -25,17 +25,15 @@ shaka.media.AdaptationSetCriteria = class {
    *
    * @param {!Array.<shaka.extern.Variant>} variants
    * @return {!shaka.media.AdaptationSet}
+   * @exportInterface
    */
   create(variants) {}
 
   /**
    * Sets the AdaptationSetCriteria configuration.
    *
-   * It is the responsibility of the AbrManager implementation to implement the
-   * restrictions behavior described in shaka.extern.AbrConfiguration.
-   *
    * @param {shaka.media.AdaptationSetCriteria.Configuration} config
-   * @exportDoc
+   * @exportInterface
    */
   configure(config) {}
 };
@@ -44,7 +42,6 @@ shaka.media.AdaptationSetCriteria = class {
  * A factory for creating the AdaptationSetCriteria.
  *
  * @typedef {function():!shaka.media.AdaptationSetCriteria}
- * @exportDoc
  * @export
  */
 shaka.media.AdaptationSetCriteria.Factory;
@@ -63,11 +60,26 @@ shaka.media.AdaptationSetCriteria.Factory;
  *   audioCodec: string
  * }}
  *
- * @property {boolean} enabled
- *   If true, enable adaptation by the current AbrManager.
- *   <br>
- *   Defaults to <code>true</code>.
- * @exportDoc
+ * @property {string} language
+ *   The language used to filter variants.
+ * @property {string} role
+ *   The adaptation role used to filter variants.
+ * @property {string} channelCount
+ *   The audio channel count used to filter variants.
+ * @property {string} hdrLevel
+ *   The HDR level used to filter variants.
+ * @property {boolean} spatialAudio
+ *   Whether should prefer audio tracks with spatial audio.
+ * @property {string} videoLayout
+ *   The video layout used to filter variants.
+ * @property {string} audioLabel
+ *   The audio label used to filter variants.
+ * @property {string} videoLabel
+ *   The video label used to filter variants.
+ * @property {shaka.config.CodecSwitchingStrategy} codecSwitchingStrategy
+ *   The codec switching strategy used to filter variants.
+ * @property {string} audioCodec
+ *   The audio codec used to filter variants.
  * @export
  */
 shaka.media.AdaptationSetCriteria.Configuration;

--- a/lib/media/adaptation_set_criteria.js
+++ b/lib/media/adaptation_set_criteria.js
@@ -7,6 +7,7 @@
 goog.provide('shaka.media.AdaptationSetCriteria');
 
 goog.require('shaka.media.AdaptationSet');
+goog.require('shaka.config.CodecSwitchingStrategy');
 
 
 /**
@@ -15,6 +16,7 @@ goog.require('shaka.media.AdaptationSet');
  * adapted between.
  *
  * @interface
+ * @export
  */
 shaka.media.AdaptationSetCriteria = class {
   /**
@@ -25,4 +27,47 @@ shaka.media.AdaptationSetCriteria = class {
    * @return {!shaka.media.AdaptationSet}
    */
   create(variants) {}
+
+  /**
+   * Sets the AdaptationSetCriteria configuration.
+   *
+   * It is the responsibility of the AbrManager implementation to implement the
+   * restrictions behavior described in shaka.extern.AbrConfiguration.
+   *
+   * @param {shaka.media.AdaptationSetCriteria.Configuration} config
+   * @exportDoc
+   */
+  configure(config) {}
 };
+
+/**
+ * A factory for creating the AdaptationSetCriteria.
+ *
+ * @typedef {function():!shaka.media.AdaptationSetCriteria}
+ * @exportDoc
+ * @export
+ */
+shaka.media.AdaptationSetCriteria.Factory;
+
+/**
+ * @typedef {{
+ *   language: string,
+ *   role: string,
+ *   channelCount: number,
+ *   hdrLevel: string,
+ *   spatialAudio: boolean,
+ *   videoLayout: string,
+ *   audioLabel: string,
+ *   videoLabel: string,
+ *   codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy,
+ *   audioCodec: string
+ * }}
+ *
+ * @property {boolean} enabled
+ *   If true, enable adaptation by the current AbrManager.
+ *   <br>
+ *   Defaults to <code>true</code>.
+ * @exportDoc
+ * @export
+ */
+shaka.media.AdaptationSetCriteria.Configuration;

--- a/lib/media/example_based_criteria.js
+++ b/lib/media/example_based_criteria.js
@@ -54,7 +54,10 @@ shaka.media.ExampleBasedCriteria = class {
     });
   }
 
-  /** @override */
+  /**
+   * @override
+   * @export
+   */
   create(variants) {
     return this.preferenceBasedCriteria_.create(variants);
   }

--- a/lib/media/example_based_criteria.js
+++ b/lib/media/example_based_criteria.js
@@ -7,7 +7,6 @@
 goog.provide('shaka.media.ExampleBasedCriteria');
 
 goog.require('shaka.media.AdaptationSetCriteria');
-goog.require('shaka.media.PreferenceBasedCriteria');
 goog.requireType('shaka.config.CodecSwitchingStrategy');
 
 
@@ -20,8 +19,10 @@ shaka.media.ExampleBasedCriteria = class {
   /**
    * @param {shaka.extern.Variant} example
    * @param {shaka.config.CodecSwitchingStrategy} codecSwitchingStrategy
+   * @param {shaka.media.AdaptationSetCriteria.Factory}
+   *     adaptationSetCriteriaFactory
    */
-  constructor(example, codecSwitchingStrategy) {
+  constructor(example, codecSwitchingStrategy, adaptationSetCriteriaFactory) {
     // We can't know if role and label are really important, so we don't use
     // role and label for this.
     const role = '';
@@ -39,7 +40,7 @@ shaka.media.ExampleBasedCriteria = class {
         example.audio.codecs : '';
 
     /** @private {!shaka.media.AdaptationSetCriteria} */
-    this.preferenceBasedCriteria_ = new shaka.media.PreferenceBasedCriteria();
+    this.preferenceBasedCriteria_ = adaptationSetCriteriaFactory();
     this.preferenceBasedCriteria_.configure({
       language: example.language,
       role,

--- a/lib/media/example_based_criteria.js
+++ b/lib/media/example_based_criteria.js
@@ -14,6 +14,7 @@ goog.requireType('shaka.config.CodecSwitchingStrategy');
 /**
  * @implements {shaka.media.AdaptationSetCriteria}
  * @final
+ * @export
  */
 shaka.media.ExampleBasedCriteria = class {
   /**
@@ -38,14 +39,30 @@ shaka.media.ExampleBasedCriteria = class {
         example.audio.codecs : '';
 
     /** @private {!shaka.media.AdaptationSetCriteria} */
-    this.preferenceBasedCriteria_ = new shaka.media.PreferenceBasedCriteria(
-        example.language, role, channelCount, hdrLevel, spatialAudio,
-        videoLayout, audioLabel, videoLabel,
-        codecSwitchingStrategy, audioCodec);
+    this.preferenceBasedCriteria_ = new shaka.media.PreferenceBasedCriteria();
+    this.preferenceBasedCriteria_.configure({
+      language: example.language,
+      role,
+      channelCount,
+      hdrLevel,
+      spatialAudio,
+      videoLayout,
+      audioLabel,
+      videoLabel,
+      codecSwitchingStrategy,
+      audioCodec,
+    });
   }
 
   /** @override */
   create(variants) {
     return this.preferenceBasedCriteria_.create(variants);
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  configure() {
   }
 };

--- a/lib/media/example_based_criteria.js
+++ b/lib/media/example_based_criteria.js
@@ -13,7 +13,6 @@ goog.requireType('shaka.config.CodecSwitchingStrategy');
 /**
  * @implements {shaka.media.AdaptationSetCriteria}
  * @final
- * @export
  */
 shaka.media.ExampleBasedCriteria = class {
   /**
@@ -57,7 +56,6 @@ shaka.media.ExampleBasedCriteria = class {
 
   /**
    * @override
-   * @export
    */
   create(variants) {
     return this.preferenceBasedCriteria_.create(variants);
@@ -65,7 +63,6 @@ shaka.media.ExampleBasedCriteria = class {
 
   /**
    * @override
-   * @export
    */
   configure() {
   }

--- a/lib/media/preference_based_criteria.js
+++ b/lib/media/preference_based_criteria.js
@@ -34,7 +34,10 @@ shaka.media.PreferenceBasedCriteria = class {
     this.config_ = config;
   }
 
-  /** @override */
+  /**
+   * @override
+   * @export
+   */
   create(variants) {
     const Class = shaka.media.PreferenceBasedCriteria;
 

--- a/lib/media/preference_based_criteria.js
+++ b/lib/media/preference_based_criteria.js
@@ -17,7 +17,6 @@ goog.require('shaka.util.LanguageUtils');
 /**
  * @implements {shaka.media.AdaptationSetCriteria}
  * @final
- * @export
  */
 shaka.media.PreferenceBasedCriteria = class {
   /** */
@@ -28,7 +27,6 @@ shaka.media.PreferenceBasedCriteria = class {
 
   /**
    * @override
-   * @export
    */
   configure(config) {
     this.config_ = config;
@@ -36,7 +34,6 @@ shaka.media.PreferenceBasedCriteria = class {
 
   /**
    * @override
-   * @export
    */
   create(variants) {
     const Class = shaka.media.PreferenceBasedCriteria;

--- a/lib/media/preference_based_criteria.js
+++ b/lib/media/preference_based_criteria.js
@@ -17,42 +17,21 @@ goog.require('shaka.util.LanguageUtils');
 /**
  * @implements {shaka.media.AdaptationSetCriteria}
  * @final
+ * @export
  */
 shaka.media.PreferenceBasedCriteria = class {
+  /** */
+  constructor() {
+    /** @private {?shaka.media.AdaptationSetCriteria.Configuration} */
+    this.config_ = null;
+  }
+
   /**
-   * @param {string} language
-   * @param {string} role
-   * @param {number} channelCount
-   * @param {string} hdrLevel
-   * @param {boolean} spatialAudio
-   * @param {string} videoLayout
-   * @param {string} audioLabel
-   * @param {string} videoLabel
-   * @param {shaka.config.CodecSwitchingStrategy} codecSwitchingStrategy
-   * @param {string} audioCodec
+   * @override
+   * @export
    */
-  constructor(language, role, channelCount, hdrLevel, spatialAudio,
-      videoLayout, audioLabel, videoLabel, codecSwitchingStrategy, audioCodec) {
-    /** @private {string} */
-    this.language_ = language;
-    /** @private {string} */
-    this.role_ = role;
-    /** @private {number} */
-    this.channelCount_ = channelCount;
-    /** @private {string} */
-    this.hdrLevel_ = hdrLevel;
-    /** @private {boolean} */
-    this.spatialAudio_ = spatialAudio;
-    /** @private {string} */
-    this.videoLayout_ = videoLayout;
-    /** @private {string} */
-    this.audioLabel_ = audioLabel;
-    /** @private {string} */
-    this.videoLabel_ = videoLabel;
-    /** @private {shaka.config.CodecSwitchingStrategy} */
-    this.codecSwitchingStrategy_ = codecSwitchingStrategy;
-    /** @private {string} */
-    this.audioCodec_ = audioCodec;
+  configure(config) {
+    this.config_ = config;
   }
 
   /** @override */
@@ -61,7 +40,7 @@ shaka.media.PreferenceBasedCriteria = class {
 
     let current = [];
 
-    const byLanguage = Class.filterByLanguage_(variants, this.language_);
+    const byLanguage = Class.filterByLanguage_(variants, this.config_.language);
     const byPrimary = variants.filter((variant) => variant.primary);
 
     if (byLanguage.length) {
@@ -74,16 +53,16 @@ shaka.media.PreferenceBasedCriteria = class {
 
     // Now refine the choice based on role preference.  Even the empty string
     // works here, and will match variants without any roles.
-    const byRole = Class.filterVariantsByRole_(current, this.role_);
+    const byRole = Class.filterVariantsByRole_(current, this.config_.role);
     if (byRole.length) {
       current = byRole;
     } else {
       shaka.log.warning('No exact match for variant role could be found.');
     }
 
-    if (this.videoLayout_) {
+    if (this.config_.videoLayout) {
       const byVideoLayout = Class.filterVariantsByVideoLayout_(
-          current, this.videoLayout_);
+          current, this.config_.videoLayout);
       if (byVideoLayout.length) {
         current = byVideoLayout;
       } else {
@@ -92,9 +71,9 @@ shaka.media.PreferenceBasedCriteria = class {
       }
     }
 
-    if (this.hdrLevel_) {
+    if (this.config_.hdrLevel) {
       const byHdrLevel = Class.filterVariantsByHDRLevel_(
-          current, this.hdrLevel_);
+          current, this.config_.hdrLevel);
       if (byHdrLevel.length) {
         current = byHdrLevel;
       } else {
@@ -103,9 +82,9 @@ shaka.media.PreferenceBasedCriteria = class {
       }
     }
 
-    if (this.channelCount_) {
+    if (this.config_.channelCount) {
       const byChannel = Class.filterVariantsByAudioChannelCount_(
-          current, this.channelCount_);
+          current, this.config_.channelCount);
       if (byChannel.length) {
         current = byChannel;
       } else {
@@ -114,9 +93,9 @@ shaka.media.PreferenceBasedCriteria = class {
       }
     }
 
-    if (this.audioLabel_) {
+    if (this.config_.audioLabel) {
       const byLabel = Class.filterVariantsByAudioLabel_(
-          current, this.audioLabel_);
+          current, this.config_.audioLabel);
       if (byLabel.length) {
         current = byLabel;
       } else {
@@ -124,9 +103,9 @@ shaka.media.PreferenceBasedCriteria = class {
       }
     }
 
-    if (this.videoLabel_) {
+    if (this.config_.videoLabel) {
       const byLabel = Class.filterVariantsByVideoLabel_(
-          current, this.videoLabel_);
+          current, this.config_.videoLabel);
       if (byLabel.length) {
         current = byLabel;
       } else {
@@ -135,16 +114,16 @@ shaka.media.PreferenceBasedCriteria = class {
     }
 
     const bySpatialAudio = Class.filterVariantsBySpatialAudio_(
-        current, this.spatialAudio_);
+        current, this.config_.spatialAudio);
     if (bySpatialAudio.length) {
       current = bySpatialAudio;
     } else {
       shaka.log.warning('No exact match for spatial audio could be found.');
     }
 
-    if (this.audioCodec_) {
+    if (this.config_.audioCodec) {
       const byAudioCodec = Class.filterVariantsByAudioCodec_(
-          current, this.audioCodec_);
+          current, this.config_.audioCodec);
       if (byAudioCodec.length) {
         current = byAudioCodec;
       } else {
@@ -152,7 +131,8 @@ shaka.media.PreferenceBasedCriteria = class {
       }
     }
 
-    const supportsSmoothCodecTransitions = this.codecSwitchingStrategy_ ==
+    const supportsSmoothCodecTransitions =
+      this.config_.codecSwitchingStrategy ==
       shaka.config.CodecSwitchingStrategy.SMOOTH &&
         shaka.media.Capabilities.isChangeTypeSupported();
 

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -12,7 +12,6 @@ goog.require('shaka.log');
 goog.require('shaka.media.AdaptationSetCriteria');
 goog.require('shaka.media.ManifestFilterer');
 goog.require('shaka.media.ManifestParser');
-goog.require('shaka.media.PreferenceBasedCriteria');
 goog.require('shaka.media.QualityObserver');
 goog.require('shaka.media.RegionTimeline');
 goog.require('shaka.media.SegmentPrefetch');
@@ -644,17 +643,20 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
       // Copy preferred languages from the config again, in case the config was
       // changed between construction and playback.
       this.currentAdaptationSetCriteria_ =
-          new shaka.media.PreferenceBasedCriteria(
-              this.config_.preferredAudioLanguage,
-              this.config_.preferredVariantRole,
-              this.config_.preferredAudioChannelCount,
-              this.config_.preferredVideoHdrLevel,
-              this.config_.preferSpatialAudio,
-              this.config_.preferredVideoLayout,
-              this.config_.preferredAudioLabel,
-              this.config_.preferredVideoLabel,
-              this.config_.mediaSource.codecSwitchingStrategy,
-              /* audioCodec= */ '');
+          this.config_.adaptationSetCriteriaFactory();
+      this.currentAdaptationSetCriteria_.configure({
+        language: this.config_.preferredAudioLanguage,
+        role: this.config_.preferredVariantRole,
+        channelCount: this.config_.preferredAudioChannelCount,
+        hdrLevel: this.config_.preferredVideoHdrLevel,
+        spatialAudio: this.config_.preferSpatialAudio,
+        videoLayout: this.config_.preferredVideoLayout,
+        audioLabel: this.config_.preferredAudioLabel,
+        videoLabel: this.config_.preferredVideoLabel,
+        codecSwitchingStrategy:
+            this.config_.mediaSource.codecSwitchingStrategy,
+        audioCodec: '',
+      });
     }
 
     // Make the ABR manager.

--- a/lib/player.js
+++ b/lib/player.js
@@ -23,7 +23,6 @@ goog.require('shaka.media.MetaSegmentIndex');
 goog.require('shaka.media.PlayRateController');
 goog.require('shaka.media.Playhead');
 goog.require('shaka.media.PlayheadObserverManager');
-goog.require('shaka.media.PreferenceBasedCriteria');
 goog.require('shaka.media.PreloadManager');
 goog.require('shaka.media.QualityObserver');
 goog.require('shaka.media.RegionObserver');
@@ -804,17 +803,20 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     /** @private {!shaka.media.AdaptationSetCriteria} */
     this.currentAdaptationSetCriteria_ =
-        new shaka.media.PreferenceBasedCriteria(
-            this.config_.preferredAudioLanguage,
-            this.config_.preferredVariantRole,
-            this.config_.preferredAudioChannelCount,
-            this.config_.preferredVideoHdrLevel,
-            this.config_.preferSpatialAudio,
-            this.config_.preferredVideoLayout,
-            this.config_.preferredAudioLabel,
-            this.config_.preferredVideoLabel,
-            this.config_.mediaSource.codecSwitchingStrategy,
-            /* audioCodec= */ '');
+        this.config_.adaptationSetCriteriaFactory();
+    this.currentAdaptationSetCriteria_.configure({
+      language: this.config_.preferredAudioLanguage,
+      role: this.config_.preferredVariantRole,
+      channelCount: this.config_.preferredAudioChannelCount,
+      hdrLevel: this.config_.preferredVideoHdrLevel,
+      spatialAudio: this.config_.preferSpatialAudio,
+      videoLayout: this.config_.preferredVideoLayout,
+      audioLabel: this.config_.preferredAudioLabel,
+      videoLabel: this.config_.preferredVideoLabel,
+      codecSwitchingStrategy:
+          this.config_.mediaSource.codecSwitchingStrategy,
+      audioCodec: '',
+    });
 
     /** @private {string} */
     this.currentTextLanguage_ = this.config_.preferredTextLanguage;
@@ -5278,17 +5280,20 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       codec = '', spatialAudio = false) {
     const selectMediaSourceMode = () => {
       this.currentAdaptationSetCriteria_ =
-          new shaka.media.PreferenceBasedCriteria(
-              language,
-              role || '',
-              channelsCount || 0,
-              /* hdrLevel= */ '',
-              spatialAudio || false,
-              /* videoLayout= */ '',
-              /* audioLabel= */ '',
-              /* videoLabel= */ '',
-              this.config_.mediaSource.codecSwitchingStrategy,
-              codec || '');
+          this.config_.adaptationSetCriteriaFactory();
+      this.currentAdaptationSetCriteria_.configure({
+        language,
+        role: role || '',
+        channelCount: channelsCount || 0,
+        hdrLevel: '',
+        spatialAudio: spatialAudio || false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy:
+            this.config_.mediaSource.codecSwitchingStrategy,
+        audioCodec: codec || '',
+      });
 
       const diff = (a, b) => {
         if (!a.video && !b.video) {
@@ -5435,17 +5440,21 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // Because of that we assume that all the variants with the same
       // label have the same language.
       this.currentAdaptationSetCriteria_ =
-          new shaka.media.PreferenceBasedCriteria(
-              firstVariantWithLabel.language,
-              /* role= */ '',
-              /* channelCount= */ 0,
-              /* hdrLevel= */ '',
-              /* spatialAudio= */ false,
-              /* videoLayout= */ '',
-              label,
-              /* videoLabel= */ '',
-              this.config_.mediaSource.codecSwitchingStrategy,
-              /* audioCodec= */ '');
+          this.config_.adaptationSetCriteriaFactory();
+      this.currentAdaptationSetCriteria_.configure({
+        language: firstVariantWithLabel.language,
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        label,
+        videoLabel: '',
+        audioLabel: '',
+        codecSwitchingStrategy:
+            this.config_.mediaSource.codecSwitchingStrategy,
+        audioCodec: '',
+      });
 
       this.chooseVariantAndSwitch_(clearBuffer, safeMargin);
     };

--- a/lib/player.js
+++ b/lib/player.js
@@ -5189,7 +5189,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // currentAudioLanguage_.
       this.currentAdaptationSetCriteria_ = new shaka.media.ExampleBasedCriteria(
           variant,
-          this.config_.mediaSource.codecSwitchingStrategy);
+          this.config_.mediaSource.codecSwitchingStrategy,
+          this.config_.adaptationSetCriteriaFactory);
 
       // Update AbrManager variants to match these new settings.
       this.updateAbrManagerVariants_();

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -12,6 +12,7 @@ goog.require('shaka.config.AutoShowText');
 goog.require('shaka.config.CodecSwitchingStrategy');
 goog.require('shaka.log');
 goog.require('shaka.media.Capabilities');
+goog.require('shaka.media.PreferenceBasedCriteria');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.ConfigUtils');
 goog.require('shaka.util.FairPlayUtils');
@@ -440,6 +441,8 @@ shaka.util.PlayerConfiguration = class {
       mediaSource: mediaSource,
       offline: offline,
       abrFactory: () => new shaka.abr.SimpleAbrManager(),
+      adaptationSetCriteriaFactory:
+          (...args) => new shaka.media.PreferenceBasedCriteria(...args),
       abr: abr,
       autoShowText: AutoShowText.IF_SUBTITLES_MAY_BE_NEEDED,
       preferredAudioLanguage: '',

--- a/test/media/adaptation_set_criteria_unit.js
+++ b/test/media/adaptation_set_criteria_unit.js
@@ -19,17 +19,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ 'en',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: 'en',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -50,17 +52,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ 'en',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: 'en',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -106,17 +110,19 @@ describe('AdaptationSetCriteria', () => {
           return true;
         };
 
-        const builder = new shaka.media.PreferenceBasedCriteria(
-            /* language= */ 'en',
-            /* role= */ '',
-            /* channelCount= */ 0,
-            /* hdrLevel= */ '',
-            /* spatialAudio= */ false,
-            /* videoLayout= */ '',
-            /* audioLabel= */ '',
-            /* videoLabel= */ '',
-            shaka.config.CodecSwitchingStrategy.SMOOTH,
-            /* audioCodec= */ '');
+        const builder = new shaka.media.PreferenceBasedCriteria();
+        builder.configure({
+          language: 'en',
+          role: '',
+          channelCount: 0,
+          hdrLevel: '',
+          spatialAudio: false,
+          videoLayout: '',
+          audioLabel: '',
+          videoLabel: '',
+          codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.SMOOTH,
+          audioCodec: '',
+        });
         const set = builder.create(manifest.variants);
 
         expect(Array.from(set.values()).length).toBe(3);
@@ -155,17 +161,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ 'en',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: 'en',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       expect(Array.from(set.values()).length).toBe(1);
@@ -193,17 +201,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ 'en',
-          /* role= */ 'main',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: 'en',
+        role: 'main',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -252,17 +262,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ 'en',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: 'en',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       // Which role is chosen is an implementation detail.
@@ -320,17 +332,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ 'zh',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: 'zh',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       // Which role is chosen is an implementation detail.
@@ -366,17 +380,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ 'zh',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: 'zh',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       // Which language is chosen is an implementation detail.
@@ -432,17 +448,19 @@ describe('AdaptationSetCriteria', () => {
             });
           });
 
-          const builder = new shaka.media.PreferenceBasedCriteria(
-              /* language= */ 'zh',
-              /* role= */ '',
-              /* channelCount= */ 0,
-              /* hdrLevel= */ '',
-              /* spatialAudio= */ false,
-              /* videoLayout= */ '',
-              /* audioLabel= */ '',
-              /* videoLabel= */ '',
-              shaka.config.CodecSwitchingStrategy.RELOAD,
-              /* audioCodec= */ '');
+          const builder = new shaka.media.PreferenceBasedCriteria();
+          builder.configure({
+            language: 'zh',
+            role: '',
+            channelCount: 0,
+            hdrLevel: '',
+            spatialAudio: false,
+            videoLayout: '',
+            audioLabel: '',
+            videoLabel: '',
+            codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+            audioCodec: '',
+          });
           const set = builder.create(manifest.variants);
 
           // Which role is chosen is an implementation detail. Each role is
@@ -499,17 +517,19 @@ describe('AdaptationSetCriteria', () => {
             });
           });
 
-          const builder = new shaka.media.PreferenceBasedCriteria(
-              /* language= */ 'zh',
-              /* role= */ '',
-              /* channelCount= */ 0,
-              /* hdrLevel= */ '',
-              /* spatialAudio= */ false,
-              /* videoLayout= */ '',
-              /* audioLabel= */ '',
-              /* videoLabel= */ '',
-              shaka.config.CodecSwitchingStrategy.RELOAD,
-              /* audioCodec= */ '');
+          const builder = new shaka.media.PreferenceBasedCriteria();
+          builder.configure({
+            language: 'zh',
+            role: '',
+            channelCount: 0,
+            hdrLevel: '',
+            spatialAudio: false,
+            videoLayout: '',
+            audioLabel: '',
+            videoLabel: '',
+            codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+            audioCodec: '',
+          });
           const set = builder.create(manifest.variants);
 
           checkSet(set, [
@@ -537,17 +557,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ '',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ 'PQ',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: '',
+        role: '',
+        channelCount: 0,
+        hdrLevel: 'PQ',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -575,17 +597,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ '',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ 'CH-STEREO',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: '',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: 'CH-STEREO',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -613,17 +637,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ '',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ 'CH-MONO',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: '',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: 'CH-MONO',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -650,17 +676,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ '',
-          /* role= */ '',
-          /* channelCount= */ 2,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: '',
+        role: '',
+        channelCount: 2,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -689,17 +717,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ '',
-          /* role= */ '',
-          /* channelCount= */ 6,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: '',
+        role: '',
+        channelCount: 6,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -728,17 +758,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ '',
-          /* role= */ '',
-          /* channelCount= */ 2,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: '',
+        role: '',
+        channelCount: 2,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -766,17 +798,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ '',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ 'preferredLabel',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: '',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: 'preferredLabel',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -799,17 +833,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ '',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ true,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: '',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: true,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -831,17 +867,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ '',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: '',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -881,17 +919,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ 'zh',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ 'preferredLabel',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: 'zh',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: 'preferredLabel',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -919,17 +959,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ '',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ 'preferredLabel',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: '',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: 'preferredLabel',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -963,17 +1005,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ 'en',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ '');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: 'en',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: '',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
@@ -996,17 +1040,19 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const builder = new shaka.media.PreferenceBasedCriteria(
-          /* language= */ 'en',
-          /* role= */ '',
-          /* channelCount= */ 0,
-          /* hdrLevel= */ '',
-          /* spatialAudio= */ false,
-          /* videoLayout= */ '',
-          /* audioLabel= */ '',
-          /* videoLabel= */ '',
-          shaka.config.CodecSwitchingStrategy.RELOAD,
-          /* audioCodec= */ 'ec-3');
+      const builder = new shaka.media.PreferenceBasedCriteria();
+      builder.configure({
+        language: 'en',
+        role: '',
+        channelCount: 0,
+        hdrLevel: '',
+        spatialAudio: false,
+        videoLayout: '',
+        audioLabel: '',
+        videoLabel: '',
+        codecSwitchingStrategy: shaka.config.CodecSwitchingStrategy.RELOAD,
+        audioCodec: 'ec-3',
+      });
       const set = builder.create(manifest.variants);
 
       checkSet(set, [

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -1391,6 +1391,31 @@ describe('Player', () => {
     });
   });
 
+  describe('AdaptationSetCriteria.Factory', () => {
+    it('uses the provided Factory method', async () => {
+      const preferenceBasedCriteria = new shaka.media.PreferenceBasedCriteria();
+      /** @type {!jasmine.Spy} */
+      const spy1 =
+          jasmine.createSpy('AdaptationSetCriteria.Factory')
+              .and.returnValue(preferenceBasedCriteria);
+      /** @type {!jasmine.Spy} */
+      const spy2 =
+          jasmine.createSpy('AdaptationSetCriteria.Factory')
+              .and.returnValue(preferenceBasedCriteria);
+      player.configure({adaptationSetCriteriaFactory: spy1});
+
+      await player.load(fakeManifestUri, 0, fakeMimeType);
+      expect(spy1).toHaveBeenCalled();
+      expect(spy2).not.toHaveBeenCalled();
+      spy1.calls.reset();
+
+      player.configure({adaptationSetCriteriaFactory: spy2});
+      await player.load(fakeManifestUri, 0, fakeMimeType);
+      expect(spy1).not.toHaveBeenCalled();
+      expect(spy2).toHaveBeenCalled();
+    });
+  });
+
   describe('AbrManager', () => {
     beforeEach(() => {
       goog.asserts.assert(manifest, 'manifest must be non-null');


### PR DESCRIPTION
This exports AdaptationSet, and AdaptationSetCriteria to enable an `adaptationSetCriteriaFactory` method to allow for shaka users to provide their own implementation of a class that implements AdaptationSetCriteria.

Fixes #7768