### PR TITLE
feat(DASH): Add support for "Spoken Subtitles" in tva:metadata:cs:AudioPurpose

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -1993,6 +1993,9 @@ shaka.dash.DashParser = class {
         } else if (value == '2') {
           accessibilityPurpose =
               shaka.media.ManifestParser.AccessibilityPurpose.HARD_OF_HEARING;
+        } else if (value == '9') {
+          accessibilityPurpose =
+              shaka.media.ManifestParser.AccessibilityPurpose.SPOKEN_SUBTITLES;
         }
       }
     }

--- a/lib/media/manifest_parser.js
+++ b/lib/media/manifest_parser.js
@@ -181,6 +181,7 @@ shaka.media.ManifestParser.UNKNOWN = 'UNKNOWN';
 shaka.media.ManifestParser.AccessibilityPurpose = {
   VISUALLY_IMPAIRED: 'visually impaired',
   HARD_OF_HEARING: 'hard of hearing',
+  SPOKEN_SUBTITLES: 'spoken subtitles',
 };
 
 


### PR DESCRIPTION
Today we solely map visually impaired and hard hearing. I've added `Spoken Subtitles` as a new accessibility purpose.

For reference:

```
<?xml version="1.0" encoding="UTF-8"?>
<ClassificationScheme uri="urn:tva:metadata:cs:AudioPurposeCS:2007">
  <Term termID="1">
    <Name xml:lang="en">Audio description for visually impaired people</Name>
  </Term>
  <Term termID="2">
    <Name xml:lang="en">Audio description for hard of hearing people</Name>
  </Term>
  <Term termID="3">
    <Name xml:lang="en">Supplemental commentary</Name>
  </Term>
  <Term termID="4">
    <Name xml:lang="en">Director's commentary</Name>
  </Term>
  <Term termID="5">
    <Name xml:lang="en">Educational notes</Name>
  </Term>
  <Term termID="6">
    <Name xml:lang="en">Main programme audio</Name>
  </Term>
  <Term termID="7">
    <Name xml:lang="en">Clean feed - no effects mix</Name>
  </Term>
  <Term termID="8">
    <Name xml:lang="en">Dialogue Enhancement</Name>
  </Term>
  <Term termID="9">
    <Name xml:lang="en">Spoken Subtitles</Name>
  </Term>
</ClassificationScheme>
```