### PR TITLE
chore: Useless warning on UITextDisplayer

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -34,12 +34,6 @@ shaka.text.UITextDisplayer = class {
   constructor(video, videoContainer) {
     goog.asserts.assert(videoContainer, 'videoContainer should be valid.');
 
-    if (!document.fullscreenEnabled) {
-      shaka.log.alwaysWarn('Using UITextDisplayer in a browser without ' +
-          'Fullscreen API support causes subtitles to not be rendered in ' +
-          'fullscreen');
-    }
-
     /** @private {boolean} */
     this.isTextVisible_ = false;
 

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -8,7 +8,6 @@
 goog.provide('shaka.text.UITextDisplayer');
 
 goog.require('goog.asserts');
-goog.require('shaka.log');
 goog.require('shaka.text.Cue');
 goog.require('shaka.text.CueRegion');
 goog.require('shaka.text.Utils');


### PR DESCRIPTION
Eg: fullscreen is not supported on Tizen, but we want use UITextDisplayer