### PR TITLE
chore: Update jsdoc to tolerate trailing commas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "jasmine-ajax": "^4.0.0",
         "jimp": "^0.22.12",
         "js-yaml": "^4.1.0",
-        "jsdoc": "github:joeyparrish/jsdoc#2ca85bb6",
+        "jsdoc": "github:joeyparrish/jsdoc#a1e61a4e",
         "karma": "github:joeyparrish/karma#shaka-fixes",
         "karma-coverage": "^2.2.0",
         "karma-jasmine": "^4.0.1",
@@ -3816,15 +3816,15 @@
       "dev": true
     },
     "node_modules/catharsis": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
-      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "version": "0.11.0",
+      "resolved": "git+ssh://git@github.com/joeyparrish/catharsis.git#afcfb1c1dbbc582e2f129b5f1edeb6bd34c324d7",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/centra": {
@@ -6961,14 +6961,14 @@
     },
     "node_modules/jsdoc": {
       "version": "3.6.10",
-      "resolved": "git+ssh://git@github.com/joeyparrish/jsdoc.git#2ca85bb6e7686dac8790325d2b029df83547a1b4",
+      "resolved": "git+ssh://git@github.com/joeyparrish/jsdoc.git#a1e61a4e53564ddf173767a33f6c57c681fde79a",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.9.4",
         "@types/markdown-it": "^12.2.3",
         "bluebird": "^3.7.2",
-        "catharsis": "^0.9.0",
+        "catharsis": "github:joeyparrish/catharsis#afcfb1c1",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
         "klaw": "^4.0.1",
@@ -13403,12 +13403,11 @@
       "dev": true
     },
     "catharsis": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
-      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "version": "git+ssh://git@github.com/joeyparrish/catharsis.git#afcfb1c1dbbc582e2f129b5f1edeb6bd34c324d7",
       "dev": true,
+      "from": "catharsis@github:joeyparrish/catharsis#afcfb1c1",
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       }
     },
     "centra": {
@@ -15735,14 +15734,14 @@
       "dev": true
     },
     "jsdoc": {
-      "version": "git+ssh://git@github.com/joeyparrish/jsdoc.git#2ca85bb6e7686dac8790325d2b029df83547a1b4",
+      "version": "git+ssh://git@github.com/joeyparrish/jsdoc.git#a1e61a4e53564ddf173767a33f6c57c681fde79a",
       "dev": true,
-      "from": "jsdoc@github:joeyparrish/jsdoc#2ca85bb6",
+      "from": "jsdoc@github:joeyparrish/jsdoc#a1e61a4e",
       "requires": {
         "@babel/parser": "^7.9.4",
         "@types/markdown-it": "^12.2.3",
         "bluebird": "^3.7.2",
-        "catharsis": "^0.9.0",
+        "catharsis": "github:joeyparrish/catharsis#afcfb1c1",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
         "klaw": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jasmine-ajax": "^4.0.0",
     "jimp": "^0.22.12",
     "js-yaml": "^4.1.0",
-    "jsdoc": "github:joeyparrish/jsdoc#2ca85bb6",
+    "jsdoc": "github:joeyparrish/jsdoc#a1e61a4e",
     "karma": "github:joeyparrish/karma#shaka-fixes",
     "karma-coverage": "^2.2.0",
     "karma-jasmine": "^4.0.1",


### PR DESCRIPTION
jsdoc doesn't tolerate trailing commas in record types.  This is frustrating because:

 - It creates larger diffs to skip trailing commas when you add new fields
 - It requires a style in typedefs that is the opposite of the style rules in actual code

This updates our jsdoc fork (https://github.com/joeyparrish/jsdoc/commit/a1e61a4e53564ddf173767a33f6c57c681fde79a) and its parser dependency "catharsis" (https://github.com/joeyparrish/catharsis/commit/afcfb1c1dbbc582e2f129b5f1edeb6bd34c324d7) to tolerate trailing commas when parsing record types.

Closes #1236