### PR TITLE
feat: Retain segment in memory on QuotaExceededError

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1780,7 +1780,7 @@ shaka.extern.LiveSyncConfiguration;
  *   ahead of playhead in parallel.
  *   If <code>0</code>, the segments will be fetched sequentially.
  *   <br>
- *   Defaults to <code>0</code>.
+ *   Defaults to <code>1</code>.
  * @property {!Array<string>} prefetchAudioLanguages
  *   The audio languages to prefetch.
  *   <br>

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -244,7 +244,7 @@ shaka.util.PlayerConfiguration = class {
       maxDisabledTime: 30,
       // When low latency streaming is enabled, segmentPrefetchLimit will
       // default to 2 if not specified.
-      segmentPrefetchLimit: 0,
+      segmentPrefetchLimit: 1,
       prefetchAudioLanguages: [],
       disableAudioPrefetch: false,
       disableTextPrefetch: false,

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -455,6 +455,7 @@ describe('StreamingEngine', () => {
       config.rebufferingGoal = 2;
       config.bufferingGoal = 5;
       config.bufferBehind = Infinity;
+      config.maxDisabledTime = 0; // Do not disable stream by default
     }
 
     if (defaultConfig.segmentPrefetchLimit == config.segmentPrefetchLimit) {

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -447,12 +447,18 @@ describe('StreamingEngine', () => {
       return Promise.resolve();
     });
 
+    const defaultConfig =
+        shaka.util.PlayerConfiguration.createDefault().streaming;
+
     if (!config) {
-      config = shaka.util.PlayerConfiguration.createDefault().streaming;
+      config = defaultConfig;
       config.rebufferingGoal = 2;
       config.bufferingGoal = 5;
       config.bufferBehind = Infinity;
-      config.maxDisabledTime = 0; // Do not disable stream by default
+    }
+
+    if (defaultConfig.segmentPrefetchLimit == config.segmentPrefetchLimit) {
+      config.segmentPrefetchLimit = 0; // Do not prefetch segments by default
     }
 
     goog.asserts.assert(

--- a/test/ui/ui_unit.js
+++ b/test/ui/ui_unit.js
@@ -914,6 +914,8 @@ describe('UI', () => {
         shaka.media.ManifestParser.registerParserByMime(
             fakeMimeType, () => new shaka.test.FakeManifestParser(manifest));
 
+        player.configure('streaming.segmentPrefetchLimit', 0);
+
         await player.load(
             /* uri= */ 'fake', /* startTime= */ 0, fakeMimeType);
 


### PR DESCRIPTION
Closes #1352

Segment prefetch keeps the segments until the position of the segment to be requested changes, which is exactly what happens when the QuotaExceededError error occurs. So enabling this by default with a value of 1 solves this problem.