### PR TITLE
chore: Simplify DrmEngine queryMediaKeys()

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -310,36 +310,31 @@ shaka.drm.DrmEngine = class {
    */
   initForRemoval(keySystem, licenseServerUri, serverCertificate,
       audioCapabilities, videoCapabilities) {
-    /** @type {!Map<string, MediaKeySystemConfiguration>} */
-    const configsByKeySystem = new Map();
+    const mimeTypes = [];
+    if (videoCapabilities.length) {
+      mimeTypes.push(videoCapabilities[0].contentType);
+    }
+    if (audioCapabilities.length) {
+      mimeTypes.push(audioCapabilities[0].contentType);
+    }
 
-    /** @type {MediaKeySystemConfiguration} */
-    const config = {
-      audioCapabilities: audioCapabilities,
-      videoCapabilities: videoCapabilities,
-      distinctiveIdentifier: 'optional',
-      persistentState: 'required',
-      sessionTypes: ['persistent-license'],
-      label: keySystem,  // Tracked by us, ignored by EME.
+    const makeDrmInfo = (encryptionScheme) => {
+      const drmInfo = shaka.util.ManifestParserUtils.createDrmInfo(
+          keySystem, encryptionScheme, null);
+      drmInfo.licenseServerUri = licenseServerUri;
+      drmInfo.serverCertificate = serverCertificate;
+      return drmInfo;
     };
-
-    // TODO: refactor, don't stick drmInfos onto MediaKeySystemConfiguration
-    config['drmInfos'] = [{  // Non-standard attribute, ignored by EME.
-      keySystem: keySystem,
-      licenseServerUri: licenseServerUri,
-      distinctiveIdentifierRequired: false,
-      persistentStateRequired: true,
-      audioRobustness: '',  // Not required by queryMediaKeys_
-      videoRobustness: '',  // Same
-      serverCertificate: serverCertificate,
-      serverCertificateUri: '',
-      initData: null,
-      keyIds: null,
-    }];
-
-    configsByKeySystem.set(keySystem, config);
-    return this.queryMediaKeys_(configsByKeySystem,
-        /* variants= */ []);
+    const variant = shaka.util.StreamUtils.createEmptyVariant(mimeTypes);
+    if (variant.video) {
+      const drmInfo = makeDrmInfo(videoCapabilities[0].encryptionScheme || '');
+      variant.video.drmInfos.push(drmInfo);
+    }
+    if (variant.audio) {
+      const drmInfo = makeDrmInfo(audioCapabilities[0].encryptionScheme || '');
+      variant.audio.drmInfos.push(drmInfo);
+    }
+    return this.queryMediaKeys_(/* variants= */ [variant]);
   }
 
   /**
@@ -395,9 +390,6 @@ shaka.drm.DrmEngine = class {
         }
       }
     }
-
-    /** @type {!Map<string, MediaKeySystemConfiguration>} */
-    let configsByKeySystem;
 
     /**
      * Expand robustness into multiple drm infos if multiple video robustness
@@ -479,7 +471,7 @@ shaka.drm.DrmEngine = class {
       return Promise.resolve();
     }
 
-    const p = this.queryMediaKeys_(configsByKeySystem, variants);
+    const p = this.queryMediaKeys_(variants);
 
     // TODO(vaage): Look into the assertion below. If we do not have any drm
     // info, we create drm info so that content can play if it has drm info
@@ -947,19 +939,15 @@ shaka.drm.DrmEngine = class {
   }
 
   /**
-   * @param {!Map<string, MediaKeySystemConfiguration>} configsByKeySystem
-   *   A dictionary of configs, indexed by key system, with an iteration order
-   *   (insertion order) that reflects the preference for the application.
    * @param {!Array<shaka.extern.Variant>} variants
    * @return {!Promise} Resolved if/when a key system has been chosen.
    * @private
    */
-  async queryMediaKeys_(configsByKeySystem, variants) {
+  async queryMediaKeys_(variants) {
     const drmInfosByKeySystem = new Map();
 
-    const mediaKeySystemAccess = variants.length ?
-        this.getKeySystemAccessFromVariants_(variants, drmInfosByKeySystem) :
-        await this.getKeySystemAccessByConfigs_(configsByKeySystem);
+    const mediaKeySystemAccess =
+        this.getKeySystemAccessFromVariants_(variants, drmInfosByKeySystem);
 
     if (!mediaKeySystemAccess) {
       if (!navigator.requestMediaKeySystemAccess) {
@@ -987,13 +975,8 @@ shaka.drm.DrmEngine = class {
           this.config_.keySystemsMapping[mediaKeySystemAccess.keySystem] ||
           mediaKeySystemAccess.keySystem;
 
-      if (variants.length) {
-        this.currentDrmInfo_ = this.createDrmInfoByInfos_(
-            keySystem, drmInfosByKeySystem.get(keySystem));
-      } else {
-        this.currentDrmInfo_ = shaka.drm.DrmEngine.createDrmInfoByConfigs_(
-            keySystem, configsByKeySystem.get(keySystem));
-      }
+      this.currentDrmInfo_ = this.createDrmInfoByInfos_(
+          keySystem, drmInfosByKeySystem.get(keySystem));
       if (!this.currentDrmInfo_.licenseServerUri) {
         throw new shaka.util.Error(
             shaka.util.Error.Severity.CRITICAL,
@@ -1135,89 +1118,6 @@ shaka.drm.DrmEngine = class {
       }
     }
     return null;
-  }
-
-  /**
-   * Get the MediaKeySystemAccess by querying requestMediaKeySystemAccess.
-   * @param {!Map<string, MediaKeySystemConfiguration>} configsByKeySystem
-   *   A dictionary of configs, indexed by key system, with an iteration order
-   *   (insertion order) that reflects the preference for the application.
-   * @return {!Promise<MediaKeySystemAccess>} Resolved if/when a
-   *   mediaKeySystemAccess has been chosen.
-   * @private
-   */
-  async getKeySystemAccessByConfigs_(configsByKeySystem) {
-    /** @type {MediaKeySystemAccess} */
-    let mediaKeySystemAccess;
-
-    if (configsByKeySystem.size == 1 && configsByKeySystem.has('')) {
-      throw new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.DRM,
-          shaka.util.Error.Code.NO_RECOGNIZED_KEY_SYSTEMS);
-    }
-
-    // If there are no tracks of a type, these should be not present.
-    // Otherwise the query will fail.
-    for (const config of configsByKeySystem.values()) {
-      if (config.audioCapabilities.length == 0) {
-        delete config.audioCapabilities;
-      }
-      if (config.videoCapabilities.length == 0) {
-        delete config.videoCapabilities;
-      }
-    }
-
-    // If we have configured preferredKeySystems, choose the preferred one if
-    // available.
-    for (const keySystem of this.config_.preferredKeySystems) {
-      if (configsByKeySystem.has(keySystem)) {
-        const config = configsByKeySystem.get(keySystem);
-        try {
-          mediaKeySystemAccess =  // eslint-disable-next-line no-await-in-loop
-              await navigator.requestMediaKeySystemAccess(keySystem, [config]);
-          return mediaKeySystemAccess;
-        } catch (error) {
-          // Suppress errors.
-          shaka.log.v2(
-              'Requesting', keySystem, 'failed with config', config, error);
-        }
-        this.destroyer_.ensureNotDestroyed();
-      }
-    }
-
-    // Try key systems with configured license servers first.  We only have to
-    // try key systems without configured license servers for diagnostic
-    // reasons, so that we can differentiate between "none of these key
-    // systems are available" and "some are available, but you did not
-    // configure them properly."  The former takes precedence.
-    // TODO: once MediaCap implementation is complete, this part can be
-    // simplified or removed.
-    for (const shouldHaveLicenseServer of [true, false]) {
-      for (const keySystem of configsByKeySystem.keys()) {
-        const config = configsByKeySystem.get(keySystem);
-        // TODO: refactor, don't stick drmInfos onto
-        // MediaKeySystemConfiguration
-        const hasLicenseServer = config['drmInfos'].some((info) => {
-          return !!info.licenseServerUri;
-        });
-        if (hasLicenseServer != shouldHaveLicenseServer) {
-          continue;
-        }
-
-        try {
-          mediaKeySystemAccess =  // eslint-disable-next-line no-await-in-loop
-              await navigator.requestMediaKeySystemAccess(keySystem, [config]);
-          return mediaKeySystemAccess;
-        } catch (error) {
-          // Suppress errors.
-          shaka.log.v2(
-              'Requesting', keySystem, 'failed with config', config, error);
-        }
-        this.destroyer_.ensureNotDestroyed();
-      }
-    }
-    return mediaKeySystemAccess;
   }
 
   /**
@@ -2405,83 +2305,6 @@ shaka.drm.DrmEngine = class {
     }
 
     return res;
-  }
-
-  /**
-   * Creates a DrmInfo object describing the settings used to initialize the
-   * engine.
-   *
-   * @param {string} keySystem
-   * @param {MediaKeySystemConfiguration} config
-   * @return {shaka.extern.DrmInfo}
-   *
-   * @private
-   */
-  static createDrmInfoByConfigs_(keySystem, config) {
-    /** @type {!Array<string>} */
-    const encryptionSchemes = [];
-
-    /** @type {!Array<string>} */
-    const licenseServers = [];
-
-    /** @type {!Array<string>} */
-    const serverCertificateUris = [];
-
-    /** @type {!Array<!Uint8Array>} */
-    const serverCerts = [];
-
-    /** @type {!Array<!shaka.extern.InitDataOverride>} */
-    const initDatas = [];
-
-    /** @type {!Set<string>} */
-    const keyIds = new Set();
-
-    // TODO: refactor, don't stick drmInfos onto MediaKeySystemConfiguration
-    shaka.drm.DrmEngine.processDrmInfos_(
-        config['drmInfos'], encryptionSchemes, licenseServers, serverCerts,
-        serverCertificateUris, initDatas, keyIds);
-
-    if (encryptionSchemes.length > 1) {
-      shaka.log.warning('Multiple unique encryption schemes found! ' +
-                        'Only the first will be used.');
-    }
-
-    if (serverCerts.length > 1) {
-      shaka.log.warning('Multiple unique server certificates found! ' +
-                        'Only the first will be used.');
-    }
-
-    if (serverCertificateUris.length > 1) {
-      shaka.log.warning('Multiple unique server certificate URIs found! ' +
-                        'Only the first will be used.');
-    }
-
-    if (licenseServers.length > 1) {
-      shaka.log.warning('Multiple unique license server URIs found! ' +
-                        'Only the first will be used.');
-    }
-
-    // TODO: This only works when all DrmInfo have the same robustness.
-    const audioRobustness =
-        config.audioCapabilities ? config.audioCapabilities[0].robustness : '';
-    const videoRobustness =
-        config.videoCapabilities ? config.videoCapabilities[0].robustness : '';
-
-    const distinctiveIdentifier = config.distinctiveIdentifier;
-    return {
-      keySystem,
-      encryptionScheme: encryptionSchemes[0],
-      licenseServerUri: licenseServers[0],
-      distinctiveIdentifierRequired: (distinctiveIdentifier == 'required'),
-      persistentStateRequired: (config.persistentState == 'required'),
-      sessionType: config.sessionTypes[0] || 'temporary',
-      audioRobustness: audioRobustness || '',
-      videoRobustness: videoRobustness || '',
-      serverCertificate: serverCerts[0],
-      serverCertificateUri: serverCertificateUris[0],
-      initData: initDatas,
-      keyIds,
-    };
   }
 
   /**

--- a/lib/player.js
+++ b/lib/player.js
@@ -3126,8 +3126,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   async initializeSrcEqualsDrmInner_(mimeType) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
-
     goog.asserts.assert(
         this.networkingEngine_,
         '|onInitializeSrcEqualsDrm_| should never be called after |destroy|');
@@ -3165,69 +3163,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     });
 
     this.drmEngine_.configure(this.config_.drm);
-
-    // TODO: Instead of feeding DrmEngine with Variants, we should refactor
-    // DrmEngine so that it takes a minimal config derived from Variants.  In
-    // cases like this one or in removal of stored content, the details are
-    // largely unimportant.  We should have a saner way to initialize
-    // DrmEngine.
-    // That would also insulate DrmEngine from manifest changes in the future.
-    // For now, that is time-consuming and this synthetic Variant is easy, so
-    // I'm putting it off.  Since this is only expected to be used for native
-    // HLS in Safari, this should be safe. -JCP
-    /** @type {shaka.extern.Variant} */
-    const variant = {
-      id: 0,
-      language: 'und',
-      disabledUntilTime: 0,
-      primary: false,
-      audio: null,
-      video: null,
-      bandwidth: 100,
-      allowedByApplication: true,
-      allowedByKeySystem: true,
-      decodingInfos: [],
-    };
-    const stream = {
-      id: 0,
-      originalId: null,
-      groupId: null,
-      createSegmentIndex: () => Promise.resolve(),
-      segmentIndex: null,
-      mimeType: mimeType ? shaka.util.MimeUtils.getBasicType(mimeType) : '',
-      codecs: mimeType ? shaka.util.MimeUtils.getCodecs(mimeType) : '',
-      encrypted: true,
-      drmInfos: [],  // Filled in by DrmEngine config.
-      keyIds: new Set(),
-      language: 'und',
-      originalLanguage: null,
-      label: null,
-      type: ContentType.VIDEO,
-      primary: false,
-      trickModeVideo: null,
-      dependencyStream: null,
-      emsgSchemeIdUris: null,
-      roles: [],
-      forced: false,
-      channelsCount: null,
-      audioSamplingRate: null,
-      spatialAudio: false,
-      closedCaptions: null,
-      accessibilityPurpose: null,
-      external: false,
-      fastSwitching: false,
-      fullMimeTypes: new Set(),
-      isAudioMuxedInVideo: false,
-      baseOriginalId: null,
-    };
-    stream.fullMimeTypes.add(shaka.util.MimeUtils.getFullType(
-        stream.mimeType, stream.codecs));
-    if (mimeType.startsWith('audio/')) {
-      stream.type = ContentType.AUDIO;
-      variant.audio = stream;
-    } else {
-      variant.video = stream;
-    }
+    const variant = shaka.util.StreamUtils.createEmptyVariant([mimeType]);
 
     this.drmEngine_.setSrcEquals(/* srcEquals= */ true);
     await this.drmEngine_.initForPlayback(

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -2102,6 +2102,72 @@ shaka.util.StreamUtils = class {
     shaka.log.alwaysWarn('Invalid autoShowText setting!');
     return false;
   }
+
+  /**
+   * @param {!Array<string>} mimeTypes
+   * @return {!shaka.extern.Variant}
+   */
+  static createEmptyVariant(mimeTypes) {
+    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+
+    /** @type {shaka.extern.Variant} */
+    const variant = {
+      id: 0,
+      language: 'und',
+      disabledUntilTime: 0,
+      primary: false,
+      audio: null,
+      video: null,
+      bandwidth: 100,
+      allowedByApplication: true,
+      allowedByKeySystem: true,
+      decodingInfos: [],
+    };
+    for (const mimeType of mimeTypes) {
+      const stream = {
+        id: 0,
+        originalId: null,
+        groupId: null,
+        createSegmentIndex: () => Promise.resolve(),
+        segmentIndex: null,
+        mimeType: mimeType ? shaka.util.MimeUtils.getBasicType(mimeType) : '',
+        codecs: mimeType ? shaka.util.MimeUtils.getCodecs(mimeType) : '',
+        encrypted: true,
+        drmInfos: [],  // Filled in by DrmEngine config.
+        keyIds: new Set(),
+        language: 'und',
+        originalLanguage: null,
+        label: null,
+        type: ContentType.VIDEO,
+        primary: false,
+        trickModeVideo: null,
+        dependencyStream: null,
+        emsgSchemeIdUris: null,
+        roles: [],
+        forced: false,
+        channelsCount: null,
+        audioSamplingRate: null,
+        spatialAudio: false,
+        closedCaptions: null,
+        accessibilityPurpose: null,
+        external: false,
+        fastSwitching: false,
+        fullMimeTypes: new Set(),
+        isAudioMuxedInVideo: false,
+        baseOriginalId: null,
+      };
+      stream.fullMimeTypes.add(shaka.util.MimeUtils.getFullType(
+          stream.mimeType, stream.codecs));
+      if (mimeType.startsWith('audio/')) {
+        stream.type = ContentType.AUDIO;
+        variant.audio = stream;
+      } else {
+        variant.video = stream;
+      }
+    }
+
+    return variant;
+  }
 };
 
 


### PR DESCRIPTION
`queryMediaKeys()` was able to work both with variants and key system configs. The latter option was needed only for `initForRemoval()` method. By removing it we are able to make the logic more easy to follow.
Additionally, compiled build is now 2 KB smaller.