### PR TITLE
fix: Closure compiler removes call to modifyCueCallback in src= mode

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5434,7 +5434,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       for (const nativeCue of nativeCues) {
         const cue = shaka.text.Utils.mapNativeCueToShakaCue(nativeCue);
         if (cue) {
-          this.config_.mediaSource.modifyCueCallback(cue, null, time);
+          const modifyCueCallback = this.config_.mediaSource.modifyCueCallback;
+          if (modifyCueCallback) {
+            modifyCueCallback(cue, null, time);
+          }
           allCues.push(cue);
         }
       }

--- a/lib/player.js
+++ b/lib/player.js
@@ -5435,6 +5435,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         const cue = shaka.text.Utils.mapNativeCueToShakaCue(nativeCue);
         if (cue) {
           const modifyCueCallback = this.config_.mediaSource.modifyCueCallback;
+          // Closure compiler removes the call to modifyCueCallback for reasons
+          // unknown to us.
+          // See https://github.com/shaka-project/shaka-player/pull/8261
+          // We'll want to revisit this condition once we migrated to TS.
+          // See https://github.com/shaka-project/shaka-player/issues/8262 for TS.
           if (modifyCueCallback) {
             modifyCueCallback(cue, null, time);
           }


### PR DESCRIPTION
Follow up on https://github.com/shaka-project/shaka-player/pull/8254, which I tested in the demo app (debug build). The debug build contains the call to `modifyCueCallback` both with and without a reference check. The production build however does not:

Production build, without reference check (previous PR):

```js
for (var e = d.next(); !e.done; e = d.next()) {
  e = e.value;
  // ... lots of code ...
  // The call to mediaSource.modifyCueCallback is missing below.
  e && c.push(e)
}
a.B.append(c)
```

Production build, with reference check (in PR):

```js
for (var f = e.next(); !f.done; f = e.next()) {
  f = f.value;
  // ... lots of code ...
  f && ((g = a.g.mediaSource.modifyCueCallback) && g(f, null, c), d.push(f))
}
a.B.append(d)
```

It'd like to understand why Closure Compiler decides to drop the call. As far as I can tell, modifyCueCallback cannot be empty as it's provided with a default function here thus theoretically, checking whether it's present shouldn't be necessary?

https://github.com/shaka-project/shaka-player/blob/b5a261aed91b8da211af1540c0e318f0b2bdf873/lib/util/player_configuration.js#L422-L426

@joeyparrish, can you shed some light?