### PR TITLE
fix(UI): Filter audio qualities when bandwidth is missing

### DIFF
--- a/ui/resolution_selection.js
+++ b/ui/resolution_selection.js
@@ -315,6 +315,9 @@ shaka.ui.ResolutionSelection = class extends shaka.ui.SettingsMenu {
             track.label != selectedTrack.label) {
           return false;
         }
+        if (!track.bandwidth) {
+          return false;
+        }
         return true;
       });
     }


### PR DESCRIPTION
Note: This only applies to audio-only streams.