### PR TITLE
fix(HLS): Fix playback of content with mixed containers (mp4 and ts)

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -2528,7 +2528,6 @@ shaka.hls.HlsParser = class {
       firstSequenceNumber: -1,
       nextMediaSequence: -1,
       nextPart: -1,
-      loadedOnce: false,
     };
 
     const getUris = () => {
@@ -2631,7 +2630,6 @@ shaka.hls.HlsParser = class {
             realStreamInfo.mediaSequenceToStartTime;
         streamInfo.nextMediaSequence = realStreamInfo.nextMediaSequence;
         streamInfo.nextPart = realStreamInfo.nextPart;
-        streamInfo.loadedOnce = true;
         stream.segmentIndex = realStream.segmentIndex;
         stream.encrypted = realStream.encrypted;
         stream.drmInfos = realStream.drmInfos;
@@ -2671,18 +2669,6 @@ shaka.hls.HlsParser = class {
         if (this.manifest_ && closedCaptionsUpdated) {
           this.playerInterface_.makeTextStreamsForClosedCaptions(
               this.manifest_);
-        }
-
-        if (type == ContentType.VIDEO || type == ContentType.AUDIO) {
-          for (const otherStreamInfo of this.uriToStreamInfosMap_.values()) {
-            if (!otherStreamInfo.loadedOnce && otherStreamInfo.type == type &&
-                !otherStreamInfo.stream.isAudioMuxedInVideo) {
-              // To aid manifest filtering, assume before loading that all video
-              // renditions have the same MIME type.  (And likewise for audio.)
-              otherStreamInfo.stream.mimeType = realStream.mimeType;
-              this.setFullTypeForStream_(otherStreamInfo.stream);
-            }
-          }
         }
 
         if (type == ContentType.TEXT) {
@@ -3101,7 +3087,6 @@ shaka.hls.HlsParser = class {
       nextMediaSequence,
       nextPart,
       mediaSequenceToStartTime,
-      loadedOnce: false,
     };
   }
 
@@ -5195,7 +5180,6 @@ shaka.hls.HlsParser = class {
  *   firstSequenceNumber: number,
  *   nextMediaSequence: number,
  *   nextPart: number,
- *   loadedOnce: boolean,
  * }}
  *
  * @description
@@ -5231,8 +5215,6 @@ shaka.hls.HlsParser = class {
  *   The next media sequence.
  * @property {number} nextPart
  *   The next part.
- * @property {boolean} loadedOnce
- *   True if the stream has been loaded at least once.
  */
 shaka.hls.HlsParser.StreamInfo;
 

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -5789,12 +5789,8 @@ describe('HlsParser', () => {
 
     await actualVideo0.createSegmentIndex();
 
-    // After loading just ONE stream, all MIME types agree again, and have been
-    // updated to reflect the TS content found inside the loaded playlist.
-    // This is how we avoid having the unloaded tracks filtered out during
-    // startup.
     expect(actualVideo0.mimeType).toBe('video/mp2t');
-    expect(actualVideo1.mimeType).toBe('video/mp2t');
+    expect(actualVideo1.mimeType).toBe('video/mp4');
   });
 
   it('lazy-loads AAC content without filtering it out', async () => {
@@ -5849,13 +5845,9 @@ describe('HlsParser', () => {
 
     await actualAudio0.createSegmentIndex();
 
-    // After loading just ONE stream, all MIME types agree again, and have been
-    // updated to reflect the AAC content found inside the loaded playlist.
-    // This is how we avoid having the unloaded tracks filtered out during
-    // startup.
     expect(actualAudio0.mimeType).toBe('audio/aac');
     expect(actualAudio0.codecs).toBe('mp4a');
-    expect(actualAudio1.mimeType).toBe('audio/aac');
+    expect(actualAudio1.mimeType).toBe('audio/mp4');
     expect(actualAudio1.codecs).toBe('mp4a');
   });
 


### PR DESCRIPTION
We currently have many integrated transmuxers, so we should avoid assigning the same mimetype to all unloaded variants. 
We can dynamically transmux all content; we just need a compatible codec. 
Partial reverts https://github.com/shaka-project/shaka-player/pull/4601