### PR TITLE
perf: Optimize getAllThumbnails()

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5367,18 +5367,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!imageStream.segmentIndex) {
       await imageStream.createSegmentIndex();
     }
-    return imageStream;
-  }
-
-  /**
-   * Return a Thumbnail object from a image stream and time.
-   *
-   * @param {shaka.extern.Stream} imageStream
-   * @param {number} time
-   * @return {?shaka.extern.Thumbnail}
-   * @private
-   */
-  getThumbnailsByStream_(imageStream, time) {
     const referencePosition = imageStream.segmentIndex.find(time);
     if (referencePosition == null) {
       return null;

--- a/lib/player.js
+++ b/lib/player.js
@@ -5277,7 +5277,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         const duration = reference.trueEndTime - reference.startTime;
         for (let i = 0; i < numThumbnails; i++) {
           const sampleTime = reference.startTime + duration * i / numThumbnails;
-          const thumbnail = this.getThumbnailsByReference_(reference,
+          const thumbnail = this.getThumbnailByReference_(reference,
               /** @type {shaka.extern.Stream} */ (imageStream), sampleTime,
               dimensions);
           thumbnails.push(thumbnail);
@@ -5332,7 +5332,18 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!imageStream) {
       return null;
     }
-    return this.getThumbnailsByStream_(imageStream, time);
+    const referencePosition = imageStream.segmentIndex.find(time);
+    if (referencePosition == null) {
+      return null;
+    }
+    const reference = imageStream.segmentIndex.get(referencePosition);
+    const dimensions = this.parseTilesLayout_(
+        reference.getTilesLayout() || imageStream.tilesLayout);
+    if (!dimensions) {
+      return null;
+    }
+    return this.getThumbnailByReference_(reference, imageStream, time,
+        dimensions);
   }
 
   /**
@@ -5367,22 +5378,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!imageStream.segmentIndex) {
       await imageStream.createSegmentIndex();
     }
-    const referencePosition = imageStream.segmentIndex.find(time);
-    if (referencePosition == null) {
-      return null;
-    }
-    const reference = imageStream.segmentIndex.get(referencePosition);
-    const dimensions = this.parseTilesLayout_(
-        reference.getTilesLayout() || imageStream.tilesLayout);
-    if (!dimensions) {
-      return null;
-    }
-    return this.getThumbnailsByReference_(reference, imageStream, time,
-        dimensions);
+    return imageStream;
   }
 
   /**
-   * Return a Thumbnail object from a referemce.
+   * Return a Thumbnail object from a reference.
    *
    * @param {shaka.media.SegmentReference} reference
    * @param {shaka.extern.Stream} imageStream
@@ -5391,7 +5391,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @return {!shaka.extern.Thumbnail}
    * @private
    */
-  getThumbnailsByReference_(reference, imageStream, time, dimensions) {
+  getThumbnailByReference_(reference, imageStream, time, dimensions) {
     const fullImageWidth = imageStream.width || 0;
     const fullImageHeight = imageStream.height || 0;
     let width = fullImageWidth / dimensions.columns;

--- a/lib/player.js
+++ b/lib/player.js
@@ -5277,12 +5277,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         const duration = reference.trueEndTime - reference.startTime;
         for (let i = 0; i < numThumbnails; i++) {
           const sampleTime = reference.startTime + duration * i / numThumbnails;
-          const thumbnail =
-              this.getThumbnailsByStream_(
-              /** @type {shaka.extern.Stream} */ (imageStream), sampleTime);
-          if (thumbnail) {
-            thumbnails.push(thumbnail);
-          }
+          const thumbnail = this.getThumbnailsByReference_(reference,
+              /** @type {shaka.extern.Stream} */ (imageStream), sampleTime,
+              dimensions);
+          thumbnails.push(thumbnail);
         }
       }
     });
@@ -5391,6 +5389,21 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!dimensions) {
       return null;
     }
+    return this.getThumbnailsByReference_(reference, imageStream, time,
+        dimensions);
+  }
+
+  /**
+   * Return a Thumbnail object from a referemce.
+   *
+   * @param {shaka.media.SegmentReference} reference
+   * @param {shaka.extern.Stream} imageStream
+   * @param {number} time
+   * @param {{columns: number, rows: number}} dimensions
+   * @return {!shaka.extern.Thumbnail}
+   * @private
+   */
+  getThumbnailsByReference_(reference, imageStream, time, dimensions) {
     const fullImageWidth = imageStream.width || 0;
     const fullImageHeight = imageStream.height || 0;
     let width = fullImageWidth / dimensions.columns;


### PR DESCRIPTION
Use segment references from `forEachTopLevelReference()` callback to avoid unnecessary linear search on every possible thumbnail.