### PR TITLE
fix(tXml): Allow case insensitive in parseDuration

### DIFF
--- a/lib/util/tXml.js
+++ b/lib/util/tXml.js
@@ -631,7 +631,7 @@ shaka.util.TXml = class {
 
     const re = '^P(?:([0-9]*)Y)?(?:([0-9]*)M)?(?:([0-9]*)D)?' +
         '(?:T(?:([0-9]*)H)?(?:([0-9]*)M)?(?:([0-9.]*)S)?)?$';
-    const matches = new RegExp(re).exec(durationString);
+    const matches = new RegExp(re, 'i').exec(durationString);
 
     if (!matches) {
       shaka.log.warning('Invalid duration string:', durationString);

--- a/test/util/tXml_unit.js
+++ b/test/util/tXml_unit.js
@@ -284,6 +284,12 @@ describe('tXml', () => {
     expect(TXml.parseDuration('P1Y1M1DT1H2M3S')).toBeGreaterThan(
         (60 * 60 * 24 * 365) + (60 * 60 * 24 * 28) + 90123 - 1);
 
+    // Supports case insensitive
+    expect(TXml.parseDuration('p1y1m1dt1h2m3s')).toBeLessThan(
+        (60 * 60 * 24 * 366) + (60 * 60 * 24 * 31) + 90123 + 1);
+    expect(TXml.parseDuration('p1y1m1dt1h2m3s')).toBeGreaterThan(
+        (60 * 60 * 24 * 365) + (60 * 60 * 24 * 28) + 90123 - 1);
+
     expect(TXml.parseDuration('PT')).toBe(0);
     expect(TXml.parseDuration('P')).toBe(0);
 


### PR DESCRIPTION
This is not in the spec, but it is used to make some malformed content work. Dash.js already does this by default.