### PR TITLE
fix(DASH): Update timeline on PTO change

### DIFF
--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -913,11 +913,20 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
       this.periodStart_ = periodStart;
       this.periodEnd_ = periodEnd;
     } else {
-      const currentTimeline = this.templateInfo_.timeline;
+      if (this.templateInfo_.unscaledPresentationTimeOffset !==
+          info.unscaledPresentationTimeOffset) {
+        this.templateInfo_.timeline = info.timeline;
+        this.templateInfo_.unscaledPresentationTimeOffset =
+          info.unscaledPresentationTimeOffset;
+        this.templateInfo_.scaledPresentationTimeOffset =
+          info.scaledPresentationTimeOffset;
+      }
 
       if (this.templateInfo_.mediaTemplate !== info.mediaTemplate) {
         this.templateInfo_.mediaTemplate = info.mediaTemplate;
       }
+
+      const currentTimeline = this.templateInfo_.timeline;
 
       // Append timeline
       let newEntries;


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/8351.

When we detect a change in `unscaledPresentationTimeOffset`, we'll update the timeline along with both the scaled and unscaled presentationTimeOffset.

For reference, updating `templateInfo_` introduced a memory leak a while back (https://github.com/shaka-project/shaka-player/issues/6610), I ran this change for 2 hours straight and memory was kept in check.