### PR TITLE
refactor: fix upcoming Closure Compiler type errors on Symbol.iterator

### DIFF
--- a/build/generateExterns.js
+++ b/build/generateExterns.js
@@ -496,7 +496,7 @@ function createExternMethod(node) {
     assert.equal(
         node.key.type, 'MemberExpression',
         'Unexpected exported member name in exported class!');
-    methodString += `['${id}']`;
+    methodString += `[${id}]`;
   }
   methodString += '(' + params.join(', ') + ') {}';
   return methodString;

--- a/build/generateExterns.js
+++ b/build/generateExterns.js
@@ -490,7 +490,15 @@ function createExternMethod(node) {
   if (node.static) {
     methodString += 'static ';
   }
-  methodString += id + '(' + params.join(', ') + ') {}';
+  if (node.key.type === 'Identifier') {
+    methodString += id;
+  } else {
+    assert.equal(
+        node.key.type, 'MemberExpression',
+        'Unexpected exported member name in exported class!');
+    methodString += `['${id}']`;
+  }
+  methodString += '(' + params.join(', ') + ') {}';
   return methodString;
 }
 
@@ -566,6 +574,11 @@ function createExternAssignment(name, node, alwaysIncludeConstructor) {
           // constructor in some situations.
           if (member.key.name == 'constructor' && alwaysIncludeConstructor) {
             // Fall through and generate externs.
+          } else if (member.key.type === 'MemberExpression' &&
+               getIdentifierString(member.key) === 'Symbol.iterator') {
+            // Symbol.iterator is needed to implement the Iterable interface for
+            // Closure Compiler, so always assume it is exported.
+            // Closure Compiler does not allow putting an explicit @export.
           } else {
             // Skip extern generation.
             continue;

--- a/externs/domstringlist.js
+++ b/externs/domstringlist.js
@@ -26,3 +26,9 @@
  * @suppress {duplicate}
  */
 var DOMStringList = function() {};
+
+/**
+ * @override
+ * @return {!Iterator<string>}
+ */
+DOMStringList.prototype[Symbol.iterator] = function() {};

--- a/externs/texttrackcuelist.js
+++ b/externs/texttrackcuelist.js
@@ -24,3 +24,6 @@
  * @suppress {duplicate}
  */
 var TextTrackCueList = function() {};
+
+/** @override */
+TextTrackCueList.prototype[Symbol.iterator] = function() {};

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -773,7 +773,7 @@ shaka.dash.SegmentTemplate = class {
  *
  * @extends shaka.media.SegmentIndex
  * @implements {shaka.util.IReleasable}
- * @implements {Iterable<!shaka.media.SegmentReference>}
+ * @implements {Iterable<?shaka.media.SegmentReference>}
  *
  * @private
  *

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -721,7 +721,7 @@ shaka.media.SegmentIterator = class {
  *
  * @extends shaka.media.SegmentIndex
  * @implements {shaka.util.IReleasable}
- * @implements {Iterable<!shaka.media.SegmentReference>}
+ * @implements {Iterable<?shaka.media.SegmentReference>}
  * @export
  */
 shaka.media.MetaSegmentIndex = class extends shaka.media.SegmentIndex {

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -20,7 +20,7 @@ goog.require('shaka.util.Timer');
  *
  * @implements {shaka.extern.SegmentIndex}
  * @implements {shaka.util.IReleasable}
- * @implements {Iterable<!shaka.media.SegmentReference>}
+ * @implements {Iterable<?shaka.media.SegmentReference>}
  * @export
  */
 shaka.media.SegmentIndex = class {
@@ -414,7 +414,10 @@ shaka.media.SegmentIndex = class {
   }
 
 
-  /** @return {!shaka.media.SegmentIterator} */
+  /**
+   * @return {!shaka.media.SegmentIterator}
+   * @override
+   */
   [Symbol.iterator]() {
     const iter = this.getIteratorForTime(0);
     goog.asserts.assert(iter != null, 'Iterator for 0 should never be null!');
@@ -564,18 +567,18 @@ if (goog.DEBUG) {
 /**
  * An iterator over a SegmentIndex's references.
  *
- * @implements {Iterator<shaka.media.SegmentReference>}
+ * @implements {Iterator<?shaka.media.SegmentReference>}
  * @export
  */
 shaka.media.SegmentIterator = class {
   /**
-   * @param {shaka.media.SegmentIndex} segmentIndex
+   * @param {!shaka.media.SegmentIndex} segmentIndex
    * @param {number} index
    * @param {number} partialSegmentIndex
    * @param {boolean} reverse
    */
   constructor(segmentIndex, index, partialSegmentIndex, reverse) {
-    /** @private {shaka.media.SegmentIndex} */
+    /** @private {!shaka.media.SegmentIndex} */
     this.segmentIndex_ = segmentIndex;
 
     /** @private {number} */
@@ -605,7 +608,7 @@ shaka.media.SegmentIterator = class {
   }
 
   /**
-   * @return {shaka.media.SegmentReference}
+   * @return {?shaka.media.SegmentReference}
    * @export
    */
   current() {
@@ -634,6 +637,7 @@ shaka.media.SegmentIterator = class {
   /**
    * @override
    * @export
+   * @return {!IIterableResult<?shaka.media.SegmentReference>}
    */
   next() {
     const ref = this.segmentIndex_.get(this.currentPosition_);


### PR DESCRIPTION
Closure Compiler will soon start typechecking well-known symbol properties, such as Symbol.iterator - see
https://github.com/google/closure-compiler/issues/1737.

This will cause some type errors in existing code that implements `Iterable` (for context, I ran into these errors  in google's internal repo) that is missing a Symbol.iterator override or `@override` annotation