### PR TITLE
fix(DASH): Fix Dolby Atmos detection

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -2310,7 +2310,7 @@ shaka.dash.DashParser = class {
     const codecs = context.representation.codecs;
     // Detect the presence of Dolby Atmos audio content based on the codec and
     // bandwidth. Bandwidth above 384 kbps is a good indicator of Atmos content.
-    const isAtmos = codecs.includes('ec-3') && context.bandwidth >= 384000;
+    const isAtmos = codecs.includes('ec-3') && context.bandwidth > 384000;
     let spatialAudio = false;
     if (hasJoc || isAtmos) {
       spatialAudio = true;

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -545,7 +545,7 @@ describe('DashParser Manifest', () => {
       '<MPD>',
       '  <Period duration="PT30M">',
       '    <AdaptationSet mimeType="audio/mp4" lang="\u2603">',
-      '      <Representation bandwidth="384000" codecs="ec-3">',
+      '      <Representation bandwidth="768000" codecs="ec-3">',
       '        <BaseURL>http://example.com</BaseURL>',
       '        <SegmentTemplate media="2.mp4" duration="1" />',
       '      </Representation>',


### PR DESCRIPTION
dolby digital plus tracks can have a bandwidth of exactly 384000

Fixes https://github.com/shaka-project/shaka-player/issues/7965