### PR TITLE
fix: Take into account the live info in DRM engine

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -264,7 +264,7 @@ shaka.drm.DrmEngine = class {
     // persistent licenses.
     this.usePersistentLicenses_ = usePersistentLicenses;
 
-    return this.init_(variants);
+    return this.init_(variants, /* isLive= */ false);
   }
 
   /**
@@ -273,9 +273,10 @@ shaka.drm.DrmEngine = class {
    * @param {!Array<shaka.extern.Variant>} variants
    *    The variants that we want to support playing.
    * @param {!Array<string>} offlineSessionIds
+   * @param {boolean=} isLive
    * @return {!Promise}
    */
-  initForPlayback(variants, offlineSessionIds) {
+  initForPlayback(variants, offlineSessionIds, isLive = true) {
     this.storedPersistentSessions_ = new Map();
 
     for (const sessionId of offlineSessionIds) {
@@ -291,7 +292,7 @@ shaka.drm.DrmEngine = class {
 
     this.usePersistentLicenses_ = this.storedPersistentSessions_.size > 0;
 
-    return this.init_(variants);
+    return this.init_(variants, isLive);
   }
 
   /**
@@ -348,10 +349,11 @@ shaka.drm.DrmEngine = class {
    * @param {!Array<shaka.extern.Variant>} variants
    *    The variants that we expect to operate with during the drm engine's
    *    lifespan of the drm engine.
+   * @param {boolean} isLive
    * @return {!Promise} Resolved if/when a key system has been chosen.
    * @private
    */
-  async init_(variants) {
+  async init_(variants, isLive) {
     goog.asserts.assert(this.config_,
         'DrmEngine configure() must be called before init()!');
 
@@ -374,7 +376,7 @@ shaka.drm.DrmEngine = class {
     //
     // To avoid this, we will set the drm engine up to work with as many key
     // systems as possible so that we will be ready.
-    if (!hadDrmInfo) {
+    if (!hadDrmInfo && isLive) {
       const servers = shaka.util.MapUtils.asMap(this.config_.servers);
       shaka.drm.DrmEngine.replaceDrmInfo_(variants, servers);
     }

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -593,9 +593,16 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
 
     const playableVariants = shaka.util.StreamUtils.getPlayableVariants(
         this.manifest_.variants);
+    let isLive = this.manifest_.presentationTimeline.isLive();
+    // In HLS we need to parse the media playlist to know if it is Live or not.
+    // So at this point we don't know yet. By default we assume it is Live.
+    if (this.manifest_.type == shaka.media.ManifestParser.HLS) {
+      isLive = true;
+    }
     await this.drmEngine_.initForPlayback(
         playableVariants,
-        this.manifest_.offlineSessionIds);
+        this.manifest_.offlineSessionIds,
+        isLive);
     this.throwIfDestroyed_();
     if (media) {
       await this.drmEngine_.attach(media);


### PR DESCRIPTION
This avoids having to initialize DRM in cases where it is not needed.