### PR TITLE
chore(EME): Remove cbcs-1-9 testing on probeSupport

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -1905,7 +1905,6 @@ shaka.drm.DrmEngine = class {
       null,
       'cenc',
       'cbcs',
-      'cbcs-1-9',
     ];
 
     /** @type {!Map<string, ?shaka.extern.DrmSupportType>} */


### PR DESCRIPTION
It's been removed because only the cenc and cbcs patterns are used. cbcs-1-9 was added for FairPlay, but Safari uses cbcs for this use case.