### PR TITLE
feat: Allow apps to override stall detector

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1820,6 +1820,7 @@ shaka.extern.LiveSyncConfiguration;
  *   stallEnabled: boolean,
  *   stallThreshold: number,
  *   stallSkip: number,
+ *   shouldBeMakingProgressCallback: function(): boolean,
  *   useNativeHlsForFairPlay: boolean,
  *   inaccurateManifestTolerance: number,
  *   lowLatencyMode: boolean,
@@ -1958,6 +1959,11 @@ shaka.extern.LiveSyncConfiguration;
  *   <br>
  *   Defaults to <code>0.1</code>  except on Tizen, WebOS, Chromecast,
  *   Hisense whose default value is <code>0</code>.
+ * @property {function(): boolean} shouldBeMakingProgressCallback
+ *   A callback to decide whether the player should be making progress.
+ *   Applications can override the stall detector operation when necessary.
+ *   Return true for stall detector to continue to handle stalls.
+ *   Return false to force stall detector to no-op.
  * @property {boolean} useNativeHlsForFairPlay
  *   Desktop Safari has both MediaSource and their native HLS implementation.
  *   Depending on the application's needs, it may prefer one over the other.

--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -336,7 +336,9 @@ shaka.media.GapJumpingController = class {
     // When we see a stall, we will try to "jump-start" playback by moving the
     // playhead forward.
     const detector = new shaka.media.StallDetector(
-        new shaka.media.StallDetector.MediaElementImplementation(this.video_),
+        new shaka.media.StallDetector.MediaElementImplementation(this.video_,
+            this.config_.shouldBeMakingProgressCallback,
+        ),
         threshold, onStall);
 
     return detector;
@@ -478,10 +480,13 @@ shaka.media.StallDetector.Implementation = class {
 shaka.media.StallDetector.MediaElementImplementation = class {
   /**
    * @param {!HTMLMediaElement} mediaElement
+   * @param {!function(): boolean} shouldBeMakingProgressCallback
    */
-  constructor(mediaElement) {
+  constructor(mediaElement, shouldBeMakingProgressCallback) {
     /** @private {!HTMLMediaElement} */
     this.mediaElement_ = mediaElement;
+    /** @private {!function(): boolean} */
+    this.shouldBeMakingProgressCallback_ = shouldBeMakingProgressCallback;
   }
 
   /** @override */
@@ -499,6 +504,13 @@ shaka.media.StallDetector.MediaElementImplementation = class {
     // buffering.
     if (this.mediaElement_.buffered.length == 0) {
       return false;
+    }
+
+    // check if app wants to override.
+    if (this.shouldBeMakingProgressCallback_) {
+      if (!this.shouldBeMakingProgressCallback_()) {
+        return false;
+      }
     }
 
     return this.hasContentFor_(this.mediaElement_.buffered,

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -227,6 +227,9 @@ shaka.util.PlayerConfiguration = class {
       stallEnabled: true,
       stallThreshold: 1 /* seconds */,
       stallSkip: 0.1 /* seconds */,
+      shouldBeMakingProgressCallback: () => {
+        return true;
+      },
       useNativeHlsForFairPlay: true,
       // If we are within 2 seconds of the start of a live segment, fetch the
       // previous one.  This allows for segment drift, but won't download an


### PR DESCRIPTION
In some smart tv platforms, playback may stall due to audio focus lost. This stall shouldn't trigger the stall detector to seek or pause/play. Let the apps handle overriding stall detector in such situations. Introduced a callback config shouldBeMakingProgressCallback.

Return true for stall detector to continue to handle stalls. Return false to force stall detector to no-op.