### PR TITLE
fix: Fix 4k stream support within browser env on Tizen

### DIFF
--- a/lib/device/tizen.js
+++ b/lib/device/tizen.js
@@ -111,7 +111,11 @@ shaka.device.Tizen = class extends shaka.device.AbstractDevice {
    * @override
    */
   detectMaxHardwareResolution() {
-    const maxResolution = {width: 1920, height: 1080};
+    const devicePixelRatio = window.devicePixelRatio;
+    const maxResolution = {
+      width: window.screen.width * devicePixelRatio > 1920 ? 3840 : 1920,
+      height: window.screen.height * devicePixelRatio > 1080 ? 2160 : 1080
+    };
     try {
       if (webapis.systeminfo && webapis.systeminfo.getMaxVideoResolution) {
         const maxVideoResolution =

--- a/lib/device/tizen.js
+++ b/lib/device/tizen.js
@@ -114,7 +114,7 @@ shaka.device.Tizen = class extends shaka.device.AbstractDevice {
     const devicePixelRatio = window.devicePixelRatio;
     const maxResolution = {
       width: window.screen.width * devicePixelRatio > 1920 ? 3840 : 1920,
-      height: window.screen.height * devicePixelRatio > 1080 ? 2160 : 1080
+      height: window.screen.height * devicePixelRatio > 1080 ? 2160 : 1080,
     };
     try {
       if (webapis.systeminfo && webapis.systeminfo.getMaxVideoResolution) {


### PR DESCRIPTION
Earlier this year https://github.com/shaka-project/shaka-player/pull/8365 provided a solution to the maxResolution detection on Tizen devices. This was then refactored into the device api under https://github.com/shaka-project/shaka-player/pull/8210 but the earlier fix was not propagated. This PR reinstates it.