### PR TITLE
fix(Transmuxer): Fix width calculation when using HEVC-TS

### DIFF
--- a/lib/transmuxer/h265.js
+++ b/lib/transmuxer/h265.js
@@ -359,10 +359,12 @@ shaka.transmuxer.H265 = class {
       gb.readBoolean(); // frame_field_info_present_flag
       defaultDisplayWindowFlag = gb.readBoolean();
       if (defaultDisplayWindowFlag) {
-        gb.readUnsignedExpGolomb();
-        gb.readUnsignedExpGolomb();
-        gb.readUnsignedExpGolomb();
-        gb.readUnsignedExpGolomb();
+        // We ignore these 4 offsets since they are not necessary for
+        // calculating the width and height.
+        gb.skipExpGolomb();
+        gb.skipExpGolomb();
+        gb.skipExpGolomb();
+        gb.skipExpGolomb();
       }
       const vuiTimingInfoPresentFlag = gb.readBoolean();
       if (vuiTimingInfoPresentFlag) {

--- a/lib/transmuxer/h265.js
+++ b/lib/transmuxer/h265.js
@@ -359,10 +359,10 @@ shaka.transmuxer.H265 = class {
       gb.readBoolean(); // frame_field_info_present_flag
       defaultDisplayWindowFlag = gb.readBoolean();
       if (defaultDisplayWindowFlag) {
-        leftOffset += gb.readUnsignedExpGolomb();
-        rightOffset += gb.readUnsignedExpGolomb();
-        topOffset += gb.readUnsignedExpGolomb();
-        bottomOffset += gb.readUnsignedExpGolomb();
+        gb.readUnsignedExpGolomb();
+        gb.readUnsignedExpGolomb();
+        gb.readUnsignedExpGolomb();
+        gb.readUnsignedExpGolomb();
       }
       const vuiTimingInfoPresentFlag = gb.readBoolean();
       if (vuiTimingInfoPresentFlag) {


### PR DESCRIPTION
`default_display_window_flag` is not somehow used to compute video dimensions from SPS.
Only offsets of display window.