### PR TITLE
chore: Remove older version of Chrome in layout tests

### DIFF
--- a/test/test/util/layout_tests.js
+++ b/test/test/util/layout_tests.js
@@ -178,20 +178,13 @@ shaka.test.TextLayoutTests = class extends shaka.test.LayoutTests {
     // We only trust Safari for native text layout tests if explicitly flagged.
     // We only do this in our lab, where we control device a11y settings that
     // impact these tests heavily.
-    if (shaka.util.Platform.safariVersion() &&
+    if (shaka.util.Platform.isApple() &&
         !getClientArg('trustSafariNativeTextLayout')) {
       return false;
     }
 
     const baseSupported = await super.supported();
     if (!baseSupported) {
-      return false;
-    }
-
-    // Due to updates in the rendering and/or default styles in Chrome, the
-    // screenshots for native rendering only match in Chrome 106+.
-    const chromeVersion = shaka.util.Platform.chromeVersion();
-    if (chromeVersion && chromeVersion < 106) {
       return false;
     }
 


### PR DESCRIPTION
The current version is 133, so it is safe to make this change.