### PR TITLE
fix: Fix memory leak on Metadata and EMSG timelines

### DIFF
--- a/lib/media/region_timeline.js
+++ b/lib/media/region_timeline.js
@@ -23,16 +23,16 @@ goog.require('shaka.util.Timer');
  */
 shaka.media.RegionTimeline = class extends shaka.util.FakeEventTarget {
   /**
-   * @param {!function():{start: number, end: number}} getSeekRange
+   * @param {!function():{start: number, end: number}} getFilterRange
    */
-  constructor(getSeekRange) {
+  constructor(getFilterRange) {
     super();
 
     /** @private {!Map<string, T>} */
     this.regions_ = new Map();
 
     /** @private {!function():{start: number, end: number}} */
-    this.getSeekRange_ = getSeekRange;
+    this.getFilterRange_ = getFilterRange;
 
     /**
      * Make sure all of the regions we're tracking are within the
@@ -72,15 +72,15 @@ shaka.media.RegionTimeline = class extends shaka.util.FakeEventTarget {
   /**
    * @private
    */
-  filterBySeekRange_() {
-    const seekRange = this.getSeekRange_();
+  filterByRange_() {
+    const filterRange = this.getFilterRange_();
     for (const [key, region] of this.regions_) {
       // Only consider the seek range start here.
       // Future regions might become relevant eventually,
       // but regions that are in the past and can't ever be
       // seeked to will never come up again, and there's no
       // reason to store or process them.
-      if (region.endTime < seekRange.start) {
+      if (region.endTime < filterRange.start) {
         this.regions_.delete(key);
         const event = new shaka.util.FakeEvent('regionremove', new Map([
           ['region', region],
@@ -99,7 +99,7 @@ shaka.media.RegionTimeline = class extends shaka.util.FakeEventTarget {
       return;
     }
     this.filterTimer_ = new shaka.util.Timer(() => {
-      this.filterBySeekRange_();
+      this.filterByRange_();
     }).tickEvery(
         /* seconds= */ shaka.media.RegionTimeline.REGION_FILTER_INTERVAL);
   }

--- a/lib/player.js
+++ b/lib/player.js
@@ -1791,8 +1791,28 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // Make sure that the app knows of the new buffering state.
       this.updateBufferState_();
 
+      const bufferRange = () => {
+        const bufferedInfo = this.getBufferedInfo();
+        const range = {
+          start: 0,
+          end: 0,
+        };
+        if (bufferedInfo.total.length) {
+          range.start = Infinity;
+          for (const buffered of bufferedInfo.total) {
+            if (buffered.start < range.start) {
+              range.start = buffered.start;
+            }
+            if (buffered.end > range.end) {
+              range.end = buffered.end;
+            }
+          }
+        }
+        return range;
+      };
+
       this.metadataRegionTimeline_ =
-          new shaka.media.RegionTimeline(() => this.seekRange());
+          new shaka.media.RegionTimeline(bufferRange);
 
       if (shouldUseSrcEquals) {
         await mutexWrapOperation(async () => {
@@ -1805,7 +1825,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         }, 'srcEqualsInner_');
       } else {
         this.emsgRegionTimeline_ =
-            new shaka.media.RegionTimeline(() => this.seekRange());
+            new shaka.media.RegionTimeline(bufferRange);
         // Wait for the manifest to be parsed.
         await mutexWrapOperation(async () => {
           await preloadManager.waitForManifest();


### PR DESCRIPTION
What this change does is remove from the timeline using  the buffered instead of the seekRange for Metadata and EMSG.

Fixes #8535