### PR TITLE
feat: Allow switch between UITextDisplayer and NativeTextDisplayer on runtime

### DIFF
--- a/docs/tutorials/text-displayer.md
+++ b/docs/tutorials/text-displayer.md
@@ -10,7 +10,9 @@ which can be used to render & style content subtitles.
 {@link shaka.text.NativeTextDisplayer} which uses browser's native cue
 renderer. Shaka Player creates corresponding text tracks for text streams on
 the video element and provides necessary data so video element can render it.
-This is the default displayer when shaka UI is **not** used.
+This is the default displayer when shaka UI is **not** used, we also use
+NativeTextDisplayer when using PiP and Fullscreen API of the video element
+itself.
 
 #### UITextDisplayer
 

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2864,8 +2864,11 @@ shaka.extern.TextDisplayerConfiguration;
  * @property {shaka.extern.TextDisplayerConfiguration} textDisplayer
  *   Text displayer configuration and settings.
  * @property {shaka.extern.TextDisplayer.Factory} textDisplayFactory
- *   A factory to construct a text displayer. Note that, if this is changed
- *   during playback, it will cause the text tracks to be reloaded.
+ *   A factory to construct a text displayer. If this is changed during
+ *   playback, it will cause the text tracks to be reloaded. During playback it
+ *   may be called automatically if a change in
+ *   <code>webkitPresentationMode</code> is detected and
+ *   <code>setVideoContainer</code> has been called.
  * @exportDoc
  */
 shaka.extern.PlayerConfiguration;

--- a/lib/player.js
+++ b/lib/player.js
@@ -2576,15 +2576,17 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   }
 
   /**
+   * @param {boolean=} force
+   *
    * @private
    */
-  createAndConfigureTextDisplayer_() {
+  createAndConfigureTextDisplayer_(force = false) {
     // When changing text visibility we need to update both the text displayer
     // and streaming engine because we don't always stream text. To ensure
     // that the text displayer and streaming engine are always in sync, wait
     // until they are both initialized before setting the initial value.
     const textDisplayerFactory = this.config_.textDisplayFactory;
-    if (this.lastTextFactory_ !== textDisplayerFactory) {
+    if (this.lastTextFactory_ !== textDisplayerFactory || force) {
       const oldDisplayer = this.textDisplayer_;
       this.textDisplayer_ = textDisplayerFactory();
       if (this.textDisplayer_.configure) {
@@ -2725,6 +2727,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           () => this.onTracksChanged_());
       this.loadEventManager_.listen(mediaElement.videoTracks, 'change',
           () => this.onTracksChanged_());
+    }
+    if (mediaElement.webkitPresentationMode) {
+      this.loadEventManager_.listen(mediaElement,
+          'webkitpresentationmodechanged', () => {
+            if (this.videoContainer_) {
+              this.createAndConfigureTextDisplayer_(/* force= */ true);
+            }
+          });
     }
 
     if (mediaElement.textTracks) {
@@ -7616,13 +7626,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // Because this.video_ may not be set when the config is built, the default
     // TextDisplay factory must capture a reference to "this".
     config.textDisplayFactory = () => {
-      // On iOS where the Fullscreen API is not available we prefer
-      // NativeTextDisplayer because it works with the Fullscreen API of the
+      // We prefer NativeTextDisplayer when using PiP and Fullscreen API of the
       // video element itself.
-      const device = shaka.device.DeviceFactory.getDevice();
       if (this.videoContainer_ &&
-          (document.fullscreenEnabled || device.getBrowserEngine() !==
-          shaka.device.IDevice.BrowserEngine.WEBKIT)) {
+          (!this.video_.webkitPresentationMode ||
+          this.video_.webkitPresentationMode == 'inline')) {
         return new shaka.text.UITextDisplayer(
             this.video_, this.videoContainer_);
       } else {


### PR DESCRIPTION
We prefer NativeTextDisplayer when using PiP and Fullscreen API of the video element itself. Otherwise we prefer UITextDisplayer