### PR TITLE
fix: Improve boundary gap mitigation at DASH period transitions

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -2333,7 +2333,7 @@ shaka.media.MediaSourceEngine = class {
 
       this.destroyer_.ensureNotDestroyed();
 
-      this.eventManager_.listenOnce(this.video_, 'canplaythrough', () => {
+      this.eventManager_.listenOnce(this.video_, 'canplay', () => {
         // Don't use ensureNotDestroyed() from this event listener, because
         // that results in an uncaught exception.  Instead, just check the
         // flag.

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -2333,7 +2333,7 @@ shaka.media.MediaSourceEngine = class {
 
       this.destroyer_.ensureNotDestroyed();
 
-      this.eventManager_.listenOnce(this.video_, 'canplay', () => {
+      this.eventManager_.listenOnce(this.video_, 'canplaythrough', () => {
         // Don't use ensureNotDestroyed() from this event listener, because
         // that results in an uncaught exception.  Instead, just check the
         // flag.

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -145,6 +145,9 @@ shaka.media.MediaSourceEngine = class {
     /** @private {boolean} */
     this.reloadingMediaSource_ = false;
 
+    /** @private {boolean} */
+    this.playAfterReset_ = false;
+
     /** @type {!shaka.util.Destroyer} */
     this.destroyer_ = new shaka.util.Destroyer(() => this.doDestroy_());
 
@@ -2254,7 +2257,9 @@ shaka.media.MediaSourceEngine = class {
     // Playing can also end up in a paused state after a codec switch
     // so we need to remember the current states.
     const previousAutoPlayState = this.video_.autoplay;
-    const previousPausedState = this.video_.paused;
+    if (!this.video_.paused) {
+      this.playAfterReset_ = true;
+    }
     if (this.playbackHasBegun_) {
       // Only set autoplay to false if the video playback has already begun.
       // When a codec switch happens before playback has begun this can cause
@@ -2337,7 +2342,8 @@ shaka.media.MediaSourceEngine = class {
         }
 
         this.video_.autoplay = previousAutoPlayState;
-        if (!previousPausedState) {
+        if (this.playAfterReset_) {
+          this.playAfterReset_ = false;
           this.video_.play();
         }
       });

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -875,6 +875,7 @@ shaka.media.StreamingEngine = class {
       return this.playerInterface_.mediaSourceEngine.isBuffered(
           type, presentationTime);
     };
+
     let streamCleared = false;
     for (const type of this.mediaStates_.keys()) {
       const mediaState = this.mediaStates_.get(type);
@@ -1508,7 +1509,6 @@ shaka.media.StreamingEngine = class {
       // a SegmentReference eventually.
       return updateIntervalSeconds;
     }
-
     // Get media state adaptation and reset this value. By guarding it during
     // actual stream change we ensure it won't be cleaned by accident on regular
     // append.

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3130,14 +3130,9 @@ shaka.media.StreamingEngine = class {
           'from=', mediaState.lastInitSegmentReference,
           'to=', reference.initSegmentReference);
 
-      const video = this.playerInterface_.video;
-      const pausedBeforeReset = video.paused;
       this.resetMediaSource(/* force= */ true).then(() => {
         const eventName = shaka.util.FakeEvent.EventName.BoundaryCrossed;
         this.playerInterface_.onEvent(new shaka.util.FakeEvent(eventName));
-        if (!pausedBeforeReset) {
-          video.play();
-        }
       });
     }
     return discard;

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3130,9 +3130,14 @@ shaka.media.StreamingEngine = class {
           'from=', mediaState.lastInitSegmentReference,
           'to=', reference.initSegmentReference);
 
+      const video = this.playerInterface_.video;
+      const pausedBeforeReset = video.paused;
       this.resetMediaSource(/* force= */ true).then(() => {
         const eventName = shaka.util.FakeEvent.EventName.BoundaryCrossed;
         this.playerInterface_.onEvent(new shaka.util.FakeEvent(eventName));
+        if (!pausedBeforeReset) {
+          video.play();
+        }
       });
     }
     return discard;

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3052,7 +3052,7 @@ shaka.media.StreamingEngine = class {
     const mediaState = this.mediaStates_.get(ContentType.VIDEO) ||
       this.mediaStates_.get(ContentType.AUDIO);
 
-    if (!mediaState || mediaState.clearingBuffer) {
+    if (!mediaState) {
       return;
     }
 

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -864,13 +864,17 @@ shaka.media.StreamingEngine = class {
       return;
     }
 
+    const CrossBoundaryStrategy = shaka.config.CrossBoundaryStrategy;
+    if (this.config_.crossBoundaryStrategy !== CrossBoundaryStrategy.KEEP) {
+      this.forwardTimeForCrossBoundary();
+    }
+
     const presentationTime = this.playerInterface_.getPresentationTime();
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
     const newTimeIsBuffered = (type) => {
       return this.playerInterface_.mediaSourceEngine.isBuffered(
           type, presentationTime);
     };
-
     let streamCleared = false;
     for (const type of this.mediaStates_.keys()) {
       const mediaState = this.mediaStates_.get(type);
@@ -1504,6 +1508,7 @@ shaka.media.StreamingEngine = class {
       // a SegmentReference eventually.
       return updateIntervalSeconds;
     }
+
     // Get media state adaptation and reset this value. By guarding it during
     // actual stream change we ensure it won't be cleaned by accident on regular
     // append.
@@ -3114,9 +3119,14 @@ shaka.media.StreamingEngine = class {
           'from=', mediaState.lastInitSegmentReference,
           'to=', reference.initSegmentReference);
 
+      const video = this.playerInterface_.video;
+      const pausedBeforeReset = video.paused;
       this.resetMediaSource(/* force= */ true).then(() => {
         const eventName = shaka.util.FakeEvent.EventName.BoundaryCrossed;
         this.playerInterface_.onEvent(new shaka.util.FakeEvent(eventName));
+        if (!pausedBeforeReset) {
+          video.play();
+        }
       });
     }
     return discard;
@@ -3332,3 +3342,15 @@ shaka.media.StreamingEngine.MAX_RUN_AHEAD_SEGMENTS_ = 1;
  * @private
  */
 shaka.media.StreamingEngine.CROSS_BOUNDARY_END_THRESHOLD_ = 1;
+
+
+/**
+ * The threshold to decide if we're going to force playhead to the boundary
+ * end after a seek. When MSE stalls due to misalignment at a boundary end,
+ * and the time is within this threshold from the boundary end,
+ * we'll assume the boundary shall be crossed.
+ *
+ * @const {number}
+ * @private
+ */
+shaka.media.StreamingEngine.CROSS_BOUNDARY_SEEK_THRESHOLD_ = 0.1;

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -864,11 +864,6 @@ shaka.media.StreamingEngine = class {
       return;
     }
 
-    const CrossBoundaryStrategy = shaka.config.CrossBoundaryStrategy;
-    if (this.config_.crossBoundaryStrategy !== CrossBoundaryStrategy.KEEP) {
-      this.forwardTimeForCrossBoundary();
-    }
-
     const presentationTime = this.playerInterface_.getPresentationTime();
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
     const newTimeIsBuffered = (type) => {
@@ -920,6 +915,13 @@ shaka.media.StreamingEngine = class {
         // that they will need to be at a new position (for sequence mode).
         mediaState.seeked = true;
       }
+    }
+
+    const CrossBoundaryStrategy = shaka.config.CrossBoundaryStrategy;
+    if (this.config_.crossBoundaryStrategy !== CrossBoundaryStrategy.KEEP) {
+      // We might have seeked near a boundary, forward time in case MSE does not
+      // recover due to segment misalignment near the boundary.
+      this.forwardTimeForCrossBoundary();
     }
 
     if (!streamCleared) {

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3342,15 +3342,3 @@ shaka.media.StreamingEngine.MAX_RUN_AHEAD_SEGMENTS_ = 1;
  * @private
  */
 shaka.media.StreamingEngine.CROSS_BOUNDARY_END_THRESHOLD_ = 1;
-
-
-/**
- * The threshold to decide if we're going to force playhead to the boundary
- * end after a seek. When MSE stalls due to misalignment at a boundary end,
- * and the time is within this threshold from the boundary end,
- * we'll assume the boundary shall be crossed.
- *
- * @const {number}
- * @private
- */
-shaka.media.StreamingEngine.CROSS_BOUNDARY_SEEK_THRESHOLD_ = 0.1;

--- a/lib/player.js
+++ b/lib/player.js
@@ -2625,8 +2625,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             () => forwardTimeForCrossBoundary(/* immediate= */ true));
         this.loadEventManager_.listen(mediaElement, 'timeupdate',
             () => forwardTimeForCrossBoundary());
-        this.loadEventManager_.listen(mediaElement, 'seeked',
-            () => forwardTimeForCrossBoundary());
       }
     }
 

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -1339,7 +1339,7 @@ describe('MediaSourceEngine', () => {
 
       let canPlayThroughListener = null;
       mockVideo.addEventListener.and.callFake((eventName, callback, _) => {
-        if (eventName == 'canplay') {
+        if (eventName == 'canplaythrough') {
           canPlayThroughListener = callback;
         }
       });
@@ -1383,7 +1383,7 @@ describe('MediaSourceEngine', () => {
 
       let canPlayThroughListener = null;
       mockVideo.addEventListener.and.callFake((eventName, callback, _) => {
-        if (eventName == 'canplay') {
+        if (eventName == 'canplaythrough') {
           canPlayThroughListener = callback;
         }
       });

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -1339,7 +1339,7 @@ describe('MediaSourceEngine', () => {
 
       let canPlayThroughListener = null;
       mockVideo.addEventListener.and.callFake((eventName, callback, _) => {
-        if (eventName == 'canplaythrough') {
+        if (eventName == 'canplay') {
           canPlayThroughListener = callback;
         }
       });
@@ -1383,7 +1383,7 @@ describe('MediaSourceEngine', () => {
 
       let canPlayThroughListener = null;
       mockVideo.addEventListener.and.callFake((eventName, callback, _) => {
-        if (eventName == 'canplaythrough') {
+        if (eventName == 'canplay') {
           canPlayThroughListener = callback;
         }
       });


### PR DESCRIPTION
With resetting MSE on boundary crossing, we might seek into a gap. This would cause MSE not to reset properly, and playback will stall. The following changes are made:

- We rely on `seeking` to check if we need to start the boundary timer. The timer assumes we will cross a boundary in a short period of time, and is built to handle edge cases like misalignment & subtle gaps. We first relied on `seeked` but that event might never come when MSE does not reset. Thus seeking into a gap near a boundary end would have never spawned the timer in the first place, leaving the player endlessly stalling.
- When crossing a boundary, the MSE resets but never completes (as explained earlier). In this case, the timer will advance the playhead. However, due to the incomplete MSE reset, the video element remains paused. Since the previous state was paused, playback does not resume automatically after crossing the boundary. I now keep a variable that indicates we need to resume playback when MSE reset completes.

Reproduce:

- Load [example](https://shaka-player-demo.appspot.com/demo/#audiolang=en-US;textlang=en-US;crossBoundaryStrategy=reset;uilang=en-US;assetBase64=eyJuYW1lIjoiU2ludGVsIDRrIChtdWx0aXBlcmlvZCwgbWl4ZWQgZW5jcnlwdGlvbiwgY2xlYXIgZmlyc3QpIiwic2hvcnROYW1lIjoiIiwiaWNvblVyaSI6Imh0dHBzOi8vc3RvcmFnZS5nb29nbGVhcGlzLmNvbS9zaGFrYS1hc3NldC1pY29ucy9zaW50ZWwucG5nIiwibWFuaWZlc3RVcmkiOiJodHRwczovL3N0b3JhZ2UuZ29vZ2xlYXBpcy5jb20vc2hha2EtZGVtby1hc3NldHMvc2ludGVsLW1peGVkLWVuY3J5cHRpb24vY2xlYXItZW5jLWNsZWFyLm1wZCIsInNvdXJjZSI6IlNoYWthIiwiZm9jdXMiOmZhbHNlLCJkaXNhYmxlZCI6ZmFsc2UsImV4dHJhVGV4dCI6W10sImV4dHJhVGh1bWJuYWlsIjpbXSwiZXh0cmFDaGFwdGVyIjpbXSwiY2VydGlmaWNhdGVVcmkiOm51bGwsImRlc2NyaXB0aW9uIjpudWxsLCJpc0ZlYXR1cmVkIjpmYWxzZSwiZHJtIjpbIldpZGV2aW5lIERSTSJdLCJmZWF0dXJlcyI6WyJEQVNIIiwiRG93bmxvYWRhYmxlIiwiTVA0IiwiU3VidGl0bGVzIiwiVWx0cmEtaGlnaCBkZWZpbml0aW9uIiwiVk9EIiwiV2ViTSJdLCJsaWNlbnNlU2VydmVycyI6eyJfX3R5cGVfXyI6Im1hcCIsImNvbS53aWRldmluZS5hbHBoYSI6Imh0dHBzOi8vY3dpcC1zaGFrYS1wcm94eS5hcHBzcG90LmNvbS9ub19hdXRoIn0sIm9mZmxpbmVMaWNlbnNlU2VydmVycyI6eyJfX3R5cGVfXyI6Im1hcCJ9LCJsaWNlbnNlUmVxdWVzdEhlYWRlcnMiOnsiX190eXBlX18iOiJtYXAifSwicmVxdWVzdEZpbHRlciI6bnVsbCwicmVzcG9uc2VGaWx0ZXIiOm51bGwsImNsZWFyS2V5cyI6eyJfX3R5cGVfXyI6Im1hcCJ9LCJleHRyYUNvbmZpZyI6eyJkcm0iOnsiYWR2YW5jZWQiOnsiY29tLndpZGV2aW5lLmFscGhhIjp7InNlcnZlckNlcnRpZmljYXRlVXJpIjoiaHR0cHM6Ly9jd2lwLXNoYWthLXByb3h5LmFwcHNwb3QuY29tL3NlcnZpY2UtY2VydCJ9fSwic2VydmVycyI6eyJjb20ud2lkZXZpbmUuYWxwaGEiOiJodHRwczovL2N3aXAtc2hha2EtcHJveHkuYXBwc3BvdC5jb20vbm9fYXV0aCJ9fX0sImV4dHJhVWlDb25maWciOm51bGwsImFkVGFnVXJpIjpudWxsLCJpbWFWaWRlb0lkIjpudWxsLCJpbWFBc3NldEtleSI6bnVsbCwiaW1hQ29udGVudFNyY0lkIjpudWxsLCJpbWFNYW5pZmVzdFR5cGUiOm51bGwsIm1lZGlhVGFpbG9yVXJsIjpudWxsLCJtZWRpYVRhaWxvckFkc1BhcmFtcyI6bnVsbCwidXNlSU1BIjp0cnVlLCJtaW1lVHlwZSI6bnVsbH0=;panel=ALL_CONTENT;build=uncompiled)
- Use `streaming.crossBoundaryStrategy` set to `RESET` or `RESET_TO_ENCRYPTED`.
- Seek to 1000 (this would cross the boundary at 888.015)
- Seek back to 888 (which is 0.015s from the boundary end)