### PR TITLE
fix: Only expand robustness on each stream once

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -446,24 +446,31 @@ shaka.drm.DrmEngine = class {
       return newDrmInfos;
     };
 
+    const expandedStreams = new Set();
+
     for (const variant of variants) {
-      if (variant.video) {
+      if (variant.video && !expandedStreams.has(variant.video)) {
         variant.video.drmInfos =
             expandRobustness(variant.video.drmInfos,
                 'videoRobustness');
         variant.video.drmInfos =
             expandRobustness(variant.video.drmInfos,
                 'audioRobustness');
+        expandedStreams.add(variant.video);
       }
-      if (variant.audio) {
+      if (variant.audio && !expandedStreams.has(variant.audio)) {
         variant.audio.drmInfos =
             expandRobustness(variant.audio.drmInfos,
                 'videoRobustness');
         variant.audio.drmInfos =
             expandRobustness(variant.audio.drmInfos,
                 'audioRobustness');
+        expandedStreams.add(variant.audio);
       }
     }
+
+    // expandedStreams is no longer needed, so, clear it
+    expandedStreams.clear();
 
     // We should get the decodingInfo results for the variants after we filling
     // in the drm infos, and before queryMediaKeys_().


### PR DESCRIPTION
Without this change, `expandRobustness` ended up running 480 times for the stream `Angel One (multicodec, multilingual, Widevine)` with `SW_SECURE_CRYPTO,SW_SECURE_CRYPTO,SW_SECURE_CRYPTO` set up as the multiple robustness. With it, it only runs 44 times, which is expected because there are 22 unique streams, and it expands `videoRobustness` and `audioRobustness` on each.

Fixes #8408