### PR TITLE
perf(HLS): Reduce load time when loading in the player a media playlist

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1147,6 +1147,7 @@ shaka.hls.HlsParser = class {
       const initResponse = await this.makeNetworkRequest_(
           initSegmentRequest, requestType, {type: initType}).promise;
       initData = initResponse.data;
+      initSegmentRef.setSegmentData(initData);
       if (initSegmentRef.aesKey) {
         initData = await shaka.media.SegmentUtils.aesDecrypt(
             initData, initSegmentRef.aesKey, 0);
@@ -1166,6 +1167,7 @@ shaka.hls.HlsParser = class {
     const response = await this.makeNetworkRequest_(
         segmentRequest, requestType, {type}).promise;
     let data = response.data;
+    segment.setSegmentData(data, /* singleUse= */ true);
     if (segment.aesKey) {
       data = await shaka.media.SegmentUtils.aesDecrypt(
           data, segment.aesKey, segmentIndex);

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1147,11 +1147,11 @@ shaka.hls.HlsParser = class {
       const initResponse = await this.makeNetworkRequest_(
           initSegmentRequest, requestType, {type: initType}).promise;
       initData = initResponse.data;
-      initSegmentRef.setSegmentData(initData);
       if (initSegmentRef.aesKey) {
         initData = await shaka.media.SegmentUtils.aesDecrypt(
             initData, initSegmentRef.aesKey, 0);
       }
+      initSegmentRef.setSegmentData(initData);
 
       initMimeType = initResponse.headers['content-type'];
       if (initMimeType) {
@@ -1167,11 +1167,11 @@ shaka.hls.HlsParser = class {
     const response = await this.makeNetworkRequest_(
         segmentRequest, requestType, {type}).promise;
     let data = response.data;
-    segment.setSegmentData(data, /* singleUse= */ true);
     if (segment.aesKey) {
       data = await shaka.media.SegmentUtils.aesDecrypt(
           data, segment.aesKey, segmentIndex);
     }
+    segment.setSegmentData(data, /* singleUse= */ true);
 
     let contentMimeType = response.headers['content-type'];
     if (contentMimeType) {

--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -114,7 +114,7 @@ shaka.media.SegmentPrefetch = class {
           shaka.media.SegmentReference.Status.MISSING) {
         prefetchAllowed = false;
       }
-      if (reference.getSegmentData()) {
+      if (reference.getSegmentData(/* allowDeleteOnSingleUse= */ false)) {
         prefetchAllowed = false;
       }
       if (prefetchAllowed && reference.initSegmentReference) {

--- a/lib/media/segment_reference.js
+++ b/lib/media/segment_reference.js
@@ -118,6 +118,15 @@ shaka.media.InitSegmentReference = class {
   }
 
   /**
+   * Set the segment data.
+   *
+   * @param {!BufferSource} segmentData
+   */
+  setSegmentData(segmentData) {
+    this.segmentData = segmentData;
+  }
+
+  /**
    * Return the segment data.
    *
    * @return {?BufferSource}
@@ -333,6 +342,9 @@ shaka.media.SegmentReference = class {
 
     /** @type {BufferSource|null} */
     this.segmentData = null;
+
+    /** @type {boolean} */
+    this.removeSegmentDataOnGet_ = false;
   }
 
   /**
@@ -616,20 +628,27 @@ shaka.media.SegmentReference = class {
    * Set the segment data.
    *
    * @param {!BufferSource} segmentData
+   * @param {boolean=} singleUse
    * @export
    */
-  setSegmentData(segmentData) {
+  setSegmentData(segmentData, singleUse = false) {
     this.segmentData = segmentData;
+    this.removeSegmentDataOnGet_ = singleUse;
   }
 
   /**
    * Return the segment data.
    *
+   * @param {boolean=} allowDeleteOnSingleUse
    * @return {?BufferSource}
    * @export
    */
-  getSegmentData() {
-    return this.segmentData;
+  getSegmentData(allowDeleteOnSingleUse = true) {
+    const ret = this.segmentData;
+    if (allowDeleteOnSingleUse && this.removeSegmentDataOnGet_) {
+      this.segmentData = null;
+    }
+    return ret;
   }
 
   /**

--- a/lib/media/segment_reference.js
+++ b/lib/media/segment_reference.js
@@ -344,7 +344,7 @@ shaka.media.SegmentReference = class {
     this.segmentData = null;
 
     /** @type {boolean} */
-    this.removeSegmentDataOnGet_ = false;
+    this.removeSegmentDataOnGet = false;
   }
 
   /**
@@ -633,7 +633,7 @@ shaka.media.SegmentReference = class {
    */
   setSegmentData(segmentData, singleUse = false) {
     this.segmentData = segmentData;
-    this.removeSegmentDataOnGet_ = singleUse;
+    this.removeSegmentDataOnGet = singleUse;
   }
 
   /**
@@ -645,7 +645,7 @@ shaka.media.SegmentReference = class {
    */
   getSegmentData(allowDeleteOnSingleUse = true) {
     const ret = this.segmentData;
-    if (allowDeleteOnSingleUse && this.removeSegmentDataOnGet_) {
+    if (allowDeleteOnSingleUse && this.removeSegmentDataOnGet) {
       this.segmentData = null;
     }
     return ret;

--- a/lib/offline/download_info.js
+++ b/lib/offline/download_info.js
@@ -48,7 +48,7 @@ shaka.offline.DownloadInfo = class {
    * @return {string}
    */
   static idForSegmentRef(ref) {
-    const segmentData = ref.getSegmentData();
+    const segmentData = ref.getSegmentData(/* allowDeleteOnSingleUse= */ false);
     if (segmentData) {
       return shaka.util.Uint8ArrayUtils.toBase64(segmentData);
     }

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -561,7 +561,8 @@ shaka.offline.Storage = class {
 
         const ref = /** @type {!shaka.media.SegmentReference} */ (
           download.ref);
-        const segmentData = ref.getSegmentData();
+        const segmentData =
+            ref.getSegmentData(/* allowDeleteOnSingleUse= */ false);
         if (segmentData) {
           downloader.queueData(download.groupId,
               segmentData, estimateId, isInitSegment, onDownloaded);

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -3176,7 +3176,7 @@ describe('HlsParser', () => {
       const master = [
         '#EXTM3U\n',
         '#EXT-X-STREAM-INF:BANDWIDTH=200,CODECS="avc1.4d401f,vtt",',
-        'RESOLUTION=960x540,FRAME-RATE=60\n',
+        'RESOLUTION=960x540,FRAME-RATE=60,CLOSED-CAPTIONS=NONE\n',
         'video\n',
       ].join('');
 

--- a/test/test/util/manifest_parser_util.js
+++ b/test/test/util/manifest_parser_util.js
@@ -102,6 +102,8 @@ shaka.test.ManifestParser = class {
     ref.bandwidth = /** @type {?} */(new shaka.test.AnyOrNull(Number));
     ref.codecs = /** @type {?} */(jasmine.any(String));
     ref.mimeType = /** @type {?} */(jasmine.any(String));
+    ref.segmentData = /** @type {?} */(new shaka.test.AnythingOrNull());
+    ref.removeSegmentDataOnGet = /** @type {?} */(jasmine.any(Boolean));
     return ref;
   }
 };

--- a/test/test/util/util.js
+++ b/test/test/util/util.js
@@ -58,6 +58,35 @@ shaka.test.AnyOrNull = class {
   }
 };
 
+shaka.test.AnythingOrNull = class {
+  constructor() {
+    /** @type {!Object} */
+    this.anything = jasmine.anything();
+  }
+
+  /**
+   * @param {?Object} other
+   * @return {boolean}
+   * @suppress {checkTypes}
+   */
+  asymmetricMatch(other) {
+    if (other == null) {
+      return true;
+    } else {
+      return this.anything.asymmetricMatch(other);
+    }
+  }
+
+  /**
+   * @return {boolean}
+   * @suppress {checkTypes}
+   */
+  jasmineToString() {
+    return this.anything.jasmineToString()
+        .replace('jasmine.anything', 'shaka.test.AnythingOrNull');
+  }
+};
+
 shaka.test.Util = class {
   /**
    * Fakes an event loop. Each tick processes some number of instantaneous


### PR DESCRIPTION
This allows temporary caching of init segment and data segment used to obtain the data (eg: codec) needed for playback.