### PR TITLE
chore(DRM): DRM Engine init improvements

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -370,6 +370,9 @@ shaka.drm.DrmEngine = class {
       return false;
     });
 
+    const servers = shaka.util.MapUtils.asMap(this.config_.servers);
+    const advanced = shaka.util.MapUtils.asMap(this.config_.advanced || {});
+
     // When preparing to play live streams, it is possible that we won't know
     // about some upcoming encrypted content. If we initialize the drm engine
     // with no key systems, we won't be able to play when the encrypted content
@@ -378,25 +381,19 @@ shaka.drm.DrmEngine = class {
     // To avoid this, we will set the drm engine up to work with as many key
     // systems as possible so that we will be ready.
     if (!hadDrmInfo && isLive) {
-      const servers = shaka.util.MapUtils.asMap(this.config_.servers);
       shaka.drm.DrmEngine.replaceDrmInfo_(variants, servers);
     }
 
-    /** @type {!Set<shaka.extern.DrmInfo>} */
-    const drmInfos = new Set();
+    const drmInfos = new WeakSet();
     for (const variant of variants) {
       const variantDrmInfos = this.getVariantDrmInfos_(variant);
       for (const info of variantDrmInfos) {
-        drmInfos.add(info);
+        if (!drmInfos.has(info)) {
+          drmInfos.add(info);
+          shaka.drm.DrmEngine.fillInDrmInfoDefaults_(
+              info, servers, advanced, this.config_.keySystemsMapping);
+        }
       }
-    }
-
-    for (const info of drmInfos) {
-      shaka.drm.DrmEngine.fillInDrmInfoDefaults_(
-          info,
-          shaka.util.MapUtils.asMap(this.config_.servers),
-          shaka.util.MapUtils.asMap(this.config_.advanced || {}),
-          this.config_.keySystemsMapping);
     }
 
     /** @type {!Map<string, MediaKeySystemConfiguration>} */
@@ -417,9 +414,8 @@ shaka.drm.DrmEngine = class {
       const newDrmInfos = [];
       for (const drmInfo of drmInfos) {
         let items = drmInfo[robustnessType] ||
-            (this.config_.advanced &&
-            this.config_.advanced[drmInfo.keySystem] &&
-            this.config_.advanced[drmInfo.keySystem][robustnessType]) || '';
+            (advanced.has(drmInfo.keySystem) &&
+            advanced.get(drmInfo.keySystem)[robustnessType]) || '';
         if (items == '' &&
             shaka.drm.DrmUtils.isWidevineKeySystem(drmInfo.keySystem)) {
           if (robustnessType == 'audioRobustness') {
@@ -446,7 +442,7 @@ shaka.drm.DrmEngine = class {
       return newDrmInfos;
     };
 
-    const expandedStreams = new Set();
+    const expandedStreams = new WeakSet();
 
     for (const variant of variants) {
       if (variant.video && !expandedStreams.has(variant.video)) {
@@ -469,9 +465,6 @@ shaka.drm.DrmEngine = class {
       }
     }
 
-    // expandedStreams is no longer needed, so, clear it
-    expandedStreams.clear();
-
     // We should get the decodingInfo results for the variants after we filling
     // in the drm infos, and before queryMediaKeys_().
     await shaka.util.StreamUtils.getDecodingInfosForVariants(variants,
@@ -479,7 +472,7 @@ shaka.drm.DrmEngine = class {
         this.config_.preferredKeySystems);
     this.destroyer_.ensureNotDestroyed();
 
-    const hasDrmInfo = hadDrmInfo || Object.keys(this.config_.servers).length;
+    const hasDrmInfo = hadDrmInfo || servers.size > 0;
     // An unencrypted content is initialized.
     if (!hasDrmInfo) {
       this.initialized_ = true;


### PR DESCRIPTION
- map `servers` and `advanced` config fields to maps once
- use `WeakSet` instead of `Set` to mark which objects have been processed