### PR TITLE
fix: Handle null response body for fetch responses

### DIFF
--- a/lib/net/http_fetch_plugin.js
+++ b/lib/net/http_fetch_plugin.js
@@ -136,70 +136,84 @@ shaka.net.HttpFetchPlugin = class {
         goog.asserts.assert(response.body,
             'non-HEAD responses should have a body');
 
-        // Getting the reader in this way allows us to observe the process of
-        // downloading the body, instead of just waiting for an opaque promise
-        // to resolve.
-        // We first clone the response because calling getReader locks the body
-        // stream; if we didn't clone it here, we would be unable to get the
-        // response's arrayBuffer later.
-        const reader = response.clone().body.getReader();
-
         const contentLengthRaw = response.headers.get('Content-Length');
         const contentLength =
             contentLengthRaw ? parseInt(contentLengthRaw, 10) : 0;
 
-        const start = (controller) => {
-          const push = async () => {
-            let readObj;
-            try {
-              readObj = await reader.read();
-            } catch (e) {
-              // If we abort the request, we'll get an error here.  Just ignore
-              // it since real errors will be reported when we read the buffer
-              // below.
-              shaka.log.v1('error reading from stream', e.message);
-              return;
-            }
-
-            if (!readObj.done) {
-              loaded += readObj.value.byteLength;
-              if (streamDataCallback) {
-                await streamDataCallback(readObj.value);
+        // Fetch returning a ReadableStream response body is not currently
+        // supported by all browsers.
+        // Browser compatibility:
+        // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+        // If it is not supported, returning the whole segment when
+        // it's ready (as xhr)
+        if (!response.body) {
+          arrayBuffer = await response.arrayBuffer();
+          const currentTime = Date.now();
+          // If the time between last time and this time we got progress event
+          // is long enough, or if a whole segment is downloaded, call
+          // progressUpdated().
+          progressUpdated(currentTime - lastTime, arrayBuffer.byteLength, 0);
+        } else {
+          // Getting the reader in this way allows us to observe the process of
+          // downloading the body, instead of just waiting for an opaque
+          // promise to resolve.
+          // We first clone the response because calling getReader lock the body
+          // stream; if we didn't clone it here, we would be unable to get the
+          // response's arrayBuffer later.
+          const reader = response.clone().body.getReader();
+          const start = (controller) => {
+            const push = async () => {
+              let readObj;
+              try {
+                readObj = await reader.read();
+              } catch (e) {
+                // If we abort the request, we'll get an error here.
+                // Just ignore it
+                // since real errors will be reported when we read
+                // the buffer below.
+                shaka.log.v1('error reading from stream', e.message);
+                return;
               }
-            }
+              if (!readObj.done) {
+                loaded += readObj.value.byteLength;
+                if (streamDataCallback) {
+                  await streamDataCallback(readObj.value);
+                }
+              }
 
-            const currentTime = Date.now();
-            const chunkSize = loaded - lastLoaded;
-            // If the time between last time and this time we got progress event
-            // is long enough, or if a whole segment is downloaded, call
-            // progressUpdated().
-            if ((currentTime - lastTime > 100 && chunkSize >= minBytes) ||
-                readObj.done) {
-              const numBytesRemaining =
-                  readObj.done ? 0 : contentLength - loaded;
-              progressUpdated(currentTime - lastTime, chunkSize,
-                  numBytesRemaining);
-              lastLoaded = loaded;
-              lastTime = currentTime;
-            }
+              const currentTime = Date.now();
+              const chunkSize = loaded - lastLoaded;
+              // If the time between last time and this time we got
+              // progress event is long enough, or if a whole segment
+              // is downloaded, call progressUpdated().
+              if ((currentTime - lastTime > 100 && chunkSize >= minBytes) ||
+                  readObj.done) {
+                const numBytesRemaining =
+                    readObj.done ? 0 : contentLength - loaded;
+                progressUpdated(currentTime - lastTime, chunkSize,
+                    numBytesRemaining);
+                lastLoaded = loaded;
+                lastTime = currentTime;
+              }
 
-            if (readObj.done) {
-              goog.asserts.assert(!readObj.value,
-                  'readObj should be unset when "done" is true.');
-              controller.close();
-            } else {
-              controller.enqueue(readObj.value);
-              push();
-            }
+              if (readObj.done) {
+                goog.asserts.assert(!readObj.value,
+                    'readObj should be unset when "done" is true.');
+                controller.close();
+              } else {
+                controller.enqueue(readObj.value);
+                push();
+              }
+            };
+            push();
           };
-          push();
-        };
-        // Create a ReadableStream to use the reader. We don't need to use the
-        // actual stream for anything, though, as we are using the response's
-        // arrayBuffer method to get the body, so we don't store the
-        // ReadableStream.
-        new ReadableStream({start}); // eslint-disable-line no-new
-        arrayBuffer = await response.arrayBuffer();
+          // Create a ReadableStream to use the reader. We don't need to use the
+          // actual stream for anything, though, as we are using the response's
+          // arrayBuffer method to get the body, so we don't store the
+          // ReadableStream.
+          new ReadableStream({start}); // eslint-disable-line no-new
+          arrayBuffer = await response.arrayBuffer();
+        }
       }
     } catch (error) {
       if (abortStatus.canceled) {


### PR DESCRIPTION
fetch API returning a ReadableStream response body is not supported by all browsers.
Browser compatibility:
https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API If it is not supported, download the whole segment in one shot