### PR TITLE
test: Fix crash of Firefox on Windows

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -1919,7 +1919,8 @@ shaka.drm.DrmEngine = class {
         // to crash when we create the CDM here.
         if (goog.DEBUG &&  // not a production build
             shaka.util.Platform.isWindows() &&  // on Windows
-            shaka.util.Platform.isFirefox()) {  // with Firefox
+            shaka.util.Platform.isFirefox() &&  // with Firefox
+            shaka.drm.DrmUtils.isClearKeySystem(keySystem)) {
           // Reject this, since it crashes our tests.
           throw new Error('Suppressing Firefox Windows ClearKey in testing!');
         } else {


### PR DESCRIPTION
Fixes 9aea3587ef4fcf51bc2e1601fc0318dc5c1bd780 as it should only occur with ClearKey