### PR TITLE
fix: Sony Bravia TV Playready DRM Failure

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -1736,7 +1736,7 @@ shaka.drm.DrmEngine = class {
       // However, unlike Edge and Chromecast, Tizen doesn't have this problem.
       if (shaka.drm.DrmUtils.isPlayReadyKeySystem(
           this.currentDrmInfo_.keySystem) &&
-          keyId.byteLength === 16 &&
+          keyId.byteLength == 16 &&
           (shaka.util.Platform.isEdge() ||
           shaka.util.Platform.isPS4() ||
           shaka.util.Platform.isSonyTV())) {

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -1736,8 +1736,10 @@ shaka.drm.DrmEngine = class {
       // However, unlike Edge and Chromecast, Tizen doesn't have this problem.
       if (shaka.drm.DrmUtils.isPlayReadyKeySystem(
           this.currentDrmInfo_.keySystem) &&
-          keyId.byteLength == 16 &&
-          (shaka.util.Platform.isEdge() || shaka.util.Platform.isPS4())) {
+          keyId.byteLength === 16 &&
+          (shaka.util.Platform.isEdge() ||
+          shaka.util.Platform.isPS4() ||
+          shaka.util.Platform.isSonyTV())) {
         // Read out some fields in little-endian:
         const dataView = shaka.util.BufferUtils.toDataView(keyId);
         const part0 = dataView.getUint32(0, /* LE= */ true);

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -342,6 +342,14 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is Sony TV.
+   * @return {boolean}
+   */
+  static isSonyTV() {
+    return shaka.util.Platform.userAgentContains_('sony.hbbtv.tv.G5');
+  }
+
+  /**
    * Check if the current platform is Hisense.
    * @return {boolean}
    */

--- a/project-words.txt
+++ b/project-words.txt
@@ -180,6 +180,7 @@ Clearkey
 Clearkeys
 Clutz
 codem
+hbbtv
 Conax
 cvox
 expressjs


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/8576
Browser on this Sony TV returns little-endian, which results in false-positive unsupported key system. Looks like this is a known issue impacting couple of other platforms as well. I need to add this TV as well. 