### PR TITLE
chore: Stop using "Object" in StreamBandwidthEstimator annotations

### DIFF
--- a/lib/offline/stream_bandwidth_estimator.js
+++ b/lib/offline/stream_bandwidth_estimator.js
@@ -19,8 +19,8 @@ goog.requireType('shaka.media.SegmentReference');
 shaka.offline.StreamBandwidthEstimator = class {
   /** */
   constructor() {
-    /** @private {!Object<number, number>} */
-    this.estimateByStreamId_ = {};
+    /** @private {!Map<number, number>} */
+    this.estimateByStreamId_ = new Map();
   }
 
   /**
@@ -80,7 +80,7 @@ shaka.offline.StreamBandwidthEstimator = class {
    * @private
    */
   setBitrate_(stream, bitRate) {
-    this.estimateByStreamId_[stream] = bitRate;
+    this.estimateByStreamId_.set(stream, bitRate);
   }
 
   /**
@@ -89,8 +89,8 @@ shaka.offline.StreamBandwidthEstimator = class {
    * @param {shaka.extern.Stream} text
    */
   addText(text) {
-    this.estimateByStreamId_[text.id] =
-        shaka.offline.StreamBandwidthEstimator.DEFAULT_TEXT_BITRATE_;
+    this.estimateByStreamId_.set(text.id,
+        shaka.offline.StreamBandwidthEstimator.DEFAULT_TEXT_BITRATE_);
   }
 
   /**
@@ -99,8 +99,8 @@ shaka.offline.StreamBandwidthEstimator = class {
    * @param {shaka.extern.Stream} image
    */
   addImage(image) {
-    this.estimateByStreamId_[image.id] = image.bandwidth ||
-        shaka.offline.StreamBandwidthEstimator.DEFAULT_IMAGE_BITRATE_;
+    this.estimateByStreamId_.set(image.id, image.bandwidth ||
+        shaka.offline.StreamBandwidthEstimator.DEFAULT_IMAGE_BITRATE_);
   }
 
   /**
@@ -136,7 +136,7 @@ shaka.offline.StreamBandwidthEstimator = class {
    * @private
    */
   getEstimate_(id) {
-    let bitRate = this.estimateByStreamId_[id];
+    let bitRate = this.estimateByStreamId_.get(id);
 
     if (bitRate == null) {
       bitRate = 0;


### PR DESCRIPTION
Related to #1672