### PR TITLE
chore: Remove "Override Cast Receiver App ID" in the nightly workflow

### DIFF
--- a/.github/workflows/nightly-demo.yaml
+++ b/.github/workflows/nightly-demo.yaml
@@ -25,14 +25,6 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
-      # The nightly demo has its own receiver app ID that points to the nightly
-      # demo itself for the receiver side.
-      - name: Override Cast Receiver App ID
-        run: |
-          sed \
-            -i demo/index.html \
-            -e 's/\(data-shaka-player-cast-receiver-id\)="[^"]*"/\1="07AEE832"/'
-
       - uses: ./.github/workflows/custom-actions/prep-for-appspot
 
       - uses: google-github-actions/auth@v2


### PR DESCRIPTION
There is no need to do this anymore because we always use that ID in any release