### PR TITLE
ci: Only run Safari native layout tests in lab

### DIFF
--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -309,6 +309,12 @@ jobs:
             extra_flags+=(--html-coverage-report --uncompiled)
           fi
 
+          # In the lab, and only in the lab, we trust Safari to run these
+          # native text layout tests.
+          if [[ "${{ matrix.browser }}" == "Safari" ]]; then
+            extra_flags+=(--trust-safari-native-text-layout)
+          fi
+
           if [[ "${{ inputs.test_filter }}" != "" ]]; then
             echo "Adding filter: ${{ inputs.test_filter }}"
             extra_flags+=(--filter "${{ inputs.test_filter }}")

--- a/build/test.py
+++ b/build/test.py
@@ -206,6 +206,11 @@ class Launcher:
         dest='drm',
         action='store_false')
     running_commands.add_argument(
+        '--trust-safari-native-text-layout',
+        help='Trust layout tests for native text display on Safari. ',
+             'Rendering may be inconsistent across devices.',
+        action='store_true')
+    running_commands.add_argument(
         '--quarantined',
         help='Run tests that have been quarantined.',
         action='store_true')
@@ -405,6 +410,7 @@ class Launcher:
       'test_timeout',
       'tls_key',
       'tls_cert',
+      'trust_safari_native_text_layout',
       'uncompiled',
     ]
 

--- a/build/test.py
+++ b/build/test.py
@@ -207,7 +207,7 @@ class Launcher:
         action='store_false')
     running_commands.add_argument(
         '--trust-safari-native-text-layout',
-        help='Trust layout tests for native text display on Safari. ',
+        help='Trust layout tests for native text display on Safari. '
              'Rendering may be inconsistent across devices.',
         action='store_true')
     running_commands.add_argument(

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -365,6 +365,11 @@ module.exports = (config) => {
 
         // Overrides the default test timeout value.
         testTimeout: settings.test_timeout,
+
+        // Without this flag, we don't trust Safari to run native layout tests.
+        // Rendering on these is super inconsistent from device to device, so
+        // this flag is used in our lab environment explicitly.
+        trustSafariNativeTextLayout: settings.trust_safari_native_text_layout,
       }],
     },
 

--- a/test/test/util/layout_tests.js
+++ b/test/test/util/layout_tests.js
@@ -175,16 +175,16 @@ shaka.test.TextLayoutTests = class extends shaka.test.LayoutTests {
 
   /** @override */
   static async supported() {
-    const baseSupported = await super.supported();
-    if (!baseSupported) {
+    // We only trust Safari for native text layout tests if explicitly flagged.
+    // We only do this in our lab, where we control device a11y settings that
+    // impact these tests heavily.
+    if (shaka.util.Platform.safariVersion() &&
+        !getClientArg('trustSafariNativeTextLayout')) {
       return false;
     }
 
-    // Due to a Safari implementation bug, the browser only does the correct
-    // thing for a timing edge case on Safari 16+.  Skip the tests on earlier
-    // versions.
-    const safariVersion = shaka.util.Platform.safariVersion();
-    if (safariVersion && safariVersion < 16) {
+    const baseSupported = await super.supported();
+    if (!baseSupported) {
       return false;
     }
 


### PR DESCRIPTION
Native text layout in Safari renders differently on different devices, OS versions, and with different OS a11y settings.  Because this is so inconsistent across devices, we now have a flag to explicity enable native text layout tests on Safari.  This flag will be used in our lab only.  Our lab tests on Safari will be the source of canonical results for Safari layout tests.