### PR TITLE
fix(cast): Fix proxying of Player methods in CastProxy

### DIFF
--- a/lib/cast/cast_proxy.js
+++ b/lib/cast/cast_proxy.js
@@ -731,6 +731,16 @@ shaka.cast.CastProxy = class extends shaka.util.FakeEventTarget {
       return () => this.localPlayer_.getAdManager();
     }
 
+    if (name == 'getChapters') {
+      // This does not follow our standard pattern (takes an arguments), and
+      // therefore can't be proactively proxied and cached the way other
+      // synchronous getters can.
+      if (this.sender_.isCasting()) {
+        shaka.log.warning('NOTE: getChapters() does not work while casting!');
+      }
+      return () => [];
+    }
+
     if (name == 'setVideoContainer') {
       // Always returns a local instance.
       if (this.sender_.isCasting()) {
@@ -748,7 +758,7 @@ shaka.cast.CastProxy = class extends shaka.util.FakeEventTarget {
         };
       }
 
-      if (name == 'attach' || name == 'detach') {
+      if (name == 'attach' || name == 'attachCanvas' || name == 'detach') {
         return () => {
           shaka.log.alwaysWarn(name + '() does not work while casting!');
           return Promise.resolve();

--- a/lib/cast/cast_utils.js
+++ b/lib/cast/cast_utils.js
@@ -297,7 +297,8 @@ shaka.cast.CastUtils.VideoVoidMethods = [
 
 
 /**
- * Player getter methods that are proxied while casting.
+ * Player getter methods that are proxied while casting.  These must take no
+ * arguments and return a synchronous response (not a Promise).
  * The key is the method, the value is the frequency of updates.
  * Frequency 1 translates to every update; frequency 2 to every 2 updates, etc.
  * @const {!Map<string, number>}
@@ -309,7 +310,6 @@ shaka.cast.CastUtils.PlayerGetterMethods = new Map()
     .set('getAudioLanguagesAndRoles', 4)
     .set('getBufferFullness', 1)
     .set('getBufferedInfo', 2)
-    .set('getChapters', 4)
     .set('getExpiration', 2)
     .set('getKeyStatuses', 2)
     .set('getLoadMode', 10)
@@ -327,7 +327,6 @@ shaka.cast.CastUtils.PlayerGetterMethods = new Map()
     .set('isFullyLoaded', 1)
     .set('isInProgress', 1)
     .set('isLive', 10)
-    .set('isRemotePlayback', 10)
     .set('isTextTrackVisible', 1)
     .set('keySystem', 10)
     .set('seekRange', 1);
@@ -336,7 +335,8 @@ shaka.cast.CastUtils.PlayerGetterMethods = new Map()
 /**
  * Player getter methods with data large enough to be sent in their own update
  * messages, to reduce the size of each message.  The format of this is
- * identical to PlayerGetterMethods.
+ * identical to PlayerGetterMethods.  These must take no arguments and return a
+ * synchronous response (not a Promise).
  * @const {!Map<string, number>}
  */
 shaka.cast.CastUtils.LargePlayerGetterMethods = new Map()
@@ -355,7 +355,8 @@ shaka.cast.CastUtils.LargePlayerGetterMethods = new Map()
 
 /**
  * Player getter methods that are proxied while casting, but only when casting
- * a livestream.
+ * a livestream.  These must take no arguments and return a synchronous
+ * response (not a Promise).
  * The key is the method, the value is the frequency of updates.
  * Frequency 1 translates to every update; frequency 2 to every 2 updates, etc.
  * @const {!Map<string, number>}
@@ -409,7 +410,6 @@ shaka.cast.CastUtils.PlayerVoidMethods = [
   'selectVariantsByLabel',
   'selectVariantTrack',
   'selectVideoTrack',
-  'setMaxHardwareResolution',
   'setTextTrackVisibility',
   'trickPlay',
   'updateStartTime',
@@ -422,20 +422,11 @@ shaka.cast.CastUtils.PlayerVoidMethods = [
  */
 shaka.cast.CastUtils.PlayerPromiseMethods = [
   'addChaptersTrack',
-  'addFont',
   'addTextTrackAsync',
   'addThumbnailsTrack',
-  'attach',
-  'destroy',
-  'destroyAllPreloads',
-  'detachAndSavePreload',
-  'detach',
-  'getAllThumbnails',
   'getThumbnails',
   // The manifestFactory parameter of load is not supported.
   'load',
-  'preload',
-  'unloadAndSavePreload',
   'unload',
 ];
 

--- a/lib/cast/cast_utils.js
+++ b/lib/cast/cast_utils.js
@@ -309,8 +309,12 @@ shaka.cast.CastUtils.PlayerGetterMethods = new Map()
     .set('getAudioLanguagesAndRoles', 4)
     .set('getBufferFullness', 1)
     .set('getBufferedInfo', 2)
+    .set('getChapters', 4)
     .set('getExpiration', 2)
     .set('getKeyStatuses', 2)
+    .set('getLoadMode', 10)
+    .set('getLiveLatency', 8)
+    .set('getManifestType', 10)
     // NOTE: The 'getManifest' property is not proxied, as it is very large.
     // NOTE: The 'getManifestParserFactory' property is not proxied, as it would
     // not serialize.
@@ -319,15 +323,14 @@ shaka.cast.CastUtils.PlayerGetterMethods = new Map()
     .set('getTextLanguagesAndRoles', 4)
     .set('isAudioOnly', 10)
     .set('isBuffering', 1)
+    .set('isEnded', 1)
+    .set('isFullyLoaded', 1)
     .set('isInProgress', 1)
     .set('isLive', 10)
+    .set('isRemotePlayback', 10)
     .set('isTextTrackVisible', 1)
     .set('keySystem', 10)
-    .set('seekRange', 1)
-    .set('getLoadMode', 10)
-    .set('getManifestType', 10)
-    .set('isFullyLoaded', 1)
-    .set('isEnded', 1);
+    .set('seekRange', 1);
 
 
 /**
@@ -343,10 +346,10 @@ shaka.cast.CastUtils.LargePlayerGetterMethods = new Map()
     .set('getConfigurationForLowLatency', 4)
     .set('getStats', 5)
     .set('getAudioTracks', 2)
+    .set('getChaptersTracks', 2)
     .set('getImageTracks', 2)
     .set('getVideoTracks', 2)
     .set('getTextTracks', 2)
-    .set('getThumbnails', 2)
     .set('getVariantTracks', 2);
 
 
@@ -393,27 +396,23 @@ shaka.cast.CastUtils.PlayerInitAfterLoadState = [
  * @const {!Array<string>}
  */
 shaka.cast.CastUtils.PlayerVoidMethods = [
-  'addChaptersTrack',
-  'addTextTrackAsync',
-  'addThumbnailsTrack',
   'cancelTrickPlay',
-  'configure',
   'configurationForLowLatency',
-  'getChapters',
-  'getChaptersTracks',
+  'configure',
+  'goToLive',
   'resetConfiguration',
   'retryStreaming',
   'selectAudioLanguage',
   'selectAudioTrack',
   'selectTextLanguage',
   'selectTextTrack',
-  'selectVariantTrack',
   'selectVariantsByLabel',
+  'selectVariantTrack',
   'selectVideoTrack',
+  'setMaxHardwareResolution',
   'setTextTrackVisibility',
   'trickPlay',
   'updateStartTime',
-  'goToLive',
 ];
 
 
@@ -422,11 +421,21 @@ shaka.cast.CastUtils.PlayerVoidMethods = [
  * @const {!Array<string>}
  */
 shaka.cast.CastUtils.PlayerPromiseMethods = [
+  'addChaptersTrack',
+  'addFont',
+  'addTextTrackAsync',
+  'addThumbnailsTrack',
   'attach',
-  'attachCanvas',
+  'destroy',
+  'destroyAllPreloads',
+  'detachAndSavePreload',
   'detach',
+  'getAllThumbnails',
+  'getThumbnails',
   // The manifestFactory parameter of load is not supported.
   'load',
+  'preload',
+  'unloadAndSavePreload',
   'unload',
 ];
 

--- a/test/cast/cast_utils_unit.js
+++ b/test/cast/cast_utils_unit.js
@@ -13,8 +13,12 @@ describe('CastUtils', () => {
 
   it('includes every Player member', () => {
     const ignoredMembers = [
+      'attach',  // Stubbed
+      'attachCanvas',  // Stubbed
+      'detach',  // Stubbed
       'constructor',  // JavaScript added field
       'getAdManager',  // Handled specially
+      'getChapters',  // Not serialized
       'getSharedConfiguration',  // Handled specially
       'getNetworkingEngine',  // Handled specially
       'getDrmEngine',  // Handled specially
@@ -35,7 +39,6 @@ describe('CastUtils', () => {
       'getNonDefaultConfiguration',
       'addFont',
       'getFetchedPlaybackInfo',
-      'getLiveLatency',
       'isRemotePlayback',
 
       // Test helper methods (not @export'd)


### PR DESCRIPTION
These maps of proxied methods have not been properly maintained, so some methods were not working while casting.

In the case of getThumbnails, it was incorrectly categorized as a synchronous getter, and so the return value while casting was a deserialized Promise, which is an empty object.

Several async methods were called void methods, as were several synchronous getters.  This should be up-to-date now.