### PR TITLE
fix: Fix exception updating partial config with deprecated fields

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -4158,6 +4158,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.Deprecate.deprecateFeature(5,
           'streaming.forceTransmuxTS configuration',
           'Please Use mediaSource.forceTransmux instead.');
+      config['mediaSource'] = config['mediaSource'] || {};
       config['mediaSource']['mediaSource'] =
           config['streaming']['forceTransmuxTS'];
       delete config['streaming']['forceTransmuxTS'];
@@ -4168,6 +4169,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.Deprecate.deprecateFeature(5,
           'streaming.forceTransmux configuration',
           'Please Use mediaSource.forceTransmux instead.');
+      config['mediaSource'] = config['mediaSource'] || {};
       config['mediaSource']['mediaSource'] =
           config['streaming']['forceTransmux'];
       delete config['streaming']['forceTransmux'];
@@ -4341,6 +4343,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.Deprecate.deprecateFeature(5,
           'streaming.dispatchAllEmsgBoxes configuration',
           'Please Use mediaSource.dispatchAllEmsgBoxes instead.');
+      config['mediaSource'] = config['mediaSource'] || {};
       config['mediaSource']['dispatchAllEmsgBoxes'] =
           config['streaming']['dispatchAllEmsgBoxes'];
       delete config['streaming']['dispatchAllEmsgBoxes'];
@@ -4447,6 +4450,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.Deprecate.deprecateFeature(5,
           'streaming.forceHTTP configuration',
           'Please Use networking.forceHTTP instead.');
+      config['networking'] = config['networking'] || {};
       config['networking']['forceHTTP'] = config['streaming']['forceHTTP'];
       delete config['streaming']['forceHTTP'];
     }
@@ -4456,6 +4460,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.Deprecate.deprecateFeature(5,
           'streaming.forceHTTPS configuration',
           'Please Use networking.forceHTTP instead.');
+      config['networking'] = config['networking'] || {};
       config['networking']['forceHTTPS'] = config['streaming']['forceHTTPS'];
       delete config['streaming']['forceHTTPS'];
     }
@@ -4466,6 +4471,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.Deprecate.deprecateFeature(5,
           'streaming.minBytesForProgressEvents configuration',
           'Please Use networking.minBytesForProgressEvents instead.');
+      config['networking'] = config['networking'] || {};
       config['networking']['minBytesForProgressEvents'] =
           config['streaming']['minBytesForProgressEvents'];
       delete config['streaming']['minBytesForProgressEvents'];


### PR DESCRIPTION
When calling configure() with a partial configuration (which is the usual practice), not every field is present.  When we update that configuration to move deprecated fields to their new location, we can't assume that the hierarchy before the new location is present.  We took care of this already in several cases, but not all.

Discovered while casting and transferring the configuration to the remote device.  This bug prevented the existing content state from being transferred correctly, forcing me to reload the content after casting.