### PR TITLE
feat: Add canupdatestarttime to allow update the startTime safely

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -441,6 +441,17 @@ goog.requireType('shaka.media.PresentationTimeline');
 
 
 /**
+ * @event shaka.Player.CanUpdateStartTimeEvent
+ * @description Fired when it is safe to update the start time of a stream. You
+ *   may use this event to get the seek range and update the start time,
+ *   eg: on live streams.
+ * @property {string} type
+ *   'canupdatestarttime'
+ * @exportDoc
+ */
+
+
+/**
  * @event shaka.Player.AbrStatusChangedEvent
  * @description Fired when the state of abr has been changed.
  *    (Enabled or disabled).
@@ -2831,6 +2842,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.streamingEngine_.applyPlayRange(
         this.config_.playRangeStart, this.config_.playRangeEnd);
 
+    this.fullyLoaded_ = true;
+
+    this.dispatchEvent(shaka.Player.makeEvent_(
+        shaka.util.FakeEvent.EventName.CanUpdateStartTime));
+
     const setupPlayhead = (startTime) => {
       this.playhead_ = this.createPlayhead(startTime);
       this.playheadObservers_ =
@@ -2989,8 +3005,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (this.adManager_) {
       this.adManager_.onManifestUpdated(isLive);
     }
-
-    this.fullyLoaded_ = true;
   }
 
   /**
@@ -3138,6 +3152,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.cleanupOnUnload_.push(() => {
       unloaded = true;
     });
+
+    this.dispatchEvent(shaka.Player.makeEvent_(
+        shaka.util.FakeEvent.EventName.CanUpdateStartTime));
 
     if (this.startTime_ != null) {
       this.playhead_.setStartTime(this.startTime_);

--- a/lib/util/fake_event.js
+++ b/lib/util/fake_event.js
@@ -159,6 +159,7 @@ shaka.util.FakeEvent.EventName = {
   AudioTracksChanged: 'audiotrackschanged',
   BoundaryCrossed: 'boundarycrossed',
   Buffering: 'buffering',
+  CanUpdateStartTime: 'canupdatestarttime',
   Complete: 'complete',
   DownloadCompleted: 'downloadcompleted',
   DownloadFailed: 'downloadfailed',

--- a/project-words.txt
+++ b/project-words.txt
@@ -10,6 +10,7 @@ audiotrackchanged
 audiotrackschanged
 autoplaying
 boundarycrossed
+canupdatestarttime
 captionselectionupdated
 caststatuschanged
 clearlead


### PR DESCRIPTION
Close https://github.com/shaka-project/shaka-player/issues/8506

Example of use:

```
this.player_.addEventListener('canupdatestarttime', () => {
  this.player_.updateStartTime(this.player_.seekRange().start + 300);
});
```