### PR TITLE
perf(DASH): Only process the timeline for current streams

### DIFF
--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -261,9 +261,10 @@ shaka.dash.MpdUtils = class {
    * @param {function(?shaka.dash.DashParser.InheritanceFrame):
    *   ?shaka.extern.xml.Node} callback
    *   Gets the element that contains the segment info.
+   * @param {boolean=} processTimeline
    * @return {shaka.dash.MpdUtils.SegmentInfo}
    */
-  static parseSegmentInfo(context, callback) {
+  static parseSegmentInfo(context, callback, processTimeline = false) {
     goog.asserts.assert(
         callback(context.representation),
         'There must be at least one element of the given type.');
@@ -295,13 +296,14 @@ shaka.dash.MpdUtils = class {
 
     /** @type {Array<shaka.media.PresentationTimeline.TimeRange>} */
     let timeline = null;
-    const timelineNode =
+    let timelineNode =
         MpdUtils.inheritChild(context, callback, 'SegmentTimeline');
-    if (timelineNode) {
+    if (processTimeline && timelineNode) {
       const timePoints = TXml.findChildren(timelineNode, 'S');
       timeline = MpdUtils.createTimeline(
           timePoints, timescale, unscaledPresentationTimeOffset,
           context.periodInfo.duration || Infinity, startNumber);
+      timelineNode = null;
     }
 
     const scaledPresentationTimeOffset =
@@ -314,6 +316,7 @@ shaka.dash.MpdUtils = class {
       scaledPresentationTimeOffset: scaledPresentationTimeOffset,
       unscaledPresentationTimeOffset: unscaledPresentationTimeOffset,
       timeline: timeline,
+      timelineNode: timelineNode,
     };
   }
 
@@ -569,7 +572,8 @@ shaka.dash.MpdUtils = class {
  *   startNumber: number,
  *   scaledPresentationTimeOffset: number,
  *   unscaledPresentationTimeOffset: number,
- *   timeline: Array<shaka.media.PresentationTimeline.TimeRange>
+ *   timeline: Array<shaka.media.PresentationTimeline.TimeRange>,
+ *   timelineNode: ?shaka.extern.xml.Node
  * }}
  *
  * @description
@@ -589,6 +593,8 @@ shaka.dash.MpdUtils = class {
  *   The presentation time offset of the representation, in timescale units.
  * @property {Array<shaka.media.PresentationTimeline.TimeRange>} timeline
  *   The timeline of the representation, if given.  Times in seconds.
+ * @property {?shaka.extern.xml.Node} timelineNode
+ *   The timeline node, if given.
  */
 shaka.dash.MpdUtils.SegmentInfo;
 

--- a/lib/dash/segment_list.js
+++ b/lib/dash/segment_list.js
@@ -116,7 +116,8 @@ shaka.dash.SegmentList = class {
 
     const mediaSegments = SegmentList.parseMediaSegments_(context);
     const segmentInfo =
-        MpdUtils.parseSegmentInfo(context, SegmentList.fromInheritance_);
+        MpdUtils.parseSegmentInfo(context, SegmentList.fromInheritance_,
+            /** processTimeline= */ true);
 
     let startNumber = segmentInfo.startNumber;
     if (startNumber == 0) {

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -79,6 +79,8 @@ shaka.dash.SegmentTemplate = class {
 
       return {
         generateSegmentIndex: () => {
+          SegmentTemplate.processTimelineFromTimelineNode(
+              info, shallowCopyOfContext.periodInfo.duration);
           return SegmentTemplate.generateSegmentIndexFromIndexTemplate_(
               shallowCopyOfContext, requestSegment, initSegmentReference,
               info);
@@ -105,6 +107,8 @@ shaka.dash.SegmentTemplate = class {
 
       return {
         generateSegmentIndex: () => {
+          SegmentTemplate.processTimelineFromTimelineNode(
+              info, shallowCopyOfContext.periodInfo.duration);
           return SegmentTemplate.generateSegmentIndexFromDuration_(
               shallowCopyOfContext, info, segmentLimit, initSegmentReference,
               periodDurationMap, aesKey, lastSegmentNumber,
@@ -125,9 +129,10 @@ shaka.dash.SegmentTemplate = class {
         }
       }
 
+      const periodDuration = context.periodInfo.duration;
       const periodStart = context.periodInfo.start;
-      const periodEnd = context.periodInfo.duration ? periodStart +
-        context.periodInfo.duration : Infinity;
+      const periodEnd = periodDuration ? periodStart +
+        periodDuration : Infinity;
 
       shaka.log.debug(`New manifest ${periodStart} - ${periodEnd}`);
 
@@ -172,13 +177,17 @@ shaka.dash.SegmentTemplate = class {
 
       return {
         generateSegmentIndex: () => {
+          SegmentTemplate.processTimelineFromTimelineNode(
+              info, shallowCopyOfContext.periodInfo.duration);
           // If segmentIndex is deleted, or segmentIndex's references are
           // released by closeSegmentIndex(), we should set the value of
           // segmentIndex again.
-          if (segmentIndex instanceof shaka.dash.TimelineSegmentIndex &&
-              segmentIndex.isEmpty()) {
-            segmentIndex.appendTemplateInfo(info, periodStart,
-                periodEnd, initSegmentReference);
+          if (segmentIndex instanceof shaka.dash.TimelineSegmentIndex) {
+            segmentIndex.fitTimeline();
+            if (segmentIndex.isEmpty()) {
+              segmentIndex.appendTemplateInfo(info, periodStart,
+                  periodEnd, initSegmentReference);
+            }
           }
           return Promise.resolve(segmentIndex);
         },
@@ -268,6 +277,7 @@ shaka.dash.SegmentTemplate = class {
       unscaledPresentationTimeOffset:
           segmentInfo.unscaledPresentationTimeOffset,
       timeline: segmentInfo.timeline,
+      timelineNode: segmentInfo.timelineNode,
       mediaTemplate: media && StringUtils.htmlUnescape(media),
       indexTemplate: index,
       mimeType: context.representation.mimeType,
@@ -287,7 +297,7 @@ shaka.dash.SegmentTemplate = class {
   static checkSegmentTemplateInfo_(context, info) {
     let n = 0;
     n += info.indexTemplate ? 1 : 0;
-    n += info.timeline ? 1 : 0;
+    n += (info.timeline || info.timelineNode) ? 1 : 0;
     n += info.segmentDuration ? 1 : 0;
 
     if (n == 0) {
@@ -312,7 +322,8 @@ shaka.dash.SegmentTemplate = class {
         info.unscaledSegmentDuration = null;
         info.segmentDuration = null;
       } else {
-        goog.asserts.assert(info.timeline, 'There should be a timeline');
+        goog.asserts.assert((info.timeline || info.timelineNode),
+            'There should be a timeline');
         shaka.log.info('Using the SegmentTimeline by default.');
         info.unscaledSegmentDuration = null;
         info.segmentDuration = null;
@@ -707,6 +718,23 @@ shaka.dash.SegmentTemplate = class {
     }
     return ref;
   }
+
+  /**
+   * @param {!shaka.dash.SegmentTemplate.SegmentTemplateInfo} info
+   * @param {?number} duration
+   */
+  static processTimelineFromTimelineNode(info, duration) {
+    if (!info.timelineNode || (info.timeline && info.timeline.length)) {
+      return;
+    }
+    const MpdUtils = shaka.dash.MpdUtils;
+    const TXml = shaka.util.TXml;
+    const timePoints = TXml.findChildren(info.timelineNode, 'S');
+    info.timeline = MpdUtils.createTimeline(
+        timePoints, info.timescale, info.unscaledPresentationTimeOffset,
+        duration || Infinity, info.startNumber);
+    info.timelineNode = null;
+  }
 };
 
 
@@ -799,7 +827,7 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
    * @override
    */
   evict(time) {
-    if (!this.templateInfo_) {
+    if (!this.templateInfo_ || !this.templateInfo_.timeline) {
       return;
     }
     shaka.log.debug(`${this.representationId_} Evicting at ${time}`);
@@ -852,21 +880,26 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
       if (this.templateInfo_.mediaTemplate !== info.mediaTemplate) {
         this.templateInfo_.mediaTemplate = info.mediaTemplate;
       }
+      if (currentTimeline) {
+        // Append timeline
+        let newEntries;
+        if (currentTimeline.length) {
+          if (!info.timeline) {
+            shaka.dash.SegmentTemplate.processTimelineFromTimelineNode(
+                info, periodEnd - periodStart);
+          }
+          const lastCurrentEntry = currentTimeline[currentTimeline.length - 1];
+          newEntries = info.timeline.filter((entry) => {
+            return entry.end > lastCurrentEntry.end;
+          });
+        } else {
+          newEntries = info.timeline.slice();
+        }
 
-      // Append timeline
-      let newEntries;
-      if (currentTimeline.length) {
-        const lastCurrentEntry = currentTimeline[currentTimeline.length - 1];
-        newEntries = info.timeline.filter((entry) => {
-          return entry.end > lastCurrentEntry.end;
-        });
-      } else {
-        newEntries = info.timeline.slice();
-      }
-
-      if (newEntries.length > 0) {
-        shaka.log.debug(`Appending ${newEntries.length} entries`);
-        this.templateInfo_.timeline.push(...newEntries);
+        if (newEntries.length > 0) {
+          shaka.log.debug(`Appending ${newEntries.length} entries`);
+          this.templateInfo_.timeline.push(...newEntries);
+        }
       }
 
       if (this.periodEnd_ !== periodEnd) {
@@ -915,7 +948,8 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
    * Fit timeline entries to period boundaries
    */
   fitTimeline() {
-    if (!this.templateInfo_ || this.getIsImmutable()) {
+    if (!this.templateInfo_ || !this.templateInfo_.timeline ||
+        this.getIsImmutable()) {
       return;
     }
     const timeline = this.templateInfo_.timeline;
@@ -1178,6 +1212,7 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
  *   scaledPresentationTimeOffset: number,
  *   unscaledPresentationTimeOffset: number,
  *   timeline: Array<shaka.media.PresentationTimeline.TimeRange>,
+ *   timelineNode: ?shaka.extern.xml.Node,
  *   mediaTemplate: ?string,
  *   indexTemplate: ?string,
  *   mimeType: string,
@@ -1203,6 +1238,8 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
  *   The presentation time offset of the representation, in timescale units.
  * @property {Array<shaka.media.PresentationTimeline.TimeRange>} timeline
  *   The timeline of the representation, if given.  Times in seconds.
+ * @property {?shaka.extern.xml.Node} timelineNode
+ *   The timeline node, if given.
  * @property {?string} mediaTemplate
  *   The media URI template, if given.
  * @property {?string} indexTemplate

--- a/test/dash/dash_parser_segment_template_unit.js
+++ b/test/dash/dash_parser_segment_template_unit.js
@@ -971,6 +971,7 @@ function makeTemplateInfo(timeline) {
     'scaledPresentationTimeOffset': 0,
     'unscaledPresentationTimeOffset': 0,
     'timeline': timeline,
+    'timelineNode': null,
     'mediaTemplate': 'master_540_2997_$Number%09d$.cmfv',
     'indexTemplate': null,
     'mimeType': 'video/mp4',


### PR DESCRIPTION
This avoid create large timelines when there are not necessary. For example using SegmentTimeline with a large "r"