### PR TITLE
fix: Another Sony Bravia TV Playready Failure

### DIFF
--- a/lib/device/default_browser.js
+++ b/lib/device/default_browser.js
@@ -69,7 +69,7 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
 
     /** @private {!shaka.util.Lazy<boolean>} */
     this.isSonyTV_ = new shaka.util.Lazy(() => {
-      return navigator.userAgent.includes('sony.hbbtv.tv.G5');
+      return navigator.userAgent.includes('sony.hbbtv.tv');
     });
   }
 


### PR DESCRIPTION
See -> [issue/8790](https://github.com/shaka-project/shaka-player/issues/8790)
There is another Sony TV model (called Bluefin) that also requires little endianness conversion. Future proofed Sony tv detection to include all the G models.