### PR TITLE
PlayReady expecting 'encrypted' event on Google Chrome Canary M139

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -605,7 +605,6 @@ shaka.drm.DrmEngine = class {
 
     const keySystem = this.currentDrmInfo_.keySystem;
     const needWaitForEncryptedEvent =
-        keySystem.startsWith('com.microsoft.playready.recommendation') ||
         keySystem == 'com.apple.fps';
 
     /**


### PR DESCRIPTION
Support for PlayReady on Windows was added In Google Chrome Canary M139. Significantly, the KeySystem passed in MediaCapabilities.decodingInfo() must be 'com.microsoft.playready.recommendation'. This is different to Microsoft Edge.

There is a heuristic in drm_engine.js to defer setting of the MediaKeys for 'com.microsoft.playready.recommendation' until after the 'encrypted' event is fired.  Google Chrome never fires that event; the MediaKeys are not set on the video element and the secure pipeline is never instantiated.

To enable PlayReady in Google Chrome, configure the following flags:

```
Go to chrome://flags/#enable-hardware-secure-decryption to enable Hardware Secure Decryption.
Also disable chrome://flags/#enable-hardware-secure-decryption-fallback
```

You'll need some custom shaka-player configury:

```
{
    drm: {
        keySystemsMapping: {
            'com.microsoft.playready': 'com.microsoft.playready.recommendation'
        },
        advanced: {
            'com.microsoft.playready.recommendation': { videoRobustness:  '3000']
         }
    }
}
```

With this PR, PlayReady HWDRM content can play on Windows. It's not totally stable and requires a few refreshes before it works.  I guess someone initially had a need for the heuristic, but it's too generic.

Here are some test streams (DolbyVision, but are backward compatible with HEVC):

* https://chromium.dolby.link/oss-kit/dolby-vision/playready/color_pattern_24_dvh1_081_1920x1080_cenc.mpd
* https://chromium.dolby.link/oss-kit/dolby-vision/playready/color_pattern_24_dvh1_084_1920x1080_cenc.mpd

If you want these streams to render as Dolby Vision, MediaSource.isTypeSupported() needs to be overridden (since it always returns false for encrypted content):
```
    const isTypeSupported = MediaSource.isTypeSupported
    MediaSource.isTypeSupported = function(mimeType) {
        return  isTypeSupported(mimeType) || mimeType.includes('dvh1') || mimeType.includes('dvhe')
    }
```

Patched player that works with Chrome Canary M139:

[Dolby Vision P8.1 w/ PlayReady HWDRM](https://player.dolby.link/shaka.html?url=https%3A%2F%2Fchromium.dolby.link%2Foss-kit%2Fdolby-vision%2Fplayready%2Fcolor_pattern_24_dvh1_081_1920x1080_cenc.mpd&autoplay=true&video-only=true&hardware-drm=true)
[Dolby Vision P8.4 w/ Playready HWDRM](https://player.dolby.link/shaka.html?url=https%3A%2F%2Fchromium.dolby.link%2Foss-kit%2Fdolby-vision%2Fplayready%2Fcolor_pattern_24_dvh1_084_1920x1080_cenc.mpd&autoplay=true&video-only=true&hardware-drm=true)