### PR TITLE
fix: NativeTextDisplayer.remove() maybe called endlessly

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -119,4 +119,4 @@ João Nabais <jlnabais@gmail.com>
 Koen Romers <koenromers@gmail.com>
 Zhenghang Chen <czhtju@gmail.com>
 Xperi <*@xperi.com>
-Shen Xiao <dead.xx@gmail.com>
+Xiao Shen <dead.xx@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -168,4 +168,4 @@ Zhenghang Chen <czhtju@gmail.com>
 Ashley Manners <ashley.manners@xperi.com>
 Bidisha Das <officialbidisha1@gmail.com>
 Chafroud Tarek <chafroudtarek3@gmail.com>
-Shen Xiao <dead.xx@gmail.com>
+Xiao Shen <dead.xx@gmail.com>

--- a/lib/text/native_text_displayer.js
+++ b/lib/text/native_text_displayer.js
@@ -202,13 +202,15 @@ shaka.text.NativeTextDisplayer = class {
    * @export
    */
   remove(start, end) {
-    if (!this.video_ || this.trackId_ < 0) {
+    // Do NOT return false when no track is selected or
+    // this method will be called endlessly by StreamingEngine
+    if (!this.video_) {
       return false;
+    } else if (this.trackId_ >= 0) {
+      shaka.text.Utils.removeCuesFromTextTrack(
+          this.trackNodes_.get(this.trackId_).track,
+          (cue) => cue.startTime < end && cue.endTime > start);
     }
-
-    shaka.text.Utils.removeCuesFromTextTrack(
-        this.trackNodes_.get(this.trackId_).track,
-        (cue) => cue.startTime < end && cue.endTime > start);
 
     return true;
   }


### PR DESCRIPTION
When this method returns false, it may cause [`StreamingEngine`](https://github.com/shaka-project/shaka-player/blob/b752f779cfde99bb6bfa4f7f7dec31bb4f64209e/lib/media/streaming_engine.js#L2627) to call it repeatedly, thus blocking the thread. So now it will return true even if there is no subtitle track selected.

