### PR TITLE
fix(HLS): Fix preload initial variant

### DIFF
--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -430,13 +430,18 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
         await this.parseManifestInner_();
         this.throwIfDestroyed_();
 
+        await this.chooseInitialVariant_();
+        this.throwIfDestroyed_();
+
         if (!shaka.drm.DrmUtils.isMediaKeysPolyfilled('webkit')) {
           await this.initializeDrm();
           this.throwIfDestroyed_();
         }
 
-        await this.chooseInitialVariantAndPrefetchInner_();
-        this.throwIfDestroyed_();
+        if (this.allowPrefetch_) {
+          await this.prefetchInner_();
+          this.throwIfDestroyed_();
+        }
 
         // We don't need the drm keys to load completely for the initial variant
         // to be chosen, but we won't mark the load as a success until it has
@@ -552,19 +557,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     if (!this.manifest_) {
       this.manifest_ = await this.parser_.start(
           this.assetUri_, this.manifestPlayerInterface_);
-
-      if (this.manifest_.variants.length == 1) {
-        const createSegmentIndexPromises = [];
-        const variant = this.manifest_.variants[0];
-        for (const stream of [variant.video, variant.audio]) {
-          if (stream && !stream.segmentIndex) {
-            createSegmentIndexPromises.push(stream.createSegmentIndex());
-          }
-        }
-        if (createSegmentIndexPromises.length > 0) {
-          await Promise.all(createSegmentIndexPromises);
-        }
-      }
     }
 
     this.manifestPromise_.resolve();
@@ -627,10 +619,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     const playableVariants = shaka.util.StreamUtils.getPlayableVariants(
         this.manifest_.variants);
     let isLive = true;
-    // In HLS we need to parse the media playlist to know if it is Live or not.
-    // So at this point we don't know yet. By default we assume it is Live.
-    if (this.manifest_ && this.manifest_.presentationTimeline &&
-        this.manifest_.type != shaka.media.ManifestParser.HLS) {
+    if (this.manifest_ && this.manifest_.presentationTimeline) {
       isLive = this.manifest_.presentationTimeline.isLive();
     }
     await this.drmEngine_.initForPlayback(
@@ -679,13 +668,13 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
   }
 
   /**
-   * Performs a final filtering of the manifest, and chooses the initial
-   * variant. Also prefetches segments.
+   * Performs a filtering of the manifest, and chooses the initial
+   * variant.
    *
    * @return {!Promise}
    * @private
    */
-  async chooseInitialVariantAndPrefetchInner_() {
+  async chooseInitialVariant_() {
     goog.asserts.assert(
         this.manifest_, 'The manifest should already be parsed.');
 
@@ -724,37 +713,90 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
       this.abrManager_.configure(this.config_.abr);
     }
 
-    if (this.allowPrefetch_) {
-      const isLive = this.manifest_.presentationTimeline.isLive();
-      // Prefetch segments for the predicted first variant.
-      // We start these here, but don't wait for them; it's okay to start the
-      // full load process while the segments are being prefetched.
-      const playableVariants = shaka.util.StreamUtils.getPlayableVariants(
-          this.manifest_.variants);
-      const adaptationSet = this.currentAdaptationSetCriteria_.create(
-          playableVariants);
-      // Guess what the first variant will be, based on a SimpleAbrManager.
-      this.abrManager_.configure(this.config_.abr);
-      this.abrManager_.setVariants(Array.from(adaptationSet.values()));
+    const playableVariants = shaka.util.StreamUtils.getPlayableVariants(
+        this.manifest_.variants);
+    const adaptationSet = this.currentAdaptationSetCriteria_.create(
+        playableVariants);
+    // Guess what the first variant will be, based on a SimpleAbrManager.
+    this.abrManager_.configure(this.config_.abr);
+    this.abrManager_.setVariants(Array.from(adaptationSet.values()));
+
+    if (this.shouldCreateSegmentIndexBeforeDrmEngineInitialization_()) {
       const variant = this.abrManager_.chooseVariant();
       if (variant) {
-        const promises = [];
-        this.prefetchedVariant_ = variant;
-        if (variant.video) {
-          promises.push(this.prefetchStream_(variant.video, isLive));
+        const createSegmentIndexPromises = [];
+        for (const stream of [variant.video, variant.audio]) {
+          if (stream && !stream.segmentIndex) {
+            createSegmentIndexPromises.push(stream.createSegmentIndex());
+          }
         }
-        if (variant.audio) {
-          promises.push(this.prefetchStream_(variant.audio, isLive));
+        if (createSegmentIndexPromises.length > 0) {
+          await Promise.all(createSegmentIndexPromises);
         }
-        const textStream = this.chooseTextStream_();
-        if (textStream && shaka.util.StreamUtils.shouldInitiallyShowText(
-            variant.audio, textStream, this.config_)) {
-          promises.push(this.prefetchStream_(textStream, isLive));
-          this.prefetchedTextStream_ = textStream;
-        }
-
-        await Promise.all(promises);
       }
+    }
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  shouldCreateSegmentIndexBeforeDrmEngineInitialization_() {
+    goog.asserts.assert(
+        this.manifest_, 'The manifest should already be parsed.');
+
+    // If we only have one variant, it is useful to preload it, because it will
+    // be the only one we can use.
+    if (this.manifest_.variants.length == 1) {
+      return true;
+    }
+
+    // In HLS, DRM information is usually included in the media playlist, so we
+    // need to download the media playlist to get the real information.
+    if (this.manifest_.type == shaka.media.ManifestParser.HLS) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Prefetches segments.
+   *
+   * @return {!Promise}
+   * @private
+   */
+  async prefetchInner_() {
+    goog.asserts.assert(this.currentAdaptationSetCriteria_,
+        'Must have an AdaptationSetCriteria');
+
+    const playableVariants = shaka.util.StreamUtils.getPlayableVariants(
+        this.manifest_.variants);
+    const adaptationSet = this.currentAdaptationSetCriteria_.create(
+        playableVariants);
+    // Guess what the first variant will be, based on a SimpleAbrManager.
+    this.abrManager_.configure(this.config_.abr);
+    this.abrManager_.setVariants(Array.from(adaptationSet.values()));
+
+    const variant = this.abrManager_.chooseVariant();
+    if (variant) {
+      const isLive = this.manifest_.presentationTimeline.isLive();
+      const promises = [];
+      this.prefetchedVariant_ = variant;
+      if (variant.video) {
+        promises.push(this.prefetchStream_(variant.video, isLive));
+      }
+      if (variant.audio) {
+        promises.push(this.prefetchStream_(variant.audio, isLive));
+      }
+      const textStream = this.chooseTextStream_();
+      if (textStream && shaka.util.StreamUtils.shouldInitiallyShowText(
+          variant.audio, textStream, this.config_)) {
+        promises.push(this.prefetchStream_(textStream, isLive));
+        this.prefetchedTextStream_ = textStream;
+      }
+
+      await Promise.all(promises);
     }
   }
 


### PR DESCRIPTION
This is necessary to obtain the necessary DRM information, which in most cases is not available until the media playlist is downloaded. Also avoid DRM setup for VOD that does not need it for HLS

Fixes #8830