### PR TITLE
test: Fix crash of Firefox on Windows

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -1912,7 +1912,17 @@ shaka.drm.DrmEngine = class {
     const processMediaKeySystemAccess = async (keySystem, access) => {
       let mediaKeys;
       try {
-        mediaKeys = await access.createMediaKeys();
+        // Workaround: Our automated test lab runs Windows browsers under a
+        // headless service.  In this environment, Firefox's ClearKey CDM seems
+        // to crash when we create the CDM here.
+        if (goog.DEBUG &&  // not a production build
+            shaka.util.Platform.isWindows() &&  // on Windows
+            shaka.util.Platform.isFirefox()) {  // with Firefox
+          // Do nothing, to avoid a crash in the FF ClearKey CDM.
+        } else {
+          // Otherwise, create the CDM.
+          mediaKeys = await access.createMediaKeys();
+        }
       } catch (error) {
         // In some cases, we can get a successful access object but fail to
         // create a MediaKeys instance.  When this happens, don't update the


### PR DESCRIPTION
Our automated test lab runs Windows browsers under a headless service.  In this environment, Firefox's ClearKey CDM seems to crash when we create the CDM in probeSupport().

To avoid this, we check for a debug or uncompiled build running in Firefox on Windows, and if this combination is found, we skip createMediaKeys() in probeSupport().

Because the check uses the compile-time constant goog.DEBUG, we avoid any penalty in a production build.