### PR TITLE
chore: Simplify Apple detection

### DIFF
--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -60,9 +60,8 @@ shaka.polyfill.MediaCapabilities = class {
         shaka.util.Platform.isPS4() ||
         shaka.util.Platform.isWebOS() ||
         shaka.util.Platform.isTizen() ||
-        shaka.util.Platform.isEOS() ||
         shaka.util.Platform.isHisense() ||
-        shaka.util.Platform.isComcastX1()) {
+        shaka.util.Platform.isWebkitSTB()) {
       canUseNativeMCap = false;
     }
     if (canUseNativeMCap && navigator.mediaCapabilities) {

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -417,7 +417,7 @@ shaka.util.Platform = class {
   }
 
   /**
-   * Guesses if the platform is an Apple mobile one (iOS, iPad).
+   * Guesses if the platform is an Apple mobile one (iOS, iPad, iPod).
    * @return {boolean}
    */
   static isIOS() {

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -303,19 +303,8 @@ shaka.util.Platform = class {
    * @return {boolean}
    */
   static isApple() {
-    return !!navigator.vendor && navigator.vendor.includes('Apple') &&
-        !shaka.util.Platform.isTizen() &&
-        !shaka.util.Platform.isEOS() &&
-        !shaka.util.Platform.isAPL() &&
-        !shaka.util.Platform.isAPP() &&
-        !shaka.util.Platform.isVirginMedia() &&
-        !shaka.util.Platform.isOrange() &&
-        !shaka.util.Platform.isPS4() &&
-        !shaka.util.Platform.isAmazonFireTV() &&
-        !shaka.util.Platform.isComcastX1() &&
-        !shaka.util.Platform.isZenterio() &&
-        !shaka.util.Platform.isSkyQ() &&
-        !shaka.util.Platform.isMultiChoice();
+    return shaka.util.Platform.isAppleVendor_() &&
+        (shaka.util.Platform.isMac() || shaka.util.Platform.isIOS());
   }
 
   /**
@@ -349,14 +338,6 @@ shaka.util.Platform = class {
   }
 
   /**
-   * Check if the current platform is Virgin Media device.
-   * @return {boolean}
-   */
-  static isVirginMedia() {
-    return shaka.util.Platform.userAgentContains_('VirginMedia');
-  }
-
-  /**
    * Check if the current platform is Orange.
    * @return {boolean}
    */
@@ -373,16 +354,6 @@ shaka.util.Platform = class {
   }
 
   /**
-   * Check if the current platform is Amazon Fire TV.
-   * https://developer.amazon.com/docs/fire-tv/identify-amazon-fire-tv-devices.html
-   *
-   * @return {boolean}
-   */
-  static isAmazonFireTV() {
-    return shaka.util.Platform.userAgentContains_('AFT');
-  }
-
-  /**
    * Check if the current platform is Comcast X1.
    * @return {boolean}
    */
@@ -396,16 +367,6 @@ shaka.util.Platform = class {
    */
   static isZenterio() {
     return shaka.util.Platform.userAgentContains_('DT_STB_BCM');
-  }
-
-  /**
-   * Check if the current platform is a MultiChoice STB.
-   * @return {boolean}
-   */
-  static isMultiChoice() {
-    // cspell: ignore MDMP
-    return shaka.util.Platform.userAgentContains_('MDMP1001S') ||
-      shaka.util.Platform.userAgentContains_('PS5525IMC');
   }
 
   /**
@@ -465,29 +426,11 @@ shaka.util.Platform = class {
   }
 
   /**
-   * Check if the current platform is an APL set-top box.
-   *
+   * Guesses if the platform is an Apple mobile one (iOS, iPad).
    * @return {boolean}
    */
-  static isAPL() {
-    return shaka.util.Platform.userAgentContains_('PC=APL');
-  }
-
-  /**
-   * Check if the current platform is an APPSTB set-top box.
-   * @return {boolean}
-   */
-  static isAPP() {
-    return shaka.util.Platform.userAgentContains_('PC=APPSTB');
-  }
-
-  /**
-   * Guesses if the platform is a mobile one (iOS or Android).
-   *
-   * @return {boolean}
-   */
-  static isMobile() {
-    if (/(?:iPhone|iPad|iPod|Android)/.test(navigator.userAgent)) {
+  static isIOS() {
+    if (/(?:iPhone|iPad|iPod)/.test(navigator.userAgent)) {
       // This is Android, iOS, or iPad < 13.
       return true;
     }
@@ -505,7 +448,18 @@ shaka.util.Platform = class {
     // As of January 2020, this is mainly used to adjust the default UI config
     // for mobile devices, so it's low risk if something changes to break this
     // detection.
-    return shaka.util.Platform.isApple() && navigator.maxTouchPoints > 1;
+    return shaka.util.Platform.isAppleVendor_() && navigator.maxTouchPoints > 1;
+  }
+
+  /**
+   * Guesses if the platform is a mobile one.
+   * @return {boolean}
+   */
+  static isMobile() {
+    if (navigator.userAgentData) {
+      return navigator.userAgentData.mobile;
+    }
+    return shaka.util.Platform.isIOS() || shaka.util.Platform.isAndroid();
   }
 
   /**
@@ -538,6 +492,15 @@ shaka.util.Platform = class {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Checks is non-Apple STB based on Webkit.
+   * @return {boolean}
+   */
+  static isWebkitSTB() {
+    return shaka.util.Platform.isAppleVendor_() &&
+        !shaka.util.Platform.isApple();
   }
 
   /**
@@ -584,12 +547,8 @@ shaka.util.Platform = class {
     const Platform = shaka.util.Platform;
     if (Platform.isTizen() || Platform.isWebOS() ||
         Platform.isXboxOne() || Platform.isPS4() ||
-        Platform.isPS5() || Platform.isAmazonFireTV() ||
-        Platform.isEOS() || Platform.isAPL() ||
-        Platform.isVirginMedia() || Platform.isOrange() ||
-        Platform.isComcastX1() || Platform.isChromecast() ||
-        Platform.isHisense() || Platform.isZenterio() ||
-        Platform.isAPP() || Platform.isMultiChoice()) {
+        Platform.isPS5() || Platform.isChromecast() ||
+        Platform.isHisense() || Platform.isWebkitSTB()) {
       return true;
     }
     return false;
@@ -607,6 +566,14 @@ shaka.util.Platform = class {
   static userAgentContains_(key) {
     const userAgent = navigator.userAgent || '';
     return userAgent.includes(key);
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  static isAppleVendor_() {
+    return (navigator.vendor || '').includes('Apple');
   }
 
   /**

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -417,15 +417,6 @@ shaka.util.Platform = class {
   }
 
   /**
-   * Check if the current platform is an EOS set-top box.
-   *
-   * @return {boolean}
-   */
-  static isEOS() {
-    return shaka.util.Platform.userAgentContains_('PC=EOS');
-  }
-
-  /**
    * Guesses if the platform is an Apple mobile one (iOS, iPad).
    * @return {boolean}
    */

--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -41,6 +41,7 @@ describe('Platform', () => {
     });
 
     it('checks Safari version', () => {
+      setPlatform('MacIntel');
       setUserAgent(macSafari);
       expect(shaka.util.Platform.safariVersion()).toBe(18);
       setUserAgent(ipadSafari);

--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -232,25 +232,29 @@ describe('Platform', () => {
 
   /** @param {string} userAgent */
   function setUserAgent(userAgent) {
-    Object.defineProperty(
-        navigator, 'userAgent', {value: userAgent, configurable: true});
+    setNavigatorProperty('userAgent', userAgent);
   }
 
   /** @param {?Object} userAgentData */
   function setUserAgentData(userAgentData) {
-    Object.defineProperty(
-        navigator, 'userAgentData', {value: userAgentData, configurable: true});
+    setNavigatorProperty('userAgentData', userAgentData);
   }
 
   /** @param {string} vendor */
   function setVendor(vendor) {
-    Object.defineProperty(
-        navigator, 'vendor', {value: vendor, configurable: true});
+    setNavigatorProperty('vendor', vendor);
   }
 
   /** @param {string} platform */
   function setPlatform(platform) {
-    Object.defineProperty(
-        navigator, 'platform', {value: platform, configurable: true});
+    setNavigatorProperty('platform', platform);
+  }
+
+  /**
+   * @param {string} key
+   * @param {*} value
+   */
+  function setNavigatorProperty(key, value) {
+    Object.defineProperty(navigator, key, {value, configurable: true});
   }
 });

--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -41,6 +41,7 @@ describe('Platform', () => {
     });
 
     it('checks Safari version', () => {
+      setUserAgentData(null);
       setPlatform('MacIntel');
       setUserAgent(macSafari);
       expect(shaka.util.Platform.safariVersion()).toBe(18);

--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -6,8 +6,14 @@
 
 describe('Platform', () => {
   const originalUserAgent = navigator.userAgent;
+  const originalUserAgentData = navigator.userAgentData;
+  const originalVendor = navigator.vendor;
+  const originalPlatform = navigator.platform;
 
   /* eslint-disable max-len */
+  const macSafari = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Safari/605.1.15';
+  const ipadSafari = 'Mozilla/5.0 (iPad; CPU OS 18_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Mobile/15E148 Safari/604.1';
+  const iosChrome = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1';
   // See: https://developer.samsung.com/smarttv/develop/guides/fundamentals/retrieving-platform-information.html
   const tizen50 = 'Mozilla/5.0 (SMART-TV; LINUX; Tizen 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/5.0 TV Safari/537.36';
   const tizen55 = 'Mozilla/5.0 (SMART-TV; LINUX; Tizen 5.5) AppleWebKit/537.36 (KHTML, like Gecko) 69.0.3497.106.1/5.5 TV Safari/537.36';
@@ -24,103 +30,179 @@ describe('Platform', () => {
 
   afterEach(() => {
     setUserAgent(originalUserAgent);
+    setUserAgentData(originalUserAgentData);
+    setVendor(originalVendor);
+    setPlatform(originalPlatform);
   });
 
-  it('checks is Tizen 5', () => {
-    setUserAgent(webOs3);
-    expect(shaka.util.Platform.isTizen5()).toBe(false);
-    setUserAgent(tizen50);
-    expect(shaka.util.Platform.isTizen5()).toBe(true);
-    setUserAgent(tizen55);
-    expect(shaka.util.Platform.isTizen5()).toBe(true);
-    setUserAgent(tizen60);
-    expect(shaka.util.Platform.isTizen5()).toBe(false);
-    setUserAgent(tizen65);
-    expect(shaka.util.Platform.isTizen5()).toBe(false);
-    setUserAgent(tizen70);
-    expect(shaka.util.Platform.isTizen5()).toBe(false);
+  describe('Apple', () => {
+    beforeEach(() => {
+      setVendor('Apple Computer, Inc.');
+    });
+
+    it('checks Safari version', () => {
+      setUserAgent(macSafari);
+      expect(shaka.util.Platform.safariVersion()).toBe(18);
+      setUserAgent(ipadSafari);
+      expect(shaka.util.Platform.safariVersion()).toBe(18);
+      setUserAgent(iosChrome);
+      expect(shaka.util.Platform.safariVersion()).toBe(10);
+      setUserAgent(webOs6);
+      expect(shaka.util.Platform.safariVersion()).toBe(null);
+
+      setVendor('Google Inc.');
+      setUserAgent(macSafari);
+      expect(shaka.util.Platform.safariVersion()).toBe(null);
+      setUserAgent(ipadSafari);
+      expect(shaka.util.Platform.safariVersion()).toBe(null);
+      setUserAgent(iosChrome);
+      expect(shaka.util.Platform.safariVersion()).toBe(null);
+      setUserAgent(webOs6);
+      expect(shaka.util.Platform.safariVersion()).toBe(null);
+    });
+
+    it('checks is iOS', () => {
+      setUserAgent(macSafari);
+      expect(shaka.util.Platform.isIOS()).toBe(false);
+      setUserAgent(ipadSafari);
+      expect(shaka.util.Platform.isIOS()).toBe(true);
+      setUserAgent(iosChrome);
+      expect(shaka.util.Platform.isIOS()).toBe(true);
+      setUserAgent(webOs6);
+      expect(shaka.util.Platform.isIOS()).toBe(false);
+    });
+
+    it('checks is Mac', () => {
+      setUserAgentData({platform: 'macOS'});
+      expect(shaka.util.Platform.isMac()).toBe(true);
+
+      setUserAgentData(null);
+      setPlatform('MacIntel');
+      expect(shaka.util.Platform.isMac()).toBe(true);
+
+      setPlatform('Win32');
+      expect(shaka.util.Platform.isMac()).toBe(false);
+    });
+
+    it('checks is Webkit STB', () => {
+      setUserAgent(ipadSafari);
+      setUserAgentData({platform: 'macOS'});
+      expect(shaka.util.Platform.isWebkitSTB()).toBe(false);
+
+      setUserAgentData(null);
+      setPlatform('MacIntel');
+      expect(shaka.util.Platform.isWebkitSTB()).toBe(false);
+
+      setPlatform('Win32');
+      expect(shaka.util.Platform.isWebkitSTB()).toBe(false);
+
+      setUserAgent(macSafari);
+      expect(shaka.util.Platform.isWebkitSTB()).toBe(true);
+
+      setVendor('Google Inc.');
+      expect(shaka.util.Platform.isWebkitSTB()).toBe(false);
+    });
   });
 
-  it('checks is Tizen 5.0', () => {
-    setUserAgent(webOs3);
-    expect(shaka.util.Platform.isTizen5_0()).toBe(false);
-    setUserAgent(tizen50);
-    expect(shaka.util.Platform.isTizen5_0()).toBe(true);
-    setUserAgent(tizen55);
-    expect(shaka.util.Platform.isTizen5_0()).toBe(false);
-    setUserAgent(tizen60);
-    expect(shaka.util.Platform.isTizen5_0()).toBe(false);
-    setUserAgent(tizen65);
-    expect(shaka.util.Platform.isTizen5_0()).toBe(false);
-    setUserAgent(tizen70);
-    expect(shaka.util.Platform.isTizen5_0()).toBe(false);
+  describe('Samsung', () => {
+    it('checks is Tizen 5', () => {
+      setUserAgent(webOs3);
+      expect(shaka.util.Platform.isTizen5()).toBe(false);
+      setUserAgent(tizen50);
+      expect(shaka.util.Platform.isTizen5()).toBe(true);
+      setUserAgent(tizen55);
+      expect(shaka.util.Platform.isTizen5()).toBe(true);
+      setUserAgent(tizen60);
+      expect(shaka.util.Platform.isTizen5()).toBe(false);
+      setUserAgent(tizen65);
+      expect(shaka.util.Platform.isTizen5()).toBe(false);
+      setUserAgent(tizen70);
+      expect(shaka.util.Platform.isTizen5()).toBe(false);
+    });
+
+    it('checks is Tizen 5.0', () => {
+      setUserAgent(webOs3);
+      expect(shaka.util.Platform.isTizen5_0()).toBe(false);
+      setUserAgent(tizen50);
+      expect(shaka.util.Platform.isTizen5_0()).toBe(true);
+      setUserAgent(tizen55);
+      expect(shaka.util.Platform.isTizen5_0()).toBe(false);
+      setUserAgent(tizen60);
+      expect(shaka.util.Platform.isTizen5_0()).toBe(false);
+      setUserAgent(tizen65);
+      expect(shaka.util.Platform.isTizen5_0()).toBe(false);
+      setUserAgent(tizen70);
+      expect(shaka.util.Platform.isTizen5_0()).toBe(false);
+    });
+
+    it('checks is Tizen 6', () => {
+      setUserAgent(webOs3);
+      expect(shaka.util.Platform.isTizen6()).toBe(false);
+      setUserAgent(tizen50);
+      expect(shaka.util.Platform.isTizen6()).toBe(false);
+      setUserAgent(tizen55);
+      expect(shaka.util.Platform.isTizen6()).toBe(false);
+      setUserAgent(tizen60);
+      expect(shaka.util.Platform.isTizen6()).toBe(true);
+      setUserAgent(tizen65);
+      expect(shaka.util.Platform.isTizen6()).toBe(true);
+      setUserAgent(tizen70);
+      expect(shaka.util.Platform.isTizen6()).toBe(false);
+    });
   });
 
-  it('checks is Tizen 6', () => {
-    setUserAgent(webOs3);
-    expect(shaka.util.Platform.isTizen6()).toBe(false);
-    setUserAgent(tizen50);
-    expect(shaka.util.Platform.isTizen6()).toBe(false);
-    setUserAgent(tizen55);
-    expect(shaka.util.Platform.isTizen6()).toBe(false);
-    setUserAgent(tizen60);
-    expect(shaka.util.Platform.isTizen6()).toBe(true);
-    setUserAgent(tizen65);
-    expect(shaka.util.Platform.isTizen6()).toBe(true);
-    setUserAgent(tizen70);
-    expect(shaka.util.Platform.isTizen6()).toBe(false);
-  });
+  describe('LG', () => {
+    it('checks is webOS 3', () => {
+      setUserAgent(tizen50);
+      expect(shaka.util.Platform.isWebOS3()).toBe(false);
+      setUserAgent(webOs3);
+      expect(shaka.util.Platform.isWebOS3()).toBe(true);
+      setUserAgent(webOs4);
+      expect(shaka.util.Platform.isWebOS3()).toBe(false);
+      setUserAgent(webOs5);
+      expect(shaka.util.Platform.isWebOS3()).toBe(false);
+      setUserAgent(webOs6);
+      expect(shaka.util.Platform.isWebOS3()).toBe(false);
+    });
 
-  it('checks is webOS 3', () => {
-    setUserAgent(tizen50);
-    expect(shaka.util.Platform.isWebOS3()).toBe(false);
-    setUserAgent(webOs3);
-    expect(shaka.util.Platform.isWebOS3()).toBe(true);
-    setUserAgent(webOs4);
-    expect(shaka.util.Platform.isWebOS3()).toBe(false);
-    setUserAgent(webOs5);
-    expect(shaka.util.Platform.isWebOS3()).toBe(false);
-    setUserAgent(webOs6);
-    expect(shaka.util.Platform.isWebOS3()).toBe(false);
-  });
+    it('checks is webOS 4', () => {
+      setUserAgent(tizen50);
+      expect(shaka.util.Platform.isWebOS4()).toBe(false);
+      setUserAgent(webOs3);
+      expect(shaka.util.Platform.isWebOS4()).toBe(false);
+      setUserAgent(webOs4);
+      expect(shaka.util.Platform.isWebOS4()).toBe(true);
+      setUserAgent(webOs5);
+      expect(shaka.util.Platform.isWebOS4()).toBe(false);
+      setUserAgent(webOs6);
+      expect(shaka.util.Platform.isWebOS4()).toBe(false);
+    });
 
-  it('checks is webOS 4', () => {
-    setUserAgent(tizen50);
-    expect(shaka.util.Platform.isWebOS4()).toBe(false);
-    setUserAgent(webOs3);
-    expect(shaka.util.Platform.isWebOS4()).toBe(false);
-    setUserAgent(webOs4);
-    expect(shaka.util.Platform.isWebOS4()).toBe(true);
-    setUserAgent(webOs5);
-    expect(shaka.util.Platform.isWebOS4()).toBe(false);
-    setUserAgent(webOs6);
-    expect(shaka.util.Platform.isWebOS4()).toBe(false);
-  });
+    it('checks is webOS 5', () => {
+      setUserAgent(tizen50);
+      expect(shaka.util.Platform.isWebOS5()).toBe(false);
+      setUserAgent(webOs3);
+      expect(shaka.util.Platform.isWebOS5()).toBe(false);
+      setUserAgent(webOs4);
+      expect(shaka.util.Platform.isWebOS5()).toBe(false);
+      setUserAgent(webOs5);
+      expect(shaka.util.Platform.isWebOS5()).toBe(true);
+      setUserAgent(webOs6);
+      expect(shaka.util.Platform.isWebOS5()).toBe(false);
+    });
 
-  it('checks is webOS 5', () => {
-    setUserAgent(tizen50);
-    expect(shaka.util.Platform.isWebOS5()).toBe(false);
-    setUserAgent(webOs3);
-    expect(shaka.util.Platform.isWebOS5()).toBe(false);
-    setUserAgent(webOs4);
-    expect(shaka.util.Platform.isWebOS5()).toBe(false);
-    setUserAgent(webOs5);
-    expect(shaka.util.Platform.isWebOS5()).toBe(true);
-    setUserAgent(webOs6);
-    expect(shaka.util.Platform.isWebOS5()).toBe(false);
-  });
-
-  it('checks is webOS 6', () => {
-    setUserAgent(tizen50);
-    expect(shaka.util.Platform.isWebOS6()).toBe(false);
-    setUserAgent(webOs3);
-    expect(shaka.util.Platform.isWebOS6()).toBe(false);
-    setUserAgent(webOs4);
-    expect(shaka.util.Platform.isWebOS6()).toBe(false);
-    setUserAgent(webOs5);
-    expect(shaka.util.Platform.isWebOS6()).toBe(false);
-    setUserAgent(webOs6);
-    expect(shaka.util.Platform.isWebOS6()).toBe(true);
+    it('checks is webOS 6', () => {
+      setUserAgent(tizen50);
+      expect(shaka.util.Platform.isWebOS6()).toBe(false);
+      setUserAgent(webOs3);
+      expect(shaka.util.Platform.isWebOS6()).toBe(false);
+      setUserAgent(webOs4);
+      expect(shaka.util.Platform.isWebOS6()).toBe(false);
+      setUserAgent(webOs5);
+      expect(shaka.util.Platform.isWebOS6()).toBe(false);
+      setUserAgent(webOs6);
+      expect(shaka.util.Platform.isWebOS6()).toBe(true);
+    });
   });
 
   describe('isMediaKeysPolyfilled', () => {
@@ -146,10 +228,28 @@ describe('Platform', () => {
       expect(result).toBe(false);
     });
   });
-});
 
-/** @param {string} userAgent */
-function setUserAgent(userAgent) {
-  Object.defineProperty(
-      navigator, 'userAgent', {value: userAgent, configurable: true});
-}
+  /** @param {string} userAgent */
+  function setUserAgent(userAgent) {
+    Object.defineProperty(
+        navigator, 'userAgent', {value: userAgent, configurable: true});
+  }
+
+  /** @param {?Object} userAgentData */
+  function setUserAgentData(userAgentData) {
+    Object.defineProperty(
+        navigator, 'userAgentData', {value: userAgentData, configurable: true});
+  }
+
+  /** @param {string} vendor */
+  function setVendor(vendor) {
+    Object.defineProperty(
+        navigator, 'vendor', {value: vendor, configurable: true});
+  }
+
+  /** @param {string} platform */
+  function setPlatform(platform) {
+    Object.defineProperty(
+        navigator, 'platform', {value: platform, configurable: true});
+  }
+});


### PR DESCRIPTION
Our Apple device detection misdetects any Webkit-based STB as Apple, due to looking only at vendor property. To mitigate it, we were excluding another user agents, but maintenance of this is problematic.
This PR tries to change direction - an Apple device right now is a device with Apple vendor AND with characteristics of MacOS or iOS.
