### PR TITLE
perf(ContentWorkarounds): Do not override codec twice

### DIFF
--- a/lib/media/content_workarounds.js
+++ b/lib/media/content_workarounds.js
@@ -239,9 +239,6 @@ shaka.media.ContentWorkarounds = class {
         /* start= */ sourceBox.start,
         /* end= */ sourceBox.start + sourceBox.size);
 
-    // Create a view on the source box array.
-    const sourceBoxView = shaka.util.BufferUtils.toDataView(sourceBoxArray);
-
     // Create an array to hold the new encryption metadata box, which is based
     // on the source box.
     const metadataBoxArray = new Uint8Array(
@@ -257,14 +254,6 @@ shaka.media.ContentWorkarounds = class {
 
     // Append the "sinf" box to the encryption metadata box.
     metadataBoxArray.set(sinfBoxArray, /* targetOffset= */ sourceBox.size);
-
-    // Update the "sinf" box's format field (in the child "frma" box) to reflect
-    // the format of the original source box.
-    const sourceBoxType = sourceBoxView.getUint32(
-        ContentWorkarounds.BOX_TYPE_OFFSET_);
-    metadataBoxView.setUint32(
-        sourceBox.size + ContentWorkarounds.CANNED_SINF_BOX_FORMAT_OFFSET_,
-        sourceBoxType);
 
     // Now update the encryption metadata box size.
     ContentWorkarounds.updateBoxSize_(
@@ -349,15 +338,6 @@ shaka.media.ContentWorkarounds = class {
     return initSegment;
   }
 };
-
-/**
- * The location of the format field in the "frma" box inside the canned "sinf"
- * box above.
- *
- * @const {number}
- * @private
- */
-shaka.media.ContentWorkarounds.CANNED_SINF_BOX_FORMAT_OFFSET_ = 0x10;
 
 /**
  * Offset to a box's size field.


### PR DESCRIPTION
This is already done in MP4 sinf generator.