### PR TITLE
fix: Fix end-of-stream detection for VOD

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -4164,7 +4164,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.bufferObserver_,
         'Need a buffering observer to update');
 
-    const bufferedToEnd = this.isEnded() || this.playhead_.isBufferedToEnd();
+    // This means that MediaSource has buffered the final segment in all
+    // SourceBuffers and is no longer accepting additional segments.
+    const mseEnded = this.mediaSourceEngine_ ?
+        this.mediaSourceEngine_.ended() : false;
+
+    const bufferedToEnd = this.isEnded() || mseEnded ||
+        this.playhead_.isBufferedToEnd();
+
     const bufferLead = shaka.media.TimeRangesUtils.bufferedAheadOf(
         this.video_.buffered,
         this.video_.currentTime);
@@ -9347,6 +9354,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!this.video_ || this.video_.ended) {
       return true;
     }
+
     return this.fullyLoaded_ && !this.isLive() &&
         this.video_.currentTime >= this.seekRange().end;
   }


### PR DESCRIPTION
PR #8603 refactored the conditions for being "buffered to the end". Two of these conditions from Player didn't fit in the new location (Playhead).  One (this.isEnded()) was moved, and the other (this.mediaSourceEngine_.ended()) was dropped by accident.  This restores the dropped condition next to isEnded().

Verified in the Cast Application Framework.