### PR TITLE
feat: Provide Segment Reference to ABR Manager (via the request context)

### DIFF
--- a/externs/shaka/abr_manager.js
+++ b/externs/shaka/abr_manager.js
@@ -93,9 +93,11 @@ shaka.extern.AbrManager = class {
    *     to another stream.
    * @param {shaka.extern.Request=} request
    *     A reference to the request
+   * @param {shaka.extern.RequestContext=} context
+   *     A reference to the request context
    * @exportDoc
    */
-  segmentDownloaded(deltaTimeMs, numBytes, allowSwitch, request) {}
+  segmentDownloaded(deltaTimeMs, numBytes, allowSwitch, request, context) {}
 
   /**
    * Notifies the ABR that it is a time to suggest new streams. This is used by

--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -248,7 +248,7 @@ shaka.extern.HeadersReceived;
  * @property {shaka.net.NetworkingEngine.AdvancedRequestType=} type
  *   The advanced type
  * @property {shaka.extern.Stream=} stream
- *   The duration of the segment in seconds
+ *   A reference to the Stream object
  * @property {shaka.media.SegmentReference=} segment
  *   The request's segment reference
  * @property {boolean=} isPreload

--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -334,10 +334,12 @@ shaka.abr.SimpleAbrManager = class {
    *     to another stream.
    * @param {shaka.extern.Request=} request
    *     A reference to the request
+   * @param {shaka.extern.RequestContext=} context
+   *     A reference to the request context
    * @override
    * @export
    */
-  segmentDownloaded(deltaTimeMs, numBytes, allowSwitch, request) {
+  segmentDownloaded(deltaTimeMs, numBytes, allowSwitch, request, context) {
     if (deltaTimeMs < this.config_.cacheLoadThreshold) {
       // The time indicates that it could be a cache response, so we should
       // ignore this value.

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -368,7 +368,8 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
           type == shaka.net.NetworkingEngine.RequestType.SEGMENT) {
         const allowSwitch = this.allowSwitch_(context);
         this.onProgressUpdated_(
-            response.timeMs, response.data.byteLength, allowSwitch);
+            response.timeMs, response.data.byteLength, allowSwitch, request,
+            context);
       }
       if (this.onResponse_) {
         this.onResponse_(type, response, context);
@@ -574,7 +575,7 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
           packetNumber++;
           request.packetNumber = packetNumber;
           const allowSwitch = this.allowSwitch_(context);
-          this.onProgressUpdated_(time, bytes, allowSwitch, request);
+          this.onProgressUpdated_(time, bytes, allowSwitch, request, context);
           gotProgress = true;
           numBytesRemainingObj.setBytes(numBytesRemaining);
         }
@@ -998,7 +999,8 @@ shaka.net.NetworkingEngine.OnHeadersReceived;
  *    number,
  *    number,
  *    boolean,
- *    shaka.extern.Request=)}
+ *    shaka.extern.Request=,
+ *    shaka.extern.RequestContext=)}
  *
  * @description
  * A callback that is passed the duration, in milliseconds,

--- a/lib/player.js
+++ b/lib/player.js
@@ -3651,14 +3651,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     };
     /** @type {shaka.net.NetworkingEngine.onProgressUpdated} */
     const onProgressUpdated_ = (deltaTimeMs,
-        bytesDownloaded, allowSwitch, request) => {
+        bytesDownloaded, allowSwitch, request, context) => {
       // In some situations, such as during offline storage, the abr manager
       // might not yet exist. Therefore, we need to check if abr manager has
       // been initialized before using it.
       const abrManager = getAbrManager();
       if (abrManager) {
         abrManager.segmentDownloaded(deltaTimeMs, bytesDownloaded,
-            allowSwitch, request);
+            allowSwitch, request, context);
       }
     };
     /** @type {shaka.net.NetworkingEngine.OnHeadersReceived} */

--- a/test/net/networking_engine_unit.js
+++ b/test/net/networking_engine_unit.js
@@ -1211,19 +1211,25 @@ describe('NetworkingEngine', /** @suppress {accessControls} */ () => {
         return new shaka.util.AbortableOperation(p, () => {});
       });
 
+      /** @const {shaka.extern.RequestContext} */
+      const ctx = {type: shaka.net.NetworkingEngine.AdvancedRequestType.MPD};
+
       /** @const {shaka.net.NetworkingEngine.PendingRequest} */
       const resp = networkingEngine.request(
-          requestType, createRequest('resolve://'));
+          requestType, createRequest('resolve://'), ctx);
       await Util.shortDelay();  // Allow Promises to resolve.
       expect(onProgress).toHaveBeenCalledTimes(2);
-      expect(onProgress).toHaveBeenCalledWith(1, 2, true, requestLikeObject);
-      expect(onProgress).toHaveBeenCalledWith(4, 5, true, requestLikeObject);
+      expect(onProgress).toHaveBeenCalledWith(1, 2, true, requestLikeObject,
+          ctx);
+      expect(onProgress).toHaveBeenCalledWith(4, 5, true, requestLikeObject,
+          ctx);
       onProgress.calls.reset();
 
       delay.resolve();
       await resp.promise;
       expect(onProgress).toHaveBeenCalledTimes(1);
-      expect(onProgress).toHaveBeenCalledWith(7, 8, true, requestLikeObject);
+      expect(onProgress).toHaveBeenCalledWith(7, 8, true, requestLikeObject,
+          ctx);
     });
 
     it('appends request packet number', async () => {
@@ -1240,16 +1246,19 @@ describe('NetworkingEngine', /** @suppress {accessControls} */ () => {
         return new shaka.util.AbortableOperation(p, () => {});
       });
 
+      /** @const {shaka.extern.RequestContext} */
+      const ctx = {type: shaka.net.NetworkingEngine.AdvancedRequestType.MPD};
+
       /** @const {shaka.net.NetworkingEngine.PendingRequest} */
       const resp = networkingEngine.request(
-          requestType, createRequest('resolve://'));
+          requestType, createRequest('resolve://'), ctx);
       await Util.shortDelay();  // Allow Promises to resolve.
       expect(onProgress).toHaveBeenCalledWith(1, 2, true,
-          jasmine.objectContaining({packetNumber: 1}));
+          jasmine.objectContaining({packetNumber: 1}), ctx);
       delay.resolve();
       await resp.promise;
       expect(onProgress).toHaveBeenCalledWith(4, 5, true,
-          jasmine.objectContaining({packetNumber: 2}));
+          jasmine.objectContaining({packetNumber: 2}), ctx);
     });
 
     it('doesn\'t forward progress events for non-SEGMENT', async () => {


### PR DESCRIPTION
Provides the Segment Reference to the ABR Manager via the request context. This allows the ABR manager to get information about the specific segment being downloaded such as the start and end time (used to calculate segment duration).