### PR TITLE
fix: Fix getAudioTracks when audioId is null but exists originalAudioId

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5732,10 +5732,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return [];
     }
 
-    /** @type {!Map<number, shaka.extern.AudioTrack>} */
+    /** @type {!Map<string, shaka.extern.AudioTrack>} */
     const audioTracksMap = new Map();
     for (const track of filteredTracks) {
-      if (track.audioId == null) {
+      let id = track.originalAudioId;
+      if (!id && track.audioId != null) {
+        id = String(track.audioId);
+      }
+      if (!id) {
         continue;
       }
       /** @type {shaka.extern.AudioTrack} */
@@ -5753,7 +5757,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         spatialAudio: track.spatialAudio,
         originalLanguage: track.originalLanguage,
       };
-      audioTracksMap.set(track.audioId, audioTrack);
+      audioTracksMap.set(id, audioTrack);
     }
     return Array.from(audioTracksMap.values());
   }


### PR DESCRIPTION
Example native HLS or AirPlay