### PR TITLE
fix: Throw preload destroyed error when re-using same preloadManager

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -1625,6 +1625,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     let preloadManager = null;
     let assetUri = '';
     if (assetUriOrPreloader instanceof shaka.media.PreloadManager) {
+      if (assetUriOrPreloader.isDestroyed()) {
+        throw new shaka.util.Error(
+            shaka.util.Error.Severity.CRITICAL,
+            shaka.util.Error.Category.PLAYER,
+            shaka.util.Error.Code.PRELOAD_DESTROYED);
+      }
       preloadManager = assetUriOrPreloader;
       assetUri = preloadManager.getAssetUri() || '';
     } else {

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -983,6 +983,12 @@ shaka.util.Error.Code = {
   'SRC_EQUALS_PRELOAD_NOT_SUPPORTED': 7005,
 
   /**
+   * The operation failed because the preload has been destroyed. This can
+   * happen by reusing the same preload in multiple load calls.
+   */
+  'PRELOAD_DESTROYED': 7006,
+
+  /**
    * The Cast API is unavailable.  This may be because of one of the following:
    *  1. The browser may not have Cast support
    *  2. The browser may be missing a necessary Cast extension


### PR DESCRIPTION
Related to https://github.com/shaka-project/shaka-player/issues/8042