### PR TITLE
fix: Make shaka.util.Lazy work with null

### DIFF
--- a/lib/util/lazy.js
+++ b/lib/util/lazy.js
@@ -28,11 +28,11 @@ shaka.util.Lazy = class {
 
   /** @return {T} */
   value() {
-    if (this.value_ == undefined) {
+    if (this.value_ === undefined) {
       // Compiler complains about unknown fields without this cast.
       this.value_ = /** @type {*} */ (this.gen_());
       goog.asserts.assert(
-          this.value_ != undefined, 'Unable to create lazy value');
+          this.value_ !== undefined, 'Unable to create lazy value');
     }
     return this.value_;
   }

--- a/test/util/lazy_unit.js
+++ b/test/util/lazy_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2016 Google LLC
+ * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/util/lazy_unit.js
+++ b/test/util/lazy_unit.js
@@ -7,7 +7,7 @@
 describe('Lazy', () => {
   it('returns the same object each time', () => {
     const generator = jasmine.createSpy('generator').and.returnValue({});
-    const lazy = new shaka.util.Lazy(generator);
+    const lazy = new shaka.util.Lazy(shaka.test.Util.spyFunc(generator));
     const value = lazy.value();
     const value2 = lazy.value();
     expect(value).toBe(value2);
@@ -16,7 +16,7 @@ describe('Lazy', () => {
 
   it('works correctly for primitive value', () => {
     const generator = jasmine.createSpy('generator').and.returnValue(7);
-    const lazy = new shaka.util.Lazy(generator);
+    const lazy = new shaka.util.Lazy(shaka.test.Util.spyFunc(generator));
     const value = lazy.value();
     const value2 = lazy.value();
     expect(value).toBe(value2);
@@ -25,7 +25,7 @@ describe('Lazy', () => {
 
   it('works correctly for null', () => {
     const generator = jasmine.createSpy('generator').and.returnValue(null);
-    const lazy = new shaka.util.Lazy(generator);
+    const lazy = new shaka.util.Lazy(shaka.test.Util.spyFunc(generator));
     const value = lazy.value();
     expect(value).toBe(null);
     expect(generator).toHaveBeenCalledTimes(1);

--- a/test/util/lazy_unit.js
+++ b/test/util/lazy_unit.js
@@ -1,0 +1,33 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('Lazy', () => {
+  it('returns the same object each time', () => {
+    const generator = jasmine.createSpy('generator').and.returnValue({});
+    const lazy = new shaka.util.Lazy(generator);
+    const value = lazy.value();
+    const value2 = lazy.value();
+    expect(value).toBe(value2);
+    expect(generator).toHaveBeenCalledTimes(1);
+  });
+
+  it('works correctly for primitive value', () => {
+    const generator = jasmine.createSpy('generator').and.returnValue(7);
+    const lazy = new shaka.util.Lazy(generator);
+    const value = lazy.value();
+    const value2 = lazy.value();
+    expect(value).toBe(value2);
+    expect(generator).toHaveBeenCalledTimes(1);
+  });
+
+  it('works correctly for null', () => {
+    const generator = jasmine.createSpy('generator').and.returnValue(null);
+    const lazy = new shaka.util.Lazy(generator);
+    const value = lazy.value();
+    expect(value).toBe(null);
+    expect(generator).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Due to usage of `==` instead of `===` Lazy utility does not work correctly with null generators, despite of what is stated in documentation.