### PR TITLE
fix: Update region observer with new rules for small regions

### DIFF
--- a/lib/media/region_observer.js
+++ b/lib/media/region_observer.js
@@ -96,19 +96,16 @@ shaka.media.RegionObserver = class extends shaka.util.FakeEventTarget {
       {
         weWere: BEFORE_THE_REGION,
         weAre: AFTER_THE_REGION,
-        wasSeeking: false,
         invoke: (region, seeking) => {
-          // This is the case of regions whose duration is smaller than the
-          // resolution of our polling.
-          this.onEvent_('enter', region, seeking);
-          this.onEvent_('exit', region, seeking);
+          if (seeking) {
+            this.onEvent_('skip', region, seeking);
+          } else {
+            // This is the case of regions whose duration is smaller than the
+            // resolution of our polling.
+            this.onEvent_('enter', region, seeking);
+            this.onEvent_('exit', region, seeking);
+          }
         },
-      },
-      {
-        weWere: BEFORE_THE_REGION,
-        weAre: AFTER_THE_REGION,
-        wasSeeking: true,
-        invoke: (region, seeking) => this.onEvent_('skip', region, seeking),
       },
       {
         weWere: AFTER_THE_REGION,
@@ -162,17 +159,8 @@ shaka.media.RegionObserver = class extends shaka.util.FakeEventTarget {
       this.oldPosition_.set(region, currentPosition);
 
       for (const rule of this.rules_) {
-        if ('wasSeeking' in rule) {
-          if (rule.weWere == previousPosition &&
-              rule.weAre == currentPosition &&
-              rule.wasSeeking == wasSeeking) {
-            rule.invoke(region, wasSeeking);
-          }
-        } else {
-          if (rule.weWere == previousPosition &&
-              rule.weAre == currentPosition) {
-            rule.invoke(region, wasSeeking);
-          }
+        if (rule.weWere == previousPosition && rule.weAre == currentPosition) {
+          rule.invoke(region, wasSeeking);
         }
       }
     }
@@ -248,7 +236,6 @@ shaka.media.RegionObserver.EventListener;
  * @typedef {{
  *    weWere: ?shaka.media.RegionObserver.RelativePosition_,
  *    weAre: ?shaka.media.RegionObserver.RelativePosition_,
- *    wasSeeking: ?boolean,
  *    invoke: shaka.media.RegionObserver.EventListener
  * }}
  *

--- a/lib/media/region_observer.js
+++ b/lib/media/region_observer.js
@@ -96,6 +96,18 @@ shaka.media.RegionObserver = class extends shaka.util.FakeEventTarget {
       {
         weWere: BEFORE_THE_REGION,
         weAre: AFTER_THE_REGION,
+        wasSeeking: false,
+        invoke: (region, seeking) => {
+          // This is the case of regions whose duration is smaller than the
+          // resolution of our polling.
+          this.onEvent_('enter', region, seeking);
+          this.onEvent_('exit', region, seeking);
+        },
+      },
+      {
+        weWere: BEFORE_THE_REGION,
+        weAre: AFTER_THE_REGION,
+        wasSeeking: true,
         invoke: (region, seeking) => this.onEvent_('skip', region, seeking),
       },
       {
@@ -150,8 +162,17 @@ shaka.media.RegionObserver = class extends shaka.util.FakeEventTarget {
       this.oldPosition_.set(region, currentPosition);
 
       for (const rule of this.rules_) {
-        if (rule.weWere == previousPosition && rule.weAre == currentPosition) {
-          rule.invoke(region, wasSeeking);
+        if ('wasSeeking' in rule) {
+          if (rule.weWere == previousPosition &&
+              rule.weAre == currentPosition &&
+              rule.wasSeeking == wasSeeking) {
+            rule.invoke(region, wasSeeking);
+          }
+        } else {
+          if (rule.weWere == previousPosition &&
+              rule.weAre == currentPosition) {
+            rule.invoke(region, wasSeeking);
+          }
         }
       }
     }
@@ -227,6 +248,7 @@ shaka.media.RegionObserver.EventListener;
  * @typedef {{
  *    weWere: ?shaka.media.RegionObserver.RelativePosition_,
  *    weAre: ?shaka.media.RegionObserver.RelativePosition_,
+ *    wasSeeking: ?boolean,
  *    invoke: shaka.media.RegionObserver.EventListener
  * }}
  *

--- a/test/media/region_observer_unit.js
+++ b/test/media/region_observer_unit.js
@@ -113,25 +113,29 @@ describe('RegionObserver', () => {
     expect(onExitRegion).toHaveBeenCalledOnceMoreWith([region, false]);
   });
 
-  it('fires skip event when we enter and leave region in one move', () => {
-    const region = createRegion('my-region', 5, 10);
-    timeline.addRegion(region);
+  it('fires start and end events when we enter and leave region in one move',
+      () => {
+        const region = createRegion('my-region', 5, 10);
+        timeline.addRegion(region);
 
-    // Make sure we are before the region starts.
-    poll(observer,
-        /* timeInSeconds= */ 4,
-        /* seeking= */ false);
-    expect(onSkipRegion).not.toHaveBeenCalled();
+        // Make sure we are before the region starts.
+        poll(observer,
+            /* timeInSeconds= */ 4,
+            /* seeking= */ false);
+        expect(onEnterRegion).not.toHaveBeenCalled();
+        expect(onExitRegion).not.toHaveBeenCalled();
+        expect(onSkipRegion).not.toHaveBeenCalled();
 
-    // Make sure we call |onSkip| when we move so far that we skip over the
-    // region.
-    poll(observer,
-        /* timeInSeconds= */ 15,
-        /* seeking= */ false);
-    expect(onSkipRegion).toHaveBeenCalledOnceMoreWith([region, false]);
-  });
+        // Make sure we call |onEnter| and |onExit|
+        poll(observer,
+            /* timeInSeconds= */ 15,
+            /* seeking= */ false);
+        expect(onEnterRegion).toHaveBeenCalledOnceMoreWith([region, false]);
+        expect(onExitRegion).toHaveBeenCalledOnceMoreWith([region, false]);
+        expect(onSkipRegion).not.toHaveBeenCalled();
+      });
 
-  it('fires skip events for zero-duration regions', () => {
+  it('fires start and end events for zero-duration regions', () => {
     // Make a region with no duration.
     const region = createRegion('my-region', 5, 5);
     timeline.addRegion(region);
@@ -140,14 +144,17 @@ describe('RegionObserver', () => {
     poll(observer,
         /* timeInSeconds= */ 4,
         /* seeking= */ false);
+    expect(onEnterRegion).not.toHaveBeenCalled();
+    expect(onExitRegion).not.toHaveBeenCalled();
     expect(onSkipRegion).not.toHaveBeenCalled();
 
-    // Make sure we call |onSkip| when we move so far that we skip over the
-    // region.
+    // Make sure we call |onEnter| and |onExit|
     poll(observer,
         /* timeInSeconds= */ 10,
         /* seeking= */ false);
-    expect(onSkipRegion).toHaveBeenCalledOnceMoreWith([region, false]);
+    expect(onEnterRegion).toHaveBeenCalledOnceMoreWith([region, false]);
+    expect(onExitRegion).toHaveBeenCalledOnceMoreWith([region, false]);
+    expect(onSkipRegion).not.toHaveBeenCalled();
   });
 
   // We want to simulate a "normal" case of overlapping regions. For this we


### PR DESCRIPTION
This is necessary because some EMSG and ID3 events might not fire because the endTime is equal to or very close to the startTime. 

Related to https://github.com/shaka-project/shaka-player/pull/8012