### PR TITLE
feat: Handle audio focus events

### DIFF
--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -522,8 +522,7 @@ shaka.media.StallDetector.MediaElementImplementation = class {
     if (this.mediaElement_.playbackRate == 0) {
       return false;
     }
-    // if playback paused due to no audio focus
-    // we ignore the stall.
+    // If playback paused due to no audio focus, we ignore the stall.
     if (this.audioFocusPaused_) {
       return false;
     }

--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -495,7 +495,7 @@ shaka.media.StallDetector.MediaElementImplementation = class {
     this.audioEventManager_.listen(this.mediaElement_,
         // cspell: disable-next-line
         'audiofocuspaused', () => {
-          shaka.log.info(`audio focus paused`);
+          shaka.log.info(`Audio focus paused`);
           this.audioFocusPaused_ = true;
         });
     this.audioEventManager_.listen(this.mediaElement_,

--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -501,7 +501,7 @@ shaka.media.StallDetector.MediaElementImplementation = class {
     this.audioEventManager_.listen(this.mediaElement_,
         // cspell: disable-next-line
         'audiofocusgranted', () => {
-          shaka.log.info(`audio focus granted`);
+          shaka.log.info(`Audio focus granted`);
           this.audioFocusPaused_ = false;
         });
     this.audioEventManager_.listen(this.mediaElement_,

--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -394,6 +394,9 @@ shaka.media.StallDetector = class {
   /** @override */
   release() {
     // Drop external references to make things easier on the GC.
+    if (this.implementation_) {
+      this.implementation_.release();
+    }
     this.implementation_ = null;
     this.onStall_ = null;
   }
@@ -465,6 +468,11 @@ shaka.media.StallDetector.Implementation = class {
    * @return {number}
    */
   getWallSeconds() {}
+
+  /**
+   * Releases object
+   */
+  release() {}
 };
 
 
@@ -572,6 +580,14 @@ shaka.media.StallDetector.MediaElementImplementation = class {
     }
 
     return false;
+  }
+
+  /** @override */
+  release() {
+    if (this.audioEventManager_) {
+      this.audioEventManager_.release();
+    }
+    this.audioEventManager_ = null;
   }
 };
 

--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -482,6 +482,34 @@ shaka.media.StallDetector.MediaElementImplementation = class {
   constructor(mediaElement) {
     /** @private {!HTMLMediaElement} */
     this.mediaElement_ = mediaElement;
+    /**
+     * For listeners scoped to the lifetime of the instance.
+     * @private {shaka.util.EventManager}
+     */
+    this.audioEventManager_ = new shaka.util.EventManager();
+    /**
+     * audio focus state
+     * @private {boolean}
+     */
+    this.audioFocusPaused_ = false;
+    this.audioEventManager_.listen(this.mediaElement_,
+        // cspell: disable-next-line
+        'audiofocuspaused', () => {
+          shaka.log.info(`audio focus paused`);
+          this.audioFocusPaused_ = true;
+        });
+    this.audioEventManager_.listen(this.mediaElement_,
+        // cspell: disable-next-line
+        'audiofocusgranted', () => {
+          shaka.log.info(`audio focus granted`);
+          this.audioFocusPaused_ = false;
+        });
+    this.audioEventManager_.listen(this.mediaElement_,
+        // cspell: disable-next-line
+        'audiofocuslost', () => {
+          shaka.log.info(`audio focus lost`);
+          this.audioFocusPaused_ = true;
+        });
   }
 
   /** @override */
@@ -494,7 +522,11 @@ shaka.media.StallDetector.MediaElementImplementation = class {
     if (this.mediaElement_.playbackRate == 0) {
       return false;
     }
-
+    // if playback paused due to no audio focus
+    // we ignore the stall.
+    if (this.audioFocusPaused_) {
+      return false;
+    }
     // If we have don't have enough content, we are not stalled, we are
     // buffering.
     if (this.mediaElement_.buffered.length == 0) {

--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -507,7 +507,7 @@ shaka.media.StallDetector.MediaElementImplementation = class {
     this.audioEventManager_.listen(this.mediaElement_,
         // cspell: disable-next-line
         'audiofocuslost', () => {
-          shaka.log.info(`audio focus lost`);
+          shaka.log.info(`Audio focus lost`);
           this.audioFocusPaused_ = true;
         });
   }

--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -488,7 +488,7 @@ shaka.media.StallDetector.MediaElementImplementation = class {
      */
     this.audioEventManager_ = new shaka.util.EventManager();
     /**
-     * audio focus state
+     * Audio focus state
      * @private {boolean}
      */
     this.audioFocusPaused_ = false;

--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -500,20 +500,20 @@ shaka.media.StallDetector.MediaElementImplementation = class {
      * @private {boolean}
      */
     this.audioFocusPaused_ = false;
+    // Audio Focus temporary leads to playback pause.
     this.audioEventManager_.listen(this.mediaElement_,
-        // cspell: disable-next-line
         'audiofocuspaused', () => {
           shaka.log.info(`Audio focus paused`);
           this.audioFocusPaused_ = true;
         });
+    // Audio Focus is granted. App can play now.
     this.audioEventManager_.listen(this.mediaElement_,
-        // cspell: disable-next-line
         'audiofocusgranted', () => {
           shaka.log.info(`Audio focus granted`);
           this.audioFocusPaused_ = false;
         });
+    // Audio focus is lost, app shouldn't play anymore.
     this.audioEventManager_.listen(this.mediaElement_,
-        // cspell: disable-next-line
         'audiofocuslost', () => {
           shaka.log.info(`Audio focus lost`);
           this.audioFocusPaused_ = true;

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,6 +1,9 @@
 # events / html
 abrstatuschanged
 adblocker
+audiofocuspaused
+audiofocusgranted
+audiofocuslost
 audiolang
 audiotrackchange
 audiotrackchanged

--- a/test/media/stall_detector_unit.js
+++ b/test/media/stall_detector_unit.js
@@ -29,6 +29,9 @@ describe('StallDetector', () => {
 
     /** @override */
     getWallSeconds() { return this.wallSeconds; }
+
+    /** @override */
+    release() {}
   }
 
   /** @type {!TestImplementation} */


### PR DESCRIPTION
In some platforms custom audio focus events are emitted. This needs to  be handled to avoid the stall detection.