### PR TITLE
fix: Do not autoplay if autoplay is not set

### DIFF
--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -171,7 +171,7 @@ shaka.util.CmcdManager = class {
    * @param {number} startTimeOfLoad
    */
   setStartTimeOfLoad(startTimeOfLoad) {
-    if (this.video_) {
+    if (this.video_ && this.video_.autoplay) {
       const playResult = this.video_.play();
       if (playResult) {
         playResult.then(() => {


### PR DESCRIPTION
b2673fd (#7412) introduced a call to video.play() in a function that says "Set start time of load if autoplay is enabled", but the function did not actually check the autoplay attribute.  This fixes the oversight.

Fixes #8022