### PR TITLE
perf: AdaptationSetCriteria improvements

### DIFF
--- a/lib/media/preference_based_criteria.js
+++ b/lib/media/preference_based_criteria.js
@@ -38,17 +38,22 @@ shaka.media.PreferenceBasedCriteria = class {
   create(variants) {
     const Class = shaka.media.PreferenceBasedCriteria;
 
-    let current = [];
+    let current;
 
-    const byLanguage = Class.filterByLanguage_(variants, this.config_.language);
-    const byPrimary = variants.filter((variant) => variant.primary);
-
-    if (byLanguage.length) {
-      current = byLanguage;
-    } else if (byPrimary.length) {
-      current = byPrimary;
-    } else {
-      current = variants;
+    if (this.config_.language) {
+      const byLanguage = Class.filterByLanguage_(
+          variants, this.config_.language);
+      if (byLanguage.length) {
+        current = byLanguage;
+      }
+    }
+    if (!current) {
+      const byPrimary = variants.filter((variant) => variant.primary);
+      if (byPrimary.length) {
+        current = byPrimary;
+      } else {
+        current = variants;
+      }
     }
 
     // Now refine the choice based on role preference.  Even the empty string


### PR DESCRIPTION
1. Don't do selection by language if it's empty.
2. Only filter by primary if we don't have match by language.