### PR TITLE
fix(DASH): Consider codec profile when matching multi-period renditions

### DIFF
--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -1184,6 +1184,20 @@ shaka.util.PeriodCombiner = class {
    * @private
    */
   static areAVStreamsExactMatch_(a, b) {
+    return a.mimeType === b.mimeType && a.codecs === b.codecs;
+  }
+
+  /**
+   * @param {T} a
+   * @param {T} b
+   * @return {boolean}
+   *
+   * @template T
+   * Accepts either a StreamDB or Stream type.
+   *
+   * @private
+   */
+  static areAVStreamsCodecsCompatible_(a, b) {
     if (a.mimeType != b.mimeType) {
       return false;
     }
@@ -1224,9 +1238,12 @@ shaka.util.PeriodCombiner = class {
     // Check for an exact match.
     if (!shaka.util.PeriodCombiner.areAVStreamsExactMatch_(
         outputStream, candidate)) {
-      // It's not an exact match. See if we can do multi-codec or multi-mimeType
+      // It's not an exact match.
+      // Check first are streams codecs compatible.
+      // If not, see if we can do multi-codec or multi-mimeType
       // stream instead, using SourceBuffer.changeType.
-      if (!this.multiTypeVariantsAllowed_) {
+      if (!shaka.util.PeriodCombiner.areAVStreamsCodecsCompatible_(
+          outputStream, candidate) && !this.multiTypeVariantsAllowed_) {
         return false;
       }
     }
@@ -1318,16 +1335,13 @@ shaka.util.PeriodCombiner = class {
     const LanguageUtils = shaka.util.LanguageUtils;
     const {BETTER, EQUAL, WORSE} = shaka.util.PeriodCombiner.BetterOrWorse;
 
-    // An exact match is better than a non-exact match.
-    const bestIsExact = shaka.util.PeriodCombiner.areAVStreamsExactMatch_(
-        outputStream, best);
-    const candidateIsExact = shaka.util.PeriodCombiner.areAVStreamsExactMatch_(
-        outputStream, candidate);
-    if (bestIsExact && !candidateIsExact) {
-      return false;
-    }
-    if (!bestIsExact && candidateIsExact) {
+    const codecsBetterOrWorse = shaka.util.PeriodCombiner.compareCodecs_(
+        outputStream, best, candidate);
+    if (codecsBetterOrWorse === BETTER) {
       return true;
+    }
+    if (codecsBetterOrWorse === WORSE) {
+      return false;
     }
 
     // The most important thing is language.  In some cases, we will accept a
@@ -1454,16 +1468,13 @@ shaka.util.PeriodCombiner = class {
   static isVideoStreamBetterMatch_(outputStream, best, candidate) {
     const {BETTER, EQUAL, WORSE} = shaka.util.PeriodCombiner.BetterOrWorse;
 
-    // An exact match is better than a non-exact match.
-    const bestIsExact = shaka.util.PeriodCombiner.areAVStreamsExactMatch_(
-        outputStream, best);
-    const candidateIsExact = shaka.util.PeriodCombiner.areAVStreamsExactMatch_(
-        outputStream, candidate);
-    if (bestIsExact && !candidateIsExact) {
-      return false;
-    }
-    if (!bestIsExact && candidateIsExact) {
+    const codecsBetterOrWorse = shaka.util.PeriodCombiner.compareCodecs_(
+        outputStream, best, candidate);
+    if (codecsBetterOrWorse === BETTER) {
       return true;
+    }
+    if (codecsBetterOrWorse === WORSE) {
+      return false;
     }
 
     // Take the video with the closest resolution to the output.
@@ -1778,6 +1789,46 @@ shaka.util.PeriodCombiner = class {
   }
 
   /**
+   * @param {T} outputValue 
+   * @param {T} bestValue 
+   * @param {T} candidateValue 
+   * @return {shaka.util.PeriodCombiner.BetterOrWorse}
+   * @template T
+   * Accepts either a StreamDB or Stream type.
+   * @private
+   */
+  static compareCodecs_(outputValue, bestValue, candidateValue) {
+    const {BETTER, EQUAL, WORSE} = shaka.util.PeriodCombiner.BetterOrWorse;
+    // An exact match is better than a non-exact match.
+    const bestIsExact = shaka.util.PeriodCombiner.areAVStreamsExactMatch_(
+        outputValue, bestValue);
+    const candidateIsExact = shaka.util.PeriodCombiner.areAVStreamsExactMatch_(
+        outputValue, candidateValue);
+    if (bestIsExact && !candidateIsExact) {
+      return WORSE;
+    }
+    if (!bestIsExact && candidateIsExact) {
+      return BETTER;
+    }
+
+    // A compatible match is better than a non-compatible match.
+    const bestIsCompatible =
+        shaka.util.PeriodCombiner.areAVStreamsCodecsCompatible_(
+            outputValue, bestValue);
+    const candidateIsCompatible =
+        shaka.util.PeriodCombiner.areAVStreamsCodecsCompatible_(
+            outputValue, candidateValue);
+    if (bestIsCompatible && !candidateIsCompatible) {
+      return WORSE;
+    }
+    if (!bestIsCompatible && candidateIsCompatible) {
+      return BETTER;
+    }
+
+    return EQUAL;
+  }
+
+  /**
    * @param {number} outputValue
    * @param {number} bestValue
    * @param {number} candidateValue
@@ -1830,7 +1881,7 @@ shaka.util.PeriodCombiner = class {
       v.fastSwitching,
       v.width,
       v.frameRate,
-      shaka.util.PeriodCombiner.getCodec_(v.codecs),
+      v.codecs,
       v.mimeType,
       v.label,
       v.roles,
@@ -1855,7 +1906,7 @@ shaka.util.PeriodCombiner = class {
       a.language,
       a.bandwidth,
       a.label,
-      shaka.util.PeriodCombiner.getCodec_(a.codecs),
+      a.codecs,
       a.mimeType,
       a.roles,
       a.audioSamplingRate,

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -1235,15 +1235,13 @@ shaka.util.PeriodCombiner = class {
    * @private
    */
   areAVStreamsCompatible_(outputStream, candidate) {
-    // Check for an exact match.
-    if (!shaka.util.PeriodCombiner.areAVStreamsExactMatch_(
+    // Check for a codec compatibility.
+    if (!shaka.util.PeriodCombiner.areAVStreamsCodecsCompatible_(
         outputStream, candidate)) {
-      // It's not an exact match.
-      // Check first are streams codecs compatible.
-      // If not, see if we can do multi-codec or multi-mimeType
+      // They are not codec compatible.
+      // See if we can do multi-codec or multi-mimeType
       // stream instead, using SourceBuffer.changeType.
-      if (!shaka.util.PeriodCombiner.areAVStreamsCodecsCompatible_(
-          outputStream, candidate) && !this.multiTypeVariantsAllowed_) {
+      if (!this.multiTypeVariantsAllowed_) {
         return false;
       }
     }

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -1787,9 +1787,9 @@ shaka.util.PeriodCombiner = class {
   }
 
   /**
-   * @param {T} outputValue 
-   * @param {T} bestValue 
-   * @param {T} candidateValue 
+   * @param {T} outputValue
+   * @param {T} bestValue
+   * @param {T} candidateValue
    * @return {shaka.util.PeriodCombiner.BetterOrWorse}
    * @template T
    * Accepts either a StreamDB or Stream type.

--- a/test/util/periods_unit.js
+++ b/test/util/periods_unit.js
@@ -1849,6 +1849,48 @@ describe('PeriodCombiner', () => {
     expect(variantsAfter4Periods).toEqual(variantsAfterAllPeriods);
   });
 
+  it('prefers matching by profile', async () => {
+    const videoStream1 = makeVideoStream(1080);
+    videoStream1.codecs = 'avc1.640028';
+    videoStream1.bandwidth = 5500000;
+    videoStream1.originalId = 'V1';
+    const videoStream2 = makeVideoStream(1080);
+    videoStream2.codecs = 'avc1.4d4028';
+    videoStream2.bandwidth = 4500000;
+    videoStream2.originalId = 'V2';
+    const videoStream3 = makeVideoStream(1080);
+    videoStream3.codecs = 'avc1.640028';
+    videoStream3.bandwidth = 6263174;
+    videoStream3.originalId = 'V3';
+    const videoStream4 = makeVideoStream(1080);
+    videoStream4.codecs = 'avc1.4d4028';
+    videoStream4.bandwidth = 4864350;
+    videoStream4.originalId = 'V4';
+    const periods = [
+      {
+        id: '0',
+        videoStreams: [videoStream1, videoStream2],
+        audioStreams: [],
+        textStreams: [],
+        imageStreams: [],
+      },
+      {
+        id: '1',
+        videoStreams: [videoStream3, videoStream4],
+        audioStreams: [],
+        textStreams: [],
+        imageStreams: [],
+      },
+    ];
+
+    await combiner.combinePeriods(periods, /* isDynamic= */ false);
+
+    const variants = combiner.getVariants();
+    expect(variants.length).toBe(2);
+    expect(variants[0].video.originalId).toBe('V1,V3');
+    expect(variants[1].video.originalId).toBe('V2,V4');
+  });
+
   it('creates 4k content streams with a pre-roll 1080p ad', async () => {
     // This test is based on the content from b/337064527
 


### PR DESCRIPTION
Fixes #8839

Changes how do we consider best AV match. Exact codec equality is now better than codec compatibility.