### PR TITLE
perf: Remove promises from getAllThumbnails loop

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5203,8 +5203,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   /**
    * Return a Thumbnail object from a image stream and time.
    *
-   * If the player has not loaded content, this will return a null.
-   *
    * @param {shaka.extern.Stream} imageStream
    * @param {number} time
    * @return {?shaka.extern.Thumbnail}

--- a/lib/player.js
+++ b/lib/player.js
@@ -5121,7 +5121,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!imageStream.segmentIndex) {
       await imageStream.createSegmentIndex();
     }
-    const promises = [];
+    const thumbnails = [];
     imageStream.segmentIndex.forEachTopLevelReference((reference) => {
       const dimensions = this.parseTilesLayout_(
           reference.getTilesLayout() || imageStream.tilesLayout);
@@ -5130,12 +5130,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         const duration = reference.trueEndTime - reference.startTime;
         for (let i = 0; i < numThumbnails; i++) {
           const sampleTime = reference.startTime + duration * i / numThumbnails;
-          promises.push(this.getThumbnails(trackId, sampleTime));
+          const thumbnail =
+              this.getThumbnailsByStream_(
+              /** @type {shaka.extern.Stream} */ (imageStream), sampleTime);
+          if (thumbnail) {
+            thumbnails.push(thumbnail);
+          }
         }
       }
     });
-    const thumbnails = await Promise.all(promises);
-    return thumbnails.filter((t) => t);
+    return thumbnails;
   }
 
   /**
@@ -5192,6 +5196,21 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!imageStream.segmentIndex) {
       await imageStream.createSegmentIndex();
     }
+
+    return this.getThumbnailsByStream_(imageStream, time);
+  }
+
+  /**
+   * Return a Thumbnail object from a image stream and time.
+   *
+   * If the player has not loaded content, this will return a null.
+   *
+   * @param {shaka.extern.Stream} imageStream
+   * @param {number} time
+   * @return {?shaka.extern.Thumbnail}
+   * @private
+   */
+  getThumbnailsByStream_(imageStream, time) {
     const referencePosition = imageStream.segmentIndex.find(time);
     if (referencePosition == null) {
       return null;


### PR DESCRIPTION
`getAllThumbnails` creates an array of promises when grabbing each thumbnail. This is because `getThumbnails` might have to create a segment index, but `getAllThumbnails` already does this. This separates `getThumbnails` into two functions so `getAllThumbnails` can get the thumbnails synchronously.