### PR TITLE
test: Reject all FF+Windows DRM testing in the lab

### DIFF
--- a/build/types/core
+++ b/build/types/core
@@ -11,6 +11,7 @@
 
 +../../lib/debug/asserts.js
 +../../lib/debug/log.js
++../../lib/debug/running_in_lab.js
 
 +../../lib/dependencies/all.js
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -371,6 +371,9 @@ module.exports = (config) => {
         // Rendering on these is super inconsistent from device to device, so
         // this flag is used in our lab environment explicitly.
         trustSafariNativeTextLayout: settings.trust_safari_native_text_layout,
+
+        // True if the test.py --grid_config option was used.
+        runningInLab: !!settings.grid_config,
       }],
     },
 

--- a/lib/debug/running_in_lab.js
+++ b/lib/debug/running_in_lab.js
@@ -1,0 +1,10 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.provide('shaka.debug.RunningInLab');
+
+/** @type {boolean} */
+shaka.debug.RunningInLab = false;

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -7,6 +7,7 @@
 goog.provide('shaka.drm.DrmEngine');
 
 goog.require('goog.asserts');
+goog.require('shaka.debug.RunningInLab');
 goog.require('shaka.log');
 goog.require('shaka.drm.DrmUtils');
 goog.require('shaka.net.NetworkingEngine');
@@ -1915,14 +1916,14 @@ shaka.drm.DrmEngine = class {
       let mediaKeys;
       try {
         // Workaround: Our automated test lab runs Windows browsers under a
-        // headless service.  In this environment, Firefox's ClearKey CDM seems
-        // to crash when we create the CDM here.
+        // headless service.  In this environment, Firefox's CDMs seem to crash
+        // when we create the CDM here.
         if (goog.DEBUG &&  // not a production build
             shaka.util.Platform.isWindows() &&  // on Windows
             shaka.util.Platform.isFirefox() &&  // with Firefox
-            shaka.drm.DrmUtils.isClearKeySystem(keySystem)) {
+            shaka.debug.RunningInLab) {  // in our headless lab
           // Reject this, since it crashes our tests.
-          throw new Error('Suppressing Firefox Windows ClearKey in testing!');
+          throw new Error('Suppressing Firefox Windows DRM in testing!');
         } else {
           // Otherwise, create the CDM.
           mediaKeys = await access.createMediaKeys();

--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -174,6 +174,15 @@ function workAroundLegacyEdgePromiseIssues() {
 }
 
 /**
+ * Work around lab crashes by flagging if we're running in the lab.  This lets
+ * us add lab-specific workarounds for our unique lab environment.  This won't
+ * affect local test runs on developer machines or GitHub Actions workflows.
+ */
+function workAroundLabCrashes() {
+  shaka.debug.RunningInLab = getClientArg('runningInLab');
+}
+
+/**
  * Returns a Jasmine callback which shims the real callback and checks for
  * a certain condition.  The test will only be run if the condition is true.
  *
@@ -459,6 +468,7 @@ async function setupTestEnvironment() {
   failTestsOnUnhandledErrors();
   disableScrollbars();
   workAroundLegacyEdgePromiseIssues();
+  workAroundLabCrashes();
 
   // The spec filter callback occurs before calls to beforeAll, so we need to
   // install polyfills here to ensure that browser support is correctly


### PR DESCRIPTION
Firefox 136 running on Windows in our lab seems to crash when accessing the CDM.  This happens in our background Windows service, but not in the foreground when run as a regular user.  We don't really understand the nature of it, so we have to disable this in lab tests.

This reverts commit eda85d66078f1756baa3b48c8f99b9588904f089 (#8173), but then goes a bit further:

 - Add a flag to we know if we're running in the lab
 - Narrow the workaround to lab test runs, not local runs or GitHub Actions VM workflows