### PR TITLE
fix: Add a small fudge to prefetch eviction

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1562,7 +1562,10 @@ shaka.media.StreamingEngine = class {
 
     if (mediaState.segmentPrefetch && mediaState.segmentIterator &&
         !this.audioPrefetchMap_.has(mediaState.stream)) {
-      mediaState.segmentPrefetch.evict(reference.startTime + 0.001);
+      // This will prevent duplicate segments from being downloaded when we
+      // are close to the live edge.
+      const fudgeTime = 0.001;
+      mediaState.segmentPrefetch.evict(reference.startTime + fudgeTime);
       mediaState.segmentPrefetch.prefetchSegmentsByTime(reference.startTime)
           // We're treating this call as sync here, so ignore async errors
           // to not propagate them further.

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1562,7 +1562,7 @@ shaka.media.StreamingEngine = class {
 
     if (mediaState.segmentPrefetch && mediaState.segmentIterator &&
         !this.audioPrefetchMap_.has(mediaState.stream)) {
-      mediaState.segmentPrefetch.evict(reference.startTime);
+      mediaState.segmentPrefetch.evict(reference.startTime + 0.001);
       mediaState.segmentPrefetch.prefetchSegmentsByTime(reference.startTime)
           // We're treating this call as sync here, so ignore async errors
           // to not propagate them further.


### PR DESCRIPTION
This will prevent duplicate segments from being downloaded when we are close to the live edge.