### PR TITLE
fix(UI): Make UI display 4096x2160 (DCI 4k) video as also being "4k"

### DIFF
--- a/ui/resolution_selection.js
+++ b/ui/resolution_selection.js
@@ -272,7 +272,7 @@ shaka.ui.ResolutionSelection = class extends shaka.ui.SettingsMenu {
       height = Math.round(trackWidth * 9 / 16);
     }
     let text = height + 'p';
-    if (height == 2160) {
+    if (height == 2160 || trackHeight == 2160) {
       text = '4K';
     }
     const frameRates = new Set();


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/8357