### PR TITLE
test: Increase playback time on HLS integration test

### DIFF
--- a/test/hls/hls_parser_integration.js
+++ b/test/hls/hls_parser_integration.js
@@ -138,6 +138,8 @@ describe('HlsParser', () => {
     await player.load('/base/test/test/assets/hls-text-no-discontinuity/index.m3u8');
     await video.play();
 
+    // This test sometimes fails on Tizen with missing cues if we use too
+    // small a delay here.
     await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 3, 30);
 
     const cues = video.textTracks[0].cues;

--- a/test/hls/hls_parser_integration.js
+++ b/test/hls/hls_parser_integration.js
@@ -138,7 +138,7 @@ describe('HlsParser', () => {
     await player.load('/base/test/test/assets/hls-text-no-discontinuity/index.m3u8');
     await video.play();
 
-    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 1, 30);
+    await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 3, 30);
 
     const cues = video.textTracks[0].cues;
     expect(cues.length).toBe(3);


### PR DESCRIPTION
Our logic never waits for subtitles, so we need to increase the playback time to ensure we process the subtitles correctly. This error is only seen on slow devices, for example Tizen.