### PR TITLE
chore: Stop using "Object" in MSS annotations

### DIFF
--- a/lib/mss/mss_parser.js
+++ b/lib/mss/mss_parser.js
@@ -610,7 +610,7 @@ shaka.mss.MssParser = class {
     // This is specifically for text tracks.
     const subType = streamIndex.attributes['Subtype'];
     if (subType) {
-      const role = MssParser.ROLE_MAPPING_[subType];
+      const role = MssParser.ROLE_MAPPING_.get(subType);
       if (role) {
         stream.roles.push(role);
       }
@@ -1107,14 +1107,13 @@ shaka.mss.MssParser.SUPPORTED_CODECS_ = [
  * MPEG-DASH Role and accessibility mapping for text tracks according to
  * ETSI TS 103 285 v1.1.1 (section 7.1.2)
  *
- * @const {!Object<string, string>}
+ * @const {!Map<string, string>}
  * @private
  */
-shaka.mss.MssParser.ROLE_MAPPING_ = {
-  'CAPT': 'main',
-  'SUBT': 'alternate',
-  'DESC': 'main',
-};
+shaka.mss.MssParser.ROLE_MAPPING_ = new Map()
+    .set('CAPT', 'main')
+    .set('SUBT', 'alternate')
+    .set('DESC', 'main');
 
 
 /**


### PR DESCRIPTION
Related to #1672