### PR TITLE
fix: Read TRUN data_offset as signed int

### DIFF
--- a/lib/util/mp4_box_parsers.js
+++ b/lib/util/mp4_box_parsers.js
@@ -186,7 +186,7 @@ shaka.util.Mp4BoxParsers = class {
 
     // "data_offset"
     if (flags & 0x000001) {
-      dataOffset = reader.readUint32();
+      dataOffset = reader.readInt32();
     }
 
     // Skip "first_sample_flags" if present.


### PR DESCRIPTION
From ISO/IEC 14496-12
```
aligned(8) class TrackRunBox
         extends FullBox('trun', version, tr_flags) {
   unsigned int(32) sample_count;
   // the following are optional fields
   signed int(32) data_offset;
   unsigned int(32) first_sample_flags;
   // all fields in the following array are optional
   {
      unsigned int(32) sample_duration;
      unsigned int(32) sample_size;
      unsigned int(32) sample_flags
      if (version == 0)
         { unsigned int(32) sample_composition_time_offset; }
      else
         { signed int(32) sample_composition_time_offset; }
   }[ sample_count ]
}
```