### PR TITLE
fix: audio label when selecting variants by label

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5791,7 +5791,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         spatialAudio: false,
         videoLayout: '',
         videoLabel: '',
-        audioLabel: label || '',
+        audioLabel: label,
         codecSwitchingStrategy:
             this.config_.mediaSource.codecSwitchingStrategy,
         audioCodec: '',

--- a/lib/player.js
+++ b/lib/player.js
@@ -5790,9 +5790,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         hdrLevel: '',
         spatialAudio: false,
         videoLayout: '',
-        label,
         videoLabel: '',
-        audioLabel: '',
+        audioLabel: label || '',
         codecSwitchingStrategy:
             this.config_.mediaSource.codecSwitchingStrategy,
         audioCodec: '',


### PR DESCRIPTION
This was introduced with version 4.13.0
This is a simple oversight on arguments of the function `this.currentAdaptationSetCriteria_.configure(...)` and made sure this was following the doc here https://shaka-player-demo.appspot.com/docs/api/shaka.media.AdaptationSetCriteria.html#.Configuration

Fixes https://github.com/shaka-project/shaka-player/issues/8037