### PR TITLE
fix(HLS): Fix preload initial variant on Tizen

### DIFF
--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -430,9 +430,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
         await this.parseManifestInner_();
         this.throwIfDestroyed_();
 
-        await this.chooseInitialVariant_();
-        this.throwIfDestroyed_();
-
         if (!shaka.drm.DrmUtils.isMediaKeysPolyfilled('webkit')) {
           await this.initializeDrm();
           this.throwIfDestroyed_();
@@ -557,6 +554,8 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     if (!this.manifest_) {
       this.manifest_ = await this.parser_.start(
           this.assetUri_, this.manifestPlayerInterface_);
+
+      await this.chooseInitialVariant_();
     }
 
     this.manifestPromise_.resolve();
@@ -675,9 +674,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
    * @private
    */
   async chooseInitialVariant_() {
-    goog.asserts.assert(
-        this.manifest_, 'The manifest should already be parsed.');
-
     // This step does not have any associated events, as it is only part of the
     // "load" state in the old state graph.
 


### PR DESCRIPTION
Regression introduced in https://github.com/shaka-project/shaka-player/pull/8835 by changing the order of operations in the preload manager.