### PR TITLE
fix(Subtitles): Prevent rounding errors when filtering duplicated cues

### DIFF
--- a/lib/text/cue.js
+++ b/lib/text/cue.js
@@ -371,8 +371,12 @@ shaka.text.Cue = class {
     // performance optimization.  We can avoid the more expensive recursive
     // checks if the top-level properties don't match.
     // See: https://github.com/shaka-project/shaka-player/issues/3018
-    if (cue1.startTime != cue2.startTime || cue1.endTime != cue2.endTime ||
-      cue1.payload != cue2.payload) {
+    if (cue1.payload != cue2.payload) {
+      return false;
+    }
+    const isDiffNegligible = (a, b) => Math.abs(a - b) < 0.001;
+    if (!isDiffNegligible(cue1.startTime, cue2.startTime) ||
+        !isDiffNegligible(cue1.endTime, cue2.endTime)) {
       return false;
     }
     for (const k in cue1) {


### PR DESCRIPTION
Related to #6773 