### PR TITLE
fix: Fix Tizen 3 default cross-boundary strategy

### DIFF
--- a/lib/device/tizen.js
+++ b/lib/device/tizen.js
@@ -151,7 +151,7 @@ shaka.device.Tizen = class extends shaka.device.AbstractDevice {
 
     if (this.getVersion() === 3) {
       config.streaming.crossBoundaryStrategy =
-          shaka.config.CrossBoundaryStrategy.RESET;
+          shaka.config.CrossBoundaryStrategy.RESET_TO_ENCRYPTED;
     }
     config.streaming.shouldFixTimestampOffset = true;
     // Tizen has long hardware pipeline that respond slowly to seeking.


### PR DESCRIPTION
The default was not ported correctly in #8210.  This fixes it to its previous (and documented) default value.