### PR TITLE
fix: Avoid codec switch for synonym codecs

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -2487,8 +2487,8 @@ shaka.media.MediaSourceEngine = class {
     }
 
     // Current/new codecs base and basic type match then no need to switch
-    if (currentCodec === newCodec && currentBasicType === newBasicType &&
-        muxedContentCheck) {
+    if (!shaka.util.MimeUtils.isCodecChanged(currentCodec, newCodec) &&
+      currentBasicType === newBasicType && muxedContentCheck) {
       if (this.transmuxers_.has(contentType) && !transmuxer) {
         this.transmuxers_.get(contentType).destroy();
         this.transmuxers_.delete(contentType);
@@ -2573,7 +2573,8 @@ shaka.media.MediaSourceEngine = class {
         MimeUtils.getCodecs(newMimeType));
     const newBasicType = MimeUtils.getBasicType(newMimeType);
 
-    return currentCodec !== newCodec || currentBasicType !== newBasicType;
+    return shaka.util.MimeUtils.isCodecChanged(currentCodec, newCodec) ||
+           currentBasicType !== newBasicType;
   }
 
   /**

--- a/lib/util/mime_utils.js
+++ b/lib/util/mime_utils.js
@@ -173,6 +173,7 @@ shaka.util.MimeUtils = class {
       case base === 'mp4a' && profile === 'a9':
         return 'dtsc'; // DTS Digital Surround
       case base === 'vp09':
+      case base === 'vp9':
         return 'vp9';
       case base === 'avc1':
       case base === 'avc3':
@@ -288,6 +289,27 @@ shaka.util.MimeUtils = class {
 
     // Make sure that we always return a "base" and "profile".
     return [base, profile];
+  }
+
+  /**
+   * Check if the two codec strings are truly different, or if they
+   * refer to the same codec.
+   * @param {string} currentCodec
+   * @param {string} newCodec
+   * @return {boolean}
+   */
+  static isCodecChanged(currentCodec, newCodec) {
+    if (currentCodec === newCodec) {
+      return false;
+    }
+    const normalizedCurrentCodec =
+      shaka.util.MimeUtils.getNormalizedCodec(currentCodec.toLowerCase());
+    const normalizedNewCodec =
+      shaka.util.MimeUtils.getNormalizedCodec(newCodec.toLowerCase());
+    if (normalizedCurrentCodec === normalizedNewCodec) {
+      return false;
+    }
+    return true;
   }
 };
 


### PR DESCRIPTION
Avoid codec switch for codecs which have
different names eg: (vp9,vp09) etc