### PR TITLE
fix: Count line break characters as ASCII

### DIFF
--- a/lib/util/string_utils.js
+++ b/lib/util/string_utils.js
@@ -179,8 +179,8 @@ shaka.util.StringUtils = class {
     }
 
     const isAscii = (i) => {
-      // arr[i] >= ' ' && arr[i] <= '~';
-      return uint8.byteLength <= i || (uint8[i] >= 0x20 && uint8[i] <= 0x7e);
+      // arr[i] >= horizontal tab && arr[i] <= '~';
+      return uint8.byteLength <= i || (uint8[i] >= 0x09 && uint8[i] <= 0x7e);
     };
 
     shaka.log.debug(

--- a/test/util/string_utils_unit.js
+++ b/test/util/string_utils_unit.js
@@ -122,6 +122,12 @@ function defineStringUtilTests() {
       expect(StringUtils.fromBytesAutoDetect(new Uint8Array(arr))).toBe('Foo');
     });
 
+    // Regression test for #8336
+    it('counts newlines as ASCII', () => {
+      const arr = [0x0a, 0x46, 0x6f];
+      expect(StringUtils.fromBytesAutoDetect(new Uint8Array(arr))).toBe('\nFo');
+    });
+
     it('fails if unable to guess', () => {
       const expected = shaka.test.Util.jasmineError(new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,


### PR DESCRIPTION
Previously, shaka.util.StringUtils.fromBytesAutoDetect assumed any character between ' ' and '~' was ASCII.
This worked for many cases, but it meant that the method would be unable to determine the encoding of a buffer if there was a newline character near the start.
This could be a problem for parsing, for example, JSON.

Closes #8336