### PR TITLE
fix(DASH): Change fallback presentation delay

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1410,7 +1410,8 @@ shaka.extern.MssManifestConfiguration;
  * @property {number} defaultPresentationDelay
  *   For DASH, it's a default <code>presentationDelay</code> value if
  *   <code>suggestedPresentationDelay</code> is missing in the MPEG DASH
- *   manifest. The default value is <code>1.5 * minBufferTime</code> if not
+ *   manifest. The default value is the lower of <code>1.5 *
+ *   minBufferTime</code> and <code>segmentAvailabilityDuration</code> if not
  *   configured or set as 0.
  *   For HLS, the default value is 3 segments duration if not configured or
  *   set as 0.

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -707,17 +707,24 @@ shaka.dash.DashParser = class {
       // feasible choices for the value.  Nothing older than
       // timeShiftBufferDepth is still available, and anything less than
       // minBufferTime will cause buffering issues.
-      //
-      // We have decided that our default will be the configured value, or
-      // 1.5 * minBufferTime if not configured. This is fairly conservative.
-      // Content providers should provide a suggestedPresentationDelay whenever
-      // possible to optimize the live streaming experience.
-      const defaultPresentationDelay =
-          this.config_.defaultPresentationDelay || minBufferTime * 1.5;
-      const presentationDelay = suggestedPresentationDelay != null ?
-          suggestedPresentationDelay : defaultPresentationDelay;
+      let delay = 0;
+      if (suggestedPresentationDelay != null) {
+        // 1. If a suggestedPresentationDelay is provided by the manifest, that
+        // will be used preferentially.
+        // Content providers should provide a suggestedPresentationDelay
+        // whenever possible to optimize the live streaming experience.
+        delay = suggestedPresentationDelay;
+      } else if (this.config_.defaultPresentationDelay > 0) {
+        // 2. If the developer provides a value for
+        // "manifest.defaultPresentationDelay", that is used as a fallback.
+        delay = this.config_.defaultPresentationDelay;
+      } else {
+        // 3. Otherwise, we default to the lower of segmentAvailabilityDuration
+        // and 1.5 * minBufferTime. This is fairly conservative.
+        delay = Math.min(minBufferTime * 1.5, segmentAvailabilityDuration);
+      }
       presentationTimeline = new shaka.media.PresentationTimeline(
-          presentationStartTime, presentationDelay,
+          presentationStartTime, delay,
           this.config_.dash.autoCorrectDrift);
     }
 


### PR DESCRIPTION
Previously, if the presentation delay was not specified either by the manifest or by configuration, we defaulted to 1.5 * minBufferTime. That approach worked for most content, but in some cases it could cause live streams to start out with a seekRangeEnd that was before the live edge. This would lead to a brief pause in the beginning of the presentation, while the live edge caught up.

This changes the DASH parser to use the segmentAvailabilityDuration if it is lower than 1.5 * minBufferTime, which fixes that issue.

It also changes how that part of the code to be formatted, in order to hopefully make the increasingly-complex logic for determining the presentation delay more clear.