### PR TITLE
chore: Stop using "Object" in MP4-CEA annotations

### DIFF
--- a/lib/cea/mp4_cea_parser.js
+++ b/lib/cea/mp4_cea_parser.js
@@ -389,8 +389,9 @@ shaka.cea.Mp4CeaParser = class {
    * @private
    */
   setBitstreamFormat_(codec) {
-    if (codec in shaka.cea.Mp4CeaParser.CodecBitstreamMap_) {
-      this.bitstreamFormat_ = shaka.cea.Mp4CeaParser.CodecBitstreamMap_[codec];
+    if (shaka.cea.Mp4CeaParser.CodecBitstreamMap_.has(codec)) {
+      this.bitstreamFormat_ =
+          shaka.cea.Mp4CeaParser.CodecBitstreamMap_.get(codec);
     }
   }
 };
@@ -403,27 +404,26 @@ shaka.cea.Mp4CeaParser.BitstreamFormat = {
   H266: 3,
 };
 
-/** @private {Object<string, shaka.cea.Mp4CeaParser.BitstreamFormat>} */
-shaka.cea.Mp4CeaParser.CodecBitstreamMap_ = {
-  // AVC
-  'avc1': shaka.cea.Mp4CeaParser.BitstreamFormat.H264,
-  'avc3': shaka.cea.Mp4CeaParser.BitstreamFormat.H264,
-  // Dolby Vision based in AVC
-  'dvav': shaka.cea.Mp4CeaParser.BitstreamFormat.H264,
-  'dva1': shaka.cea.Mp4CeaParser.BitstreamFormat.H264,
-  // HEVC
-  'hev1': shaka.cea.Mp4CeaParser.BitstreamFormat.H265,
-  'hvc1': shaka.cea.Mp4CeaParser.BitstreamFormat.H265,
-  // Dolby Vision based in HEVC
-  'dvh1': shaka.cea.Mp4CeaParser.BitstreamFormat.H265,
-  'dvhe': shaka.cea.Mp4CeaParser.BitstreamFormat.H265,
-  // VVC
-  'vvc1': shaka.cea.Mp4CeaParser.BitstreamFormat.H266,
-  'vvi1': shaka.cea.Mp4CeaParser.BitstreamFormat.H266,
-  // Dolby Vision based in VVC
-  'dvc1': shaka.cea.Mp4CeaParser.BitstreamFormat.H266,
-  'dvi1': shaka.cea.Mp4CeaParser.BitstreamFormat.H266,
-};
+/** @private {Map<string, shaka.cea.Mp4CeaParser.BitstreamFormat>} */
+shaka.cea.Mp4CeaParser.CodecBitstreamMap_ = new Map()
+    // AVC
+    .set('avc1', shaka.cea.Mp4CeaParser.BitstreamFormat.H264)
+    .set('avc3', shaka.cea.Mp4CeaParser.BitstreamFormat.H264)
+    // Dolby Vision based in AVC
+    .set('dvav', shaka.cea.Mp4CeaParser.BitstreamFormat.H264)
+    .set('dva1', shaka.cea.Mp4CeaParser.BitstreamFormat.H264)
+    // HEVC
+    .set('hev1', shaka.cea.Mp4CeaParser.BitstreamFormat.H265)
+    .set('hvc1', shaka.cea.Mp4CeaParser.BitstreamFormat.H265)
+    // Dolby Vision based in HEVC
+    .set('dvh1', shaka.cea.Mp4CeaParser.BitstreamFormat.H265)
+    .set('dvhe', shaka.cea.Mp4CeaParser.BitstreamFormat.H265)
+    // VVC
+    .set('vvc1', shaka.cea.Mp4CeaParser.BitstreamFormat.H266)
+    .set('vvi1', shaka.cea.Mp4CeaParser.BitstreamFormat.H266)
+    // Dolby Vision based in VVC
+    .set('dvc1', shaka.cea.Mp4CeaParser.BitstreamFormat.H266)
+    .set('dvi1', shaka.cea.Mp4CeaParser.BitstreamFormat.H266);
 
 /**
  * @typedef {{


### PR DESCRIPTION
Related to #1672