### PR TITLE
fix: Use infiniteLiveStreamDuration equal to true in Safari 17 or above

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1826,8 +1826,9 @@ shaka.extern.LiveSyncConfiguration;
  *   <br>
  *   Defaults to <code>0.5</code>.
  * @property {boolean} infiniteLiveStreamDuration
- *   If <code>true</code>, the media source live duration
- *   set as a<code>Infinity</code>
+ *   If <code>true</code>, the media source duration of livestreams will be set
+ *   to <code>Infinity</code>. Otherwise, it will be set to a high but
+ *   non-infinite number (2^32).
  *   <br>
  *   Defaults to <code>false</code> except on Safari 17 or above whose default
  *   value is <code>true</code>.

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1829,7 +1829,8 @@ shaka.extern.LiveSyncConfiguration;
  *   If <code>true</code>, the media source live duration
  *   set as a<code>Infinity</code>
  *   <br>
- *   Defaults to <code>false</code>.
+ *   Defaults to <code>false</code> except on Safari 17 or above whose default
+ *   value is <code>true</code>.
  * @property {number} preloadNextUrlWindow
  *   The window of time at the end of the presentation to begin preloading the
  *   next URL, such as one specified by a urn:mpeg:dash:chaining:2016 element

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -281,6 +281,11 @@ shaka.util.PlayerConfiguration = class {
         shaka.util.Platform.isTizen(),
     };
 
+    const safariVersion = shaka.util.Platform.safariVersion();
+    if (safariVersion && safariVersion >= 17) {
+      streaming.infiniteLiveStreamDuration = true;
+    }
+
     // WebOS, Tizen, Chromecast and Hisense have long hardware pipelines
     // that respond slowly to seeking.
     // Therefore we should not seek when we detect a stall


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/7899