### PR TITLE
fix(HLS): Add key ids to Fairplay DRM parser

### DIFF
--- a/lib/drm/fairplay.js
+++ b/lib/drm/fairplay.js
@@ -62,6 +62,20 @@ shaka.drm.FairPlay = class {
   }
 
   /**
+   * @param {string} uriString
+   * @return {?string}
+   */
+  static defaultGetKeyId(uriString) {
+    const uri = new goog.Uri(uriString);
+    const contentId = uri.getDomain();
+    const keyId = contentId.replace(/-/g, '').toLowerCase();
+    if (keyId.length === 32 && /^[0-9a-f]+$/.test(keyId)) {
+      return keyId;
+    }
+    return null;
+  }
+
+  /**
    * Transforms the init data buffer using the given data.  The format is:
    *
    * <pre>

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -4952,7 +4952,7 @@ shaka.hls.HlsParser = class {
       goog.asserts.assert(
           keyIdLowerCase.startsWith('0x'), 'Incorrect KEYID format!');
       // But the output should not contain the '0x':
-      drmInfo.keyIds = new Set([keyIdLowerCase.substr(2)]);
+      drmInfo.keyIds.add(keyIdLowerCase.substr(2));
     }
     return Promise.resolve(drmInfo);
   }
@@ -5049,7 +5049,7 @@ shaka.hls.HlsParser = class {
       goog.asserts.assert(
           keyIdLowerCase.startsWith('0x'), 'Incorrect KEYID format!');
       // But the output should not contain the '0x':
-      drmInfo.keyIds = new Set([keyIdLowerCase.substr(2)]);
+      drmInfo.keyIds.add(keyIdLowerCase.substr(2));
     }
     return Promise.resolve(drmInfo);
   }

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -11,6 +11,7 @@ goog.require('goog.Uri');
 goog.require('goog.asserts');
 goog.require('shaka.abr.Ewma');
 goog.require('shaka.drm.DrmUtils');
+goog.require('shaka.drm.FairPlay');
 goog.require('shaka.drm.PlayReady');
 goog.require('shaka.hls.Attribute');
 goog.require('shaka.hls.ManifestTextParser');
@@ -95,6 +96,17 @@ shaka.hls.HlsParser = class {
     this.mediaSequenceToStartTimeByType_.set(ContentType.AUDIO, new Map());
     this.mediaSequenceToStartTimeByType_.set(ContentType.TEXT, new Map());
     this.mediaSequenceToStartTimeByType_.set(ContentType.IMAGE, new Map());
+
+    /** @private {!Map<string, shaka.hls.HlsParser.DrmParser_>} */
+    this.keyFormatsToDrmParsers_ = new Map()
+        .set('com.apple.streamingkeydelivery',
+            (tag, type, ref) => this.fairplayDrmParser_(tag, type, ref))
+        .set('urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed',
+            (tag, type, ref) => this.widevineDrmParser_(tag, type, ref))
+        .set('com.microsoft.playready',
+            (tag, type, ref) => this.playreadyDrmParser_(tag, type, ref))
+        .set('urn:uuid:3d5e6d35-9b9a-41e8-b843-dd3c6e72c42c',
+            (tag, type, ref) => this.wiseplayDrmParser_(tag, type, ref));
 
     /**
      * The values are strings of the form "<VIDEO URI> - <AUDIO URI>",
@@ -253,7 +265,7 @@ shaka.hls.HlsParser = class {
     this.identityKeyMap_ = new Map();
 
     /** @private {Map<!shaka.media.InitSegmentReference, ?string>} */
-    this.identityKidMap_ = new Map();
+    this.initSegmentToKidMap_ = new Map();
 
     /** @private {boolean} */
     this.lowLatencyMode_ = false;
@@ -369,7 +381,7 @@ shaka.hls.HlsParser = class {
     this.aesKeyInfoMap_.clear();
     this.aesKeyMap_.clear();
     this.identityKeyMap_.clear();
-    this.identityKidMap_.clear();
+    this.initSegmentToKidMap_.clear();
     this.dateRangeIdsEmitted_.clear();
 
     if (this.contentSteeringManager_) {
@@ -1661,10 +1673,12 @@ shaka.hls.HlsParser = class {
               /* initSegmentRef= */ null, variables);
         } else {
           const drmParser =
-              shaka.hls.HlsParser.KEYFORMATS_TO_DRM_PARSERS_.get(keyFormat);
+              this.keyFormatsToDrmParsers_.get(keyFormat);
 
           drmInfo = drmParser ?
-              drmParser(drmTag, /* mimeType= */ '') : null;
+            // eslint-disable-next-line no-await-in-loop
+            await drmParser(drmTag, /* mimeType= */ '',
+                /* initSegmentRef= */ null) : null;
         }
         if (drmInfo) {
           if (drmInfo.keyIds) {
@@ -3290,8 +3304,11 @@ shaka.hls.HlsParser = class {
               drmTag, mimeType, getUris, initSegmentRef, variables);
         } else {
           const drmParser =
-              shaka.hls.HlsParser.KEYFORMATS_TO_DRM_PARSERS_.get(keyFormat);
-          drmInfo = drmParser ? drmParser(drmTag, mimeType) : null;
+              this.keyFormatsToDrmParsers_.get(keyFormat);
+          drmInfo = drmParser ?
+            // eslint-disable-next-line no-await-in-loop
+            await drmParser(drmTag, mimeType, initSegmentRef) :
+            null;
         }
         if (drmInfo) {
           if (drmInfo.keyIds) {
@@ -4839,10 +4856,11 @@ shaka.hls.HlsParser = class {
   /**
    * @param {!shaka.hls.Tag} drmTag
    * @param {string} mimeType
-   * @return {?shaka.extern.DrmInfo}
+   * @param {?shaka.media.InitSegmentReference} initSegmentRef
+   * @return {!Promise<?shaka.extern.DrmInfo>}
    * @private
    */
-  static fairplayDrmParser_(drmTag, mimeType) {
+  async fairplayDrmParser_(drmTag, mimeType, initSegmentRef) {
     if (mimeType == 'video/mp2t') {
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
@@ -4873,6 +4891,8 @@ shaka.hls.HlsParser = class {
       encryptionScheme = 'cbcs';
     }
 
+    const uri = drmTag.getRequiredAttrValue('URI');
+
     /*
      * Even if we're not able to construct initData through the HLS tag, adding
      * a DRMInfo will allow DRM Engine to request a media key system access
@@ -4881,23 +4901,33 @@ shaka.hls.HlsParser = class {
     const drmInfo = shaka.util.ManifestParserUtils.createDrmInfo(
         'com.apple.fps', encryptionScheme, [
           {initDataType: 'sinf', initData: new Uint8Array(0), keyId: null},
-        ], drmTag.getRequiredAttrValue('URI'));
+        ], uri);
+
+    let keyId = shaka.drm.FairPlay.defaultGetKeyId(uri);
+    if (!keyId && initSegmentRef) {
+      keyId = await this.getKeyIdFromInitSegment_(initSegmentRef);
+    }
+    if (keyId) {
+      drmInfo.keyIds.add(keyId);
+    }
 
     return drmInfo;
   }
 
   /**
    * @param {!shaka.hls.Tag} drmTag
-   * @return {?shaka.extern.DrmInfo}
+   * @param {string} mimeType
+   * @param {?shaka.media.InitSegmentReference} initSegmentRef
+   * @return {!Promise<?shaka.extern.DrmInfo>}
    * @private
    */
-  static widevineDrmParser_(drmTag) {
+  widevineDrmParser_(drmTag, mimeType, initSegmentRef) {
     const method = drmTag.getRequiredAttrValue('METHOD');
     const VALID_METHODS = ['SAMPLE-AES', 'SAMPLE-AES-CTR'];
     if (!VALID_METHODS.includes(method)) {
       shaka.log.error('Widevine in HLS is only supported with [',
           VALID_METHODS.join(', '), '], not', method);
-      return null;
+      return Promise.resolve(null);
     }
 
     let encryptionScheme = 'cenc';
@@ -4924,23 +4954,25 @@ shaka.hls.HlsParser = class {
       // But the output should not contain the '0x':
       drmInfo.keyIds = new Set([keyIdLowerCase.substr(2)]);
     }
-    return drmInfo;
+    return Promise.resolve(drmInfo);
   }
 
   /**
    * See: https://docs.microsoft.com/en-us/playready/packaging/mp4-based-formats-supported-by-playready-clients?tabs=case4
    *
    * @param {!shaka.hls.Tag} drmTag
-   * @return {?shaka.extern.DrmInfo}
+   * @param {string} mimeType
+   * @param {?shaka.media.InitSegmentReference} initSegmentRef
+   * @return {!Promise<?shaka.extern.DrmInfo>}
    * @private
    */
-  static playreadyDrmParser_(drmTag) {
+  playreadyDrmParser_(drmTag, mimeType, initSegmentRef) {
     const method = drmTag.getRequiredAttrValue('METHOD');
     const VALID_METHODS = ['SAMPLE-AES', 'SAMPLE-AES-CTR'];
     if (!VALID_METHODS.includes(method)) {
       shaka.log.error('PlayReady in HLS is only supported with [',
           VALID_METHODS.join(', '), '], not', method);
-      return null;
+      return Promise.resolve(null);
     }
 
     let encryptionScheme = 'cenc';
@@ -4976,21 +5008,23 @@ shaka.hls.HlsParser = class {
       drmInfo.licenseServerUri = shaka.drm.PlayReady.getLicenseUrl(input);
     }
 
-    return drmInfo;
+    return Promise.resolve(drmInfo);
   }
 
   /**
    * @param {!shaka.hls.Tag} drmTag
-   * @return {?shaka.extern.DrmInfo}
+   * @param {string} mimeType
+   * @param {?shaka.media.InitSegmentReference} initSegmentRef
+   * @return {!Promise<?shaka.extern.DrmInfo>}
    * @private
    */
-  static wiseplayDrmParser_(drmTag) {
+  wiseplayDrmParser_(drmTag, mimeType, initSegmentRef) {
     const method = drmTag.getRequiredAttrValue('METHOD');
     const VALID_METHODS = ['SAMPLE-AES', 'SAMPLE-AES-CTR'];
     if (!VALID_METHODS.includes(method)) {
       shaka.log.error('WisePlay in HLS is only supported with [',
           VALID_METHODS.join(', '), '], not', method);
-      return null;
+      return Promise.resolve(null);
     }
 
     let encryptionScheme = 'cenc';
@@ -5017,7 +5051,7 @@ shaka.hls.HlsParser = class {
       // But the output should not contain the '0x':
       drmInfo.keyIds = new Set([keyIdLowerCase.substr(2)]);
     }
-    return drmInfo;
+    return Promise.resolve(drmInfo);
   }
 
   /**
@@ -5090,27 +5124,7 @@ shaka.hls.HlsParser = class {
     let keyId = '00000000000000000000000000000000';
 
     if (initSegmentRef) {
-      let defaultKID;
-      if (this.identityKidMap_.has(initSegmentRef)) {
-        defaultKID = this.identityKidMap_.get(initSegmentRef);
-      } else {
-        const initSegmentRequest = shaka.util.Networking.createSegmentRequest(
-            initSegmentRef.getUris(),
-            initSegmentRef.getStartByte(),
-            initSegmentRef.getEndByte(),
-            this.config_.retryParameters);
-        const requestType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
-        const initType =
-            shaka.net.NetworkingEngine.AdvancedRequestType.INIT_SEGMENT;
-        const initResponse = await this.makeNetworkRequest_(
-            initSegmentRequest, requestType, {type: initType}).promise;
-
-        initSegmentRef.setSegmentData(initResponse.data);
-
-        defaultKID = shaka.media.SegmentUtils.getDefaultKID(
-            initResponse.data);
-        this.identityKidMap_.set(initSegmentRef, defaultKID);
-      }
+      const defaultKID = await this.getKeyIdFromInitSegment_(initSegmentRef);
       if (defaultKID) {
         keyId = defaultKID;
       }
@@ -5126,6 +5140,36 @@ shaka.hls.HlsParser = class {
 
     return shaka.util.ManifestParserUtils.createDrmInfoFromClearKeys(
         clearkeys, encryptionScheme);
+  }
+
+  /**
+   * @param {!shaka.media.InitSegmentReference} initSegmentRef
+   * @return {!Promise<?string>}
+   * @private
+   */
+  async getKeyIdFromInitSegment_(initSegmentRef) {
+    let keyId = null;
+    if (this.initSegmentToKidMap_.has(initSegmentRef)) {
+      keyId = this.initSegmentToKidMap_.get(initSegmentRef);
+    } else {
+      const initSegmentRequest = shaka.util.Networking.createSegmentRequest(
+          initSegmentRef.getUris(),
+          initSegmentRef.getStartByte(),
+          initSegmentRef.getEndByte(),
+          this.config_.retryParameters);
+      const requestType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
+      const initType =
+          shaka.net.NetworkingEngine.AdvancedRequestType.INIT_SEGMENT;
+      const initResponse = await this.makeNetworkRequest_(
+          initSegmentRequest, requestType, {type: initType}).promise;
+
+      initSegmentRef.setSegmentData(initResponse.data);
+
+      keyId = shaka.media.SegmentUtils.getDefaultKID(
+          initResponse.data);
+      this.initSegmentToKidMap_.set(initSegmentRef, keyId);
+    }
+    return keyId;
   }
 };
 
@@ -5296,25 +5340,13 @@ shaka.hls.HlsParser.MIME_TYPES_WITHOUT_INIT_SEGMENT_ = new Set([
 
 
 /**
- * @typedef {function(!shaka.hls.Tag, string):?shaka.extern.DrmInfo}
+ * @typedef {function(!shaka.hls.Tag,
+ *                    string,
+ *                    ?shaka.media.InitSegmentReference):
+ *                        !Promise<?shaka.extern.DrmInfo>}
  * @private
  */
 shaka.hls.HlsParser.DrmParser_;
-
-
-/**
- * @const {!Map<string, shaka.hls.HlsParser.DrmParser_>}
- * @private
- */
-shaka.hls.HlsParser.KEYFORMATS_TO_DRM_PARSERS_ = new Map()
-    .set('com.apple.streamingkeydelivery',
-        shaka.hls.HlsParser.fairplayDrmParser_)
-    .set('urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed',
-        shaka.hls.HlsParser.widevineDrmParser_)
-    .set('com.microsoft.playready',
-        shaka.hls.HlsParser.playreadyDrmParser_)
-    .set('urn:uuid:3d5e6d35-9b9a-41e8-b843-dd3c6e72c42c',
-        shaka.hls.HlsParser.wiseplayDrmParser_);
 
 
 /**

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -3979,6 +3979,7 @@ describe('HlsParser', () => {
           stream.addDrmInfo('com.apple.fps', (drmInfo) => {
             drmInfo.addInitData('sinf', new Uint8Array(0));
             drmInfo.encryptionScheme = 'cenc';
+            drmInfo.keyIds.add('f93d4e700d7ddde90529a27735d9e7cb');
             drmInfo.addKeySystemUris(new Set(
                 ['skd://f93d4e700d7ddde90529a27735d9e7cb']));
           });
@@ -4302,6 +4303,7 @@ describe('HlsParser', () => {
             stream.addDrmInfo('com.apple.fps', (drmInfo) => {
               drmInfo.addInitData('sinf', new Uint8Array(0));
               drmInfo.encryptionScheme = 'cenc';
+              drmInfo.keyIds.add('f93d4e700d7ddde90529a27735d9e7cb');
               drmInfo.addKeySystemUris(new Set(
                   ['skd://f93d4e700d7ddde90529a27735d9e7cb']));
             });
@@ -4312,6 +4314,7 @@ describe('HlsParser', () => {
             stream.addDrmInfo('com.apple.fps', (drmInfo) => {
               drmInfo.addInitData('sinf', new Uint8Array(0));
               drmInfo.encryptionScheme = 'cenc';
+              drmInfo.keyIds.add('f93d4e700d7ddde90529a27735d9e7cb');
               drmInfo.addKeySystemUris(new Set(
                   ['skd://f93d4e700d7ddde90529a27735d9e7cb']));
             });


### PR DESCRIPTION
Related to #8335 
This will allow us to put key id into fake encryption boxes.