### PR TITLE
fix(WebOS): Do not throw error during parsing ID3

### DIFF
--- a/build/types/polyfill
+++ b/build/types/polyfill
@@ -8,6 +8,7 @@
 +../../lib/polyfill/patchedmediakeys_webkit.js
 +../../lib/polyfill/random_uuid.js
 +../../lib/polyfill/symbol.js
++../../lib/polyfill/typed_array.js
 +../../lib/polyfill/video_play_promise.js
 +../../lib/polyfill/videoplaybackquality.js
 +../../lib/polyfill/vttcue.js

--- a/lib/polyfill/typed_array.js
+++ b/lib/polyfill/typed_array.js
@@ -1,0 +1,49 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.provide('shaka.polyfill.TypedArray');
+
+goog.require('shaka.polyfill');
+
+/**
+ * @summary A polyfill to provide missing TypedArray indexOf methods for older
+ * browsers.
+ * @export
+ */
+shaka.polyfill.TypedArray = class {
+  /**
+   * Install the polyfill if needed.
+   * @export
+   */
+  static install() {
+    const typedArrays = [
+      Uint8Array, Uint8ClampedArray, Uint16Array, Uint32Array,
+      Int8Array, Int16Array, Int32Array, Float32Array, Float64Array,
+    ];
+    for (const typedArray of typedArrays) {
+      // eslint-disable-next-line no-restricted-syntax
+      if (typedArray.prototype.indexOf) {
+        continue;
+      }
+      // eslint-disable-next-line no-restricted-syntax
+      typedArray.prototype.indexOf = shaka.polyfill.TypedArray.indexOf_;
+    }
+  }
+
+  /**
+   * @param {number} searchElement
+   * @param {number} fromIndex
+   * @return {number}
+   * @this {TypedArray}
+   * @private
+   */
+  static indexOf_(searchElement, fromIndex) {
+    // eslint-disable-next-line no-restricted-syntax
+    return Array.prototype.indexOf.call(this, searchElement, fromIndex);
+  }
+};
+
+shaka.polyfill.register(shaka.polyfill.TypedArray.install);

--- a/lib/polyfill/typed_array.js
+++ b/lib/polyfill/typed_array.js
@@ -9,8 +9,8 @@ goog.provide('shaka.polyfill.TypedArray');
 goog.require('shaka.polyfill');
 
 /**
- * @summary A polyfill to provide missing TypedArray indexOf methods for older
- * browsers.
+ * @summary A polyfill to provide missing TypedArray methods for older
+ * browsers (indexOf/lastIndexOf/includes).
  * @export
  */
 shaka.polyfill.TypedArray = class {
@@ -25,11 +25,21 @@ shaka.polyfill.TypedArray = class {
     ];
     for (const typedArray of typedArrays) {
       // eslint-disable-next-line no-restricted-syntax
-      if (typedArray.prototype.indexOf) {
-        continue;
+      if (!typedArray.prototype.indexOf) {
+        // eslint-disable-next-line no-restricted-syntax
+        typedArray.prototype.indexOf = shaka.polyfill.TypedArray.indexOf_;
       }
       // eslint-disable-next-line no-restricted-syntax
-      typedArray.prototype.indexOf = shaka.polyfill.TypedArray.indexOf_;
+      if (!typedArray.prototype.lastIndexOf) {
+        // eslint-disable-next-line no-restricted-syntax
+        typedArray.prototype.lastIndexOf =
+            shaka.polyfill.TypedArray.lastIndexOf_;
+      }
+      // eslint-disable-next-line no-restricted-syntax
+      if (!typedArray.prototype.includes) {
+        // eslint-disable-next-line no-restricted-syntax
+        typedArray.prototype.includes = shaka.polyfill.TypedArray.includes_;
+      }
     }
   }
 
@@ -43,6 +53,29 @@ shaka.polyfill.TypedArray = class {
   static indexOf_(searchElement, fromIndex) {
     // eslint-disable-next-line no-restricted-syntax
     return Array.prototype.indexOf.call(this, searchElement, fromIndex);
+  }
+
+  /**
+   * @param {number} searchElement
+   * @param {number} fromIndex
+   * @return {number}
+   * @this {TypedArray}
+   * @private
+   */
+  static lastIndexOf_(searchElement, fromIndex) {
+    // eslint-disable-next-line no-restricted-syntax
+    return Array.prototype.lastIndexOf.call(this, searchElement, fromIndex);
+  }
+
+  /**
+   * @param {number} searchElement
+   * @param {number} fromIndex
+   * @return {boolean}
+   * @this {TypedArray}
+   * @private
+   */
+  static includes_(searchElement, fromIndex) {
+    return this.indexOf(searchElement, fromIndex) !== -1;
   }
 };
 

--- a/shaka-player.uncompiled.js
+++ b/shaka-player.uncompiled.js
@@ -45,6 +45,7 @@ goog.require('shaka.polyfill.PatchedMediaKeysWebkit');
 goog.require('shaka.polyfill.PiPWebkit');
 goog.require('shaka.polyfill.RandomUUID');
 goog.require('shaka.polyfill.Symbol');
+goog.require('shaka.polyfill.TypedArray');
 goog.require('shaka.polyfill.VTTCue');
 goog.require('shaka.polyfill.VideoPlayPromise');
 goog.require('shaka.polyfill.VideoPlaybackQuality');


### PR DESCRIPTION
`TypedArray.prototype.indexOf` is available since Chrome 45, which means it's not implemented on WebOS 3 (using Chromium 38). As we extensively use this method in `Id3Utils` it leads to fatal errors on this platform whenever we encounter ID3 tags.
For completeness and to prevent errors in the future, I also added implementations of connected methods: `lastIndexOf` & `includes`.