### PR TITLE
fix(Ads): Reset playRangeEnd value between interstitials

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -1508,6 +1508,7 @@ shaka.ads.InterstitialAdManager = class {
     this.player_.configure(this.basePlayer_.getNonDefaultConfiguration());
     this.player_.configure('ads.disableHLSInterstitial', true);
     this.player_.configure('ads.disableDASHInterstitial', true);
+    this.player_.configure('playRangeEnd', Infinity);
     const netEngine = this.player_.getNetworkingEngine();
     goog.asserts.assert(netEngine, 'Need networking engine');
     this.basePlayer_.getNetworkingEngine().copyFiltersInto(netEngine);


### PR DESCRIPTION
This is necessary because you can have two interstitials in a row where the first one uses playRangeEnd but the second one doesn't. Without this fix the second one would have the same playRangeEnd as the first one, but this is wrong.