### PR TITLE
chore: Disable console logs in ESLint

### DIFF
--- a/build/conformance.textproto
+++ b/build/conformance.textproto
@@ -146,24 +146,6 @@ requirement: {
   error_message: "Use Date.now() instead."
 }
 
-# Disallow console logging.
-requirement: {
-  type: BANNED_PROPERTY_CALL
-  value: "Console.prototype.debug"
-  value: "Console.prototype.log"
-  value: "Console.prototype.info"
-  value: "Console.prototype.warn"
-  value: "Console.prototype.error"
-  error_message:
-    "Using \"console\" is not allowed; "
-    "use shaka.log instead"
-  whitelist_regexp: "demo/"
-  whitelist_regexp: "lib/debug/log.js"
-  whitelist_regexp: "test/test/boot.js"
-  whitelist_regexp: "node_modules/"
-  whitelist_regexp: "[synthetic:es6/promise/promise]"
-}
-
 # Disallow querySelector and querySelectorAll since they aren't supported on
 # Shaka Player Embedded.
 requirement: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,7 +81,6 @@ export default [
     },
     rules: {
       // Things the compiler already takes care of, with more precision: {{{
-      'no-console': 'off',
       'no-eq-null': 'off',
       'no-eval': 'off',
       'no-undef': 'off',
@@ -132,6 +131,7 @@ export default [
       'guard-for-in': 'off',
       'no-alert': 'error',
       'no-caller': 'error',
+      'no-console': 'error',
       'no-div-regex': 'error',
       'no-extend-native': 'error', // May conflict with future polyfills
       'no-extra-label': 'error',
@@ -338,6 +338,19 @@ export default [
     rules: {
       // JSDoc is not strictly required in externs, tests, and in load.js.
       'jsdoc/require-jsdoc': 'off',
+    },
+  },
+  {
+    files: [
+      'karma.conf.js',
+      'build/**/*.js',
+      'demo/**/*.js',
+      'lib/debug/asserts.js',
+      'lib/debug/log.js',
+      'test/**/**.js',
+    ],
+    rules: {
+      'no-console': 'off',
     },
   },
 ];


### PR DESCRIPTION
For some reason closure config does not work correctly, so enable equivalent ESLint rule.