### PR TITLE
fix(ABR): Fix abr switching in some case

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2425,7 +2425,7 @@ shaka.extern.AdsConfiguration;
  *   Indicates the value in milliseconds from which a request is not
  *   considered cached.
  *   <br>
- *   Defaults to <code>20</code>.
+ *   Defaults to <code>5</code>.
  * @property {number} minTimeToSwitch
  *   Indicates the minimum time to change quality once the real bandwidth is
  *   available, in seconds. This time is only used on the first load.

--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -345,19 +345,18 @@ shaka.abr.SimpleAbrManager = class {
         request && request.packetNumber === 1 && request.timeToFirstByte) {
       realTimeMs = deltaTimeMs - request.timeToFirstByte;
     }
-    if (realTimeMs < this.config_.cacheLoadThreshold) {
-      // The time indicates that it could be a cache response, so we should
-      // ignore this value.
-      return;
+    // The time indicates that it could be a cache response, so we should
+    // ignore this value.
+    if (realTimeMs >= this.config_.cacheLoadThreshold) {
+      shaka.log.v2('Segment downloaded:',
+          'contentType=' + (request && request.contentType),
+          'deltaTimeMs=' + realTimeMs,
+          'numBytes=' + numBytes,
+          'lastTimeChosenMs=' + this.lastTimeChosenMs_,
+          'enabled=' + this.enabled_);
+      goog.asserts.assert(realTimeMs >= 0, 'expected a non-negative duration');
+      this.bandwidthEstimator_.sample(realTimeMs, numBytes);
     }
-    shaka.log.v2('Segment downloaded:',
-        'contentType=' + (request && request.contentType),
-        'deltaTimeMs=' + realTimeMs,
-        'numBytes=' + numBytes,
-        'lastTimeChosenMs=' + this.lastTimeChosenMs_,
-        'enabled=' + this.enabled_);
-    goog.asserts.assert(realTimeMs >= 0, 'expected a non-negative duration');
-    this.bandwidthEstimator_.sample(realTimeMs, numBytes);
 
     if (allowSwitch && (this.lastTimeChosenMs_ != null) && this.enabled_) {
       this.suggestStreams_();

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -347,7 +347,7 @@ shaka.util.PlayerConfiguration = class {
       ignoreDevicePixelRatio: false,
       clearBufferSwitch: false,
       safeMarginSwitch: 0,
-      cacheLoadThreshold: 20,
+      cacheLoadThreshold: 5,
       minTimeToSwitch: 0,
       preferNetworkInformationBandwidth: false,
       removeLatencyFromFirstPacketTime: true,


### PR DESCRIPTION
Try to suggest new stream althorung cacheLoadThreshold is not met for a given segment. Change the cache Load Threshold value to a more appropriate value since we now have removeLatencyFromFirstPacketTime active by default.