### PR TITLE
fix: Avoid codec switch for synonym codecs

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -2487,8 +2487,8 @@ shaka.media.MediaSourceEngine = class {
     }
 
     // Current/new codecs base and basic type match then no need to switch
-    if (currentCodec === newCodec && currentBasicType === newBasicType &&
-        muxedContentCheck) {
+    if (!shaka.util.MimeUtils.isCodecChanged(currentCodec, newCodec) &&
+      currentBasicType === newBasicType && muxedContentCheck) {
       if (this.transmuxers_.has(contentType) && !transmuxer) {
         this.transmuxers_.get(contentType).destroy();
         this.transmuxers_.delete(contentType);
@@ -2573,7 +2573,8 @@ shaka.media.MediaSourceEngine = class {
         MimeUtils.getCodecs(newMimeType));
     const newBasicType = MimeUtils.getBasicType(newMimeType);
 
-    return currentCodec !== newCodec || currentBasicType !== newBasicType;
+    return shaka.util.MimeUtils.isCodecChanged(currentCodec, newCodec) ||
+           currentBasicType !== newBasicType;
   }
 
   /**

--- a/lib/util/mime_utils.js
+++ b/lib/util/mime_utils.js
@@ -6,6 +6,7 @@
 
 goog.provide('shaka.util.MimeUtils');
 
+goog.require('shaka.log');
 goog.require('shaka.transmuxer.TransmuxerEngine');
 goog.require('shaka.util.ManifestParserUtils');
 
@@ -288,6 +289,48 @@ shaka.util.MimeUtils = class {
 
     // Make sure that we always return a "base" and "profile".
     return [base, profile];
+  }
+
+  /**
+   * @param {string} currentCodec
+   * @param {string} newCodec
+   * @return {boolean}
+   */
+  static areVP9Codec(currentCodec, newCodec) {
+    const vp9Pattern = /vp9|vp09/g;
+    if (currentCodec.search(vp9Pattern) !== -1 &&
+        newCodec.search(vp9Pattern) !== -1) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * @param {string} currentCodec
+   * @param {string} newCodec
+   * @return {boolean}
+   */
+  static areSynonymCodec(currentCodec, newCodec) {
+    if (this.areVP9Codec(currentCodec, newCodec)) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * @param {string} currentCodec
+   * @param {string} newCodec
+   * @return {boolean}
+   */
+  static isCodecChanged(currentCodec, newCodec) {
+    if (currentCodec !== newCodec &&
+        !this.areSynonymCodec(currentCodec.toLowerCase(),
+            newCodec.toLowerCase())) {
+      shaka.log.info('Codec changed ' + currentCodec +
+        '->' + newCodec);
+      return true;
+    }
+    return false;
   }
 };
 


### PR DESCRIPTION
Avoid codec switch for codecs which have
different names eg: (vp9,vp09) etc