### PR TITLE
fix: Prevent unhandled rejections on segment fetch failures

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1554,7 +1554,10 @@ shaka.media.StreamingEngine = class {
     if (mediaState.segmentPrefetch && mediaState.segmentIterator &&
         !this.audioPrefetchMap_.has(mediaState.stream)) {
       mediaState.segmentPrefetch.evict(reference.startTime);
-      mediaState.segmentPrefetch.prefetchSegmentsByTime(reference.startTime);
+      mediaState.segmentPrefetch.prefetchSegmentsByTime(reference.startTime)
+          // We're treating this call as sync here, so ignore async errors
+          // to not propagate them further.
+          .catch(() => {});
     }
 
     const p = this.fetchAndAppend_(mediaState, presentationTime, reference,


### PR DESCRIPTION
When fetch of segments is aborted or cannot succeed due to fetch promise rejection, we may end up with unhandled promise rejections.