### PR TITLE
fix: Remove isSafari and always use isApple

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -409,16 +409,6 @@ shaka.util.Platform = class {
   }
 
   /**
-   * Check if the current platform is Apple Safari, or Webkit-based STBs,
-   * or Safari-based iOS browsers.
-   *
-   * @return {boolean}
-   */
-  static isSafari() {
-    return !!shaka.util.Platform.safariVersion();
-  }
-
-  /**
    * Guesses if the platform is an Apple mobile one (iOS, iPad, iPod).
    * @return {boolean}
    */

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1047,7 +1047,7 @@ shaka.util.StreamUtils = class {
     // major browsers.
     // See https://bugs.chromium.org/p/chromium/issues/detail?id=1422728
     if (codecs.toLowerCase() == 'flac') {
-      if (!shaka.util.Platform.isSafari()) {
+      if (!shaka.util.Platform.isApple()) {
         return 'flac';
       } else {
         return 'fLaC';
@@ -1056,7 +1056,7 @@ shaka.util.StreamUtils = class {
 
     // The same is true for 'Opus'.
     if (codecs.toLowerCase() === 'opus') {
-      if (!shaka.util.Platform.isSafari()) {
+      if (!shaka.util.Platform.isApple()) {
         return 'opus';
       } else {
         if (shaka.util.MimeUtils.getContainerType(mimeType) == 'mp4') {

--- a/ui/remote_button.js
+++ b/ui/remote_button.js
@@ -34,7 +34,7 @@ shaka.ui.RemoteButton = class extends shaka.ui.Element {
     super(parent, controls);
 
     /** @private {boolean} */
-    this.isAirPlay_ = shaka.util.Platform.isSafari();
+    this.isAirPlay_ = shaka.util.Platform.isApple();
 
     /** @private {!HTMLButtonElement} */
     this.remoteButton_ = shaka.util.Dom.createButton();
@@ -145,7 +145,7 @@ shaka.ui.RemoteButton = class extends shaka.ui.Element {
         if (this.player) {
           const disableRemote = this.video.disableRemotePlayback;
           let canCast = true;
-          if (shaka.util.Platform.isSafari()) {
+          if (shaka.util.Platform.isApple()) {
             const loadMode = this.player.getLoadMode();
             const mseMode = loadMode == shaka.Player.LoadMode.MEDIA_SOURCE;
             if (mseMode && this.player.getManifestType() != 'HLS') {


### PR DESCRIPTION
This replacement is safe to do and also reduces the number of internal operations to obtain the result.
