### PR TITLE
ci: Prevent leaked credentials

### DIFF
--- a/.github/workflows/custom-actions/prep-for-appspot/action.yaml
+++ b/.github/workflows/custom-actions/prep-for-appspot/action.yaml
@@ -54,3 +54,4 @@ runs:
       run: |
         mv app-engine/shaka-player-demo/* .
         rm README.md
+        mv app-engine/gcloudignore .gcloudignore

--- a/.github/workflows/demo-version-index.yaml
+++ b/.github/workflows/demo-version-index.yaml
@@ -36,7 +36,9 @@ jobs:
           credentials_json: '${{ secrets.APPENGINE_DEPLOY_KEY }}'
 
       - name: Generate static content
-        run: python3 app-engine/demo-version-index/generate.py
+        run: |
+          python3 app-engine/demo-version-index/generate.py
+          cp app-engine/gcloudignore app-engine/demo-version-index/.gcloudignore
 
       - uses: google-github-actions/deploy-appengine@v2
         with:
@@ -44,4 +46,3 @@ jobs:
           version: index
           working_directory: app-engine/demo-version-index/
           promote: false
-

--- a/app-engine/gcloudignore
+++ b/app-engine/gcloudignore
@@ -1,0 +1,7 @@
+# Defaults you get without an explicit .gcloudignore file
+.git
+.gitignore
+.gcloudignore
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
Naive use of google-github-actions/auth and google-github-actions/deploy-appengine can lead to leaked credentials.

In particular, uploading static content from the workspace root leads to servable copies of the credentials file written by google-github-actions/auth.  This is exactly what the Shaka Player Demo did.  Making matters worse, google-github-actions/auth logs credential filenames for all to see.

All uploaded credentials were expired before I uploaded this PR.

This fixes the leak by installing a gcloudignore file which prevents the credentials from being uploaded.