### PR TITLE
fix: Fix config failures with multiple references to an input array

### DIFF
--- a/lib/util/config_utils.js
+++ b/lib/util/config_utils.js
@@ -101,6 +101,10 @@ shaka.util.ConfigUtils = class {
         shaka.log.alwaysWarn(
             'Unexpected number of arguments for ' + subPath);
         destination[k] = source[k];
+      } else if (Array.isArray(destination[k])) {
+        // Make a copy of the input array, so that changes to the source object
+        // don't immediately affect the running config.
+        destination[k] = source[k].slice();
       } else {
         destination[k] = source[k];
       }

--- a/lib/util/config_utils.js
+++ b/lib/util/config_utils.js
@@ -104,7 +104,10 @@ shaka.util.ConfigUtils = class {
       } else if (Array.isArray(destination[k])) {
         // Make a copy of the input array, so that changes to the source object
         // don't immediately affect the running config.
-        destination[k] = source[k].slice();
+        // Since everything here is very loosely-typed, use a cast to convince
+        // the compiler we're not calling slice() on a potential ArrayBuffer,
+        // which would break Tizen.
+        destination[k] = /** @type {Array} */(source[k]).slice();
       } else {
         destination[k] = source[k];
       }


### PR DESCRIPTION
When the user passes an array-based config, we should never copy the reference.  Instead, we should clone the array.  This way, changes to that outside array don't immediately affect the running config.

Closes #8478