### PR TITLE
test: Reject all FF+Windows ClearKey testing

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -1918,7 +1918,8 @@ shaka.drm.DrmEngine = class {
         if (goog.DEBUG &&  // not a production build
             shaka.util.Platform.isWindows() &&  // on Windows
             shaka.util.Platform.isFirefox()) {  // with Firefox
-          // Do nothing, to avoid a crash in the FF ClearKey CDM.
+          // Reject this, since it crashes our tests.
+          throw new Error('Suppressing Firefox Windows ClearKey in testing!');
         } else {
           // Otherwise, create the CDM.
           mediaKeys = await access.createMediaKeys();


### PR DESCRIPTION
My previous change, #8109, didn't go far enough.  In a full test run, some ClearKey tests still crash Firefox in the lab.  By removing it from the support dictionary used to gate DRM tests, we ensure all ClearKey tests are skipped.