### PR TITLE
build: Add new JSDoc rules to ESLint

### DIFF
--- a/build/generateExterns.js
+++ b/build/generateExterns.js
@@ -315,7 +315,7 @@ function getFunctionParameters(node) {
  * Take the original block comment and prep it for the externs by removing
  * export annotations and blank lines.
  *
- * @param {string}
+ * @param {string} comment
  * @return {string}
  */
 function removeExportAnnotationsFromComment(comment) {
@@ -498,7 +498,7 @@ function createExternMethod(node) {
 /**
  * Find the constructor of an ES6 class, if it exists.
  *
- * @param {ASTNode} className
+ * @param {ASTNode} classNode
  * @return {ASTNode}
  */
 function getClassConstructor(classNode) {

--- a/demo/common/asset.js
+++ b/demo/common/asset.js
@@ -428,10 +428,9 @@ const ShakaDemoAssetInfo = class {
   /**
    * @return {!Object}
    * @override
-   *
+   * @suppress {checkTypes}
    * Suppress checkTypes warnings, so that we can access properties of this
    * object as though it were a struct.
-   * @suppress {checkTypes}
    */
   toJSON() {
     // Construct a generic object with the values of this object, but with the

--- a/demo/custom.js
+++ b/demo/custom.js
@@ -894,6 +894,7 @@ shakaDemo.Custom = class {
 
   /**
    * @param {!ShakaDemoAssetInfo} assetInProgress
+   * @return {boolean}
    * @private
    */
   checkManifestRequired_(assetInProgress) {

--- a/demo/input.js
+++ b/demo/input.js
@@ -98,10 +98,10 @@ shakaDemo.Input = class {
   }
 
   /**
-  * @param {string} prefix
-  * @return {string}
-  * @private
-  */
+   * @param {string} prefix
+   * @return {string}
+   * @private
+   */
   static generateNewId_(prefix) {
     const idNumber = shakaDemo.Input.lastId_;
     shakaDemo.Input.lastId_ += 1;

--- a/demo/main.js
+++ b/demo/main.js
@@ -1483,7 +1483,7 @@ shakaDemo.Main = class {
           goog.asserts.assert(this.video_ != null, 'this.video should exist!');
           adManager.initClientSide(
               this.controls_.getClientSideAdContainer(), this.video_,
-              /** adsRenderingSettings= **/ null);
+              /** adsRenderingSettings= */ null);
           const adRequest = new google.ima.AdsRequest();
           adRequest.adTagUrl = asset.adTagUri;
           adManager.requestClientSideAds(adRequest);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,8 +8,9 @@
 
 import js from '@eslint/js';
 import google from 'eslint-config-google';
-import globals from 'globals';
+import jsdoc from 'eslint-plugin-jsdoc';
 import shakaRules from 'eslint-plugin-shaka-rules';
+import globals from 'globals';
 
 // This is a matcher (usable in no-restricted-syntax) that matches either a
 // test or a before/after block.
@@ -53,6 +54,7 @@ export default [
     ignores: ['!**/eslint.config.mjs'],
   },
   js.configs.recommended,
+  jsdoc.configs['flat/recommended-error'],
   google,
   shakaRules.configs.config,
   {
@@ -60,7 +62,22 @@ export default [
       globals: globals.browser,
       ecmaVersion: 2017,
     },
-
+    settings: {
+      jsdoc: {
+        mode: 'closure',
+        preferredTypes: {
+          object: 'Object',
+          symbol: 'Symbol',
+        },
+        tagNamePreference: {
+          augments: 'extends',
+          constant: 'const',
+          constructor: 'constructor',
+          file: 'fileoverview',
+          returns: 'return',
+        },
+      },
+    },
     rules: {
       // Things the compiler already takes care of, with more precision: {{{
       'no-console': 'off',
@@ -206,6 +223,23 @@ export default [
         ignoreReadBeforeAssign: true,
       }],
       // }}}
+
+      // jsdoc rules {{{
+      'jsdoc/check-tag-names': ['error', {
+        definedTags: ['exportDoc', 'exportInterface'],
+      }],
+      // Do not check license, authors, etc
+      'jsdoc/check-values': 'off',
+      // This should be checked by the compiler
+      'jsdoc/no-undefined-types': 'off',
+      // Some params/props/returns are self-explanatory
+      'jsdoc/require-param-description': 'off',
+      'jsdoc/require-property-description': 'off',
+      'jsdoc/require-returns-description': 'off',
+      'jsdoc/tag-lines': 'off',
+      // It throws syntax error on @suppress {missingReturn}
+      'jsdoc/valid-types': 'off',
+      // }}}
     },
   },
   {
@@ -250,17 +284,6 @@ export default [
   },
   {
     files: [
-      'demo/load.js',
-      'externs/**/*.js',
-      'test/test/externs/*.js',
-      'ui/externs/*.js',
-    ],
-    rules: {
-      'no-restricted-syntax': 'off',
-    },
-  },
-  {
-    files: [
       // Closure requires using var in externs.
       'ui/externs/*.js',
       'externs/**/*.js',
@@ -270,7 +293,9 @@ export default [
       'demo/load.js',
     ],
     rules: {
+      'no-restricted-syntax': 'off',
       'no-var': 'off',
+      'jsdoc/require-returns-check': 'off',
     },
   },
   {
@@ -301,6 +326,17 @@ export default [
     rules: {
       // Externs naturally redeclare things eslint knows about.
       'no-redeclare': 'off',
+    },
+  },
+  {
+    files: [
+      'demo/load.js',
+      'externs/**/*.js',
+      'test/**/*.js',
+    ],
+    rules: {
+      // JSDoc is not strictly required in externs, tests, and in load.js.
+      'jsdoc/require-jsdoc': 'off',
     },
   },
 ];

--- a/externs/airplay.js
+++ b/externs/airplay.js
@@ -26,5 +26,5 @@ HTMLMediaElement.prototype.webkitShowPlaybackTargetPicker = function() {};
 
 var AirPlayEvent = class extends Event {};
 
-/** @type {String} */
+/** @type {string} */
 AirPlayEvent.prototype.availability;

--- a/externs/isoboxer.js
+++ b/externs/isoboxer.js
@@ -148,8 +148,8 @@ var ISOBoxerUtils;
  * @property {function(!string, !number, !string, !number)} _procFieldArray
  * @property {function(!string, !number, !function(!ISOEntry))} _procEntries
  * @property {function(!ISOBox, !string, !string, !number)} _procEntryField
- * @property {function(!ISOBox, !string, !number, !function(!ISOEntry))}
- *    _procSubEntries
+ * @property {function(!ISOBox, !string, !number, !function(!ISOEntry))
+ *           } _procSubEntries
  * @property {string} major_brand
  * @property {number} minor_version
  * @property {Array.<string>} compatible_brands

--- a/externs/lcevc.js
+++ b/externs/lcevc.js
@@ -5,11 +5,11 @@
  */
 
 /**
-* @fileoverview Externs for LcevcDec
-* compiler.
-*
-* @externs
-*/
+ * @fileoverview Externs for LcevcDec
+ * compiler.
+ *
+ * @externs
+ */
 
 // This empty namespace is declared to check if LcevcDec libraries are loaded.
 /** @const */
@@ -18,9 +18,9 @@ var libDPIModule = {};
 var LCEVCdec = {};
 
 /**
-* LCEVC Dec constructor
-* @constructor
-*/
+ * LCEVC Dec constructor
+ * @constructor
+ */
 LCEVCdec.LCEVCdec = class {
   /**
    * @param {HTMLVideoElement} media

--- a/externs/mediasession.js
+++ b/externs/mediasession.js
@@ -37,8 +37,9 @@ const MediaSession = class {
     /** @type {string} */
     this.type = type;
 
-    /** @type {!function(!{action: string, seekOffset: ?number,
-     *                     seekTime: ?number})}
+    /**
+     * @type {!function(!{action: string, seekOffset: ?number,
+     *                   seekTime: ?number})}
      */
     this.callback = callback;
   }

--- a/externs/prefixed_eme.js
+++ b/externs/prefixed_eme.js
@@ -49,7 +49,7 @@ HTMLMediaElement.prototype.generateKeyRequest =
  * @param {string} mimeType
  * @param {string=} keySystem
  * @return {string} '', 'maybe', or 'probably'
- * @override the standard one-argument version
+ * @override
  */
 HTMLVideoElement.prototype.canPlayType =
     function(mimeType, keySystem) {};

--- a/externs/shaka/manifest.js
+++ b/externs/shaka/manifest.js
@@ -118,29 +118,29 @@ shaka.extern.Manifest;
 
 /**
  * @typedef {{
-*   id: string,
-*   audioStreams: !Array.<shaka.extern.Stream>,
-*   videoStreams: !Array.<shaka.extern.Stream>,
-*   textStreams: !Array.<shaka.extern.Stream>,
-*   imageStreams: !Array.<shaka.extern.Stream>
-* }}
-*
-* @description Contains the streams from one DASH period.
-* For use in {@link shaka.util.PeriodCombiner}.
-*
-* @property {string} id
-*   The Period ID.
-* @property {!Array.<shaka.extern.Stream>} audioStreams
-*   The audio streams from one Period.
-* @property {!Array.<shaka.extern.Stream>} videoStreams
-*   The video streams from one Period.
-* @property {!Array.<shaka.extern.Stream>} textStreams
-*   The text streams from one Period.
-* @property {!Array.<shaka.extern.Stream>} imageStreams
-*   The image streams from one Period.
-*
-* @exportDoc
-*/
+ *   id: string,
+ *   audioStreams: !Array.<shaka.extern.Stream>,
+ *   videoStreams: !Array.<shaka.extern.Stream>,
+ *   textStreams: !Array.<shaka.extern.Stream>,
+ *   imageStreams: !Array.<shaka.extern.Stream>
+ * }}
+ *
+ * @description Contains the streams from one DASH period.
+ * For use in {@link shaka.util.PeriodCombiner}.
+ *
+ * @property {string} id
+ *   The Period ID.
+ * @property {!Array.<shaka.extern.Stream>} audioStreams
+ *   The audio streams from one Period.
+ * @property {!Array.<shaka.extern.Stream>} videoStreams
+ *   The video streams from one Period.
+ * @property {!Array.<shaka.extern.Stream>} textStreams
+ *   The text streams from one Period.
+ * @property {!Array.<shaka.extern.Stream>} imageStreams
+ *   The image streams from one Period.
+ *
+ * @exportDoc
+ */
 shaka.extern.Period;
 
 /**
@@ -489,8 +489,8 @@ shaka.extern.SegmentIndex = class {
  * @property {!Array.<string>} roles
  *   The roles of the stream as they appear on the manifest,
  *   e.g. 'main', 'caption', or 'commentary'.
- * @property {?shaka.media.ManifestParser.AccessibilityPurpose}
- *     accessibilityPurpose
+ * @property {?shaka.media.ManifestParser.AccessibilityPurpose
+ *           } accessibilityPurpose
  *   The DASH accessibility descriptor, if one was provided for this stream.
  * @property {boolean} forced
  *   <i>Defaults to false.</i> <br>

--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -191,18 +191,18 @@ shaka.extern.SchemePlugin;
 
 /**
  * @typedef {{
-*   minBytesForProgressEvents: (number|undefined)
-* }}
-*
-* @description
-*   Defines configuration object to use by SchemePlugins.
-*
-* @property {(number|undefined)} minBytesForProgressEvents
-*   Defines minimum number of bytes that should be use to emit progress event,
-*   if possible.
-*
-* @exportDoc
-*/
+ *   minBytesForProgressEvents: (number|undefined)
+ * }}
+ *
+ * @description
+ *   Defines configuration object to use by SchemePlugins.
+ *
+ * @property {(number|undefined)} minBytesForProgressEvents
+ *   Defines minimum number of bytes that should be use to emit progress event,
+ *   if possible.
+ *
+ * @exportDoc
+ */
 shaka.extern.SchemePluginConfig;
 
 

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -350,8 +350,8 @@ shaka.extern.BufferedInfo;
  *   The roles of the audio in the track, e.g. <code>'main'</code> or
  *   <code>'commentary'</code>. Will be null for text tracks or variant tracks
  *   without audio.
- * @property {?shaka.media.ManifestParser.AccessibilityPurpose}
- *     accessibilityPurpose
+ * @property {?shaka.media.ManifestParser.AccessibilityPurpose
+ *           } accessibilityPurpose
  *   The DASH accessibility descriptor, if one was provided for this track.
  *   For text tracks, this describes the text; otherwise, this is for the audio.
  * @property {boolean} forced
@@ -1545,8 +1545,8 @@ shaka.extern.DynamicTargetLatencyConfiguration;
  *   Number of seconds that playback stays in panic mode after a rebuffering.
  *   <br>
  *   Defaults to <code>60</code>.
- * @property {shaka.extern.DynamicTargetLatencyConfiguration}
- * dynamicTargetLatency
+ * @property {shaka.extern.DynamicTargetLatencyConfiguration
+ *           } dynamicTargetLatency
  *
  *   The dynamic target latency config for dynamically adjusting the target
  *   latency to be closer to edge when network conditions are good and to back
@@ -2263,8 +2263,8 @@ shaka.extern.LcevcConfiguration;
  *   numberOfParallelDownloads: number
  * }}
  *
- * @property {function(shaka.extern.TrackList):!Promise<shaka.extern.TrackList>}
- *     trackSelectionCallback
+ * @property {function(shaka.extern.TrackList):
+ *              !Promise<shaka.extern.TrackList>} trackSelectionCallback
  *   Called inside <code>store()</code> to determine which tracks to save from a
  *   manifest. It is passed an array of Tracks from the manifest and it should
  *   return an array of the tracks to store.
@@ -2369,8 +2369,8 @@ shaka.extern.TextDisplayerConfiguration;
  *   Media source configuration and settings.
  * @property {shaka.extern.AbrManager.Factory} abrFactory
  *   A factory to construct an abr manager.
- * @property {shaka.media.AdaptationSetCriteria.Factory}
- *     adaptationSetCriteriaFactory
+ * @property {shaka.media.AdaptationSetCriteria.Factory
+ *           } adaptationSetCriteriaFactory
  *   A factory to construct an adaptation set criteria.
  * @property {shaka.extern.AbrConfiguration} abr
  *   ABR configuration and settings.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,7 +12,6 @@ const _ = require('lodash');
 const fs = require('fs');
 const glob = require('glob');
 const Jimp = require('jimp');
-const path = require('path');
 const rimraf = require('rimraf');
 const {ssim} = require('ssim.js');
 const util = require('karma/common/util');
@@ -940,7 +939,7 @@ WebDriverScreenshotMiddlewareFactory.$inject = ['launcher'];
  * This could have been done through a fork of Karma itself, but this plugin
  * was clearer in some ways than using a fork of a now-extinct project.
  *
- * @param {karma.Launcher} launcher
+ * @param {!Array<karma.Reporter>} reporters
  * @param {string} settingsJson
  * @return {karma.Middleware}
  */

--- a/lib/ads/ad_manager.js
+++ b/lib/ads/ad_manager.js
@@ -538,9 +538,9 @@ shaka.ads.AdManager = class extends shaka.util.FakeEventTarget {
 
 
   /**
-  * @override
-  * @export
-  */
+   * @override
+   * @export
+   */
   onAssetUnload() {
     if (this.interstitialAdManager_) {
       this.interstitialAdManager_.stop();

--- a/lib/ads/media_tailor_ad.js
+++ b/lib/ads/media_tailor_ad.js
@@ -18,6 +18,7 @@ shaka.ads.MediaTailorAd = class {
    * @param {mediaTailor.Ad} mediaTailorAd
    * @param {number} adPosition
    * @param {number} totalAds
+   * @param {boolean} isLinear
    * @param {HTMLMediaElement} video
    */
   constructor(mediaTailorAd, adPosition, totalAds, isLinear, video) {

--- a/lib/ads/media_tailor_ad_manager.js
+++ b/lib/ads/media_tailor_ad_manager.js
@@ -80,7 +80,8 @@ shaka.ads.MediaTailorAdManager = class {
     /** @private {!Map.<string,!Array.<mediaTailorExternalResource.App>>} */
     this.staticResources_ = new Map();
 
-    /** @private {!Array.<{target: EventTarget, type: string,
+    /**
+     * @private {!Array.<{target: EventTarget, type: string,
      *           listener: shaka.util.EventManager.ListenerType}>}
      */
     this.adListeners_ = [];

--- a/lib/ads/server_side_ad_manager.js
+++ b/lib/ads/server_side_ad_manager.js
@@ -39,8 +39,9 @@ shaka.ads.ServerSideAdManager = class {
     /** @private {?shaka.extern.AdsConfiguration} */
     this.config_ = null;
 
-    /** @private
-        {?shaka.util.PublicPromise.<string>} */
+    /**
+     * @private {?shaka.util.PublicPromise.<string>}
+     */
     this.streamPromise_ = null;
 
     /** @private {number} */

--- a/lib/cast/cast_receiver.js
+++ b/lib/cast/cast_receiver.js
@@ -62,8 +62,10 @@ shaka.cast.CastReceiver = class extends shaka.util.FakeEventTarget {
 
     /** @private {?function(string):string} */
     this.contentIdCallback_ = contentIdCallback ||
-                          /** @param {string} contentId
-                              @return {string} */
+                          /**
+                           * @param {string} contentId
+                           * @return {string}
+                           */
                           ((contentId) => contentId);
 
     /**

--- a/lib/cea/cea608_data_channel.js
+++ b/lib/cea/cea608_data_channel.js
@@ -794,21 +794,21 @@ shaka.cea.Cea608DataChannel.Style;
 /**
  * CEA closed captions packet.
  * @typedef {{
-  *   pts: number,
-  *   type: number,
-  *   ccData1: number,
-  *   ccData2: number,
-  *   order: number
-  * }}
-  *
-  * @property {number} pts
-  *   Presentation timestamp (in second) at which this packet was received.
-  * @property {number} type
-  *   Type of the packet. Either 0 or 1, representing the CEA-608 field.
-  * @property {number} ccData1 CEA-608 byte 1.
-  * @property {number} ccData2 CEA-608 byte 2.
-  * @property {number} order
-  *   A number indicating the order this packet was received in a sequence
-  *   of packets. Used to break ties in a stable sorting algorithm
-  */
+ *   pts: number,
+ *   type: number,
+ *   ccData1: number,
+ *   ccData2: number,
+ *   order: number
+ * }}
+ *
+ * @property {number} pts
+ *   Presentation timestamp (in second) at which this packet was received.
+ * @property {number} type
+ *   Type of the packet. Either 0 or 1, representing the CEA-608 field.
+ * @property {number} ccData1 CEA-608 byte 1.
+ * @property {number} ccData2 CEA-608 byte 2.
+ * @property {number} order
+ *   A number indicating the order this packet was received in a sequence
+ *   of packets. Used to break ties in a stable sorting algorithm
+ */
 shaka.cea.Cea608DataChannel.Cea608Packet;

--- a/lib/cea/cea708_window.js
+++ b/lib/cea/cea708_window.js
@@ -18,6 +18,7 @@ goog.require('shaka.text.CueRegion');
 shaka.cea.Cea708Window = class {
   /**
    * @param {number} windowNum
+   * @param {number} parentService
    */
   constructor(windowNum, parentService) {
     /**
@@ -229,6 +230,7 @@ shaka.cea.Cea708Window = class {
   }
 
   /**
+   * @return {boolean}
    * @private
    */
   isPenInBounds_() {

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -331,7 +331,7 @@ shaka.dash.ContentProtection = class {
 
     const Uint8ArrayUtils = shaka.util.Uint8ArrayUtils;
     const textContent =
-    /** @type{string} */ (shaka.util.TXml.getTextContents(proNode));
+    /** @type {string} */ (shaka.util.TXml.getTextContents(proNode));
     const data = Uint8ArrayUtils.fromBase64(textContent);
     const systemId = new Uint8Array([
       0x9a, 0x04, 0xf0, 0x79, 0x98, 0x40, 0x42, 0x86,

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -1646,7 +1646,7 @@ shaka.dash.DashParser = class {
    * @param {boolean} disabled
    * @param {!Array.<!shaka.dash.DashParser.AdaptationInfo>} adaptationSets
    * @param {string} contentType
-   @private
+   * @private
    */
   getStreamsFromSets_(disabled, adaptationSets, contentType) {
     if (disabled || !adaptationSets.length) {

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -1647,7 +1647,7 @@ shaka.dash.DashParser = class {
    * @param {!Array.<!shaka.dash.DashParser.AdaptationInfo>} adaptationSets
    * @param {string} contentType
    @private
-  */
+   */
   getStreamsFromSets_(disabled, adaptationSets, contentType) {
     if (disabled || !adaptationSets.length) {
       return [];
@@ -2107,8 +2107,8 @@ shaka.dash.DashParser = class {
    * @param {!Array.<string>} roles
    * @param {Map.<string, string>} closedCaptions
    * @param {!shaka.extern.xml.Node} node
-   * @param {?shaka.media.ManifestParser.AccessibilityPurpose}
-   *   accessibilityPurpose
+   * @param {?shaka.media.ManifestParser.AccessibilityPurpose
+   *        } accessibilityPurpose
    * @param {?number} lastSegmentNumber
    *
    * @return {?shaka.extern.Stream} The Stream, or null when there is a
@@ -3426,8 +3426,8 @@ shaka.dash.DashParser.GenerateSegmentIndexFunction;
  * Contains information about a Stream. This is passed from the createStreamInfo
  * methods.
  *
- * @property {shaka.dash.DashParser.GenerateSegmentIndexFunction}
- *     generateSegmentIndex
+ * @property {shaka.dash.DashParser.GenerateSegmentIndexFunction
+ *           } generateSegmentIndex
  *   An async function to create the SegmentIndex for the stream.
  */
 shaka.dash.DashParser.StreamInfo;

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -324,7 +324,7 @@ shaka.dash.MpdUtils = class {
    * @param {function(?shaka.dash.DashParser.InheritanceFrame):
    *    ?shaka.extern.xml.Node} callback
    * @return {!Array.<!shaka.extern.xml.Node>}
-    */
+   */
   static getNodes(context, callback) {
     const Functional = shaka.util.Functional;
     goog.asserts.assert(
@@ -505,7 +505,7 @@ shaka.dash.MpdUtils = class {
    * @param {boolean} failGracefully
    * @param {string} baseUri
    * @param {!shaka.net.NetworkingEngine} networkingEngine
-   * @param {number=} linkDepth, default set to 0
+   * @param {number=} linkDepth default set to 0
    * @return {!shaka.util.AbortableOperation.<!shaka.extern.xml.Node>}
    */
   static processXlinks(

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -747,7 +747,7 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
    * @param {boolean} shouldFit
    * @param {shaka.extern.aesKey|undefined} aesKey
    * @param {number} segmentSequenceCadence
-  */
+   */
   constructor(templateInfo, representationId, bandwidth, getBaseUris,
       urlParams, periodStart, periodEnd, initSegmentReference, shouldFit,
       aesKey, segmentSequenceCadence) {

--- a/lib/dependencies/all.js
+++ b/lib/dependencies/all.js
@@ -60,6 +60,7 @@ shaka.dependencies.Allowed = {
   ISOBoxer: 'ISOBoxer',
 };
 
+// eslint-disable-next-line jsdoc/require-returns
 /**
  * Contains accessor functions to shared dependencies that could be used by
  * other components.  The default accessors can be overridden.

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -1649,7 +1649,7 @@ shaka.drm.DrmEngine = class {
     goog.asserts.assert(challenge.attributes['encoding'] == 'base64encoded',
         'Unexpected PlayReady challenge encoding!');
     request.body = shaka.util.Uint8ArrayUtils.fromBase64(
-        /** @type{string} */(shaka.util.TXml.getTextContents(challenge)));
+        /** @type {string} */(shaka.util.TXml.getTextContents(challenge)));
   }
 
   /**
@@ -2463,8 +2463,8 @@ shaka.drm.DrmEngine = class {
    * care to eliminate duplicates.
    *
    * @param {!Array.<shaka.extern.DrmInfo>} drmInfos
-   * @param {!Array.<string>} licenseServers
    * @param {!Array.<string>} encryptionSchemes
+   * @param {!Array.<string>} licenseServers
    * @param {!Array.<!Uint8Array>} serverCerts
    * @param {!Array.<string>} serverCertificateUris
    * @param {!Array.<!shaka.extern.InitDataOverride>} initDatas
@@ -2475,8 +2475,10 @@ shaka.drm.DrmEngine = class {
   static processDrmInfos_(
       drmInfos, encryptionSchemes, licenseServers, serverCerts,
       serverCertificateUris, initDatas, keyIds, keySystemUris) {
-    /** @type {function(shaka.extern.InitDataOverride,
-     *                  shaka.extern.InitDataOverride):boolean} */
+    /**
+     * @type {function(shaka.extern.InitDataOverride,
+     *                 shaka.extern.InitDataOverride):boolean}
+     */
     const initDataOverrideEqual = (a, b) => {
       if (a.keyId && a.keyId == b.keyId) {
         // Two initDatas with the same keyId are considered to be the same,
@@ -2571,8 +2573,8 @@ shaka.drm.DrmEngine = class {
    *
    * @param {shaka.extern.DrmInfo} drmInfo
    * @param {!Map.<string, string>} servers
-   * @param {!Map.<string, shaka.extern.AdvancedDrmConfiguration>}
-   *   advancedConfigs
+   * @param {!Map.<string,
+   *               shaka.extern.AdvancedDrmConfiguration>} advancedConfigs
    * @param {!Object.<string, string>} keySystemsMapping
    * @private
    */

--- a/lib/drm/drm_utils.js
+++ b/lib/drm/drm_utils.js
@@ -108,7 +108,8 @@ shaka.drm.DrmUtils = class {
 
   /**
    * @param {?shaka.extern.DrmInfo} drmInfo
-   * @return {string} */
+   * @return {string}
+   */
   static keySystem(drmInfo) {
     return drmInfo ? drmInfo.keySystem : '';
   }
@@ -221,7 +222,7 @@ shaka.drm.DrmUtils = class {
     const DrmUtils = shaka.drm.DrmUtils;
     const key = DrmUtils.generateKeySystemCacheKey_(
         videoCodec, audioCodec, keySystem);
-    return DrmUtils.memoizedMediaKeySystemAccessRequests_.set(key, mksa);
+    DrmUtils.memoizedMediaKeySystemAccessRequests_.set(key, mksa);
   }
 
   /**

--- a/lib/drm/playready.js
+++ b/lib/drm/playready.js
@@ -107,7 +107,8 @@ shaka.drm.PlayReady = class {
       if (elem.children) {
         for (const child of elem.children) {
           if (child.tagName == 'LA_URL') {
-            return /** @type{string} */(shaka.util.TXml.getTextContents(child));
+            return /** @type {string} */(
+              shaka.util.TXml.getTextContents(child));
           }
         }
       }
@@ -128,7 +129,7 @@ shaka.drm.PlayReady = class {
     const PLAYREADY_RECORD_TYPES = shaka.drm.PlayReady.PLAYREADY_RECORD_TYPES;
 
     const bytes = shaka.util.Uint8ArrayUtils.fromBase64(
-        /** @type{string} */ (shaka.util.TXml.getTextContents(element)));
+        /** @type {string} */ (shaka.util.TXml.getTextContents(element)));
     const records = shaka.drm.PlayReady.parseMsPro_(bytes);
     const record = records.filter((record) => {
       return record.type === PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT;
@@ -183,7 +184,7 @@ shaka.drm.PlayReady = class {
         // GUID: [DWORD, WORD, WORD, 8-BYTE]
         const guidBytes =
             shaka.util.Uint8ArrayUtils.fromBase64(
-                /** @type{string} */ (shaka.util.TXml.getTextContents(kid)));
+                /** @type {string} */ (shaka.util.TXml.getTextContents(kid)));
         // Reverse byte order from little-endian to big-endian
         const kidBytes = new Uint8Array([
           guidBytes[3], guidBytes[2], guidBytes[1], guidBytes[0],

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -210,7 +210,8 @@ shaka.hls.HlsParser = class {
     /** @private {number} */
     this.lastTargetDuration_ = Infinity;
 
-    /** Partial segments target duration.
+    /**
+     * Partial segments target duration.
      * @private {number}
      */
     this.partialTargetDuration_ = 0;
@@ -224,7 +225,8 @@ shaka.hls.HlsParser = class {
     /** @private {shaka.util.OperationManager} */
     this.operationManager_ = new shaka.util.OperationManager();
 
-    /** A map from closed captions' group id, to a map of closed captions info.
+    /**
+     * A map from closed captions' group id, to a map of closed captions info.
      * {group id -> {closed captions channel id -> language}}
      * @private {Map.<string, Map.<string, string>>}
      */
@@ -233,11 +235,13 @@ shaka.hls.HlsParser = class {
     /** @private {Map.<string, string>} */
     this.groupIdToCodecsMap_ = new Map();
 
-    /** A cache mapping EXT-X-MAP tag info to the InitSegmentReference created
+    /**
+     * A cache mapping EXT-X-MAP tag info to the InitSegmentReference created
      * from the tag.
      * The key is a string combining the EXT-X-MAP tag's absolute uri, and
      * its BYTERANGE if available.
-     * {!Map.<string, !shaka.media.InitSegmentReference>} */
+     * @private {!Map.<string, !shaka.media.InitSegmentReference>}
+     */
     this.mapTagToInitSegmentRefMap_ = new Map();
 
     /** @private {Map.<string, !shaka.extern.aesKey>} */
@@ -2852,6 +2856,7 @@ shaka.hls.HlsParser = class {
 
   /**
    * @param {number} streamId
+   * @param {!Map<string, string>} variables
    * @param {!shaka.hls.Playlist} playlist
    * @param {function():!Array.<string>} getUris
    * @param {string} responseUri

--- a/lib/media/example_based_criteria.js
+++ b/lib/media/example_based_criteria.js
@@ -18,8 +18,8 @@ shaka.media.ExampleBasedCriteria = class {
   /**
    * @param {shaka.extern.Variant} example
    * @param {shaka.config.CodecSwitchingStrategy} codecSwitchingStrategy
-   * @param {shaka.media.AdaptationSetCriteria.Factory}
-   *     adaptationSetCriteriaFactory
+   * @param {shaka.media.AdaptationSetCriteria.Factory
+   *        } adaptationSetCriteriaFactory
    */
   constructor(example, codecSwitchingStrategy, adaptationSetCriteriaFactory) {
     // We can't know if role and label are really important, so we don't use

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -72,17 +72,23 @@ shaka.media.MediaSourceEngine = class {
     /** @private {shaka.extern.TextDisplayer} */
     this.textDisplayer_ = textDisplayer;
 
-    /** @private {!Object.<shaka.util.ManifestParserUtils.ContentType,
-                           SourceBuffer>} */
+    /**
+     * @private {!Object.<shaka.util.ManifestParserUtils.ContentType,
+     *                    SourceBuffer>}
+     */
     this.sourceBuffers_ = {};
 
-    /** @private {!Object.<shaka.util.ManifestParserUtils.ContentType,
-                           string>} */
+    /**
+     * @private {!Object.<shaka.util.ManifestParserUtils.ContentType,
+     *                    string>}
+     */
     this.sourceBufferTypes_ = {};
 
 
-    /** @private {!Object.<shaka.util.ManifestParserUtils.ContentType,
-                           boolean>} */
+    /**
+     * @private {!Object.<shaka.util.ManifestParserUtils.ContentType,
+     *                    boolean>}
+     */
     this.expectedEncryption_ = {};
 
     /** @private {shaka.text.TextEngine} */
@@ -164,8 +170,10 @@ shaka.media.MediaSourceEngine = class {
     /** @private {?number} */
     this.lastDuration_ = null;
 
-    /** @private {!Object.<shaka.util.ManifestParserUtils.ContentType,
-                           !shaka.util.TsParser>} */
+    /**
+     * @private {!Object.<shaka.util.ManifestParserUtils.ContentType,
+     *                    !shaka.util.TsParser>}
+     */
     this.tsParsers_ = {};
 
     /** @private {?number} */

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -847,8 +847,8 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
  * }}
  *
  * @property {!shaka.extern.PlayerConfiguration} config
- * @property {!shaka.extern.ManifestParser.PlayerInterface}
- *   manifestPlayerInterface
+ * @property {!shaka.extern.ManifestParser.PlayerInterface
+ *           } manifestPlayerInterface
  * @property {!shaka.media.RegionTimeline} regionTimeline
  * @property {?shaka.media.QualityObserver} qualityObserver
  * @property {function():!shaka.drm.DrmEngine} createDrmEngine

--- a/lib/media/quality_observer.js
+++ b/lib/media/quality_observer.js
@@ -310,9 +310,9 @@ shaka.media.QualityObserver = class extends shaka.util.FakeEventTarget {
  * Identifies the position of a media quality change in the
  * source buffer.
  *
- * @property {shaka.extern.MediaQualityInfo} !mediaQuality
+ * @property {!shaka.extern.MediaQualityInfo} mediaQuality
  *   The new media quality for content after position in the source buffer.
- * @property {number} !position
+ * @property {!number} position
  *   A position in seconds in the source buffer
  */
 shaka.media.QualityObserver.QualityChangePosition;

--- a/lib/media/quality_observer.js
+++ b/lib/media/quality_observer.js
@@ -301,40 +301,40 @@ shaka.media.QualityObserver = class extends shaka.util.FakeEventTarget {
 };
 
 /**
-  * @typedef {{
-  *   mediaQuality: !shaka.extern.MediaQualityInfo,
-  *   position: !number
-  * }}
-  *
-  * @description
-  * Identifies the position of a media quality change in the
-  * source buffer.
-  *
-  * @property {shaka.extern.MediaQualityInfo} !mediaQuality
-  *   The new media quality for content after position in the source buffer.
-  * @property {number} !position
-  *   A position in seconds in the source buffer
-  */
+ * @typedef {{
+ *   mediaQuality: !shaka.extern.MediaQualityInfo,
+ *   position: !number
+ * }}
+ *
+ * @description
+ * Identifies the position of a media quality change in the
+ * source buffer.
+ *
+ * @property {shaka.extern.MediaQualityInfo} !mediaQuality
+ *   The new media quality for content after position in the source buffer.
+ * @property {number} !position
+ *   A position in seconds in the source buffer
+ */
 shaka.media.QualityObserver.QualityChangePosition;
 
 /**
-  * @typedef {{
-  *  qualityChangePositions:
-  *   !Array.<shaka.media.QualityObserver.QualityChangePosition>,
-  *  currentQuality: ?shaka.extern.MediaQualityInfo,
-  *  contentType: !string
-  * }}
-  *
-  * @description
-  * Contains media quality information for a specific content type
-  * e.g. video or audio.
-  *
-  * @property {!Array.<shaka.media.QualityObserver.QualityChangePosition>}
-  * qualityChangePositions
-  *   Quality changes ordered by position ascending.
-  * @property {?shaka.media.MediaQualityInfo} currentMediaQuality
-  *   The media quality at the playhead position.
-  * @property {string} contentType
-  *   The contentType e.g. 'video' or 'audio'
-  */
+ * @typedef {{
+ *  qualityChangePositions:
+ *   !Array.<shaka.media.QualityObserver.QualityChangePosition>,
+ *  currentQuality: ?shaka.extern.MediaQualityInfo,
+ *  contentType: !string
+ * }}
+ *
+ * @description
+ * Contains media quality information for a specific content type
+ * e.g. video or audio.
+ *
+ * @property {!Array.<shaka.media.QualityObserver.QualityChangePosition>
+ *           } qualityChangePositions
+ *   Quality changes ordered by position ascending.
+ * @property {?shaka.media.MediaQualityInfo} currentMediaQuality
+ *   The media quality at the playhead position.
+ * @property {string} contentType
+ *   The contentType e.g. 'video' or 'audio'
+ */
 shaka.media.QualityObserver.ContentTypeState;

--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -41,14 +41,14 @@ shaka.media.SegmentPrefetch = class {
 
     /**
      * @private {!Map.<
-     *        !(shaka.media.SegmentReference),
+     *        !shaka.media.SegmentReference,
      *        !shaka.media.SegmentPrefetchOperation>}
      */
     this.segmentPrefetchMap_ = new Map();
 
     /**
      * @private {!Map.<
-     *        !(shaka.media.InitSegmentReference),
+     *        !shaka.media.InitSegmentReference,
      *        !shaka.media.SegmentPrefetchOperation>}
      */
     this.initSegmentPrefetchMap_ = new Map();
@@ -173,8 +173,8 @@ shaka.media.SegmentPrefetch = class {
 
   /**
    * Get the result of prefetched segment if already exists.
-   * @param {!(shaka.media.SegmentReference|shaka.media.InitSegmentReference)}
-   *        reference
+   * @param {!(shaka.media.SegmentReference|
+   *           shaka.media.InitSegmentReference)} reference
    * @param {?function(BufferSource):!Promise=} streamDataCallback
    * @return {?shaka.net.NetworkingEngine.PendingRequest} op
    * @public
@@ -225,6 +225,9 @@ shaka.media.SegmentPrefetch = class {
 
   /**
    * Clear All Helper
+   * @param {!Map<T,
+   *        !shaka.media.SegmentPrefetchOperation>} map
+   * @template T SegmentReference or InitSegmentReference
    * @private
    */
   clearMap_(map) {
@@ -355,8 +358,8 @@ shaka.media.SegmentPrefetch = class {
 
   /**
    * Remove a segment from prefetch map and abort it.
-   * @param {!(shaka.media.SegmentReference|shaka.media.InitSegmentReference)}
-   *        reference
+   * @param {!(shaka.media.SegmentReference|
+   *           shaka.media.InitSegmentReference)} reference
    * @private
    */
   abortPrefetchedSegment_(reference) {
@@ -384,6 +387,7 @@ shaka.media.SegmentPrefetch = class {
 
   /**
    * The prefix of the logs that are created in this class.
+   * @param {shaka.extern.Stream} stream
    * @return {string}
    * @private
    */
@@ -419,10 +423,10 @@ shaka.media.SegmentPrefetchOperation = class {
   }
 
   /**
-   * Fetch a segments
+   * Fetch segments
    *
-   * @param {!(shaka.media.SegmentReference|shaka.media.InitSegmentReference)}
-   *        reference
+   * @param {!(shaka.media.SegmentReference|
+   *           shaka.media.InitSegmentReference)} reference
    * @param {!shaka.extern.Stream} stream
    * @return {!Promise}
    * @public

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -2421,8 +2421,8 @@ shaka.media.StreamingEngine = class {
    * Fetches the given segment.
    *
    * @param {!shaka.media.StreamingEngine.MediaState_} mediaState
-   * @param {(!shaka.media.InitSegmentReference|!shaka.media.SegmentReference)}
-   *   reference
+   * @param {(!shaka.media.InitSegmentReference|
+   *          !shaka.media.SegmentReference)} reference
    * @param {?function(BufferSource):!Promise=} streamDataCallback
    *
    * @return {!Promise.<BufferSource>}
@@ -2462,9 +2462,9 @@ shaka.media.StreamingEngine = class {
   /**
    * Fetches the given segment.
    *
+   * @param {(!shaka.media.InitSegmentReference|
+   *          !shaka.media.SegmentReference)} reference
    * @param {!shaka.extern.Stream} stream
-   * @param {(!shaka.media.InitSegmentReference|!shaka.media.SegmentReference)}
-   *   reference
    * @param {?function(BufferSource):!Promise=} streamDataCallback
    * @param {boolean=} isPreload
    *
@@ -2482,9 +2482,9 @@ shaka.media.StreamingEngine = class {
   /**
    * Fetches the given segment.
    *
+   * @param {(!shaka.media.InitSegmentReference|
+   *          !shaka.media.SegmentReference)} reference
    * @param {!shaka.extern.Stream} stream
-   * @param {(!shaka.media.InitSegmentReference|!shaka.media.SegmentReference)}
-   *   reference
    * @param {?function(BufferSource):!Promise} streamDataCallback
    * @param {shaka.extern.RetryParameters} retryParameters
    * @param {!shaka.net.NetworkingEngine} netEngine
@@ -2869,8 +2869,8 @@ shaka.media.StreamingEngine = class {
  * @property {function(!shaka.media.SegmentReference,
  *     !shaka.extern.Stream)} onSegmentAppended
  *   Called after a segment is successfully appended to a MediaSource.
- * @property
- *  {function(!number, !shaka.media.InitSegmentReference)} onInitSegmentAppended
+ * @property {function(!number,
+ *                     !shaka.media.InitSegmentReference)} onInitSegmentAppended
  *   Called when an init segment is appended to a MediaSource.
  * @property {!function(shaka.util.ManifestParserUtils.ContentType,
  *   !BufferSource):Promise} beforeAppendSegment

--- a/lib/mss/content_protection.js
+++ b/lib/mss/content_protection.js
@@ -77,7 +77,7 @@ shaka.mss.ContentProtection = class {
   static getInitDataFromPro_(element, systemID, keyId) {
     const Uint8ArrayUtils = shaka.util.Uint8ArrayUtils;
     const data = Uint8ArrayUtils.fromBase64(
-        /** @type{string} */ (shaka.util.TXml.getTextContents(element)));
+        /** @type {string} */ (shaka.util.TXml.getTextContents(element)));
     const systemId = Uint8ArrayUtils.fromHex(systemID.replace(/-/g, ''));
     const keyIds = new Set();
     const psshVersion = 0;

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -53,8 +53,8 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
    *   of whether the switching is allowed.
    * @param {shaka.net.NetworkingEngine.OnHeadersReceived=} onHeadersReceived
    *   Called when the headers are received for a download.
-   * @param {shaka.net.NetworkingEngine.OnDownloadCompleted=}
-   *   onDownloadCompleted Called when a download completed successfully.
+   * @param {shaka.net.NetworkingEngine.OnDownloadCompleted=
+   *        } onDownloadCompleted Called when a download completed successfully.
    * @param {shaka.net.NetworkingEngine.OnDownloadFailed=} onDownloadFailed
    *   Called when a download fails, for any reason.
    * @param {shaka.net.NetworkingEngine.OnRequest=} onRequest
@@ -471,8 +471,8 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
    * @param {shaka.net.NetworkingEngine.RequestType} type
    * @param {shaka.extern.Request} request
    * @param {(shaka.extern.RequestContext|undefined)} context
-   * @param {shaka.net.NetworkingEngine.NumBytesRemainingClass}
-   *            numBytesRemainingObj
+   * @param {shaka.net.NetworkingEngine.NumBytesRemainingClass
+   *        } numBytesRemainingObj
    * @return {!shaka.extern.IAbortableOperation.<
    *            shaka.net.NetworkingEngine.ResponseAndGotProgress>}
    * @private
@@ -495,8 +495,8 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
    * @param {!shaka.net.Backoff} backoff
    * @param {number} index
    * @param {?shaka.util.Error} lastError
-   * @param {shaka.net.NetworkingEngine.NumBytesRemainingClass}
-   *     numBytesRemainingObj
+   * @param {shaka.net.NetworkingEngine.NumBytesRemainingClass
+   *        } numBytesRemainingObj
    * @return {!shaka.extern.IAbortableOperation.<
    *               shaka.net.NetworkingEngine.ResponseAndGotProgress>}
    * @private
@@ -735,8 +735,8 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
 
   /**
    * @param {shaka.net.NetworkingEngine.RequestType} type
-   * @param {shaka.net.NetworkingEngine.ResponseAndGotProgress}
-   *        responseAndGotProgress
+   * @param {shaka.net.NetworkingEngine.ResponseAndGotProgress
+   *        } responseAndGotProgress
    * @param {shaka.extern.RequestContext=} context
    * @return {!shaka.extern.IAbortableOperation.<
    *               shaka.net.NetworkingEngine.ResponseAndGotProgress>}
@@ -867,8 +867,8 @@ class extends shaka.util.AbortableOperation {
    *   undone.  abort() should return a Promise which is resolved when the
    *   underlying operation has been aborted.  The returned Promise should
    *   never be rejected.
-   * @param {shaka.net.NetworkingEngine.NumBytesRemainingClass}
-   *   numBytesRemainingObj
+   * @param {shaka.net.NetworkingEngine.NumBytesRemainingClass
+   *        } numBytesRemainingObj
    */
   constructor(promise, onAbort, numBytesRemainingObj) {
     super(promise, onAbort);

--- a/lib/offline/indexeddb/db_operation.js
+++ b/lib/offline/indexeddb/db_operation.js
@@ -62,8 +62,8 @@ shaka.offline.indexeddb.DBOperation = class {
   /**
    * Calls the given callback for each entry in the database.
    *
-   * @param {function(!IDBKeyType, T, !IDBCursorWithValue=):(Promise|undefined)}
-   *   callback
+   * @param {function(!IDBKeyType, T, !IDBCursorWithValue=):
+   *             (Promise|undefined)} callback
    * @return {!Promise}
    * @template T
    */

--- a/lib/text/cue.js
+++ b/lib/text/cue.js
@@ -764,6 +764,7 @@ shaka.text.Cue = class {
   /**
    * @param {string} value
    * @param {string} defaultValue
+   * @return {string}
    * @private
    */
   static getOrDefault_(value, defaultValue) {

--- a/lib/text/stub_text_displayer.js
+++ b/lib/text/stub_text_displayer.js
@@ -7,11 +7,11 @@
 goog.provide('shaka.text.StubTextDisplayer');
 
 /**
-* A stub text displayer plugin that does nothing
-*
-* @implements {shaka.extern.TextDisplayer}
-* @export
-*/
+ * A stub text displayer plugin that does nothing
+ *
+ * @implements {shaka.extern.TextDisplayer}
+ * @export
+ */
 shaka.text.StubTextDisplayer = class {
   /**
    * @override

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -63,7 +63,8 @@ shaka.text.TextEngine = class {
      * re-fetching the video segments they were embedded in.
      * Structure of closed caption map:
      * closed caption id -> {start and end time -> cues}
-     * @private {!Map.<string, !Map.<string, !Array.<shaka.text.Cue>>>} */
+     * @private {!Map.<string, !Map.<string, !Array.<shaka.text.Cue>>>}
+     */
     this.closedCaptionsMap_ = new Map();
   }
 

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -926,7 +926,7 @@ shaka.text.UITextDisplayer = class {
    * @param {HTMLElement} videoContainer
    * @return {string}
    * @private
-  */
+   */
   static convertLengthValue_(lengthValue, cue, videoContainer) {
     const lengthValueInfo =
         shaka.text.UITextDisplayer.getLengthValueInfo_(lengthValue);
@@ -958,7 +958,7 @@ shaka.text.UITextDisplayer = class {
    * @return {string}
    *
    * @private
-   * */
+   */
   static getAbsoluteLengthInPixels_(value, cue, videoContainer) {
     const containerHeight = videoContainer.clientHeight;
 

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -44,8 +44,8 @@ shaka.util.CmcdManager = class {
     this.playbackStarted_ = false;
 
     /**
-    * @private {boolean}
-    */
+     * @private {boolean}
+     */
     this.buffering_ = true;
 
     /**
@@ -91,7 +91,7 @@ shaka.util.CmcdManager = class {
   /**
    * Set media element and setup event listeners
    * @param {HTMLMediaElement} mediaElement The video element
-  */
+   */
   setMediaElement(mediaElement) {
     this.video_ = mediaElement;
     this.setupMSDEventListeners_();
@@ -446,7 +446,7 @@ shaka.util.CmcdManager = class {
   /**
    * Setup event listeners for msd calculation
    * @private
-  */
+   */
   setupMSDEventListeners_() {
     const onPlaybackPlay = () => this.onPlaybackPlay_();
     this.eventManager_.listenOnce(
@@ -568,6 +568,7 @@ shaka.util.CmcdManager = class {
    *
    * @param {shaka.extern.RequestContext} context
    *   The request context
+   * @return {shaka.util.CmcdManager.ObjectType|undefined}
    * @private
    */
   getObjectType_(context) {
@@ -817,7 +818,7 @@ shaka.util.CmcdManager = class {
   /**
    * Get the highest bandwidth for a given type.
    *
-   * @param {string} type
+   * @param {shaka.util.CmcdManager.ObjectType|undefined} type
    * @return {number}
    * @private
    */

--- a/lib/util/content_steering_manager.js
+++ b/lib/util/content_steering_manager.js
@@ -329,7 +329,7 @@ shaka.util.ContentSteeringManager = class {
  *
  * @property {string} VERSION
  * @property {number} TTL
- * @property {string RELOAD-URI
+ * @property {string} RELOAD-URI
  * @property {!Array.<string>} PATHWAY-PRIORITY
  * @property {!Array.<
  *            shaka.util.ContentSteeringManager.PathwayClone>} PATHWAY-CLONES

--- a/lib/util/data_view_reader.js
+++ b/lib/util/data_view_reader.js
@@ -13,9 +13,9 @@ goog.require('shaka.util.StringUtils');
 
 
 /**
-  * @summary DataViewReader abstracts a DataView object.
-  * @export
-  */
+ * @summary DataViewReader abstracts a DataView object.
+ * @export
+ */
 shaka.util.DataViewReader = class {
   /**
    * @param {BufferSource} data

--- a/lib/util/fairplay_utils.js
+++ b/lib/util/fairplay_utils.js
@@ -138,6 +138,7 @@ shaka.util.FairPlayUtils = class {
    * @param {!Uint8Array} initData
    * @param {string} initDataType
    * @param {?shaka.extern.DrmInfo} drmInfo
+   * @return {!Uint8Array}
    * @private
    */
   static basicInitDataTransform_(initData, initDataType, drmInfo) {
@@ -158,6 +159,7 @@ shaka.util.FairPlayUtils = class {
    * @param {!Uint8Array} initData
    * @param {string} initDataType
    * @param {?shaka.extern.DrmInfo} drmInfo
+   * @return {!Uint8Array}
    * @export
    */
   static verimatrixInitDataTransform(initData, initDataType, drmInfo) {
@@ -171,6 +173,7 @@ shaka.util.FairPlayUtils = class {
    * @param {!Uint8Array} initData
    * @param {string} initDataType
    * @param {?shaka.extern.DrmInfo} drmInfo
+   * @return {!Uint8Array}
    * @export
    */
   static ezdrmInitDataTransform(initData, initDataType, drmInfo) {
@@ -191,6 +194,7 @@ shaka.util.FairPlayUtils = class {
    * @param {!Uint8Array} initData
    * @param {string} initDataType
    * @param {?shaka.extern.DrmInfo} drmInfo
+   * @return {!Uint8Array}
    * @export
    */
   static conaxInitDataTransform(initData, initDataType, drmInfo) {
@@ -221,6 +225,7 @@ shaka.util.FairPlayUtils = class {
    * @param {!Uint8Array} initData
    * @param {string} initDataType
    * @param {?shaka.extern.DrmInfo} drmInfo
+   * @return {!Uint8Array}
    * @export
    */
   static expressplayInitDataTransform(initData, initDataType, drmInfo) {

--- a/lib/util/mp4_generator.js
+++ b/lib/util/mp4_generator.js
@@ -1081,6 +1081,7 @@ shaka.util.Mp4Generator = class {
   /**
    * Generate a MDAT box
    *
+   * @param {shaka.util.Mp4Generator.StreamInfo} streamInfo
    * @return {!Uint8Array}
    * @private
    */

--- a/lib/util/object_utils.js
+++ b/lib/util/object_utils.js
@@ -22,7 +22,11 @@ shaka.util.ObjectUtils = class {
     const seenObjects = new WeakSet();
     // This recursively clones the value |val|, using the captured variable
     // |seenObjects| to track the objects we have already cloned.
-    /** @suppress {strictMissingProperties} */
+    /**
+     * @param {*} val
+     * @return {*}
+     * @suppress {strictMissingProperties}
+     */
     const clone = (val) => {
       switch (typeof val) {
         case 'undefined':

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -93,7 +93,7 @@ shaka.util.PeriodCombiner = class {
    * @return {!Array.<shaka.extern.Stream>}
    *
    * @export
-  */
+   */
   getTextStreams() {
     // Return a copy of the array because makeTextStreamsForClosedCaptions
     // may make changes to the contents of the array. Those changes should not

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -331,6 +331,7 @@ shaka.util.Platform = class {
 
   /**
    * Check if the current platform is Playstation 4.
+   * @return {boolean}
    */
   static isPS4() {
     return shaka.util.Platform.userAgentContains_('PlayStation 4');
@@ -338,6 +339,7 @@ shaka.util.Platform = class {
 
   /**
    * Check if the current platform is Hisense.
+   * @return {boolean}
    */
   static isHisense() {
     return shaka.util.Platform.userAgentContains_('Hisense') ||
@@ -346,6 +348,7 @@ shaka.util.Platform = class {
 
   /**
    * Check if the current platform is Virgin Media device.
+   * @return {boolean}
    */
   static isVirginMedia() {
     return shaka.util.Platform.userAgentContains_('VirginMedia');
@@ -353,6 +356,7 @@ shaka.util.Platform = class {
 
   /**
    * Check if the current platform is Orange.
+   * @return {boolean}
    */
   static isOrange() {
     return shaka.util.Platform.userAgentContains_('SOPOpenBrowser');
@@ -360,6 +364,7 @@ shaka.util.Platform = class {
 
   /**
    * Check if the current platform is SkyQ STB.
+   * @return {boolean}
    */
   static isSkyQ() {
     return shaka.util.Platform.userAgentContains_('Sky_STB');

--- a/lib/util/string_utils.js
+++ b/lib/util/string_utils.js
@@ -334,7 +334,10 @@ shaka.util.StringUtils = class {
 
 /** @private {!shaka.util.Lazy.<function(!TypedArray):string>} */
 shaka.util.StringUtils.fromCharCodeImpl_ = new shaka.util.Lazy(() => {
-  /** @param {number} size @return {boolean} */
+  /**
+   * @param {number} size
+   * @return {boolean}
+   */
   const supportsChunkSize = (size) => {
     try {
       // The compiler will complain about suspicious value if this isn't

--- a/lib/util/tXml.js
+++ b/lib/util/tXml.js
@@ -13,7 +13,7 @@ goog.require('shaka.log');
 /**
  * This code is a modified version of the tXml library.
  *
- * @author: Tobias Nickel
+ * @author Tobias Nickel
  * created: 06.04.2015
  * https://github.com/TobiasNickel/tXml
  */
@@ -57,6 +57,7 @@ shaka.util.TXml = class {
    * Parse some data
    * @param {string} xmlString
    * @param {string=} expectedRootElemName
+   * @param {boolean=} includeParent
    * @return {shaka.extern.xml.Node | null}
    */
   static parseXmlString(xmlString, expectedRootElemName,
@@ -132,9 +133,12 @@ shaka.util.TXml = class {
 
     /**
      * parsing a list of entries
+     * @param {string} tagName
+     * @param {boolean=} preserveSpace
+     * @return {!Array<shaka.extern.xml.Node | string>}
      */
     function parseChildren(tagName, preserveSpace = false) {
-      /** @type {Array.<shaka.extern.xml.Node | string>} */
+      /** @type {!Array.<shaka.extern.xml.Node | string>} */
       const children = [];
       while (S[pos]) {
         if (S.charCodeAt(pos) == openBracketCC) {
@@ -228,7 +232,8 @@ shaka.util.TXml = class {
     }
 
     /**
-     *    returns the text outside of texts until the first '<'
+     * returns the text outside of texts until the first '<'
+     * @return {string}
      */
     function parseText() {
       const start = pos;
@@ -857,6 +862,7 @@ shaka.util.TXml = class {
    * @param {!Array<shaka.extern.xml.Node>} nodes
    * @param {!string} attribute
    * @param {!number} value
+   * @return {?number}
    * @private
    */
   static nodePositionByAttribute_(nodes, attribute, value) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "es6-promise-polyfill": "^1.2.0",
         "eslint": "^9.18.0",
         "eslint-config-google": "github:google/eslint-config-google#3ae571a",
+        "eslint-plugin-jsdoc": "^50.6.1",
         "eslint-plugin-shaka-rules": "file:./build/eslint-plugin-shaka-rules",
         "esprima": "^4.0.1",
         "fontfaceonload": "^1.0.2",
@@ -2254,6 +2255,21 @@
         "node": ">=18.0"
       }
     },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.49.0.tgz",
+      "integrity": "sha512-xjZTSFgECpb9Ohuk5yMX5RhUEbfeQcuOp8IF60e+wyzWEF0M5xeSgqsfLtvPEX8BIyOX9saZqzuGPmZ8oWc+5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
@@ -3018,6 +3034,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -3286,6 +3315,16 @@
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/argparse": {
@@ -4020,6 +4059,16 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/compress-commons": {
       "version": "2.1.1",
@@ -4883,6 +4932,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es6-promise-polyfill": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
@@ -4983,6 +5039,94 @@
       },
       "peerDependencies": {
         "eslint": ">=5.16.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "50.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.6.1.tgz",
+      "integrity": "sha512-UWyaYi6iURdSfdVVqvfOs2vdCVz0J40O/z/HTsv2sFjdjmdlUI/qlKLOTmwbPQ2tAfQnE5F9vqx+B+poF71DBQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.49.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.3.6",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.1.0",
+        "esquery": "^1.6.0",
+        "parse-imports": "^2.1.1",
+        "semver": "^7.6.3",
+        "spdx-expression-parse": "^4.0.0",
+        "synckit": "^0.9.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/eslint-plugin-shaka-rules": {
@@ -6811,6 +6955,16 @@
         "node": ">=8.15.0"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsdoc/node_modules/escape-string-regexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
@@ -8085,6 +8239,20 @@
       "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==",
       "dev": true
     },
+    "node_modules/parse-imports": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-2.2.1.tgz",
+      "integrity": "sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==",
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "dependencies": {
+        "es-module-lexer": "^1.5.3",
+        "slashes": "^3.0.12"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -9024,6 +9192,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/slashes": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/slashes/-/slashes-3.0.12.tgz",
+      "integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -9501,6 +9676,23 @@
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
     },
+    "node_modules/synckit": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/table": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
@@ -9766,10 +9958,11 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -11992,6 +12185,17 @@
       "integrity": "sha512-LMvReIndW1ckvemElfDgTt282fb2C3C/ZXfsm0pJsTV5ZmtdelCHwzmgSBmY5fDr7D66XDp8EurotSE0K6BTvw==",
       "dev": true
     },
+    "@es-joy/jsdoccomment": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.49.0.tgz",
+      "integrity": "sha512-xjZTSFgECpb9Ohuk5yMX5RhUEbfeQcuOp8IF60e+wyzWEF0M5xeSgqsfLtvPEX8BIyOX9saZqzuGPmZ8oWc+5Q==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.1.0"
+      }
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
@@ -12549,6 +12753,12 @@
         "fastq": "^1.6.0"
       }
     },
+    "@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true
+    },
     "@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -12781,6 +12991,12 @@
           }
         }
       }
+    },
+    "are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -13337,6 +13553,12 @@
           "dev": true
         }
       }
+    },
+    "comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true
     },
     "compress-commons": {
       "version": "2.1.1",
@@ -13993,6 +14215,12 @@
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true
     },
+    "es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "dev": true
+    },
     "es6-promise-polyfill": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
@@ -14183,6 +14411,64 @@
       "dev": true,
       "from": "eslint-config-google@github:google/eslint-config-google#3ae571a",
       "requires": {}
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "50.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.6.1.tgz",
+      "integrity": "sha512-UWyaYi6iURdSfdVVqvfOs2vdCVz0J40O/z/HTsv2sFjdjmdlUI/qlKLOTmwbPQ2tAfQnE5F9vqx+B+poF71DBQ==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "~0.49.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.3.6",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.1.0",
+        "esquery": "^1.6.0",
+        "parse-imports": "^2.1.1",
+        "semver": "^7.6.3",
+        "spdx-expression-parse": "^4.0.0",
+        "synckit": "^0.9.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+          "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        }
+      }
     },
     "eslint-plugin-shaka-rules": {
       "version": "file:build/eslint-plugin-shaka-rules"
@@ -15417,6 +15703,12 @@
         }
       }
     },
+    "jsdoc-type-pratt-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -16399,6 +16691,16 @@
       "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==",
       "dev": true
     },
+    "parse-imports": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-2.2.1.tgz",
+      "integrity": "sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==",
+      "dev": true,
+      "requires": {
+        "es-module-lexer": "^1.5.3",
+        "slashes": "^3.0.12"
+      }
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -17085,6 +17387,12 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "slashes": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/slashes/-/slashes-3.0.12.tgz",
+      "integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
+      "dev": true
+    },
     "slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -17454,6 +17762,16 @@
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
     },
+    "synckit": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+      "dev": true,
+      "requires": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
     "table": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
@@ -17670,9 +17988,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "es6-promise-polyfill": "^1.2.0",
     "eslint": "^9.18.0",
     "eslint-config-google": "github:google/eslint-config-google#3ae571a",
+    "eslint-plugin-jsdoc": "^50.6.1",
     "eslint-plugin-shaka-rules": "file:./build/eslint-plugin-shaka-rules",
     "esprima": "^4.0.1",
     "fontfaceonload": "^1.0.2",

--- a/test/cast/cast_receiver_integration.js
+++ b/test/cast/cast_receiver_integration.js
@@ -363,16 +363,21 @@ filterDescribe('CastReceiver', castReceiverIntegrationSupport, () => {
   function waitForUpdateMessageWrapper(prototype, name, methodName) {
     pendingWaitWrapperCalls += 1;
     const original = prototype[methodName];
-    // eslint-disable-next-line no-restricted-syntax
-    prototype[methodName] = /** @this {Object} @return {*} */ async function() {
-      pendingWaitWrapperCalls -= 1;
-      shaka.log.debug(
-          'Waiting for update message before calling ' +
-          name + '.' + methodName + '...');
-      const originalArguments = Array.from(arguments);
-      await waitForUpdateMessages();
-      return original.apply(this, originalArguments);
-    };
+    prototype[methodName] =
+      /**
+       * @this {Object}
+       * @return {*}
+       */
+      // eslint-disable-next-line no-restricted-syntax
+      async function() {
+        pendingWaitWrapperCalls -= 1;
+        shaka.log.debug(
+            'Waiting for update message before calling ' +
+            name + '.' + methodName + '...');
+        const originalArguments = Array.from(arguments);
+        await waitForUpdateMessages();
+        return original.apply(this, originalArguments);
+      };
     toRestore.push(() => {
       prototype[methodName] = original;
     });

--- a/test/cea/cea708_service_unit.js
+++ b/test/cea/cea708_service_unit.js
@@ -59,6 +59,7 @@ describe('Cea708Service', () => {
    * and converts it into a CEA-708 DTVCC Packet.
    * @param {!Array<number>} bytes
    * @param {number} pts
+   * @return {!shaka.cea.DtvccPacket}
    */
   const createCea708PacketFromBytes = (bytes, pts) => {
     const cea708Bytes = bytes.map((code, i) => {
@@ -77,6 +78,7 @@ describe('Cea708Service', () => {
    * and returns all the captions inside of them, using the service to decode.
    * @param {!shaka.cea.Cea708Service} service
    * @param {...!shaka.cea.DtvccPacket} packets
+   * @return {!Array<shaka.extern.ICaptionDecoder.ClosedCaption>}
    */
   const getCaptionsFromPackets = (service, ...packets) => {
     const captions = [];

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -2637,9 +2637,9 @@ describe('DashParser Manifest', () => {
   });
 
   /**
-     * @param {!Array.<number>} periods Start time of multiple periods
-     * @return {string}
-     */
+   * @param {!Array.<number>} periods Start time of multiple periods
+   * @return {string}
+   */
   function buildManifestWithPeriodStartTime(periods) {
     const mpdTemplate = [
       `<MPD type="dynamic"`,

--- a/test/dash/mpd_utils_unit.js
+++ b/test/dash/mpd_utils_unit.js
@@ -734,13 +734,13 @@ describe('MpdUtils', () => {
     }
 
     /**
-    * Creates an XML string with an xlink link to another URL,
-    * for use in testing recursive chains of xlink links.
-    * @param {number} variable
-    * @param {string} link
-    * @return {string}
-    * @private
-    */
+     * Creates an XML string with an xlink link to another URL,
+     * for use in testing recursive chains of xlink links.
+     * @param {number} variable
+     * @param {string} link
+     * @return {string}
+     * @private
+     */
     function makeRecursiveXMLString(variable, link) {
       const format =
           '<ToReplace xmlns="urn:mpeg:dash:schema:mpd:2011" ' +

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -1295,7 +1295,11 @@ describe('MediaSourceEngine', () => {
     initObject.set(ContentType.VIDEO, fakeVideoStream);
     initObject.set(ContentType.AUDIO, fakeAudioStream);
 
-    /** @suppress {visibility} */
+    /**
+     * @param {!Map<shaka.util.ManifestParserUtils.ContentType,
+     *              shaka.extern.Stream>} initObject
+     * @suppress {visibility}
+     */
     async function resetMSE(initObject) {
       await mediaSourceEngine.reset_(initObject);
     }

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -108,6 +108,7 @@ describe('StreamingEngine', () => {
    * @param {number=} mediaOffset The offset from 0 for the segment start times
    * @param {shaka.extern.aesKey=} aesKey The AES-128 key to put in
    *   the manifest, if one should exist
+   * @param {boolean=} secondaryAudioVariant
    */
   function setupVod(trickMode, mediaOffset, aesKey,
       secondaryAudioVariant = false) {
@@ -370,6 +371,7 @@ describe('StreamingEngine', () => {
    * @param {number} secondPeriodStartTime
    * @param {number} presentationDuration
    * @param {shaka.extern.aesKey=} aesKey
+   * @param {boolean=} secondaryAudioVariant
    */
   function setupManifest(
       firstPeriodStartTime, secondPeriodStartTime, presentationDuration,
@@ -424,7 +426,7 @@ describe('StreamingEngine', () => {
 
   /**
    * Creates the StreamingEngine.
-   **
+   *
    * @param {shaka.extern.StreamingConfiguration=} config Optional
    *   configuration object which overrides the default one.
    */
@@ -3775,6 +3777,7 @@ describe('StreamingEngine', () => {
 
   /**
    * Expect buffers have been added to MSE.
+   * @param {boolean=} secondaryAudioVariant
    */
   function expectHasBuffer(secondaryAudioVariant = false) {
     expect(mediaSourceEngine.initSegments).toEqual({

--- a/test/mss/mss_parser_unit.js
+++ b/test/mss/mss_parser_unit.js
@@ -244,7 +244,7 @@ describe('MssParser Manifest', () => {
     fakeNetEngine.setResponseText('dummy://foo', manifestText);
     const config = shaka.util.PlayerConfiguration.createDefault().manifest;
     config.mss.manifestPreprocessorTXml = (mss) => {
-      /** @type{shaka.extern.xml.Node} */ (mss).children.pop();
+      /** @type {shaka.extern.xml.Node} */ (mss).children.pop();
     };
     parser.configure(config);
 

--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -47,7 +47,11 @@ function failTestsOnNamespacedElementOrAttributeNames() {
   const patchElementNamespaceFunction = (name) => {
     // eslint-disable-next-line no-restricted-syntax
     const real = Element.prototype[name];
-    /** @this {Element} */
+    /**
+     * @this {Element}
+     * @param {string} arg
+     * @return {*}
+     */
     // eslint-disable-next-line no-restricted-syntax
     Element.prototype[name] = function(arg) {
       // Ignore xml: namespaces since it's builtin.

--- a/test/test/util/cea_utils.js
+++ b/test/test/util/cea_utils.js
@@ -13,6 +13,7 @@ shaka.test.CeaUtils = class {
    * @param {number} startTime
    * @param {number} endTime
    * @param {string} payload
+   * @return {!shaka.text.Cue}
    */
   static createDefaultCue(startTime, endTime, payload) {
     const cue = new shaka.text.Cue(startTime, endTime, payload);

--- a/test/test/util/fake_media_source_engine.js
+++ b/test/test/util/fake_media_source_engine.js
@@ -14,8 +14,8 @@
  */
 shaka.test.FakeMediaSourceEngine = class {
   /**
-   * @param {!Object.<string, shaka.test.FakeMediaSourceEngine.SegmentData>}
-   *   segmentData
+   * @param {!Object.<string,
+   *                  shaka.test.FakeMediaSourceEngine.SegmentData>} segmentData
    * @param {number=} drift Optional drift. Defaults to 0.
    */
   constructor(segmentData, drift) {

--- a/test/test/util/fake_networking_engine.js
+++ b/test/test/util/fake_networking_engine.js
@@ -17,7 +17,8 @@ shaka.test.FakeNetworkingEngine = class {
     /**
      * @private {!Map.<
      *    string,
-     *    shaka.test.FakeNetworkingEngine.MockedResponse>} */
+     *    shaka.test.FakeNetworkingEngine.MockedResponse>}
+     */
     this.responseMap_ = new Map();
 
     /** @private {!Map.<string, !Object.<string, string>>} */

--- a/test/test/util/fake_segment_prefetch.js
+++ b/test/test/util/fake_segment_prefetch.js
@@ -15,14 +15,20 @@
 shaka.test.FakeSegmentPrefetch = class {
   /**
    * Suppress the JSC_PRIVATE_OVERRIDE error for overriding prefetchPosTime_
+   * @param {number} prefetchLimit
+   * @param {!shaka.extern.Stream} stream
+   * @param {!Object<string,
+   *                 shaka.test.FakeMediaSourceEngine.SegmentData>} segmentData
    * @suppress {visibility}
    */
   constructor(prefetchLimit, stream, segmentData) {
     /** @private {number} */
     this.prefetchLimit_ = prefetchLimit;
 
-    /** @private {(Set.<!shaka.media.SegmentReference|
-     *      !shaka.media.InitSegmentReference>)} */
+    /**
+     * @private {(Set.<!shaka.media.SegmentReference|
+     *      !shaka.media.InitSegmentReference>)}
+     */
     this.requestedReferences_ = new Set();
 
     /** @private {shaka.extern.Stream} */

--- a/test/test/util/jasmine_fetch.js
+++ b/test/test/util/jasmine_fetch.js
@@ -32,8 +32,11 @@ jasmine.Fetch = class {
     /** @type {!Response} */
     jasmine.Fetch.container_.latestResponse;
 
-    window.Headers = /** @type {function (new:Headers,
-          (!Array<!Array<string>>|Headers|Object<string,string>)=)} */(
+    window.Headers =
+    /**
+     * @type {function (new:Headers,
+     *     (!Array<!Array<string>>|Headers|Object<string,string>)=)}
+     */(
         jasmine.Fetch.Headers);
 
     window.AbortController = /** @type {function (new:AbortController)} */

--- a/test/test/util/manifest_generator.js
+++ b/test/test/util/manifest_generator.js
@@ -667,6 +667,7 @@ shaka.test.ManifestGenerator.Stream = class {
    *   index and give a URI.
    * @param {number} segmentDuration
    * @param {?number=} segmentSize
+   * @return {shaka.test.ManifestGenerator.Stream}
    */
   useSegmentTemplate(template, segmentDuration, segmentSize = null) {
     goog.asserts.assert(this.manifest_,

--- a/test/test/util/waiter.js
+++ b/test/test/util/waiter.js
@@ -149,7 +149,7 @@ shaka.test.Waiter = class {
    *
    * @param {!HTMLMediaElement} mediaElement
    * @return {!Promise}
-  */
+   */
   waitUntilVodTransition(mediaElement) {
     // The name of what we're waiting for
     const goalName = 'manifest to be static';

--- a/test/ui/ui_integration.js
+++ b/test/ui/ui_integration.js
@@ -607,11 +607,11 @@ describe('UI', () => {
   }
 
   /**
-    * @param {!Array.<!HTMLElement>} buttons
-    * @param {!Array.<string>|!Array.<number>} choices
-    * @param {function(string):string|function(number):string} modifier
-    * @return {!Map.<string, !HTMLElement>|!Map.<number, !HTMLElement>}
-    */
+   * @param {!Array.<!HTMLElement>} buttons
+   * @param {!Array.<string>|!Array.<number>} choices
+   * @param {function(string):string|function(number):string} modifier
+   * @return {!Map.<string, !HTMLElement>|!Map.<number, !HTMLElement>}
+   */
   function mapChoicesToButtons(buttons, choices, modifier) {
     expect(buttons.length).toBe(choices.length);
 

--- a/test/util/periods_unit.js
+++ b/test/util/periods_unit.js
@@ -1990,6 +1990,7 @@ describe('PeriodCombiner', () => {
    * @param {number} height
    * @param {string} language
    * @param {number=} channels
+   * @param {!Array<string>=} roles
    * @return {shaka.extern.Variant}
    */
   function makeAVVariant(height, language, channels = 2, roles = []) {

--- a/ui/ad_statistics_button.js
+++ b/ui/ad_statistics_button.js
@@ -170,7 +170,11 @@ shaka.ui.AdStatisticsButton = class extends shaka.ui.Element {
     this.stateSpan_.textContent = this.localization.resolve(labelText);
   }
 
-  /** @private */
+  /**
+   * @param {string} name
+   * @return {!HTMLElement}
+   * @private
+   */
   generateComponent_(name) {
     const section = shaka.util.Dom.createHTMLElement('div');
 

--- a/ui/airplay_button.js
+++ b/ui/airplay_button.js
@@ -110,6 +110,7 @@ shaka.ui.AirPlayButton = class extends shaka.ui.Element {
   }
 
   /**
+   * @param {!AirPlayEvent} e
    * @private
    */
   onAirPlayAvailabilityChange_(e) {

--- a/ui/externs/ui.js
+++ b/ui/externs/ui.js
@@ -115,7 +115,7 @@ shaka.extern.UIVolumeBarColors;
  *   The ordered list of ad statistics present in the ad statistics container.
  * @property {!Array.<number>} playbackRates
  *   The ordered list of rates for playback selection.
-  * @property {!Array.<number>} fastForwardRates
+ * @property {!Array.<number>} fastForwardRates
  *   The ordered list of rates for fast forward selection.
  * @property {!Array.<number>} rewindRates
  *   The ordered list of rates for rewind selection.

--- a/ui/gl_matrix/matrix_4x4.js
+++ b/ui/gl_matrix/matrix_4x4.js
@@ -35,6 +35,7 @@ shaka.ui.Matrix4x4 = class {
    * @param {!Array.<number>} eye Position of the viewer
    * @param {!Array.<number>} center Point the viewer is looking at
    * @param {!Array.<number>} up Vector pointing up
+   * @return {!Float32Array}
    */
   static lookAt(out, eye, center, up) {
     let x0;
@@ -166,6 +167,7 @@ shaka.ui.Matrix4x4 = class {
    * @param {number} aspect Aspect ratio. typically viewport width/height
    * @param {number} near Near bound of the frustum
    * @param {number} far Far bound of the frustum, can be null or Infinity
+   * @return {!Float32Array}
    */
   static perspective(out, fovy, aspect, near, far) {
     const f = 1.0 / Math.tan(fovy / 2);
@@ -267,6 +269,7 @@ shaka.ui.Matrix4x4 = class {
    * @param {number} top Top bound of the frustum
    * @param {number} near Near bound of the frustum
    * @param {number} far Far bound of the frustum
+   * @return {!Float32Array}
    */
   static frustum(out, left, right, bottom, top, near, far) {
     const rl = 1 / (right - left);
@@ -424,6 +427,7 @@ shaka.ui.Matrix4x4 = class {
    * same as the quaternion originally supplied.
    * @param {!Float32Array} out Quaternion to receive the rotation component
    * @param {!Float32Array} mat Matrix to be decomposed (input)
+   * @return {!Float32Array}
    */
   static getRotation(out, mat) {
     const scaling = new Float32Array(3);
@@ -526,12 +530,14 @@ shaka.ui.Matrix4x4 = class {
    * Set a 4x4 matrix to the identity matrix
    *
    * @param {!Float32Array} out the receiving matrix
+   * @return {!Float32Array}
    * @private
    */
   static identity_(out) {
     for (let i = 0; i < 16; i++) {
       out[i] = (i % 5) == 0 ? 1 : 0;
     }
+    return out;
   }
 
   /**

--- a/ui/presentation_time.js
+++ b/ui/presentation_time.js
@@ -64,7 +64,10 @@ shaka.ui.PresentationTimeTracker = class extends shaka.ui.Element {
         });
   }
 
-  /** @private */
+  /**
+   * @param {string} value
+   * @private
+   */
   setValue_(value) {
     // To avoid constant updates to the DOM, which makes debugging more
     // difficult, only set the value if it has changed.  If we don't do this

--- a/ui/seek_bar.js
+++ b/ui/seek_bar.js
@@ -313,7 +313,7 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
 
   /**
    * @override
-  */
+   */
   isShowing() {
     // It is showing by default, so it is hidden if shaka-hidden is in the list.
     return !this.container.classList.contains('shaka-hidden');

--- a/ui/statistics_button.js
+++ b/ui/statistics_button.js
@@ -220,7 +220,11 @@ shaka.ui.StatisticsButton = class extends shaka.ui.Element {
     this.stateSpan_.textContent = this.localization.resolve(labelText);
   }
 
-  /** @private */
+  /**
+   * @param {string} name
+   * @return {!HTMLElement}
+   * @private
+   */
   generateComponent_(name) {
     const section = shaka.util.Dom.createHTMLElement('div');
 

--- a/ui/vr_manager.js
+++ b/ui/vr_manager.js
@@ -551,7 +551,7 @@ shaka.ui.VRManager = class extends shaka.util.FakeEventTarget {
 };
 
 /**
- * @constant {number}
+ * @const {number}
  * @private
  */
 shaka.ui.VRManager.TO_RADIANS_ = Math.PI / 180;

--- a/ui/vr_utils.js
+++ b/ui/vr_utils.js
@@ -162,7 +162,7 @@ shaka.ui.VRUtils = class {
 /**
  * Sphere vertex shader.
  *
- * @constant {string}
+ * @const {string}
  */
 shaka.ui.VRUtils.VERTEX_SPHERE_SHADER =
 `attribute vec4 a_vPosition;
@@ -183,7 +183,7 @@ void main()
 /**
  * Sphere fragment shader.
  *
- * @constant {string}
+ * @const {string}
  */
 shaka.ui.VRUtils.FRAGMENT_SPHERE_SHADER =
 `precision highp float;
@@ -204,7 +204,7 @@ highp vec4 texelColor =
 /**
  * Cube vertex shader.
  *
- * @constant {string}
+ * @const {string}
  */
 shaka.ui.VRUtils.VERTEX_CUBE_SHADER =
 `attribute vec4 aVertexPosition;
@@ -221,7 +221,7 @@ void main(void) {
 /**
  * Cube fragment shader.
  *
- * @constant {string}
+ * @const {string}
  */
 shaka.ui.VRUtils.FRAGMENT_CUBE_SHADER =
 `varying highp vec2 vTextureCoord;

--- a/ui/vr_webgl.js
+++ b/ui/vr_webgl.js
@@ -694,6 +694,6 @@ shaka.ui.VRWebgl = class {
 };
 
 /**
- * @constant {number}
+ * @const {number}
  */
 shaka.ui.VRWebgl.ANIMATION_DURATION_ = 0.5;


### PR DESCRIPTION
Adds a replacement for removed JSDoc checks from ESLint v9.
Additionally fixes lots of issues found in the JSDoc, such as:
- missing `@param`/`@return` annotations
- bad formatting
- params order
- param name in the same line as type definition (tried to disable it, but it was causing other issues and we didn't have lots of places with such formatting)

Minor fixes in code found by Closure Compiler after fixing JSDoc are also included.