### PR TITLE
fix(HLS): Fix resync issues on Safari

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1551,7 +1551,7 @@ shaka.media.MediaSourceEngine = class {
     // Avoid changing timestampOffset when the difference is less than 100 ms
     // from the end of the current buffer.
     const bufferEnd = this.bufferEnd(contentType);
-    if (bufferEnd && Math.abs(bufferEnd - timestampOffset) < 0.1) {
+    if (bufferEnd && Math.abs(bufferEnd - timestampOffset) < 0.15) {
       return;
     }
 
@@ -1807,21 +1807,7 @@ shaka.media.MediaSourceEngine = class {
       timestampOffset += 0.001;
     }
 
-
-    let shouldChangeTimestampOffset = true;
-    if (this.manifestType_ == shaka.media.ManifestParser.HLS) {
-      // Avoid changing timestampOffset when the difference is less than 150 ms
-      // from the end of the current buffer when using sequenceMode
-      const bufferEnd = this.bufferEnd(contentType);
-      if (!bufferEnd || Math.abs(bufferEnd - timestampOffset) > 0.15) {
-        shouldChangeTimestampOffset = true;
-      } else {
-        shouldChangeTimestampOffset = false;
-      }
-    }
-    if (shouldChangeTimestampOffset) {
-      this.sourceBuffers_.get(contentType).timestampOffset = timestampOffset;
-    }
+    this.sourceBuffers_.get(contentType).timestampOffset = timestampOffset;
 
     // Fake an 'updateend' event to resolve the operation.
     this.onUpdateEnd_(contentType);


### PR DESCRIPTION
Removes duplicated logic around timestamp offset checks - now check is only in `resync()` method. It should stay there, because it ensures it will be executed only in sequence mode and also avoids otherwise unnecessary `abort()` call.

Increases threshold to 150 ms as it was the originally proposed value and gives better experience.