### PR TITLE
fix: Text tracks disappear when crossing a boundary in RESET mode.

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3071,6 +3071,11 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   discardReferenceByBoundary_(mediaState, reference) {
+    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    if (mediaState.type === ContentType.TEXT) {
+      return false;
+    }
+
     const lastInitRef = mediaState.lastInitSegmentReference;
     if (!lastInitRef) {
       return false;


### PR DESCRIPTION
Text track handling is not managed by MSE but by ourselves, thus we do not need to discard text references.

As we do not reset the text engine alongside MSE, text tracks would simply disappear when crossing a boundary and MSE was reset.