### PR TITLE
fix: Support more Dolby codec notations

### DIFF
--- a/lib/util/manifest_parser_utils.js
+++ b/lib/util/manifest_parser_utils.js
@@ -315,6 +315,8 @@ shaka.util.ManifestParserUtils.AUDIO_CODEC_REGEXPS_ = [
   /^dts[cex]$/, // DTS Digital Surround (dtsc), DTS Express (dtse), DTS:X (dtsx)
   /^iamf/,
   /^mhm[12]/, // MPEG-H Audio LC
+  /^ac3$/, // sometimes ac3 is used instead of ac-3
+  /^eac3$/, // sometimes "eac3" is used instead of "ec-3"
 ];
 
 

--- a/lib/util/mime_utils.js
+++ b/lib/util/mime_utils.js
@@ -159,9 +159,15 @@ shaka.util.MimeUtils = class {
       case base === 'mp4a' && profile === '40.42': // Extended HE-AAC
         return 'aac';
       case base === 'mp4a' && profile === 'a5':
+      case base === 'ac3':
+      case base === 'ac-3':
         return 'ac-3'; // Dolby Digital
       case base === 'mp4a' && profile === 'a6':
+      case base === 'eac3':
+      case base === 'ec-3':
         return 'ec-3'; // Dolby Digital Plus
+      case base === 'ac-4':
+        return 'ac-4'; // Dolby AC-4
       case base === 'mp4a' && profile === 'b2':
         return 'dtsx'; // DTS:X
       case base === 'mp4a' && profile === 'a9':

--- a/test/util/mime_utils_unit.js
+++ b/test/util/mime_utils_unit.js
@@ -26,10 +26,14 @@ describe('MimeUtils', () => {
     expect(getNormalizedCodec('mp4a.40.42')).toBe('aac');
 
     expect(getNormalizedCodec('ac-3')).toBe('ac-3');
+    expect(getNormalizedCodec('ac3')).toBe('ac-3');
     expect(getNormalizedCodec('mp4a.a5')).toBe('ac-3');
     expect(getNormalizedCodec('mp4a.A5')).toBe('ac-3');
 
     expect(getNormalizedCodec('ec-3')).toBe('ec-3');
+    expect(getNormalizedCodec('eac3')).toBe('ec-3');
+    expect(getNormalizedCodec('ac-4')).toBe('ac-4');
+
     expect(getNormalizedCodec('mp4a.a6')).toBe('ec-3');
     expect(getNormalizedCodec('mp4a.A6')).toBe('ec-3');
 


### PR DESCRIPTION
Player errors out for Dolby contents in adaptive streaming because correct mimetype is not identified.
This change adds ac3, ac-3, eac3, ec-3, and ac-4 mimetype support.