### PR TITLE
chore: Add @suppress {constantProperty} to shaka externs.

### DIFF
--- a/build/generateExterns.js
+++ b/build/generateExterns.js
@@ -860,7 +860,7 @@ function main(args) {
       '/**\n' +
       ' * @fileoverview Generated externs.  DO NOT EDIT!\n' +
       ' * @externs\n' +
-      ' * @suppress {duplicate} To prevent compiler errors with the\n' +
+      ' * @suppress {constantProperty, duplicate} To prevent compiler errors with the\n' +
       ' *   namespace being declared both here and by goog.provide in the\n' +
       ' *   library.\n' +
       ' */\n\n' +


### PR DESCRIPTION
Add `@suppress {constantProperty}` to generated shaka externs to fix build errors in external projects.