### PR TITLE
fix(DASH): Fix playback of ClearKey when only part of keys are defined

### DIFF
--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -1774,6 +1774,7 @@ shaka.util.PeriodCombiner = class {
       v.roles,
       v.closedCaptions ? Array.from(v.closedCaptions.entries()) : null,
       v.bandwidth,
+      Array.from(v.keyIds),
     ]);
   }
 
@@ -1796,6 +1797,7 @@ shaka.util.PeriodCombiner = class {
       a.roles,
       a.audioSamplingRate,
       a.primary,
+      Array.from(a.keyIds),
     ]);
   }
 

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -836,7 +836,7 @@ shaka.util.PeriodCombiner = class {
     clone.roles = clone.roles.slice();
     clone.segmentIndex = null;
     clone.emsgSchemeIdUris = [];
-    clone.keyIds = new Set();
+    clone.keyIds = new Set(stream.keyIds);
     clone.closedCaptions = stream.closedCaptions ?
       new Map(stream.closedCaptions) : null;
     clone.trickModeVideo = null;
@@ -860,7 +860,7 @@ shaka.util.PeriodCombiner = class {
     clone.roles = clone.roles.slice();
     // These are wiped out now and rebuilt later from the various per-period
     // streams that match this output.
-    clone.keyIds = new Set();
+    clone.keyIds = new Set(streamDb.keyIds);
     clone.segments = [];
     clone.variantIds = [];
     clone.closedCaptions = streamDb.closedCaptions ?


### PR DESCRIPTION
Fixes #8052
Key ids were not used when looking for stream duplicates, so it was possible to filter out streams without accompanying configuration. Now we will use key ids as well for duplicates detection.