### PR TITLE
feat: Do not make corrective seeks when setLiveSeekableRange is used

### DIFF
--- a/lib/media/playhead.js
+++ b/lib/media/playhead.js
@@ -10,6 +10,7 @@ goog.provide('shaka.media.SrcEqualsPlayhead');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
+goog.require('shaka.media.Capabilities');
 goog.require('shaka.media.GapJumpingController');
 goog.require('shaka.media.TimeRangesUtils');
 goog.require('shaka.media.VideoWrapper');
@@ -410,7 +411,14 @@ shaka.media.MediaSourcePlayhead = class {
     const targetTime = this.reposition_(currentTime);
 
     const gapLimit = shaka.media.GapJumpingController.BROWSER_GAP_TOLERANCE;
-    if (Math.abs(targetTime - currentTime) > gapLimit) {
+
+    // We don't need to perform corrective seeks for the playhead range when
+    // MediaSource's setLiveSeekableRange() can handle it for us.
+    const mightNeedCorrectiveSeek =
+        !shaka.media.Capabilities.isInfiniteLiveStreamDurationSupported();
+
+    if (mightNeedCorrectiveSeek &&
+        Math.abs(targetTime - currentTime) > gapLimit) {
       let canCorrectiveSeek = false;
       if (shaka.util.Platform.isSeekingSlow()) {
         // You can only seek like this every so often. This is to prevent an


### PR DESCRIPTION
MediaSource's setLiveSeekableRange overrides seeks outside the seekable range automatically without any additional corrective seeking.  When this API is active, we should not make additional corrective seeks in Playhead.