### PR TITLE
test: Added platform unit tests for Chromecast devices

### DIFF
--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -31,9 +31,9 @@ describe('Platform', () => {
   // cspell: disable-next-line
   const vizio = 'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36 CrKey/1.0.999999 VIZIO SmartCast(Conjure/MTKF-5.1.516.1 FW/0.6.11.1-2 Model/V50C6-J09)';
   // cspell: disable-next-line
-  const chromecastBuiltinOrOlder = 'Mozilla/5.0 (X11; Linuz armv71) AppleWbKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000';
+  const chromecastBuiltinOrOlder = 'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000 DeviceType/Chromecast';
   // cspell: disable-next-line
-  const chromecastFuchsia = 'Mozilla/5.0 (Fuchsia) AppleWbKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000';
+  const chromecastFuchsia = 'Mozilla/5.0 (Fuchsia) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 CrKey/1.56.500000';
   // cspell: disable-next-line
   const chromecastAndroid = 'Mozilla/5.0 (Linux; Android 12; Build/STTL.240206.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.0 Safari/537.36 CrKey/1.56.500000 DeviceType/AndroidTV';
   /* eslint-enable @stylistic/max-len */

--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -30,8 +30,11 @@ describe('Platform', () => {
 
   // cspell: disable-next-line
   const vizio = 'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36 CrKey/1.0.999999 VIZIO SmartCast(Conjure/MTKF-5.1.516.1 FW/0.6.11.1-2 Model/V50C6-J09)';
+  // cspell: disable-next-line
   const chromecastBuiltinOrOlder = 'Mozilla/5.0 (X11; Linuz armv71) AppleWbKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000';
+  // cspell: disable-next-line
   const chromecastFuchsia = 'Mozilla/5.0 (Fuchsia) AppleWbKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000';
+  // cspell: disable-next-line
   const chromecastAndroid = 'Mozilla/5.0 (Linux; Android 12; Build/STTL.240206.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.0 Safari/537.36 CrKey/1.56.500000 DeviceType/AndroidTV';
   /* eslint-enable @stylistic/max-len */
 

--- a/test/util/platform_unit.js
+++ b/test/util/platform_unit.js
@@ -30,6 +30,9 @@ describe('Platform', () => {
 
   // cspell: disable-next-line
   const vizio = 'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36 CrKey/1.0.999999 VIZIO SmartCast(Conjure/MTKF-5.1.516.1 FW/0.6.11.1-2 Model/V50C6-J09)';
+  const chromecastBuiltinOrOlder = 'Mozilla/5.0 (X11; Linuz armv71) AppleWbKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000';
+  const chromecastFuchsia = 'Mozilla/5.0 (Fuchsia) AppleWbKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000';
+  const chromecastAndroid = 'Mozilla/5.0 (Linux; Android 12; Build/STTL.240206.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.0 Safari/537.36 CrKey/1.56.500000 DeviceType/AndroidTV';
   /* eslint-enable @stylistic/max-len */
 
   afterEach(() => {
@@ -217,6 +220,33 @@ describe('Platform', () => {
     setUserAgent(vizio);
     expect(shaka.util.Platform.isVizio()).toBe(true);
     expect(shaka.util.Platform.isChromecast()).toBe(false);
+  });
+
+  it('checks is Chromecast Fuchsia', () => {
+    setUserAgent(chromecastFuchsia);
+    setUserAgentData(null);
+    expect(shaka.util.Platform.isVizio()).toBe(false);
+    expect(shaka.util.Platform.isChromecast()).toBe(true);
+    expect(shaka.util.Platform.isAndroidCastDevice()).toBe(false);
+    expect(shaka.util.Platform.isFuchsia()).toBe(true);
+  });
+
+  it('checks is Chromecast Android', () => {
+    setUserAgent(chromecastAndroid);
+    setUserAgentData(null);
+    expect(shaka.util.Platform.isVizio()).toBe(false);
+    expect(shaka.util.Platform.isChromecast()).toBe(true);
+    expect(shaka.util.Platform.isAndroidCastDevice()).toBe(true);
+    expect(shaka.util.Platform.isFuchsia()).toBe(false);
+  });
+
+  it('checks is Chromecast', () => {
+    setUserAgent(chromecastBuiltinOrOlder);
+    setUserAgentData(null);
+    expect(shaka.util.Platform.isVizio()).toBe(false);
+    expect(shaka.util.Platform.isChromecast()).toBe(true);
+    expect(shaka.util.Platform.isAndroidCastDevice()).toBe(false);
+    expect(shaka.util.Platform.isFuchsia()).toBe(false);
   });
 
   /** @param {string} userAgent */


### PR DESCRIPTION
Added platform-detection unit tests for three flavors of Chromecast:
- Android-based
- Fuchsia-based
- Older Chromecasts (including Vizio builtins)

Closes https://github.com/shaka-project/shaka-player/issues/8308