### PR TITLE
chore: Add trailing commas to all record types

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -1819,7 +1819,7 @@ shaka.ads.InterstitialAdManager = class {
 /**
  * @typedef {{
  *   ASSETS: !Array<shaka.ads.InterstitialAdManager.Asset>,
- *   SKIP-CONTROL: ?shaka.ads.InterstitialAdManager.SkipControl
+ *   SKIP-CONTROL: ?shaka.ads.InterstitialAdManager.SkipControl,
  * }}
  *
  * @property {!Array<shaka.ads.InterstitialAdManager.Asset>} ASSETS
@@ -1830,7 +1830,7 @@ shaka.ads.InterstitialAdManager.AssetsList;
 
 /**
  * @typedef {{
- *   URI: string
+ *   URI: string,
  * }}
  *
  * @property {string} URI
@@ -1841,7 +1841,7 @@ shaka.ads.InterstitialAdManager.Asset;
 /**
  * @typedef {{
  *   ENABLE-SKIP-AFTER: number,
- *   ENABLE-SKIP-FOR: number
+ *   ENABLE-SKIP-FOR: number,
  * }}
  *
  * @property {number} ENABLE-SKIP-AFTER

--- a/lib/cast/cast_utils.js
+++ b/lib/cast/cast_utils.js
@@ -152,7 +152,7 @@ shaka.cast.CastUtils = class {
    * @return {{
    *   length: number,
    *   start: function(number): number,
-   *   end: function(number): number
+   *   end: function(number): number,
    * }}
    * @private
    */
@@ -443,7 +443,7 @@ shaka.cast.CastUtils.PlayerPromiseMethods = [
  *   startTime: ?number,
  *   addThumbnailsTrackCalls: !Array<?>,
  *   addTextTrackAsyncCalls: !Array<?>,
- *   addChaptersTrackCalls: !Array<?>
+ *   addChaptersTrackCalls: !Array<?>,
  * }}
  * @property {Object} video
  *   Dictionary of video properties to be set.

--- a/lib/cea/cea608_data_channel.js
+++ b/lib/cea/cea608_data_channel.js
@@ -786,7 +786,7 @@ shaka.cea.Cea608DataChannel.TEXT_COLORS = [
  *   textColor: ?string,
  *   backgroundColor: ?string,
  *   italics: ?boolean,
- *   underline: ?boolean
+ *   underline: ?boolean,
  * }}
  */
 shaka.cea.Cea608DataChannel.Style;
@@ -798,7 +798,7 @@ shaka.cea.Cea608DataChannel.Style;
  *   type: number,
  *   ccData1: number,
  *   ccData2: number,
- *   order: number
+ *   order: number,
  * }}
  *
  * @property {number} pts

--- a/lib/cea/cea708_service.js
+++ b/lib/cea/cea708_service.js
@@ -715,7 +715,7 @@ shaka.cea.Cea708Service.Colors = [
  *   pts: number,
  *   type: number,
  *   value: number,
- *   order: number
+ *   order: number,
  * }}
  *
  * @property {number} pts

--- a/lib/cea/mp4_cea_parser.js
+++ b/lib/cea/mp4_cea_parser.js
@@ -429,7 +429,7 @@ shaka.cea.Mp4CeaParser.CodecBitstreamMap_ = new Map()
  *    defaultSampleDuration: number,
  *    defaultSampleSize: number,
  *    parsedTRUNs: !Array<shaka.util.ParsedTRUNBox>,
- *    timescale: number
+ *    timescale: number,
  * }}
  *
  * @property {?number} baseMediaDecodeTime

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -617,7 +617,7 @@ shaka.dash.ContentProtection = class {
  *   defaultInit: Array<shaka.extern.InitDataOverride>,
  *   drmInfos: !Array<shaka.extern.DrmInfo>,
  *   aes128Info: ?shaka.dash.ContentProtection.Aes128Info,
- *   firstRepresentation: boolean
+ *   firstRepresentation: boolean,
  * }}
  *
  * @description
@@ -645,7 +645,7 @@ shaka.dash.ContentProtection.Context;
 /**
  * @typedef {{
  *   keyUri: string,
- *   iv: !Uint8Array
+ *   iv: !Uint8Array,
  * }}
  *
  * @description
@@ -665,7 +665,7 @@ shaka.dash.ContentProtection.Aes128Info;
  *   schemeUri: string,
  *   keyId: ?string,
  *   init: Array<shaka.extern.InitDataOverride>,
- *   encryptionScheme: ?string
+ *   encryptionScheme: ?string,
  * }}
  *
  * @description

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -1334,7 +1334,7 @@ shaka.dash.DashParser = class {
    * @return {{
    *   periods: !Array<shaka.extern.Period>,
    *   duration: ?number,
-   *   durationDerivedFromPeriods: boolean
+   *   durationDerivedFromPeriods: boolean,
    * }}
    * @private
    */
@@ -3389,7 +3389,7 @@ shaka.dash.DashParser = class {
  *   profiles: !Array<string>,
  *   availabilityTimeOffset: number,
  *   getBaseUris: ?function():!Array<string>,
- *   publishTime: number
+ *   publishTime: number,
  * }}
  *
  * @property {string} mpdId
@@ -3460,7 +3460,7 @@ shaka.dash.DashParser.RequestSegmentCallback;
  *   aesKey: (shaka.extern.aesKey|undefined),
  *   segmentSequenceCadence: number,
  *   label: ?string,
- *   encrypted: boolean
+ *   encrypted: boolean,
  * }}
  *
  * @description
@@ -3536,7 +3536,7 @@ shaka.dash.DashParser.InheritanceFrame;
  *   mediaPresentationDuration: ?number,
  *   profiles: !Array<string>,
  *   roles: ?Array<string>,
- *   urlParams: function():string
+ *   urlParams: function():string,
  * }}
  *
  * @description
@@ -3578,7 +3578,7 @@ shaka.dash.DashParser.Context;
  *   start: number,
  *   duration: ?number,
  *   node: ?shaka.extern.xml.Node,
- *   isLastPeriod: boolean
+ *   isLastPeriod: boolean,
  * }}
  *
  * @description
@@ -3607,7 +3607,7 @@ shaka.dash.DashParser.PeriodInfo;
  *   drmInfos: !Array<shaka.extern.DrmInfo>,
  *   trickModeFor: ?string,
  *   representationIds: !Array<string>,
- *   dependencyStreamMap: !Map<string, shaka.extern.Stream>
+ *   dependencyStreamMap: !Map<string, shaka.extern.Stream>,
  * }}
  *
  * @description
@@ -3650,7 +3650,7 @@ shaka.dash.DashParser.GenerateSegmentIndexFunction;
  *   timeline: number,
  *   endTime: number,
  *   generateSegmentIndex: shaka.dash.DashParser.GenerateSegmentIndexFunction,
- *   timescale: number
+ *   timescale: number,
  * }}
  *
  * @description

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -569,7 +569,7 @@ shaka.dash.MpdUtils = class {
  *   startNumber: number,
  *   scaledPresentationTimeOffset: number,
  *   unscaledPresentationTimeOffset: number,
- *   timeline: Array<shaka.media.PresentationTimeline.TimeRange>
+ *   timeline: Array<shaka.media.PresentationTimeline.TimeRange>,
  * }}
  *
  * @description

--- a/lib/dash/segment_list.js
+++ b/lib/dash/segment_list.js
@@ -333,7 +333,7 @@ shaka.dash.SegmentList = class {
  * @typedef {{
  *   mediaUri: string,
  *   start: number,
- *   end: ?number
+ *   end: ?number,
  * }}
  *
  * @property {string} mediaUri
@@ -353,7 +353,7 @@ shaka.dash.SegmentList.MediaSegment;
  *   scaledPresentationTimeOffset: number,
  *   timescale: number,
  *   timeline: Array<shaka.media.PresentationTimeline.TimeRange>,
- *   mediaSegments: !Array<shaka.dash.SegmentList.MediaSegment>
+ *   mediaSegments: !Array<shaka.dash.SegmentList.MediaSegment>,
  * }}
  * @private
  *

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -1266,7 +1266,7 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
  *   mimeType: string,
  *   codecs: string,
  *   bandwidth: number,
- *   numChunks: number
+ *   numChunks: number,
  * }}
  *
  * @description

--- a/lib/device/webos.js
+++ b/lib/device/webos.js
@@ -217,7 +217,7 @@ shaka.device.WebOS = class extends shaka.device.AbstractDevice {
 
 /**
  * @typedef {{
- *   configs: Object
+ *   configs: Object,
  * }}
  *
  * @property {Object} configs

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -2764,7 +2764,7 @@ shaka.drm.DrmEngine = class {
  *   initDataType: ?string,
  *   oldExpiration: number,
  *   type: string,
- *   updatePromise: shaka.util.PublicPromise
+ *   updatePromise: shaka.util.PublicPromise,
  * }}
  *
  * @description A record to track sessions and suppress duplicate init data.
@@ -2794,7 +2794,7 @@ shaka.drm.DrmEngine.SessionMetaData;
  *   onError: function(!shaka.util.Error),
  *   onKeyStatus: function(!Object<string,string>),
  *   onExpirationUpdated: function(string,number),
- *   onEvent: function(!Event)
+ *   onEvent: function(!Event),
  * }}
  *
  * @property {shaka.net.NetworkingEngine} netEngine
@@ -2816,7 +2816,7 @@ shaka.drm.DrmEngine.PlayerInterface;
 /**
  * @typedef {{
  *   kids: !Array<string>,
- *   type: string
+ *   type: string,
  * }}
  *
  * @property {!Array<string>} kids

--- a/lib/drm/playready.js
+++ b/lib/drm/playready.js
@@ -209,7 +209,7 @@ shaka.drm.PlayReady = class {
 /**
  * @typedef {{
  *   type: number,
- *   value: !Uint8Array
+ *   value: !Uint8Array,
  * }}
  *
  * @description

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -3259,7 +3259,7 @@ shaka.hls.HlsParser = class {
    *   drmInfos: !Array<shaka.extern.DrmInfo>,
    *   keyIds: !Set<string>,
    *   encrypted: boolean,
-   *   aesEncrypted: boolean
+   *   aesEncrypted: boolean,
    * }>}
    * @private
    */
@@ -5190,7 +5190,7 @@ shaka.hls.HlsParser = class {
  *   firstSequenceNumber: number,
  *   nextMediaSequence: number,
  *   nextPart: number,
- *   loadedOnce: boolean
+ *   loadedOnce: boolean,
  * }}
  *
  * @description
@@ -5235,7 +5235,7 @@ shaka.hls.HlsParser.StreamInfo;
 /**
  * @typedef {{
  *   audio: !Array<shaka.hls.HlsParser.StreamInfo>,
- *   video: !Array<shaka.hls.HlsParser.StreamInfo>
+ *   video: !Array<shaka.hls.HlsParser.StreamInfo>,
  * }}
  *
  * @description Audio and video stream infos.

--- a/lib/media/adaptation_set_criteria.js
+++ b/lib/media/adaptation_set_criteria.js
@@ -69,7 +69,7 @@ shaka.media.AdaptationSetCriteria.Factory;
  *   activeAudioCodec: string,
  *   activeAudioChannelCount: number,
  *   preferredAudioCodecs: !Array<string>,
- *   preferredAudioChannelCount: number
+ *   preferredAudioChannelCount: number,
  * }}
  *
  * @property {string} language

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -2333,9 +2333,13 @@ shaka.media.MediaSourceEngine = class {
    * @param {shaka.util.ManifestParserUtils.ContentType} contentType
    * @param {string} mimeType
    * @param {string} codecs
-   * @return {{transmuxer: ?shaka.extern.Transmuxer,
-   *          transmuxerMuxed: boolean, basicType: string, codec: string,
-   *          mimeType: string}}
+   * @return {{
+   *   transmuxer: ?shaka.extern.Transmuxer,
+   *   transmuxerMuxed: boolean,
+   *   basicType: string,
+   *   codec: string,
+   *   mimeType: string,
+   * }}
    * @private
    */
   getRealInfo_(contentType, mimeType, codecs) {
@@ -2406,8 +2410,11 @@ shaka.media.MediaSourceEngine = class {
    * @param {string} codecs
    * @param {!Map<shaka.util.ManifestParserUtils.ContentType,
    *               shaka.extern.Stream>} streamsByType
-   * @return {{type: string, newMimeType: string,
-   *           transmuxer: ?shaka.extern.Transmuxer}}
+   * @return {{
+   *   type: string,
+   *   newMimeType: string,
+   *   transmuxer: ?shaka.extern.Transmuxer,
+   * }}
    * @private
    */
   getInfoAboutResetOrChangeType_(contentType, mimeType, codecs, streamsByType) {
@@ -2593,7 +2600,7 @@ shaka.media.MediaSourceEngine.createObjectURL = window.URL.createObjectURL;
  * @typedef {{
  *   start: function(),
  *   p: !shaka.util.PublicPromise,
- *   uri: ?string
+ *   uri: ?string,
  * }}
  *
  * @summary An operation in queue.
@@ -2634,7 +2641,7 @@ shaka.media.MediaSourceEngine.ResetMode_ = {
  *   onMetadata: function(!Array<shaka.extern.ID3Metadata>, number, ?number),
  *   onEmsg: function(!shaka.extern.EmsgInfo),
  *   onEvent: function(!Event),
- *   onManifestUpdate: function()
+ *   onManifestUpdate: function(),
  * }}
  *
  * @summary Player interface

--- a/lib/media/play_rate_controller.js
+++ b/lib/media/play_rate_controller.js
@@ -171,7 +171,7 @@ shaka.media.PlayRateController = class {
  *   getRate: function():number,
  *   getDefaultRate: function():number,
  *   setRate: function(number),
- *   movePlayhead: function(number)
+ *   movePlayhead: function(number),
  * }}
  *
  * @description

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -928,7 +928,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
  *   networkingEngine: !shaka.net.NetworkingEngine,
  *   manifestFilterer: !shaka.media.ManifestFilterer,
  *   allowPrefetch: boolean,
- *   allowMakeAbrManager: boolean
+ *   allowMakeAbrManager: boolean,
  * }}
  *
  * @property {!shaka.extern.PlayerConfiguration} config

--- a/lib/media/presentation_timeline.js
+++ b/lib/media/presentation_timeline.js
@@ -720,7 +720,7 @@ shaka.media.PresentationTimeline = class {
  *   unscaledStart: number,
  *   end: number,
  *   partialSegments: number,
- *   segmentPosition: number
+ *   segmentPosition: number,
  * }}
  *
  * @description

--- a/lib/media/quality_observer.js
+++ b/lib/media/quality_observer.js
@@ -303,7 +303,7 @@ shaka.media.QualityObserver = class extends shaka.util.FakeEventTarget {
 /**
  * @typedef {{
  *   mediaQuality: !shaka.extern.MediaQualityInfo,
- *   position: !number
+ *   position: !number,
  * }}
  *
  * @description
@@ -322,7 +322,7 @@ shaka.media.QualityObserver.QualityChangePosition;
  *  qualityChangePositions:
  *   !Array<shaka.media.QualityObserver.QualityChangePosition>,
  *  currentQuality: ?shaka.extern.MediaQualityInfo,
- *  contentType: !string
+ *  contentType: !string,
  * }}
  *
  * @description

--- a/lib/media/region_observer.js
+++ b/lib/media/region_observer.js
@@ -236,7 +236,7 @@ shaka.media.RegionObserver.EventListener;
  * @typedef {{
  *    weWere: ?shaka.media.RegionObserver.RelativePosition_,
  *    weAre: ?shaka.media.RegionObserver.RelativePosition_,
- *    invoke: shaka.media.RegionObserver.EventListener
+ *    invoke: shaka.media.RegionObserver.EventListener,
  * }}
  *
  * @private

--- a/lib/media/segment_reference.js
+++ b/lib/media/segment_reference.js
@@ -692,7 +692,7 @@ shaka.media.AnySegmentReference;
  *   height: number,
  *   positionX: number,
  *   positionY: number,
- *   width: number
+ *   width: number,
  * }}
  *
  * @property {number} height

--- a/lib/media/segment_utils.js
+++ b/lib/media/segment_utils.js
@@ -628,7 +628,7 @@ shaka.media.SegmentUtils = class {
  *   closedCaptions: Map<string, string>,
  *   videoRange: ?string,
  *   colorGamut: ?string,
- *   frameRate: ?string
+ *   frameRate: ?string,
  * }}
  *
  * @property {string} type

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3265,7 +3265,7 @@ shaka.media.StreamingEngine = class {
  *   onInitSegmentAppended: function(!number,!shaka.media.InitSegmentReference),
  *   beforeAppendSegment: function(
  *     shaka.util.ManifestParserUtils.ContentType,!BufferSource):Promise,
- *   disableStream: function(!shaka.extern.Stream, number):boolean
+ *   disableStream: function(!shaka.extern.Stream, number):boolean,
  * }}
  *
  * @property {function():number} getPresentationTime
@@ -3329,7 +3329,7 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   hasError: boolean,
  *   operation: shaka.net.NetworkingEngine.PendingRequest,
  *   segmentPrefetch: shaka.media.SegmentPrefetch,
- *   dependencyMediaState: ?shaka.media.StreamingEngine.MediaState_
+ *   dependencyMediaState: ?shaka.media.StreamingEngine.MediaState_,
  * }}
  *
  * @description

--- a/lib/mss/mss_parser.js
+++ b/lib/mss/mss_parser.js
@@ -1125,7 +1125,7 @@ shaka.mss.MssParser.ROLE_MAPPING_ = new Map()
  *   variants: !Array<shaka.extern.Variant>,
  *   textStreams: !Array<shaka.extern.Stream>,
  *   timescale: number,
- *   duration: number
+ *   duration: number,
  * }}
  *
  * @property {!Array<shaka.extern.Variant>} variants
@@ -1144,7 +1144,7 @@ shaka.mss.MssParser.Context;
  * @typedef {{
  *   start: number,
  *   unscaledStart: number,
- *   end: number
+ *   end: number,
  * }}
  *
  * @description

--- a/lib/net/http_fetch_plugin.js
+++ b/lib/net/http_fetch_plugin.js
@@ -308,7 +308,7 @@ shaka.net.HttpFetchPlugin = class {
 /**
  * @typedef {{
  *   canceled: boolean,
- *   timedOut: boolean
+ *   timedOut: boolean,
  * }}
  * @property {boolean} canceled
  *   Indicates if the request was canceled.

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -946,7 +946,7 @@ shaka.net.NetworkingEngine.PluginPriority = {
  * @typedef {{
  *   plugin: shaka.extern.SchemePlugin,
  *   priority: number,
- *   progressSupport: boolean
+ *   progressSupport: boolean,
  * }}
  * @property {shaka.extern.SchemePlugin} plugin
  *   The associated plugin.
@@ -968,7 +968,7 @@ shaka.net.NetworkingEngine.schemes_ = new Map();
 /**
  * @typedef {{
  *   response: shaka.extern.Response,
- *   gotProgress: boolean
+ *   gotProgress: boolean,
  * }}
  *
  * @description

--- a/lib/offline/session_deleter.js
+++ b/lib/offline/session_deleter.js
@@ -146,7 +146,7 @@ shaka.offline.SessionDeleter = class {
 /**
  * @typedef {{
  *   info: shaka.extern.EmeSessionDB,
- *   sessionIds: !Array<string>
+ *   sessionIds: !Array<string>,
  * }}
  */
 shaka.offline.SessionDeleter.Bucket_;

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -872,7 +872,7 @@ shaka.offline.Storage = class {
    * @param {boolean} usePersistentLicense
    * @return {{
    *   manifestDB: shaka.extern.ManifestDB,
-   *   toDownload: !Array<!shaka.offline.DownloadInfo>
+   *   toDownload: !Array<!shaka.offline.DownloadInfo>,
    * }}
    * @private
    */
@@ -1604,7 +1604,7 @@ shaka.offline.Storage = class {
    * @param {shaka.extern.PlayerConfiguration} config
    * @return {{
    *   streams: !Array<shaka.extern.StreamDB>,
-   *   toDownload: !Array<!shaka.offline.DownloadInfo>
+   *   toDownload: !Array<!shaka.offline.DownloadInfo>,
    * }}
    * @private
    */

--- a/lib/offline/storage_muxer.js
+++ b/lib/offline/storage_muxer.js
@@ -14,8 +14,8 @@ goog.require('shaka.util.IDestroyable');
 
 /**
  * @typedef {{
- *  mechanism: string,
- *  cell: string
+ *   mechanism: string,
+ *   cell: string,
  * }}
  *
  * @property {string} mechanism
@@ -29,7 +29,7 @@ shaka.offline.StorageCellPath;
 /**
  * @typedef {{
  *   path: shaka.offline.StorageCellPath,
- *   cell: !shaka.extern.StorageCell
+ *   cell: !shaka.extern.StorageCell,
  * }}
  *
  * @property {shaka.offline.StorageCellPath} path

--- a/lib/player.js
+++ b/lib/player.js
@@ -5503,7 +5503,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @param {string|undefined} tilesLayout
    * @return {?{
    *   columns: number,
-   *   rows: number
+   *   rows: number,
    * }}
    * @private
    */

--- a/lib/queue/queue_manager.js
+++ b/lib/queue/queue_manager.js
@@ -41,8 +41,10 @@ shaka.queue.QueueManager = class extends shaka.util.FakeEventTarget {
     this.currentItemIndex_ = -1;
 
     /**
-     * @private {?{item: shaka.extern.QueueItem,
-     *             preloadManager: ?shaka.media.PreloadManager}}
+     * @private {?{
+     *   item: shaka.extern.QueueItem,
+     *   preloadManager: ?shaka.media.PreloadManager,
+     * }}
      */
     this.preloadNext_ = null;
 

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -80,7 +80,7 @@ shaka.text.UITextDisplayer = class {
      * @private {Map<!shaka.text.Cue, !{
      *   cueElement: !HTMLElement,
      *   regionElement: HTMLElement,
-     *   wrapper: !HTMLElement
+     *   wrapper: !HTMLElement,
      * }>}
      */
     this.currentCuesMap_ = new Map();

--- a/lib/transmuxer/ac3.js
+++ b/lib/transmuxer/ac3.js
@@ -14,8 +14,12 @@ shaka.transmuxer.Ac3 = class {
   /**
    * @param {!Uint8Array} data
    * @param {!number} offset
-   * @return {?{sampleRate: number, channelCount: number,
-   *          audioConfig: !Uint8Array, frameLength: number}}
+   * @return {?{
+   *   sampleRate: number,
+   *   channelCount: number,
+   *   audioConfig: !Uint8Array,
+   *   frameLength: number,
+   * }}
    */
   static parseFrame(data, offset) {
     if (offset + 8 > data.length) {

--- a/lib/transmuxer/ec3.js
+++ b/lib/transmuxer/ec3.js
@@ -16,8 +16,12 @@ shaka.transmuxer.Ec3 = class {
   /**
    * @param {!Uint8Array} data
    * @param {!number} offset
-   * @return {?{sampleRate: number, channelCount: number,
-   *          audioConfig: !Uint8Array, frameLength: number}}
+   * @return {?{
+   *   sampleRate: number,
+   *   channelCount: number,
+   *   audioConfig: !Uint8Array,
+   *   frameLength: number,
+   * }}
    */
   static parseFrame(data, offset) {
     if (offset + 8 > data.length) {

--- a/lib/transmuxer/h264.js
+++ b/lib/transmuxer/h264.js
@@ -20,8 +20,13 @@ shaka.transmuxer.H264 = class {
    * describes the properties of upcoming video frames.
    *
    * @param {!Array<shaka.extern.VideoNalu>} nalus
-   * @return {?{height: number, width: number, videoConfig: !Uint8Array,
-   *            hSpacing: number, vSpacing: number}}
+   * @return {?{
+   *   height: number,
+   *   width: number,
+   *   videoConfig: !Uint8Array,
+   *   hSpacing: number,
+   *   vSpacing: number,
+   * }}
    */
   static parseInfo(nalus) {
     const H264 = shaka.transmuxer.H264;

--- a/lib/transmuxer/h265.js
+++ b/lib/transmuxer/h265.js
@@ -20,8 +20,13 @@ shaka.transmuxer.H265 = class {
    * describes the properties of upcoming video frames.
    *
    * @param {!Array<shaka.extern.VideoNalu>} nalus
-   * @return {?{height: number, width: number, videoConfig: !Uint8Array,
-   *            hSpacing: number, vSpacing: number}}
+   * @return {?{
+   *   height: number,
+   *   width: number,
+   *   videoConfig: !Uint8Array,
+   *   hSpacing: number,
+   *   vSpacing: number,
+   * }}
    */
   static parseInfo(nalus) {
     const H265 = shaka.transmuxer.H265;
@@ -757,8 +762,8 @@ shaka.transmuxer.H265.NALU_TYPE_SEI_SUFFIX_ = 0x28;
 
 /**
  * @typedef {{
- *  numTemporalLayers: number,
- *  temporalIdNested: boolean
+ *   numTemporalLayers: number,
+ *   temporalIdNested: boolean,
  * }}
  *
  * @property {number} numTemporalLayers
@@ -769,29 +774,29 @@ shaka.transmuxer.H265.VPSConfiguration;
 
 /**
  * @typedef {{
- *  generalProfileSpace: number,
- *  generalTierFlag: number,
- *  generalLevelIdc: number,
- *  generalProfileIdc: number,
- *  generalProfileCompatibilityFlags1: number,
- *  generalProfileCompatibilityFlags2: number,
- *  generalProfileCompatibilityFlags3: number,
- *  generalProfileCompatibilityFlags4: number,
- *  generalConstraintIndicatorFlags1: number,
- *  generalConstraintIndicatorFlags2: number,
- *  generalConstraintIndicatorFlags3: number,
- *  generalConstraintIndicatorFlags4: number,
- *  generalConstraintIndicatorFlags5: number,
- *  generalConstraintIndicatorFlags6: number,
- *  constantFrameRate: number,
- *  minSpatialSegmentationIdc: number,
- *  chromaFormatIdc: number,
- *  bitDepthLumaMinus8: number,
- *  bitDepthChromaMinus8: number,
- *  width: number,
- *  height: number,
- *  sarWidth: number,
- *  sarHeight: number
+ *   generalProfileSpace: number,
+ *   generalTierFlag: number,
+ *   generalLevelIdc: number,
+ *   generalProfileIdc: number,
+ *   generalProfileCompatibilityFlags1: number,
+ *   generalProfileCompatibilityFlags2: number,
+ *   generalProfileCompatibilityFlags3: number,
+ *   generalProfileCompatibilityFlags4: number,
+ *   generalConstraintIndicatorFlags1: number,
+ *   generalConstraintIndicatorFlags2: number,
+ *   generalConstraintIndicatorFlags3: number,
+ *   generalConstraintIndicatorFlags4: number,
+ *   generalConstraintIndicatorFlags5: number,
+ *   generalConstraintIndicatorFlags6: number,
+ *   constantFrameRate: number,
+ *   minSpatialSegmentationIdc: number,
+ *   chromaFormatIdc: number,
+ *   bitDepthLumaMinus8: number,
+ *   bitDepthChromaMinus8: number,
+ *   width: number,
+ *   height: number,
+ *   sarWidth: number,
+ *   sarHeight: number,
  * }}
  *
  * @property {number} generalProfileSpace
@@ -823,7 +828,7 @@ shaka.transmuxer.H265.SPSConfiguration;
 
 /**
  * @typedef {{
- *  parallelismType: number
+ *   parallelismType: number,
  * }}
  *
  * @property {number} parallelismType
@@ -833,28 +838,28 @@ shaka.transmuxer.H265.PPSConfiguration;
 
 /**
  * @typedef {{
- *  numTemporalLayers: number,
- *  temporalIdNested: boolean,
- *  generalProfileSpace: number,
- *  generalTierFlag: number,
- *  generalLevelIdc: number,
- *  generalProfileIdc: number,
- *  generalProfileCompatibilityFlags1: number,
- *  generalProfileCompatibilityFlags2: number,
- *  generalProfileCompatibilityFlags3: number,
- *  generalProfileCompatibilityFlags4: number,
- *  generalConstraintIndicatorFlags1: number,
- *  generalConstraintIndicatorFlags2: number,
- *  generalConstraintIndicatorFlags3: number,
- *  generalConstraintIndicatorFlags4: number,
- *  generalConstraintIndicatorFlags5: number,
- *  generalConstraintIndicatorFlags6: number,
- *  constantFrameRate: number,
- *  minSpatialSegmentationIdc: number,
- *  chromaFormatIdc: number,
- *  bitDepthLumaMinus8: number,
- *  bitDepthChromaMinus8: number,
- *  parallelismType: number
+ *   numTemporalLayers: number,
+ *   temporalIdNested: boolean,
+ *   generalProfileSpace: number,
+ *   generalTierFlag: number,
+ *   generalLevelIdc: number,
+ *   generalProfileIdc: number,
+ *   generalProfileCompatibilityFlags1: number,
+ *   generalProfileCompatibilityFlags2: number,
+ *   generalProfileCompatibilityFlags3: number,
+ *   generalProfileCompatibilityFlags4: number,
+ *   generalConstraintIndicatorFlags1: number,
+ *   generalConstraintIndicatorFlags2: number,
+ *   generalConstraintIndicatorFlags3: number,
+ *   generalConstraintIndicatorFlags4: number,
+ *   generalConstraintIndicatorFlags5: number,
+ *   generalConstraintIndicatorFlags6: number,
+ *   constantFrameRate: number,
+ *   minSpatialSegmentationIdc: number,
+ *   chromaFormatIdc: number,
+ *   bitDepthLumaMinus8: number,
+ *   bitDepthChromaMinus8: number,
+ *   parallelismType: number,
  * }}
  *
  * @property {number} numTemporalLayers

--- a/lib/transmuxer/mpeg_audio.js
+++ b/lib/transmuxer/mpeg_audio.js
@@ -16,8 +16,12 @@ shaka.transmuxer.MpegAudio = class {
   /**
    * @param {!Uint8Array} data
    * @param {!number} offset
-   * @return {?{sampleRate: number, channelCount: number,
-   * frameLength: number, samplesPerFrame: number}}
+   * @return {?{
+   *   sampleRate: number,
+   *   channelCount: number,
+   *   frameLength: number,
+   *   samplesPerFrame: number,
+   * }}
    */
   static parseHeader(data, offset) {
     const MpegAudio = shaka.transmuxer.MpegAudio;

--- a/lib/transmuxer/transmuxer_engine.js
+++ b/lib/transmuxer/transmuxer_engine.js
@@ -128,7 +128,7 @@ shaka.transmuxer.TransmuxerEngine = class {
 /**
  * @typedef {{
  *   plugin: shaka.extern.TransmuxerPlugin,
- *   priority: number
+ *   priority: number,
  * }}
  * @property {shaka.extern.TransmuxerPlugin} plugin
  *   The associated plugin.

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -1195,7 +1195,7 @@ shaka.util.CmcdManager = class {
  *   getVariantTracks: function():Array<shaka.extern.Track>,
  *   isLive: function():boolean,
  *   getLiveLatency: function():number,
- *   getNetworkingEngine: function():shaka.net.NetworkingEngine
+ *   getNetworkingEngine: function():shaka.net.NetworkingEngine,
  * }}
  *
  * @property {function():number} getBandwidthEstimate

--- a/lib/util/content_steering_manager.js
+++ b/lib/util/content_steering_manager.js
@@ -321,7 +321,7 @@ shaka.util.ContentSteeringManager = class {
  *   TTL: number,
  *   RELOAD-URI: string,
  *   PATHWAY-PRIORITY: !Array<string>,
- *   PATHWAY-CLONES: !Array<shaka.util.ContentSteeringManager.PathwayClone>
+ *   PATHWAY-CLONES: !Array<shaka.util.ContentSteeringManager.PathwayClone>,
  * }}
  *
  * @description
@@ -341,7 +341,7 @@ shaka.util.ContentSteeringManager.SteeringManifest;
  * @typedef {{
  *   BASE-ID: string,
  *   ID: string,
- *   URI-REPLACEMENT: !Array<shaka.util.ContentSteeringManager.UriReplacement>
+ *   URI-REPLACEMENT: !Array<shaka.util.ContentSteeringManager.UriReplacement>,
  * }}
  *
  * @property {string} BASE-ID
@@ -354,7 +354,7 @@ shaka.util.ContentSteeringManager.PathwayClone;
 
 /**
  * @typedef {{
- *   HOST: string
+ *   HOST: string,
  * }}
  *
  * @property {string} HOST

--- a/lib/util/mp4_box_parsers.js
+++ b/lib/util/mp4_box_parsers.js
@@ -741,11 +741,11 @@ shaka.util.Mp4BoxParsers = class {
 
 /**
  * @typedef {{
- *    trackId: number,
- *    defaultSampleDuration: ?number,
- *    defaultSampleSize: ?number,
- *    baseDataOffset: ?number,
- *    sampleDescriptionIndex: ?number
+ *   trackId: number,
+ *   defaultSampleDuration: ?number,
+ *   defaultSampleSize: ?number,
+ *   baseDataOffset: ?number,
+ *   sampleDescriptionIndex: ?number,
  * }}
  *
  * @property {number} trackId
@@ -767,7 +767,7 @@ shaka.util.ParsedTFHDBox;
 
 /**
  * @typedef {{
- *    baseMediaDecodeTime: number
+ *   baseMediaDecodeTime: number,
  * }}
  *
  * @property {number} baseMediaDecodeTime
@@ -780,8 +780,8 @@ shaka.util.ParsedTFDTBox;
 
 /**
  * @typedef {{
- *    mediaTime: number,
- *    ntpTimestamp: number
+ *   mediaTime: number,
+ *   ntpTimestamp: number,
  * }}
  *
  * @exportDoc
@@ -790,8 +790,8 @@ shaka.util.ParsedPRFTBox;
 
 /**
  * @typedef {{
- *    timescale: number,
- *    language: string
+ *   timescale: number,
+ *   language: string,
  * }}
  *
  * @property {number} timescale
@@ -806,8 +806,8 @@ shaka.util.ParsedMDHDBox;
 
 /**
  * @typedef {{
- *    defaultSampleDuration: number,
- *    defaultSampleSize: number
+ *   defaultSampleDuration: number,
+ *   defaultSampleSize: number,
  * }}
  *
  * @property {number} defaultSampleDuration
@@ -821,9 +821,9 @@ shaka.util.ParsedTREXBox;
 
 /**
  * @typedef {{
- *    sampleCount: number,
- *    sampleData: !Array<shaka.util.ParsedTRUNSample>,
- *    dataOffset: ?number
+ *   sampleCount: number,
+ *   sampleData: !Array<shaka.util.ParsedTRUNSample>,
+ *   dataOffset: ?number,
  * }}
  *
  * @property {number} sampleCount
@@ -839,10 +839,10 @@ shaka.util.ParsedTRUNBox;
 
 /**
  * @typedef {{
- *    sampleDuration: ?number,
- *    sampleSize: ?number,
- *    sampleCompositionTimeOffset: ?number
- *  }}
+ *   sampleDuration: ?number,
+ *   sampleSize: ?number,
+ *   sampleCompositionTimeOffset: ?number,
+ * }}
  *
  * @property {?number} sampleDuration
  *   The length of the sample in timescale units.
@@ -860,10 +860,10 @@ shaka.util.ParsedTRUNSample;
 
 /**
  * @typedef {{
- *    trackId: number,
- *    width: number,
- *    height: number
- *  }}
+ *   trackId: number,
+ *   width: number,
+ *   height: number,
+ * }}
  *
  * @property {number} trackId
  *   Unique ID indicative of this track
@@ -878,8 +878,8 @@ shaka.util.ParsedTKHDBox;
 
 /**
  * @typedef {{
- *    codec: string
- *  }}
+ *   codec: string,
+ * }}
  *
  * @property {string} codec
  *   A fourcc for a codec
@@ -890,8 +890,8 @@ shaka.util.ParsedFRMABox;
 
 /**
  * @typedef {{
- *    defaultKID: string
- *  }}
+ *   defaultKID: string,
+ * }}
  *
  * @property {string} defaultKID
  *
@@ -901,9 +901,9 @@ shaka.util.ParsedTENCBox;
 
 /**
  * @typedef {{
- *    width: number,
- *    height: number
- *  }}
+ *   width: number,
+ *   height: number,
+ * }}
  *
  * @property {number} width
  * @property {number} height
@@ -914,9 +914,9 @@ shaka.util.ParsedVisualSampleEntryBox;
 
 /**
  * @typedef {{
- *    channelCount: number,
- *    sampleRate: number
- *  }}
+ *   channelCount: number,
+ *   sampleRate: number,
+ * }}
  *
  * @property {number} channelCount
  * @property {number} sampleRate
@@ -927,8 +927,8 @@ shaka.util.ParsedAudioSampleEntryBox;
 
 /**
  * @typedef {{
- *    codec: string
- *  }}
+ *   codec: string,
+ * }}
  *
  * @property {string} codec
  *
@@ -938,8 +938,8 @@ shaka.util.ParsedESDSBox;
 
 /**
  * @typedef {{
- *    codec: string
- *  }}
+ *   codec: string,
+ * }}
  *
  * @property {string} codec
  *
@@ -949,8 +949,8 @@ shaka.util.ParsedAVCCBox;
 
 /**
  * @typedef {{
- *    codec: string
- *  }}
+ *   codec: string,
+ * }}
  *
  * @property {string} codec
  *
@@ -960,8 +960,8 @@ shaka.util.ParsedHVCCBox;
 
 /**
  * @typedef {{
- *    codec: string
- *  }}
+ *   codec: string,
+ * }}
  *
  * @property {string} codec
  *
@@ -971,8 +971,8 @@ shaka.util.ParsedDVCCBox;
 
 /**
  * @typedef {{
- *    codec: string
- *  }}
+ *   codec: string,
+ * }}
  *
  * @property {string} codec
  *
@@ -982,8 +982,8 @@ shaka.util.ParsedDVVCBox;
 
 /**
  * @typedef {{
- *    codec: string
- *  }}
+ *   codec: string,
+ * }}
  *
  * @property {string} codec
  *
@@ -993,8 +993,8 @@ shaka.util.ParsedVPCCBox;
 
 /**
  * @typedef {{
- *    codec: string
- *  }}
+ *   codec: string,
+ * }}
  *
  * @property {string} codec
  *
@@ -1004,7 +1004,7 @@ shaka.util.ParsedAV1CBox;
 
 /**
  * @typedef {{
- *    handlerType: string
+ *   handlerType: string,
  * }}
  *
  * @property {string} handlerType
@@ -1018,7 +1018,7 @@ shaka.util.ParsedHDLRBox;
 
 /**
  * @typedef {{
- *    projection: string
+ *   projection: string,
  * }}
  *
  * @property {string} projection
@@ -1035,7 +1035,7 @@ shaka.util.ParsedPRJIBox;
 
 /**
  * @typedef {{
- *    hfov: number
+ *   hfov: number,
  * }}
  *
  * @property {number} hfov
@@ -1046,8 +1046,8 @@ shaka.util.ParsedHFOVBox;
 
 /**
  * @typedef {{
- *    colorGamut: ?string,
- *    videoRange: ?string
+ *   colorGamut: ?string,
+ *   videoRange: ?string,
  * }}
  *
  * @property {?string} colorGamut

--- a/lib/util/mp4_generator.js
+++ b/lib/util/mp4_generator.js
@@ -1363,19 +1363,19 @@ shaka.util.Mp4Generator.DINF_ = new Uint8Array([]);
 
 /**
  * @typedef {{
- *    id: number,
- *    type: string,
- *    codecs: string,
- *    encrypted: boolean,
- *    timescale: number,
- *    duration: number,
- *    videoNalus: !Array<string>,
- *    audioConfig: !Uint8Array,
- *    videoConfig: !Uint8Array,
- *    hSpacing: number,
- *    vSpacing: number,
- *    data: ?shaka.util.Mp4Generator.Data,
- *    stream: !shaka.extern.Stream
+ *   id: number,
+ *   type: string,
+ *   codecs: string,
+ *   encrypted: boolean,
+ *   timescale: number,
+ *   duration: number,
+ *   videoNalus: !Array<string>,
+ *   audioConfig: !Uint8Array,
+ *   videoConfig: !Uint8Array,
+ *   hSpacing: number,
+ *   vSpacing: number,
+ *   data: ?shaka.util.Mp4Generator.Data,
+ *   stream: !shaka.extern.Stream,
  * }}
  *
  * @property {number} id
@@ -1411,9 +1411,9 @@ shaka.util.Mp4Generator.StreamInfo;
 
 /**
  * @typedef {{
- *    sequenceNumber: number,
- *    baseMediaDecodeTime: number,
- *    samples: !Array<shaka.util.Mp4Generator.Mp4Sample>
+ *   sequenceNumber: number,
+ *   baseMediaDecodeTime: number,
+ *   samples: !Array<shaka.util.Mp4Generator.Mp4Sample>,
  * }}
  *
  * @property {number} sequenceNumber
@@ -1427,11 +1427,11 @@ shaka.util.Mp4Generator.Data;
 
 /**
  * @typedef {{
- *    data: !Uint8Array,
- *    size: number,
- *    duration: number,
- *    cts: number,
- *    flags: !shaka.util.Mp4Generator.Mp4SampleFlags
+ *   data: !Uint8Array,
+ *   size: number,
+ *   duration: number,
+ *   cts: number,
+ *   flags: !shaka.util.Mp4Generator.Mp4SampleFlags,
  * }}
  *
  * @property {!Uint8Array} data
@@ -1449,12 +1449,12 @@ shaka.util.Mp4Generator.Mp4Sample;
 
 /**
  * @typedef {{
- *    isLeading: number,
- *    isDependedOn: number,
- *    hasRedundancy: number,
- *    degradPrio: number,
- *    dependsOn: number,
- *    isNonSync: number
+ *   isLeading: number,
+ *   isDependedOn: number,
+ *   hasRedundancy: number,
+ *   degradPrio: number,
+ *   dependsOn: number,
+ *   isNonSync: number,
  * }}
  *
  * @property {number} isLeading

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -171,10 +171,10 @@ shaka.util.PeriodCombiner = class {
    * @param {!Array<shaka.extern.Period>} periods
    * @param {boolean} addDummy
    * @return {{
-   *  audioStreamsPerPeriod: !Array<!Map<string, shaka.extern.Stream>>,
-   *  videoStreamsPerPeriod: !Array<!Map<string, shaka.extern.Stream>>,
-   *  textStreamsPerPeriod: !Array<!Map<string, shaka.extern.Stream>>,
-   *  imageStreamsPerPeriod: !Array<!Map<string, shaka.extern.Stream>>
+   *   audioStreamsPerPeriod: !Array<!Map<string, shaka.extern.Stream>>,
+   *   videoStreamsPerPeriod: !Array<!Map<string, shaka.extern.Stream>>,
+   *   textStreamsPerPeriod: !Array<!Map<string, shaka.extern.Stream>>,
+   *   imageStreamsPerPeriod: !Array<!Map<string, shaka.extern.Stream>>,
    * }}
    * @private
    */

--- a/lib/util/tXml.js
+++ b/lib/util/tXml.js
@@ -970,7 +970,7 @@ shaka.util.TXml.nameSpaceToUri_ = new Map();
  *   t: ?number,
  *   n: ?number,
  *   position: ?number,
- *   attribute: ?string
+ *   attribute: ?string,
  * }}
  */
 shaka.util.TXml.PathNode;

--- a/lib/util/ts_parser.js
+++ b/lib/util/ts_parser.js
@@ -889,8 +889,12 @@ shaka.util.TsParser = class {
   /**
    * Return the video information
    *
-   * @return {{height: ?string, width: ?string, codec: ?string,
-   *           frameRate: ?string}}
+   * @return {{
+   *   height: ?string,
+   *   width: ?string,
+   *   codec: ?string,
+   *   frameRate: ?string,
+   * }}
    * @export
    */
   getVideoInfo() {
@@ -924,8 +928,12 @@ shaka.util.TsParser = class {
   /**
    * Return the video information for AVC
    *
-   * @return {{height: ?string, width: ?string, codec: ?string,
-   *           frameRate: ?string}}
+   * @return {{
+   *   height: ?string,
+   *   width: ?string,
+   *   codec: ?string,
+   *   frameRate: ?string,
+   * }}
    * @private
    */
   getAvcInfo_() {
@@ -1054,8 +1062,12 @@ shaka.util.TsParser = class {
   /**
    * Return the video information for HVC
    *
-   * @return {{height: ?string, width: ?string, codec: ?string,
-   *           frameRate: ?string}}
+   * @return {{
+   *   height: ?string,
+   *   width: ?string,
+   *   codec: ?string,
+   *   frameRate: ?string,
+   * }}
    * @private
    */
   getHvcInfo_() {
@@ -1345,7 +1357,7 @@ shaka.util.TsParser.PROFILES_WITH_OPTIONAL_SPS_DATA_ =
  *   video: number,
  *   id3: number,
  *   audioCodec: string,
- *   videoCodec: string
+ *   videoCodec: string,
  * }}
  *
  * @summary PMT.
@@ -1367,7 +1379,7 @@ shaka.util.TsParser.PMT;
  * @typedef {{
  *   channelCount: number,
  *   channelConfigCode: number,
- *   sampleRate: number
+ *   sampleRate: number,
  * }}
  *
  * @summary PMT.


### PR DESCRIPTION
Now that jsdoc supports this, it will make future diffs cleaner.  See #8819 and #1236.