### PR TITLE
fix: Fix audio selection by channel count

### DIFF
--- a/lib/media/preference_based_criteria.js
+++ b/lib/media/preference_based_criteria.js
@@ -240,11 +240,27 @@ shaka.media.PreferenceBasedCriteria = class {
    */
   static filterVariantsByAudioChannelCount_(variants, channelCount) {
     return variants.filter((variant) => {
+      // Filter variants with channel count less than or equal to desired value.
       if (variant.audio && variant.audio.channelsCount &&
-          variant.audio.channelsCount != channelCount) {
+          variant.audio.channelsCount > channelCount) {
         return false;
       }
       return true;
+    }).sort((v1, v2) => {
+      // We need to sort variants list by channels count, so the most close one
+      // to desired value will be first on the list. It's important for the call
+      // to shaka.media.AdaptationSet, which will base set of variants based on
+      // first variant.
+      if (!v1.audio && !v2.audio) {
+        return 0;
+      }
+      if (!v1.audio) {
+        return -1;
+      }
+      if (!v2.audio) {
+        return 1;
+      }
+      return (v2.audio.channelsCount || 0) - (v1.audio.channelsCount || 0);
     });
   }
 

--- a/test/media/adaptation_set_criteria_unit.js
+++ b/test/media/adaptation_set_criteria_unit.js
@@ -706,13 +706,18 @@ describe('AdaptationSetCriteria', () => {
           });
         });
         manifest.addVariant(2, (variant) => {
+          variant.addAudio(30, (stream) => {
+            stream.channelsCount = 4;
+          });
+        });
+        manifest.addVariant(3, (variant) => {
           variant.addAudio(20, (stream) => {
             stream.channelsCount = 8;
           });
         });
-        manifest.addVariant(3, (variant) => {
+        manifest.addVariant(4, (variant) => {
           variant.addAudio(30, (stream) => {
-            stream.channelsCount = 2;
+            stream.channelsCount = 4;
           });
         });
       });
@@ -733,8 +738,8 @@ describe('AdaptationSetCriteria', () => {
       const set = builder.create(manifest.variants);
 
       checkSet(set, [
-        manifest.variants[0],
-        manifest.variants[2],
+        manifest.variants[1],
+        manifest.variants[3],
       ]);
     });
 


### PR DESCRIPTION
One of unit tests indicated that when we have channel count preference, but don't have direct match, we should select variants with largest channel count less than config. Test was falsy positive, as we don't have logic to satisfy that scenario.