### PR TITLE
fix: Fit template check template info

### DIFF
--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -910,7 +910,7 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
    * Fit timeline entries to period boundaries
    */
   fitTimeline() {
-    if (this.getIsImmutable()) {
+    if (!this.templateInfo_ || this.getIsImmutable()) {
       return;
     }
     const timeline = this.templateInfo_.timeline;


### PR DESCRIPTION
`TimelineSegmentIndex` `fitTimeline` doesn't check if `templateInfo` is null. This means it errors in this case when it tries to access the `timeline` property. It now exits early if it's null