### PR TITLE
chore: Update maintained branches

### DIFF
--- a/maintained-branches.md
+++ b/maintained-branches.md
@@ -2,9 +2,8 @@
 
 We are currently maintaining the following branches of Shaka Player:
 
- - v4.13 (latest)
+ - v4.13 (latest, in use by the Cast Application Framework)
  - v4.12 (previous)
- - v4.9 (in use by the Cast Application Framework)
  - No active LTS branches at this time
 
 Other branches are no longer receiving bug fixes, and we recommend you upgrade


### PR DESCRIPTION
The next Cast Application Framework release will target Shaka Player v4.13.

This version of CAF isn't out yet, but we will no longer maintain v4.9, which is getting increasingly complex to do.