### PR TITLE
chore: Move wait for encrypted event check to device API

### DIFF
--- a/lib/device/abstract_device.js
+++ b/lib/device/abstract_device.js
@@ -317,6 +317,13 @@ shaka.device.AbstractDevice = class {
   /**
    * @override
    */
+  needWaitForEncryptedEvent(keySystem) {
+    return keySystem === 'com.apple.fps';
+  }
+
+  /**
+   * @override
+   */
   toString() {
     return `Device: ${this.getDeviceName()} v${this.getVersion()}; ` +
         `Type: ${this.getDeviceType()}`;

--- a/lib/device/default_browser.js
+++ b/lib/device/default_browser.js
@@ -187,6 +187,16 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
     }
     return super.supportsCbcsWithoutEncryptionSchemeSupport();
   }
+
+  /**
+   * @override
+   */
+  needWaitForEncryptedEvent(keySystem) {
+    if (this.getBrowserEngine() === shaka.device.IDevice.BrowserEngine.GECKO) {
+      return keySystem.startsWith('com.microsoft.playready.recommendation');
+    }
+    return super.needWaitForEncryptedEvent(keySystem);
+  }
 };
 
 shaka.device.DeviceFactory.registerDefaultDeviceFactory(

--- a/lib/device/i_device.js
+++ b/lib/device/i_device.js
@@ -229,6 +229,14 @@ shaka.device.IDevice = class {
    * @return {boolean}
    */
   supportsCbcsWithoutEncryptionSchemeSupport() {}
+
+  /**
+   * Returns true if the platform needs to wait for the encrypted event in order
+   * to initialize CDM correctly.
+   * @param {string} keySystem
+   * @return {boolean}
+   */
+  needWaitForEncryptedEvent(keySystem) {}
 };
 
 /**

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -593,14 +593,8 @@ shaka.drm.DrmEngine = class {
       ) || null) : null;
 
     const keySystem = this.currentDrmInfo_.keySystem;
-    let needWaitForEncryptedEvent = keySystem == 'com.apple.fps';
-    const browserEngine =
-        shaka.device.DeviceFactory.getDevice().getBrowserEngine();
-    if (browserEngine === shaka.device.IDevice.BrowserEngine.GECKO &&
-        keySystem.startsWith('com.microsoft.playready.recommendation')) {
-      needWaitForEncryptedEvent = true;
-    }
-
+    const needWaitForEncryptedEvent = shaka.device.DeviceFactory.getDevice()
+        .needWaitForEncryptedEvent(keySystem);
     /**
      * We can attach media keys before the playback actually begins when:
      *  - If we are not using FairPlay Modern EME


### PR DESCRIPTION
This info should be abstract to DRM Engine.