### PR TITLE
perf: Remove extendedType when checking isTypeSupported on Tizen

### DIFF
--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -177,19 +177,6 @@ shaka.polyfill.MediaCapabilities = class {
           await shaka.polyfill.MediaCapabilities.canCastDisplayType_(
               videoConfig);
       return isSupported;
-    } else if (shaka.util.Platform.isTizen()) {
-      let extendedType = videoConfig.contentType;
-      if (videoConfig.width && videoConfig.height) {
-        extendedType += `; width=${videoConfig.width}`;
-        extendedType += `; height=${videoConfig.height}`;
-      }
-      if (videoConfig.framerate) {
-        extendedType += `; framerate=${videoConfig.framerate}`;
-      }
-      if (videoConfig.bitrate) {
-        extendedType += `; bitrate=${videoConfig.bitrate}`;
-      }
-      return shaka.media.Capabilities.isTypeSupported(extendedType);
     }
     return shaka.media.Capabilities.isTypeSupported(videoConfig.contentType);
   }


### PR DESCRIPTION
This is no longer necessary since we dynamically detect the resolution and this allows us to cache isTypeSupported calls with less dispersion.