### PR TITLE
feat: Use Date for playback start time

### DIFF
--- a/lib/media/playhead.js
+++ b/lib/media/playhead.js
@@ -45,7 +45,7 @@ shaka.media.Playhead = class {
    * Set the start time. If the content has already started playback, this will
    * be ignored.
    *
-   * @param {number} startTime
+   * @param {number|Date} startTime
    */
   setStartTime(startTime) {}
 
@@ -93,7 +93,7 @@ shaka.media.SrcEqualsPlayhead = class {
     this.mediaElement_ = mediaElement;
     /** @private {boolean} */
     this.started_ = false;
-    /** @private {?number} */
+    /** @private {?number|Date} */
     this.startTime_ = null;
 
     /** @private {shaka.util.EventManager} */
@@ -107,18 +107,35 @@ shaka.media.SrcEqualsPlayhead = class {
         'Playhead should not be released before calling ready()',
     );
 
-    // We listen for the loaded-data-event so that we know when we can
+    // We listen for the canplay event so that we know when we can
     // interact with |currentTime|.
-    const onLoaded = () => {
+    // We were using loadeddata before, but if we set time on that event,
+    // browser may adjust it on its own during live playback.
+    const onCanPlay = () => {
       if (this.startTime_ == null ||
           (this.startTime_ == 0 && this.mediaElement_.duration != Infinity)) {
         this.started_ = true;
       } else {
         const currentTime = this.mediaElement_.currentTime;
-        let newTime = this.startTime_;
+        let newTime = null;
+        if (typeof this.startTime_ === 'number') {
+          newTime = this.startTime_;
+        } else if (this.startTime_ instanceof Date) {
+          const programStartTime = this.getProgramStartTime_();
+          if (programStartTime !== null) {
+            newTime = (this.startTime_.getTime() / 1000.0) - programStartTime;
+            newTime = this.clampTime_(newTime);
+          }
+        }
+
+        if (newTime == null) {
+          this.started_ = true;
+          return;
+        }
+
         // Using the currentTime allows using a negative number in Live HLS
-        if (this.startTime_ < 0) {
-          newTime = Math.max(0, currentTime + this.startTime_);
+        if (newTime < 0) {
+          newTime = Math.max(0, currentTime + newTime);
         }
         if (currentTime != newTime) {
           // Startup is complete only when the video element acknowledges the
@@ -134,9 +151,9 @@ shaka.media.SrcEqualsPlayhead = class {
     };
 
     shaka.util.MediaReadyState.waitForReadyState(this.mediaElement_,
-        HTMLMediaElement.HAVE_CURRENT_DATA,
+        HTMLMediaElement.HAVE_FUTURE_DATA,
         this.eventManager_, () => {
-          onLoaded();
+          onCanPlay();
         });
   }
 
@@ -161,9 +178,13 @@ shaka.media.SrcEqualsPlayhead = class {
   getTime() {
     // If we have not started playback yet, return the start time. However once
     // we start playback we assume that we can always return the current time.
-    const time = this.started_ ?
+    let time = this.started_ ?
                  this.mediaElement_.currentTime :
                  this.startTime_;
+    if (time instanceof Date) {
+      time = (time.getTime() / 1000.0) - (this.getProgramStartTime_() || 0);
+      time = this.clampTime_(time);
+    }
 
     // In the case that we have not started playback, but the start time was
     // never set, we don't know what the start time should be. To ensure we
@@ -183,6 +204,36 @@ shaka.media.SrcEqualsPlayhead = class {
 
   /** @override */
   notifyOfBufferingChange() {}
+
+  /**
+   * @return {?number} program start time in seconds.
+   * @private
+   */
+  getProgramStartTime_() {
+    if (this.mediaElement_.getStartDate) {
+      const startDate = this.mediaElement_.getStartDate();
+      const startTime = startDate.getTime();
+      if (!isNaN(startTime)) {
+        return startTime / 1000.0;
+      }
+    }
+    return null;
+  }
+
+
+  /**
+   * @param {number} time
+   * @return {number}
+   * @private
+   */
+  clampTime_(time) {
+    const seekable = this.mediaElement_.seekable;
+    if (seekable.length > 0) {
+      time = Math.max(seekable.start(0), time);
+      time = Math.min(seekable.end(seekable.length - 1), time);
+    }
+    return time;
+  }
 };
 
 
@@ -202,7 +253,7 @@ shaka.media.MediaSourcePlayhead = class {
    * @param {!HTMLMediaElement} mediaElement
    * @param {shaka.extern.Manifest} manifest
    * @param {shaka.extern.StreamingConfiguration} config
-   * @param {?number} startTime
+   * @param {?number|Date} startTime
    *     The playhead's initial position in seconds. If null, defaults to the
    *     start of the presentation for VOD and the live-edge for live.
    * @param {function()} onSeek
@@ -291,7 +342,7 @@ shaka.media.MediaSourcePlayhead = class {
 
   /** @override */
   setStartTime(startTime) {
-    this.videoWrapper_.setTime(startTime);
+    this.videoWrapper_.setTime(this.getStartTime_(startTime));
   }
 
   /** @override */
@@ -327,7 +378,7 @@ shaka.media.MediaSourcePlayhead = class {
   /**
    * Gets the playhead's initial position in seconds.
    *
-   * @param {?number} startTime
+   * @param {?number|Date} startTime
    * @return {number}
    * @private
    */
@@ -341,6 +392,13 @@ shaka.media.MediaSourcePlayhead = class {
         // Otherwise, start near the live-edge.
         startTime = this.timeline_.getSeekRangeEnd();
       }
+    } else if (startTime instanceof Date) {
+      const presentationStartTime =
+          this.timeline_.getInitialProgramDateTime() ||
+          this.timeline_.getPresentationStartTime();
+      goog.asserts.assert(presentationStartTime != null,
+          'Presentation start time should not be null!');
+      startTime = (startTime.getTime() / 1000.0) - presentationStartTime;
     } else if (startTime < 0) {
       // For live streams, if the startTime is negative, start from a certain
       // offset time from the live edge.  If the offset from the live edge is
@@ -349,7 +407,8 @@ shaka.media.MediaSourcePlayhead = class {
       startTime = this.timeline_.getSeekRangeEnd() + startTime;
     }
 
-    return this.clampSeekToDuration_(this.clampTime_(startTime));
+    return this.clampSeekToDuration_(
+        this.clampTime_(/** @type {number} */(startTime)));
   }
 
   /** @override */

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -37,7 +37,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
   /**
    * @param {string} assetUri
    * @param {?string} mimeType
-   * @param {?number} startTime
+   * @param {?number|Date} startTime
    * @param {*} playerInterface
    */
   constructor(assetUri, mimeType, startTime, playerInterface) {
@@ -59,7 +59,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     /** @private {!shaka.net.NetworkingEngine} */
     this.networkingEngine_ = typedPlayerInterface.networkingEngine;
 
-    /** @private {?number} */
+    /** @private {?number|Date} */
     this.startTime_ = startTime;
 
     /** @private {?shaka.media.AdaptationSetCriteria} */
@@ -214,11 +214,15 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
   /** @param {number} offset */
   setOffsetToStartTime(offset) {
     if (this.startTime_ && offset) {
-      this.startTime_ += offset;
+      if (typeof this.startTime_ === 'number') {
+        this.startTime_ += offset;
+      } else {
+        this.startTime_.setTime(this.startTime_.getTime() + offset * 1000);
+      }
     }
   }
 
-  /** @return {?number} */
+  /** @return {?number|Date} */
   getStartTime() {
     return this.startTime_;
   }
@@ -785,7 +789,9 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     if (!stream.segmentIndex) {
       await stream.createSegmentIndex();
     }
-    const startTime = this.startTime_ || 0;
+    // Ignore if start time is a Date, as we do not prefetch segments for live
+    // anyway.
+    const startTime = typeof this.startTime_ === 'number' ? this.startTime_ : 0;
     const prefetchSegmentIterator =
         stream.segmentIndex.getIteratorForTime(startTime);
     let prefetchSegment = null;

--- a/lib/player.js
+++ b/lib/player.js
@@ -2777,9 +2777,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.config_.playRangeStart, this.config_.playRangeEnd);
 
     const setupPlayhead = (startTime) => {
-      if (startTime instanceof Date) {
-        startTime = this.getRelativeTimeFromDate_(startTime);
-      }
       this.playhead_ = this.createPlayhead(startTime);
       this.playheadObservers_ =
           this.createPlayheadObserversForMSE_(startTime);
@@ -2806,7 +2803,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         const timeline = this.manifest_.presentationTimeline;
         let initialTime;
         if (this.startTime_ instanceof Date) {
-          const time = this.getRelativeTimeFromDate_(this.startTime_);
+          const presentationStartTime = timeline.getInitialProgramDateTime() ||
+              timeline.getPresentationStartTime();
+          goog.asserts.assert(presentationStartTime != null,
+              'Presentation start time should not be null!');
+          const time = (this.startTime_.getTime() / 1000.0) -
+              presentationStartTime;
           if (time != null) {
             initialTime = time;
           }
@@ -3082,19 +3084,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       unloaded = true;
     });
 
-    let startTime = this.startTime_;
-    if (startTime instanceof Date) {
-      startTime = this.getRelativeTimeFromDate_(startTime);
-    }
-    const seekRange = this.seekRange();
-    console.warn('start time', startTime, 'seek range', seekRange);
-
-    if (startTime != null) {
-      this.playhead_.setStartTime(startTime);
+    if (this.startTime_ != null) {
+      this.playhead_.setStartTime(this.startTime_);
     }
 
     this.playheadObservers_ =
-        this.createPlayheadObserversForSrcEquals_(startTime || 0);
+        this.createPlayheadObserversForSrcEquals_(this.startTime_ || 0);
 
     this.playRateController_ = new shaka.media.PlayRateController({
       getRate: () => mediaElement.playbackRate,
@@ -3756,7 +3751,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Creates a new instance of Playhead.  This can be replaced by tests to
    * create fake instances instead.
    *
-   * @param {?number} startTime
+   * @param {?number|Date} startTime
    * @return {!shaka.media.Playhead}
    */
   createPlayhead(startTime) {
@@ -3775,7 +3770,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Create the observers for MSE playback. These observers are responsible for
    * notifying the app and player of specific events during MSE playback.
    *
-   * @param {number} startTime
+   * @param {number|Date} startTime
    * @return {!shaka.media.PlayheadObserverManager}
    * @private
    */
@@ -3788,7 +3783,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         'Must have emsg region timeline');
     goog.asserts.assert(this.video_, 'Must have video element');
 
-    const startsPastZero = this.isLive() || startTime > 0;
+    const startsPastZero = this.isLive() ||
+        (typeof startTime === 'number' && startTime > 0);
 
     // Create the region observer. This will allow us to notify the app when we
     // move in and out of timeline regions.
@@ -3866,7 +3862,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * responsible for notifying the app and player of specific events during src
    * equals playback.
    *
-   * @param {number} startTime
+   * @param {number|!Date} startTime
    * @return {!shaka.media.PlayheadObserverManager}
    * @private
    */
@@ -3875,7 +3871,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         'Must have metadata region timeline');
     goog.asserts.assert(this.video_, 'Must have video element');
 
-    const startsPastZero = startTime > 0;
+    const startsPastZero = startTime instanceof Date || startTime > 0;
 
     /**
      * @type {!shaka.media.RegionObserver<
@@ -6323,19 +6319,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.log.warning('No way to get presentation start time as Date!');
       return null;
     }
-  }
-
-  /**
-   * @param {!Date} time
-   * @return {?number}
-   * @private
-   */
-  getRelativeTimeFromDate_(time) {
-    const presentationStartDate = this.getPresentationStartTimeAsDate();
-    if (presentationStartDate === null) {
-      return null;
-    }
-    return (time.getTime() - presentationStartDate.getTime()) / 1000.0;
   }
 
   /**

--- a/lib/player.js
+++ b/lib/player.js
@@ -794,7 +794,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @private {?string} */
     this.mimeType_ = null;
 
-    /** @private {?number} */
+    /** @private {?number|Date} */
     this.startTime_ = null;
 
     /** @private {boolean} */
@@ -1612,7 +1612,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * event handler to update the start position based on information in the
    * manifest.
    *
-   * @param {number} startTime
+   * @param {number|Date} startTime
    * @export
    */
   updateStartTime(startTime) {
@@ -1624,7 +1624,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * If another stream was already playing, first unloads that stream.
    *
    * @param {string|shaka.media.PreloadManager} assetUriOrPreloader
-   * @param {?number=} startTime
+   * @param {?number|Date=} startTime
    *    When <code>startTime</code> is <code>null</code> or
    *    <code>undefined</code>, playback will start at the default start time (0
    *    for VOD and liveEdge for LIVE).
@@ -2032,7 +2032,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * asset must be played with src=, which cannot be preloaded.
    *
    * @param {string} assetUri
-   * @param {?number=} startTime
+   * @param {?number|Date=} startTime
    *    When <code>startTime</code> is <code>null</code> or
    *    <code>undefined</code>, playback will start at the default start time (0
    *    for VOD and liveEdge for LIVE).
@@ -2071,7 +2071,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
   /**
    * @param {string} assetUri
-   * @param {?number} startTime
+   * @param {?number|Date} startTime
    * @param {?string=} mimeType
    * @param {boolean=} standardLoad
    * @return {!Promise<?shaka.media.PreloadManager>}
@@ -2129,7 +2129,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
   /**
    * @param {string} assetUri
-   * @param {?number} startTime
+   * @param {?number|Date} startTime
    * @param {?string} mimeType
    * @param {boolean=} allowPrefetch
    * @param {boolean=} disableVideo
@@ -2777,6 +2777,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.config_.playRangeStart, this.config_.playRangeEnd);
 
     const setupPlayhead = (startTime) => {
+      if (startTime instanceof Date) {
+        startTime = this.getRelativeTimeFromDate_(startTime);
+      }
       this.playhead_ = this.createPlayhead(startTime);
       this.playheadObservers_ =
           this.createPlayheadObserversForMSE_(startTime);
@@ -2801,7 +2804,17 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // align to a segment boundary.
       if (this.config_.streaming.startAtSegmentBoundary) {
         const timeline = this.manifest_.presentationTimeline;
-        let initialTime = this.startTime_ || this.video_.currentTime;
+        let initialTime;
+        if (this.startTime_ instanceof Date) {
+          const time = this.getRelativeTimeFromDate_(this.startTime_);
+          if (time != null) {
+            initialTime = time;
+          }
+        }
+        if (initialTime == null) {
+          initialTime = typeof this.startTime_ === 'number' ? this.startTime_ :
+              this.video_.currentTime;
+        }
         if (this.startTime_ == null && this.manifest_.startTime) {
           initialTime = this.manifest_.startTime;
         }
@@ -3069,12 +3082,19 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       unloaded = true;
     });
 
-    if (this.startTime_ != null) {
-      this.playhead_.setStartTime(this.startTime_);
+    let startTime = this.startTime_;
+    if (startTime instanceof Date) {
+      startTime = this.getRelativeTimeFromDate_(startTime);
+    }
+    const seekRange = this.seekRange();
+    console.warn('start time', startTime, 'seek range', seekRange);
+
+    if (startTime != null) {
+      this.playhead_.setStartTime(startTime);
     }
 
     this.playheadObservers_ =
-        this.createPlayheadObserversForSrcEquals_(this.startTime_ || 0);
+        this.createPlayheadObserversForSrcEquals_(startTime || 0);
 
     this.playRateController_ = new shaka.media.PlayRateController({
       getRate: () => mediaElement.playbackRate,
@@ -6243,6 +6263,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // would start at the live edge, but we don't have that yet, so return
       // the current date & time.
       return new Date();
+    } else if (this.startTime_ instanceof Date) {
+      // A specific start time as a Date has been requested.  Return it without
+      // any modification.
+      return this.startTime_;
     } else {
       // A specific start time has been requested.  This is what Playhead will
       // use once it is created.
@@ -6299,6 +6323,19 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.log.warning('No way to get presentation start time as Date!');
       return null;
     }
+  }
+
+  /**
+   * @param {!Date} time
+   * @return {?number}
+   * @private
+   */
+  getRelativeTimeFromDate_(time) {
+    const presentationStartDate = this.getPresentationStartTimeAsDate();
+    if (presentationStartDate === null) {
+      return null;
+    }
+    return (time.getTime() - presentationStartDate.getTime()) / 1000.0;
   }
 
   /**

--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -130,6 +130,8 @@ describe('Playhead', () => {
     timeline.getSeekRangeStart.and.returnValue(5);
     timeline.getSeekRangeEnd.and.returnValue(60);
     timeline.getDuration.and.returnValue(60);
+    timeline.getInitialProgramDateTime.and.returnValue(
+        new Date(2005, 3, 2, 21, 37).getTime() / 1000.0);
 
     // These tests should not cause these methods to be invoked.
     timeline.getSegmentAvailabilityStart.and.throwError(new Error());
@@ -330,6 +332,24 @@ describe('Playhead', () => {
           Util.spyFunc(onEvent));
 
       expect(playhead.getTime()).toBe(45);
+    });
+
+    it('playback using Date for live', () => {
+      video.readyState = HTMLMediaElement.HAVE_METADATA;
+      timeline.isLive.and.returnValue(true);
+      timeline.getDuration.and.returnValue(Infinity);
+      timeline.getSeekRangeStart.and.returnValue(0);
+      timeline.getSeekRangeEnd.and.returnValue(60);
+
+      playhead = new shaka.media.MediaSourcePlayhead(
+          video,
+          manifest,
+          config,
+          /* startTime= */ new Date(2005, 3, 2, 21, 37, 20),
+          Util.spyFunc(onSeek),
+          Util.spyFunc(onEvent));
+
+      expect(playhead.getTime()).toBe(20);
     });
 
     it('playback from segment seek range start time', () => {

--- a/test/test/util/simple_fakes.js
+++ b/test/test/util/simple_fakes.js
@@ -304,6 +304,10 @@ shaka.test.FakePresentationTimeline = class {
         jasmine.createSpy('getPresentationStartTime');
 
     /** @type {!jasmine.Spy} */
+    this.getInitialProgramDateTime =
+        jasmine.createSpy('getInitialProgramDateTime');
+
+    /** @type {!jasmine.Spy} */
     this.setClockOffset = jasmine.createSpy('setClockOffset');
 
     /** @type {!jasmine.Spy} */


### PR DESCRIPTION
Closes #8402 

This PR introduces ability to pass Date object instead of number to `shaka.Player#load()` call. Date, together with PDT is used to calculate relative start time.
If stream does not have PDT, nothing will happen.

Additionally, for src= playback, we set current time on `canplay` event now instead of `loadeddata`. It seems that Safari goes to live edge on it's own if we set time too soon.