### PR TITLE
fix(HLS): Do not skip DateRanges based on ID

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -286,9 +286,6 @@ shaka.hls.HlsParser = class {
     /** @private {boolean} */
     this.needsClosedCaptionsDetection_ = true;
 
-    /** @private {Set<string>} */
-    this.dateRangeIdsEmitted_ = new Set();
-
     /** @private {shaka.util.EventManager} */
     this.eventManager_ = new shaka.util.EventManager();
 
@@ -382,7 +379,6 @@ shaka.hls.HlsParser = class {
     this.aesKeyMap_.clear();
     this.identityKeyMap_.clear();
     this.initSegmentToKidMap_.clear();
-    this.dateRangeIdsEmitted_.clear();
 
     if (this.contentSteeringManager_) {
       this.contentSteeringManager_.destroy();
@@ -4102,10 +4098,6 @@ shaka.hls.HlsParser = class {
     for (let i = 0; i < dateRangeTags.length; i++) {
       const tag = dateRangeTags[i];
       try {
-        const id = tag.getRequiredAttrValue('ID');
-        if (this.dateRangeIdsEmitted_.has(id)) {
-          continue;
-        }
         const startDateValue = tag.getRequiredAttrValue('START-DATE');
         const startDate = shaka.util.TXml.parseDate(startDateValue);
         if (isNaN(startDate)) {
@@ -4215,8 +4207,6 @@ shaka.hls.HlsParser = class {
         if (values.length > 1) {
           this.playerInterface_.onMetadata(type, startTime, endTime, values);
         }
-
-        this.dateRangeIdsEmitted_.add(id);
       } catch (e) {
         shaka.log.warning('Ignoring DATERANGE with errors', tag.toString());
       }

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -6094,42 +6094,6 @@ describe('HlsParser', () => {
       expect(onMetadataSpy).toHaveBeenCalledWith(metadataType, 0, 5, values);
     });
 
-    it('skip duplicate IDs', async () => {
-      const mediaPlaylist = [
-        '#EXTM3U\n',
-        '#EXT-X-TARGETDURATION:5\n',
-        '#EXT-X-PROGRAM-DATE-TIME:2000-01-01T00:00:00.00Z\n',
-        '#EXTINF:5,\n',
-        'video1.ts\n',
-        '#EXT-X-DATERANGE:ID="0",START-DATE="2000-01-01T00:00:00.00Z",',
-        'DURATION=1,X-SHAKA="FOREVER"\n',
-        '#EXT-X-DATERANGE:ID="0",START-DATE="2000-01-01T00:00:00.00Z",',
-        'DURATION=1,X-SHAKA="FOREVER"\n',
-        '#EXT-X-DATERANGE:ID="0",START-DATE="2000-01-01T00:00:00.00Z",',
-        'DURATION=1,X-SHAKA="FOREVER"\n',
-      ].join('');
-
-      fakeNetEngine
-          .setResponseText('test:/master', mediaPlaylist)
-          .setResponseValue('test:/video1.ts', tsSegmentData);
-
-      await parser.start('test:/master', playerInterface);
-
-      const metadataType = 'com.apple.quicktime.HLS';
-      const values = [
-        jasmine.objectContaining({
-          key: 'ID',
-          data: '0',
-        }),
-        jasmine.objectContaining({
-          key: 'X-SHAKA',
-          data: 'FOREVER',
-        }),
-      ];
-      expect(onMetadataSpy).toHaveBeenCalledTimes(1);
-      expect(onMetadataSpy).toHaveBeenCalledWith(metadataType, 0, 1, values);
-    });
-
     it('with no EXT-X-PROGRAM-DATE-TIME', async () => {
       const mediaPlaylist = [
         '#EXTM3U\n',


### PR DESCRIPTION
According to HLS spec, there might be few date ranges with the same ID, which complement each other (i.e. SCTE35-IN / SCTE35-OUT).

If date ranges are true duplicates (i.e. due to live update) it will be filter out anyway by `RegionTimeline` logic.