### PR TITLE
fix: Avoid launch RESTRICTIONS_CANNOT_BE_MET when it's not necessary

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -54,6 +54,7 @@ goog.require('shaka.util.Functional');
 goog.require('shaka.util.IDestroyable');
 goog.require('shaka.util.LanguageUtils');
 goog.require('shaka.util.ManifestParserUtils');
+goog.require('shaka.util.MapUtils');
 goog.require('shaka.util.MediaReadyState');
 goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Mutex');
@@ -8115,6 +8116,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // Only filter tracks for keys if we have some key statuses to look at.
     if (keyIds.length) {
+      const currentKeySystem = this.keySystem();
+      const clearKeys = shaka.util.MapUtils.asMap(this.config_.drm.clearKeys);
+
       for (const variant of this.manifest_.variants) {
         const streams = shaka.util.StreamUtils.getVariantStreams(variant);
 
@@ -8124,13 +8128,33 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           // Only update if we have key IDs for the stream.  If the keys aren't
           // all present, then the track should be restricted.
           if (stream.keyIds.size) {
-            variant.allowedByKeySystem = true;
+            if (stream.drmInfos.length && !clearKeys.size) {
+              for (const drmInfo of stream.drmInfos) {
+                if (drmInfo.keyIds.size &&
+                    drmInfo.keySystem == currentKeySystem) {
+                  variant.allowedByKeySystem = true;
 
-            for (const keyId of stream.keyIds) {
-              const keyStatus = keyStatusMap[isGlobalStatus ? '00' : keyId];
-              if (keyStatus || this.drmEngine_.hasManifestInitData()) {
-                variant.allowedByKeySystem = variant.allowedByKeySystem &&
-                    !!keyStatus && !restrictedStatuses.includes(keyStatus);
+                  for (const keyId of drmInfo.keyIds) {
+                    const keyStatus =
+                        keyStatusMap[isGlobalStatus ? '00' : keyId];
+                    if (keyStatus || this.drmEngine_.hasManifestInitData()) {
+                      variant.allowedByKeySystem =
+                          variant.allowedByKeySystem &&
+                          !!keyStatus &&
+                          !restrictedStatuses.includes(keyStatus);
+                    }
+                  }
+                }
+              }
+            } else {
+              variant.allowedByKeySystem = true;
+
+              for (const keyId of stream.keyIds) {
+                const keyStatus = keyStatusMap[isGlobalStatus ? '00' : keyId];
+                if (keyStatus || this.drmEngine_.hasManifestInitData()) {
+                  variant.allowedByKeySystem = variant.allowedByKeySystem &&
+                      !!keyStatus && !restrictedStatuses.includes(keyStatus);
+                }
               }
             }
           }

--- a/lib/player.js
+++ b/lib/player.js
@@ -8128,6 +8128,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           // Only update if we have key IDs for the stream.  If the keys aren't
           // all present, then the track should be restricted.
           if (stream.keyIds.size) {
+            // If we are not using clearkeys, and the stream has drmInfos we
+            // only want to check the keyIds of the keySystem we are using.
+            // Other keySystems might have other keyIds that might not be
+            // valid in this case. This can happen in HLS if the manifest
+            // has Widevine with keyIds and PlayReady without keyIds and we are
+            // using PlayReady.
             if (stream.drmInfos.length && !clearKeys.size) {
               for (const drmInfo of stream.drmInfos) {
                 if (drmInfo.keyIds.size &&
@@ -8142,10 +8148,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
                           variant.allowedByKeySystem &&
                           !!keyStatus &&
                           !restrictedStatuses.includes(keyStatus);
-                    }
-                  }
-                }
-              }
+                    } // if (keyStatus || this.drmEngine_.hasManifestInitData())
+                  } // for (const keyId of drmInfo.keyIds)
+                } // if (drmInfo.keyIds.size && ...
+              } // for (const drmInfo of stream.drmInfos
             } else {
               variant.allowedByKeySystem = true;
 
@@ -8155,9 +8161,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
                   variant.allowedByKeySystem = variant.allowedByKeySystem &&
                       !!keyStatus && !restrictedStatuses.includes(keyStatus);
                 }
-              }
-            }
-          }
+              } // for (const keyId of stream.keyIds)
+            } // if (stream.drmInfos.length && !clearKeys.size)
+          } // if (stream.keyIds.size)
 
           if (originalAllowed != variant.allowedByKeySystem) {
             tracksChanged = true;


### PR DESCRIPTION
This can happen with HLS, when there is Widevine with keyId and PlayReady without keyId and the system only supports Playready.