### PR TITLE
feat: Remove RESET_TO_ENCRYPTED in favour of changing strategy in "boundarycrossed" event

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -597,7 +597,6 @@ shakaDemo.Config = class {
     const strategyOptionsNames = {
       'KEEP': 'Keep',
       'RESET': 'Reset',
-      'RESET_TO_ENCRYPTED': 'Reset to encrypted',
       'RESET_ON_ENCRYPTION_CHANGE': 'Reset on encryption change',
     };
 

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2090,8 +2090,8 @@ shaka.extern.LiveSyncConfiguration;
  *   Allows MSE to be reset when crossing a boundary. Optionally, we can stop
  *   resetting MSE when MSE passed an encrypted boundary.
  *   Defaults to <code>KEEP</code> except on Tizen 3 where the default value
- *   is <code>RESET_TO_ENCRYPTED</code> and WebOS 3 where the default value
- *   is <code>RESET</code>.
+ *   is <code>RESET_ON_ENCRYPTION_CHANGE</code> and WebOS 3 where the
+ *   default value is <code>RESET</code>.
  * @exportDoc
  */
 shaka.extern.StreamingConfiguration;

--- a/lib/config/cross_boundary_strategy.js
+++ b/lib/config/cross_boundary_strategy.js
@@ -20,11 +20,6 @@ shaka.config.CrossBoundaryStrategy = {
    */
   'RESET': 'reset',
   /**
-   * Reset MediaSource once, when transitioning from a plain
-   * boundary to an encrypted boundary.
-   */
-  'RESET_TO_ENCRYPTED': 'reset_to_encrypted',
-  /**
    * Reset MediaSource, when transitioning from a plain
    * boundary to an encrypted boundary or from an encrypted
    * boundary to a plain boundary.

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3109,22 +3109,8 @@ shaka.media.StreamingEngine = class {
 
     const initRef = reference.initSegmentReference;
     let discard = lastInitRef.boundaryEnd !== initRef.boundaryEnd;
-    // Some devices can play plain data when initialized with an encrypted
-    // init segment. We can keep the MediaSource in this case.
-    if (this.config_.crossBoundaryStrategy ===
-          CrossBoundaryStrategy.RESET_TO_ENCRYPTED) {
-      if (!lastInitRef.encrypted && !initRef.encrypted) {
-        // We're crossing a plain to plain boundary, allow the reference.
-        discard = false;
-      }
-      if (lastInitRef.encrypted) {
-        // We initialized MediaSource with an encrypted init segment, from
-        // now on, we can keep the buffer.
-        shaka.log.debug(logPrefix, 'stream is encrypted, ' +
-          'discard crossBoundaryStrategy');
-        this.config_.crossBoundaryStrategy = CrossBoundaryStrategy.KEEP;
-      }
-    }
+    // Some devices require MSE to reset when moving from plain to encrypted, or
+    // potentially the other way around.
     if (this.config_.crossBoundaryStrategy ===
           CrossBoundaryStrategy.RESET_ON_ENCRYPTION_CHANGE) {
       if (lastInitRef.encrypted == initRef.encrypted) {
@@ -3143,7 +3129,9 @@ shaka.media.StreamingEngine = class {
       const pausedBeforeReset = video.paused;
       this.resetMediaSource(/* force= */ true).then(() => {
         const eventName = shaka.util.FakeEvent.EventName.BoundaryCrossed;
-        this.playerInterface_.onEvent(new shaka.util.FakeEvent(eventName));
+        const data = (new Map()).set('encrypted', initRef.encrypted);
+        this.playerInterface_.onEvent(
+            new shaka.util.FakeEvent(eventName, data));
         if (!pausedBeforeReset) {
           video.play();
         }

--- a/lib/player.js
+++ b/lib/player.js
@@ -228,6 +228,9 @@ goog.requireType('shaka.media.PresentationTimeline');
  *   the MediaSource successfully.
  * @property {string} type
  *   'boundarycrossed'
+ * @property {boolean} encrypted
+ *   True when the boundary is encrypted. You can use this to change
+ *   the crossBoundaryStrategy at runtime if needed.
  * @exportDoc
  */
 

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -308,7 +308,7 @@ shaka.util.PlayerConfiguration = class {
 
     if (shaka.util.Platform.isTizen3()) {
       streaming.crossBoundaryStrategy =
-          shaka.config.CrossBoundaryStrategy.RESET_TO_ENCRYPTED;
+          shaka.config.CrossBoundaryStrategy.RESET_ON_ENCRYPTION_CHANGE;
     }
 
     const networking = {

--- a/test/player_cross_boundary_integration.js
+++ b/test/player_cross_boundary_integration.js
@@ -113,31 +113,5 @@ describe('Player Cross Boundary', () => {
       const end = player.getBufferedInfo().total[0].end;
       expect(end).toBeLessThanOrEqual(8);
     });
-
-    drmIt('should skip MSE reset from encrypted boundary', async () => {
-      if (!shakaSupport.drm['com.widevine.alpha'] &&
-          !shakaSupport.drm['com.microsoft.playready']) {
-        pending('Needed DRM is not supported on this platform');
-      }
-
-      player.configure({
-        streaming: {
-          crossBoundaryStrategy:
-            shaka.config.CrossBoundaryStrategy.RESET_TO_ENCRYPTED,
-        },
-      });
-      await player.load(MULTI_PERIOD_ASSET_URI_);
-      await video.play();
-
-      // The boundary is at 8 (from plain to encrypted period), we'll wait
-      // until we crossed it.
-      await waiter.timeoutAfter(20).waitUntilPlayheadReaches(video, 10);
-
-      video.currentTime = 1;
-
-      // When we seek back and we still have a readyState > 0, we did not
-      // reset MSE.
-      expect(video.readyState).toBeGreaterThan(0);
-    });
   });
 });


### PR DESCRIPTION
Removed `RESET_TO_ENCRYPTED` as it is device specific, I suggest the user agent changes the boundary strategy at runtime for their specific devices that cause trouble and resetting MSE is required. Eventually, we'd always prefer a content workaround for device quirks, but since they're time consuming and more complex to develop, we'll have the ability to instruct the player to reset MSE at certain times in the stream.

If MSE on your device does not handle plain to encrypted, but once initialised with an encrypted init segment, playback works fine when appending a plain segment next. You'd be able to do:

```js
player.addEventListener("boundarycrossed", (event) => {
  if (event.encrypted) {
    player.configure("streaming.crossBoundaryStrategy",
        shaka.config.CrossBoundaryStrategy.KEEP);
  }
});
```