### PR TITLE
perf(net): Do not parse headers twice in XHR plugin

### DIFF
--- a/lib/net/http_xhr_plugin.js
+++ b/lib/net/http_xhr_plugin.js
@@ -44,6 +44,7 @@ shaka.net.HttpXHRPlugin = class {
       xhr.responseType = 'arraybuffer';
       xhr.timeout = request.retryParameters.timeout;
       xhr.withCredentials = request.allowCrossSiteCredentials;
+      let headers = {};
 
       xhr.onabort = () => {
         reject(new shaka.util.Error(
@@ -52,18 +53,13 @@ shaka.net.HttpXHRPlugin = class {
             shaka.util.Error.Code.OPERATION_ABORTED,
             uri, requestType));
       };
-      let calledHeadersReceived = false;
       xhr.onreadystatechange = (event) => {
-        // See if the readyState is 2 ("HEADERS_RECEIVED").
-        if (xhr.readyState == 2 && !calledHeadersReceived) {
-          const headers = shaka.net.HttpXHRPlugin.headersToGenericObject_(xhr);
+        if (xhr.readyState === XMLHttpRequest.HEADERS_RECEIVED) {
+          headers = shaka.net.HttpXHRPlugin.headersToGenericObject_(xhr);
           headersReceived(headers);
-          // Don't send out this event twice.
-          calledHeadersReceived = true;
         }
       };
       xhr.onload = (event) => {
-        const headers = shaka.net.HttpXHRPlugin.headersToGenericObject_(xhr);
         // eslint-disable-next-line shaka-rules/buffersource-no-instanceof
         goog.asserts.assert(xhr.response instanceof ArrayBuffer,
             'XHR should have a response by now!');


### PR DESCRIPTION
Continuation of #8618 