### PR TITLE
Revert queryData to prevent url params percent encoding

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -468,7 +468,7 @@ shaka.hls.HlsParser = class {
     const manifestUris = [];
     for (const uri of streamInfo.getUris()) {
       const uriObj = new goog.Uri(uri);
-      const queryData = uriObj.getQueryData();
+      const queryData = new goog.Uri.QueryData();
       if (streamInfo.canBlockReload) {
         if (streamInfo.nextMediaSequence >= 0) {
           // Indicates that the server must hold the request until a Playlist


### PR DESCRIPTION
For a manifest that uses symbols like '=', '/', in the url params these symbols were being percent encoded which caused the url requests to fail with 403. So revert the queryData definition to prevent the percent encoding of the url params.