### PR TITLE
fix: Live to VOD discards the wrong segments when crossBoundaryStrategy is not KEEP

### DIFF
--- a/lib/dash/segment_base.js
+++ b/lib/dash/segment_base.js
@@ -78,7 +78,7 @@ shaka.dash.SegmentBase = class {
         encrypted);
     ref.codecs = context.representation.codecs;
     ref.mimeType = context.representation.mimeType;
-    if (context.periodInfo) {
+    if (context.periodInfo && !context.periodInfo.isLastPeriod) {
       ref.boundaryEnd = context.periodInfo.start + context.periodInfo.duration;
     }
     return ref;

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -759,7 +759,7 @@ shaka.dash.SegmentTemplate = class {
         encrypted);
     ref.codecs = context.representation.codecs;
     ref.mimeType = context.representation.mimeType;
-    if (context.periodInfo) {
+    if (context.periodInfo && !context.periodInfo.isLastPeriod) {
       ref.boundaryEnd = context.periodInfo.start + context.periodInfo.duration;
     }
     return ref;

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1555,6 +1555,17 @@ shaka.media.StreamingEngine = class {
       // a SegmentReference eventually.
       return updateIntervalSeconds;
     }
+
+    // Update some values mid stream for the initSegmentReference.
+    if (shaka.media.InitSegmentReference.equal(reference.initSegmentReference,
+        mediaState.lastInitSegmentReference)) {
+      const initSegRef = reference.initSegmentReference;
+      // During live, the boundaryEnd of the last period as we do not know the full
+      // duration. When live to VOD, we suddenly do know. Make sure we update the
+      // boundaryEnd or else we'll discard the segments due to a mismatch.
+      mediaState.lastInitSegmentReference.boundaryEnd = initSegRef.boundaryEnd;
+    }
+
     // Get media state adaptation and reset this value. By guarding it during
     // actual stream change we ensure it won't be cleaned by accident on regular
     // append.

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1560,9 +1560,10 @@ shaka.media.StreamingEngine = class {
     if (shaka.media.InitSegmentReference.equal(reference.initSegmentReference,
         mediaState.lastInitSegmentReference)) {
       const initSegRef = reference.initSegmentReference;
-      // During live, the boundaryEnd of the last period as we do not know the full
-      // duration. When live to VOD, we suddenly do know. Make sure we update the
-      // boundaryEnd or else we'll discard the segments due to a mismatch.
+      // During live, the boundaryEnd of the last period as we do not know the
+      // full duration. When live to VOD, we suddenly do know.
+      // Make sure we update the boundaryEnd or else we'll discard the
+      // segments due to a mismatch.
       mediaState.lastInitSegmentReference.boundaryEnd = initSegRef.boundaryEnd;
     }
 

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1557,14 +1557,16 @@ shaka.media.StreamingEngine = class {
     }
 
     // Update some values mid stream for the initSegmentReference.
-    if (shaka.media.InitSegmentReference.equal(reference.initSegmentReference,
-        mediaState.lastInitSegmentReference)) {
-      const initSegRef = reference.initSegmentReference;
+    const lastInitSegRef = mediaState.lastInitSegmentReference;
+    const initSegRef = reference.initSegmentReference;
+    if (lastInitSegRef && initSegRef &&
+        shaka.media.InitSegmentReference.equal(initSegRef, lastInitSegRef)
+    ) {
       // During live, the boundaryEnd of the last period as we do not know the
       // full duration. When live to VOD, we suddenly do know.
       // Make sure we update the boundaryEnd or else we'll discard the
       // segments due to a mismatch.
-      mediaState.lastInitSegmentReference.boundaryEnd = initSegRef.boundaryEnd;
+      lastInitSegRef.boundaryEnd = initSegRef.boundaryEnd;
     }
 
     // Get media state adaptation and reset this value. By guarding it during


### PR DESCRIPTION
Due to not setting the `boundaryEnd` for the last period, we ensure we do not discard the wrong segments in a live to VOD situation (where a boundaryEnd becomes available mid stream).

The same applies in live, when a period ends and a new period starts. The previous one will now have a boundaryEnd, the new one does not.

 Co-authored-by: @avelad