### PR TITLE
chore: Add @suppress {constantProperty} to shaka externs. (#8062)

### DIFF
--- a/build/generateExterns.js
+++ b/build/generateExterns.js
@@ -860,9 +860,9 @@ function main(args) {
       '/**\n' +
       ' * @fileoverview Generated externs.  DO NOT EDIT!\n' +
       ' * @externs\n' +
-      ' * @suppress {constantProperty, duplicate} To prevent compiler errors with the\n' +
-      ' *   namespace being declared both here and by goog.provide in the\n' +
-      ' *   library.\n' +
+      ' * @suppress {constantProperty, duplicate} To prevent compiler\n' +
+      ' *   errors with the namespace being declared both here and by\n' +
+      ' *   goog.provide in the library.\n' +
       ' */\n\n' +
       namespaceDeclarations.join('') + '\n' + externs);
 }

--- a/build/generateExterns.js
+++ b/build/generateExterns.js
@@ -860,7 +860,7 @@ function main(args) {
       '/**\n' +
       ' * @fileoverview Generated externs.  DO NOT EDIT!\n' +
       ' * @externs\n' +
-      ' * @suppress {duplicate} To prevent compiler errors with the\n' +
+      ' * @suppress {constantProperty, duplicate} To prevent compiler errors with the\n' +
       ' *   namespace being declared both here and by goog.provide in the\n' +
       ' *   library.\n' +
       ' */\n\n' +


### PR DESCRIPTION
Add `@suppress {constantProperty}` to shaka externs.

Cherry-picked from v4.13.x, where the original PR was sent by mistake.