### PR TITLE
fix: External text tracks in src mode related issues

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -7115,8 +7115,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       mimeType = 'text/vtt';
     }
 
-    const trackElement = /** @type {!HTMLTrackElement} */
-      (this.video_.ownerDocument.createElement('track'));
+    const trackElement =
+      /** @type {!HTMLTrackElement} */(document.createElement('track'));
     trackElement.src = this.cmcdManager_.appendTextTrackData(uri);
     trackElement.label = label;
     trackElement.kind = kind;

--- a/lib/player.js
+++ b/lib/player.js
@@ -918,6 +918,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @private {boolean} */
     this.preloadDueAdManagerVideoEnded_ = false;
 
+    /** @private {!Array<HTMLTrackElement>} */
+    this.externalSrcEqualsTextTracks_ = [];
+
     /** @private {shaka.util.Timer} */
     this.preloadDueAdManagerTimer_ = new shaka.util.Timer(async () => {
       if (this.preloadDueAdManager_) {
@@ -1529,8 +1532,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
 
       if (this.video_) {
-        // Remove all track nodes
-        shaka.util.Dom.removeAllChildren(this.video_);
+        // The life cycle of tracks that created by addTextTrackAsync() and
+        // their associated resources should be the same as the loaded video.
+        for (const trackNode of this.externalSrcEqualsTextTracks_) {
+          if (trackNode.src.startsWith('blob:')) {
+            URL.revokeObjectURL(trackNode.src);
+          }
+          trackNode.remove();
+        }
+        this.externalSrcEqualsTextTracks_ = [];
 
         // In order to unload a media element, we need to remove the src
         // attribute and then load again. When we destroy media source engine,
@@ -1538,8 +1548,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         //
         // DrmEngine requires this to be done before we destroy DrmEngine
         // itself.
-        if (this.video_.src) {
-          this.video_.removeAttribute('src');
+        if (shaka.util.Dom.clearSourceFromVideo(this.video_)) {
           this.video_.load();
         }
       }
@@ -2518,8 +2527,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // Remove children if we had any, i.e. from previously used src= mode.
     if (this.config_.mediaSource.useSourceElements) {
-      this.video_.removeAttribute('src');
-      shaka.util.Dom.removeAllChildren(this.video_);
+      shaka.util.Dom.clearSourceFromVideo(this.video_);
     }
 
     this.createTextDisplayer_();
@@ -3188,7 +3196,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       await this.mediaSourceEngine_.destroy();
       this.mediaSourceEngine_ = null;
     }
-    shaka.util.Dom.removeAllChildren(mediaElement);
+    shaka.util.Dom.clearSourceFromVideo(mediaElement);
 
     mediaElement.src = playbackUri;
 
@@ -6668,25 +6676,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     if (this.loadMode_ == shaka.Player.LoadMode.SRC_EQUALS) {
-      if (forced) {
+      if (forced && shaka.util.Platform.isApple()) {
         // See: https://github.com/whatwg/html/issues/4472
         kind = 'forced';
       }
-      await this.addSrcTrackElement_(uri, language, kind, mimeType, label || '',
-          adCuePoints);
-
-      const LanguageUtils = shaka.util.LanguageUtils;
-      const languageNormalized = LanguageUtils.normalize(language);
-
-      const textTracks = this.getTextTracks();
-      const srcTrack = textTracks.find((t) => {
-        return LanguageUtils.normalize(t.language) == languageNormalized &&
-            t.label == (label || '') &&
-            t.kind == kind;
-      });
-      if (srcTrack) {
+      const trackNode = await this.addSrcTrackElement_(uri, language, kind,
+          mimeType, label || '', adCuePoints);
+      if (trackNode.track) {
         this.onTracksChanged_();
-        return srcTrack;
+        return shaka.util.StreamUtils.html5TextTrackToTrack(trackNode.track);
       }
       // This should not happen, but there are browser implementations that may
       // not support the Track element.
@@ -7117,8 +7115,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       mimeType = 'text/vtt';
     }
 
-    const trackElement =
-      /** @type {!HTMLTrackElement} */(document.createElement('track'));
+    const trackElement = /** @type {!HTMLTrackElement} */
+      (this.video_.ownerDocument.createElement('track'));
     trackElement.src = this.cmcdManager_.appendTextTrackData(uri);
     trackElement.label = label;
     trackElement.kind = kind;
@@ -7135,6 +7133,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     this.video_.appendChild(trackElement);
+    this.externalSrcEqualsTextTracks_.push(trackElement);
     return trackElement;
   }
 

--- a/lib/util/dom_utils.js
+++ b/lib/util/dom_utils.js
@@ -57,6 +57,28 @@ shaka.util.Dom = class {
 
 
   /**
+   * Remove all source elements and src attribute from a video element.
+   * Returns true if any change was made.
+   * @param {!HTMLMediaElement} video
+   * @export
+   * @return {boolean}
+   */
+  static clearSourceFromVideo(video) {
+    let result = false;
+    const sources = video.getElementsByTagName('source');
+    for (let i = sources.length - 1; i >= 0; --i) {
+      video.removeChild(sources[i]);
+      result = true;
+    }
+    if (video.src) {
+      video.removeAttribute('src');
+      result = true;
+    }
+    return result;
+  }
+
+
+  /**
    * Cast a Node/Element to an HTMLElement
    *
    * @param {!Node|!Element} original


### PR DESCRIPTION
All changes were part of #8520

- Object URLs created in `addSrcTrackElement_()` are now released correctly
- Use `HTMLTrackElement.track` to access its associated `TextTrack`. Searching in `HTMLMediaElement.textTracks` is not reliable
- Remove only `<source>` elements during initialization. User added `<track>` elements are not harmful and they may want to keep them for dual subtitles for example.