### PR TITLE
fix(UI): Fix thumbnail sometimes not disappearing due to mouse hover

### DIFF
--- a/ui/less/thumbnails.less
+++ b/ui/less/thumbnails.less
@@ -8,6 +8,7 @@
   visibility: hidden;
   width: 15%;
   z-index: 1;
+  pointer-events: none;
 
   #shaka-player-ui-thumbnail-image {
     position: absolute;


### PR DESCRIPTION
The thumbnail sometimes stuck (would not disappear) when mouse cursor hovers over it (not over seek bar)

Steps to reproduce:
- Get local demo running (python build/all.py --debug?)
- Find a video with thumbnail to play

Bug reproduction

https://github.com/user-attachments/assets/d0212307-7d12-41e0-af22-c111f019cae8


Reported in https://github.com/FreeTubeApp/FreeTube/issues/5965
Fix from https://github.com/FreeTubeApp/FreeTube/pull/6812