### PR TITLE
fix: Fix setLiveSeekableRange when the seekable range is too short

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -164,6 +164,8 @@ shaka.media.StreamingEngine = class {
       }
       const startTime = this.manifest_.presentationTimeline.getSeekRangeStart();
       const endTime = this.manifest_.presentationTimeline.getSeekRangeEnd();
+      // Some older devices require the range to be greater than 1 or exceptions
+      // are thrown, due to an old and buggy implementation.
       if (endTime - startTime > 1) {
         this.playerInterface_.mediaSourceEngine.setLiveSeekableRange(
             startTime, endTime);

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -164,8 +164,12 @@ shaka.media.StreamingEngine = class {
       }
       const startTime = this.manifest_.presentationTimeline.getSeekRangeStart();
       const endTime = this.manifest_.presentationTimeline.getSeekRangeEnd();
-      this.playerInterface_.mediaSourceEngine.setLiveSeekableRange(
-          startTime, endTime);
+      if (endTime - startTime > 1) {
+        this.playerInterface_.mediaSourceEngine.setLiveSeekableRange(
+            startTime, endTime);
+      } else {
+        this.playerInterface_.mediaSourceEngine.clearLiveSeekableRange();
+      }
     });
   }
 


### PR DESCRIPTION
Some older devices require the range to be greater than 1 or exceptions are thrown, due to an old and buggy implementation.