### PR TITLE
feat(DASH): Change from L3D to non-L3D after the successful playback

### DIFF
--- a/externs/shaka/abr_manager.js
+++ b/externs/shaka/abr_manager.js
@@ -61,10 +61,12 @@ shaka.extern.AbrManager = class {
   /**
    * Chooses one variant to switch to.  Called by the Player.
    *
+   * @param {boolean=} preferFastSwitching If not provided meant "avoid fast
+   * switching if possible".
    * @return {shaka.extern.Variant}
    * @exportDoc
    */
-  chooseVariant() {}
+  chooseVariant(preferFastSwitching) {}
 
   /**
    * Enables automatic Variant choices from the last ones passed to setVariants.

--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -193,11 +193,12 @@ shaka.abr.SimpleAbrManager = class {
 
 
   /**
+   * @param {boolean=} preferFastSwitching
    * @return {shaka.extern.Variant}
    * @override
    * @export
    */
-  chooseVariant() {
+  chooseVariant(preferFastSwitching = false) {
     let maxHeight = Infinity;
     let maxWidth = Infinity;
 
@@ -230,7 +231,8 @@ shaka.abr.SimpleAbrManager = class {
     }
 
     let variants = normalVariants;
-    if (normalVariants.length != this.variants_.length) {
+    if (preferFastSwitching &&
+        normalVariants.length != this.variants_.length) {
       variants = this.variants_.filter((variant) => {
         return variant && shaka.util.StreamUtils.isFastSwitching(variant);
       });
@@ -369,8 +371,9 @@ shaka.abr.SimpleAbrManager = class {
    * @export
    */
   trySuggestStreams() {
-    if ((this.lastTimeChosenMs_ != null) && this.enabled_) {
-      this.suggestStreams_();
+    if (this.enabled_) {
+      this.lastTimeChosenMs_ = Date.now();
+      this.suggestStreams_(/* force= */ true);
     }
   }
 
@@ -478,29 +481,31 @@ shaka.abr.SimpleAbrManager = class {
    *
    * @private
    */
-  suggestStreams_() {
+  suggestStreams_(force = false) {
     shaka.log.v2('Suggesting Streams...');
     goog.asserts.assert(this.lastTimeChosenMs_ != null,
         'lastTimeChosenMs_ should not be null');
 
-    if (!this.startupComplete_) {
-      // Check if we've got enough data yet.
-      if (!this.bandwidthEstimator_.hasGoodEstimate()) {
-        shaka.log.v2('Still waiting for a good estimate...');
+    if (!force) {
+      if (!this.startupComplete_) {
+        // Check if we've got enough data yet.
+        if (!this.bandwidthEstimator_.hasGoodEstimate()) {
+          shaka.log.v2('Still waiting for a good estimate...');
+          return;
+        }
+        this.startupComplete_ = true;
+
+        this.lastTimeChosenMs_ -=
+            (this.config_.switchInterval - this.config_.minTimeToSwitch) * 1000;
+      }
+
+      // Check if we've left the switch interval.
+      const now = Date.now();
+      const delta = now - this.lastTimeChosenMs_;
+      if (delta < this.config_.switchInterval * 1000) {
+        shaka.log.v2('Still within switch interval...');
         return;
       }
-      this.startupComplete_ = true;
-
-      this.lastTimeChosenMs_ -=
-          (this.config_.switchInterval - this.config_.minTimeToSwitch) * 1000;
-    }
-
-    // Check if we've left the switch interval.
-    const now = Date.now();
-    const delta = now - this.lastTimeChosenMs_;
-    if (delta < this.config_.switchInterval * 1000) {
-      shaka.log.v2('Still within switch interval...');
-      return;
     }
 
     const chosenVariant = this.chooseVariant();

--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -479,6 +479,7 @@ shaka.abr.SimpleAbrManager = class {
   /**
    * Calls switch_() with the variant chosen by chooseVariant().
    *
+   * @param {boolean=} force
    * @private
    */
   suggestStreams_(force = false) {

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -792,7 +792,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     this.abrManager_.configure(this.config_.abr);
     this.abrManager_.setVariants(Array.from(adaptationSet.values()));
 
-    return this.abrManager_.chooseVariant();
+    return this.abrManager_.chooseVariant(/* preferFastSwitching= */ true);
   }
 
   /**
@@ -817,13 +817,20 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
   async prefetchStream_(stream, isLive) {
     // Use the prefetch limit from the config if this is set, otherwise use 2.
     const prefetchLimit = this.config_.streaming.segmentPrefetchLimit || 2;
+    const shouldPrefetchNextSegment = (reference, stream) => {
+      if (!stream.fastSwitching ||
+          !reference.isPartial() || !reference.isLastPartial()) {
+        return true;
+      }
+      return false;
+    };
     const prefetch = new shaka.media.SegmentPrefetch(
         prefetchLimit, stream, (reference, stream, streamDataCallback) => {
           return shaka.media.StreamingEngine.dispatchFetch(
               reference, stream, streamDataCallback || null,
               this.config_.streaming.retryParameters, this.networkingEngine_,
               this.isPreload_);
-        }, /* reverse= */ false);
+        }, /* reverse= */ false, shouldPrefetchNextSegment);
     this.segmentPrefetchById_.set(stream.id, prefetch);
 
     // Start prefetching a bit.

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -817,20 +817,13 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
   async prefetchStream_(stream, isLive) {
     // Use the prefetch limit from the config if this is set, otherwise use 2.
     const prefetchLimit = this.config_.streaming.segmentPrefetchLimit || 2;
-    const shouldPrefetchNextSegment = (reference, stream) => {
-      if (!stream.fastSwitching ||
-          !reference.isPartial() || !reference.isLastPartial()) {
-        return true;
-      }
-      return false;
-    };
     const prefetch = new shaka.media.SegmentPrefetch(
         prefetchLimit, stream, (reference, stream, streamDataCallback) => {
           return shaka.media.StreamingEngine.dispatchFetch(
               reference, stream, streamDataCallback || null,
               this.config_.streaming.retryParameters, this.networkingEngine_,
               this.isPreload_);
-        }, /* reverse= */ false, shouldPrefetchNextSegment);
+        }, /* reverse= */ false);
     this.segmentPrefetchById_.set(stream.id, prefetch);
 
     // Start prefetching a bit.

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -108,6 +108,9 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     /** @private {boolean} */
     this.drmEngineEntrusted_ = false;
 
+    /** @private {?shaka.extern.AbrManager.Factory} */
+    this.abrManagerFactory_ = null;
+
     /** @private {shaka.extern.AbrManager} */
     this.abrManager_ = null;
 
@@ -254,6 +257,11 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     return this.currentAdaptationSetCriteria_;
   }
 
+  /** @return {?shaka.extern.AbrManager.Factory} */
+  getAbrManagerFactory() {
+    return this.abrManagerFactory_;
+  }
+
   /**
    * Gets the abr manager, if it exists. Also marks that the abr manager should
    * not be stopped if this manager is destroyed.
@@ -382,9 +390,11 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
 
   /**
    * @param {?shaka.extern.AbrManager} abrManager
+   * @param {?shaka.extern.AbrManager.Factory} abrFactory
    */
-  attachAbrManager(abrManager) {
+  attachAbrManager(abrManager, abrFactory) {
     this.abrManager_ = abrManager;
+    this.abrManagerFactory_ = abrFactory;
   }
 
   /**
@@ -694,6 +704,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     // Make the ABR manager.
     if (this.allowMakeAbrManager_) {
       const abrFactory = this.config_.abrFactory;
+      this.abrManagerFactory_ = abrFactory;
       this.abrManager_ = abrFactory();
       this.abrManager_.configure(this.config_.abr);
     }

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -108,9 +108,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     /** @private {boolean} */
     this.drmEngineEntrusted_ = false;
 
-    /** @private {?shaka.extern.AbrManager.Factory} */
-    this.abrManagerFactory_ = null;
-
     /** @private {shaka.extern.AbrManager} */
     this.abrManager_ = null;
 
@@ -257,11 +254,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     return this.currentAdaptationSetCriteria_;
   }
 
-  /** @return {?shaka.extern.AbrManager.Factory} */
-  getAbrManagerFactory() {
-    return this.abrManagerFactory_;
-  }
-
   /**
    * Gets the abr manager, if it exists. Also marks that the abr manager should
    * not be stopped if this manager is destroyed.
@@ -390,11 +382,9 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
 
   /**
    * @param {?shaka.extern.AbrManager} abrManager
-   * @param {?shaka.extern.AbrManager.Factory} abrFactory
    */
-  attachAbrManager(abrManager, abrFactory) {
+  attachAbrManager(abrManager) {
     this.abrManager_ = abrManager;
-    this.abrManagerFactory_ = abrFactory;
   }
 
   /**
@@ -704,7 +694,6 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     // Make the ABR manager.
     if (this.allowMakeAbrManager_) {
       const abrFactory = this.config_.abrFactory;
-      this.abrManagerFactory_ = abrFactory;
       this.abrManager_ = abrFactory();
       this.abrManager_.configure(this.config_.abr);
     }

--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -28,8 +28,8 @@ shaka.media.SegmentPrefetch = class {
    * @param {shaka.extern.Stream} stream
    * @param {shaka.media.SegmentPrefetch.FetchDispatcher} fetchDispatcher
    * @param {boolean} reverse
-   * @param {function(!shaka.media.SegmentReference,
-   *         !shaka.extern.Stream):boolean} shouldPrefetchNextSegment
+   * @param {?function(!shaka.media.SegmentReference,
+   *         !shaka.extern.Stream):boolean=} shouldPrefetchNextSegment
    */
   constructor(prefetchLimit, stream, fetchDispatcher, reverse,
       shouldPrefetchNextSegment) {
@@ -62,11 +62,20 @@ shaka.media.SegmentPrefetch = class {
     /** @private {boolean} */
     this.reverse_ = reverse;
 
+    const defaultShouldPrefetchNextSegment = (reference, stream) => {
+      if (!stream.fastSwitching ||
+          !reference.isPartial() || !reference.isLastPartial()) {
+        return true;
+      }
+      return false;
+    };
+
     /**
      * @private {function(!shaka.media.SegmentReference,
      *           !shaka.extern.Stream):boolean}
      */
-    this.shouldPrefetchNextSegment_ = shouldPrefetchNextSegment;
+    this.shouldPrefetchNextSegment_ =
+        shouldPrefetchNextSegment || defaultShouldPrefetchNextSegment;
   }
 
   /**

--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -28,8 +28,11 @@ shaka.media.SegmentPrefetch = class {
    * @param {shaka.extern.Stream} stream
    * @param {shaka.media.SegmentPrefetch.FetchDispatcher} fetchDispatcher
    * @param {boolean} reverse
+   * @param {function(!shaka.media.SegmentReference,
+   *         !shaka.extern.Stream):boolean} shouldPrefetchNextSegment
    */
-  constructor(prefetchLimit, stream, fetchDispatcher, reverse) {
+  constructor(prefetchLimit, stream, fetchDispatcher, reverse,
+      shouldPrefetchNextSegment) {
     /** @private {number} */
     this.prefetchLimit_ = prefetchLimit;
 
@@ -58,6 +61,12 @@ shaka.media.SegmentPrefetch = class {
 
     /** @private {boolean} */
     this.reverse_ = reverse;
+
+    /**
+     * @private {function(!shaka.media.SegmentReference,
+     *           !shaka.extern.Stream):boolean}
+     */
+    this.shouldPrefetchNextSegment_ = shouldPrefetchNextSegment;
   }
 
   /**
@@ -127,6 +136,9 @@ shaka.media.SegmentPrefetch = class {
         promises.push(segmentPrefetchOperation.dispatchFetch(
             reference, this.stream_));
         this.segmentPrefetchMap_.set(reference, segmentPrefetchOperation);
+      }
+      if (!this.shouldPrefetchNextSegment_(reference, this.stream_)) {
+        break;
       }
     }
     this.clearInitSegments_();

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1222,7 +1222,8 @@ shaka.media.StreamingEngine = class {
           (reference, stream, streamDataCallback) => {
             return this.dispatchFetch_(reference, stream, streamDataCallback);
           },
-          reverse);
+          reverse,
+          this.playerInterface_.shouldPrefetchNextSegment);
     }
     return null;
   }
@@ -3441,6 +3442,8 @@ shaka.media.StreamingEngine = class {
  *   beforeAppendSegment: function(
  *     shaka.util.ManifestParserUtils.ContentType,!BufferSource):Promise,
  *   disableStream: function(!shaka.extern.Stream, number):boolean,
+ *   shouldPrefetchNextSegment: function(!shaka.media.SegmentReference,
+ *     !shaka.extern.Stream):boolean,
  * }}
  *
  * @property {function():number} getPresentationTime
@@ -3474,6 +3477,8 @@ shaka.media.StreamingEngine = class {
  * @property {function(!shaka.extern.Stream, number):boolean} disableStream
  *   Called to temporarily disable a stream i.e. disabling all variant
  *   containing said stream.
+ * @property {function(!shaka.media.SegmentReference,
+ *     !shaka.extern.Stream):boolean} shouldPrefetchNextSegment
  */
 shaka.media.StreamingEngine.PlayerInterface;
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -1950,30 +1950,27 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         const abrManagerFactory = preloadManager.getAbrManagerFactory();
         if (abrManagerFactory) {
           let abrManager = preloadManager.receiveAbrManager();
-          if (this.abrManager_ !== abrManager) {
+          if (this.abrManager_ && this.abrManager_ !== abrManager) {
             this.abrManager_.release();
-            // HERE log warnings about missing APIs
           }
           this.abrManager_ = abrManager;
-          if (this.abrManagerFactory_ != abrManagerFactory) {
-            if (typeof this.abrManager_.setMediaElement != 'function') {
-              shaka.Deprecate.deprecateFeature(5,
-                  'AbrManager w/o setMediaElement',
-                  'Please use an AbrManager with setMediaElement function.');
-              this.abrManager_.setMediaElement = () => {};
-            }
-            if (typeof this.abrManager_.setCmsdManager != 'function') {
-              shaka.Deprecate.deprecateFeature(5,
-                  'AbrManager w/o setCmsdManager',
-                  'Please use an AbrManager with setCmsdManager function.');
-              this.abrManager_.setCmsdManager = () => {};
-            }
-            if (typeof this.abrManager_.trySuggestStreams != 'function') {
-              shaka.Deprecate.deprecateFeature(5,
-                  'AbrManager w/o trySuggestStreams',
-                  'Please use an AbrManager with trySuggestStreams function.');
-              this.abrManager_.trySuggestStreams = () => {};
-            }
+          if (typeof this.abrManager_.setMediaElement != 'function') {
+            shaka.Deprecate.deprecateFeature(5,
+                'AbrManager w/o setMediaElement',
+                'Please use an AbrManager with setMediaElement function.');
+            this.abrManager_.setMediaElement = () => {};
+          }
+          if (typeof this.abrManager_.setCmsdManager != 'function') {
+            shaka.Deprecate.deprecateFeature(5,
+                'AbrManager w/o setCmsdManager',
+                'Please use an AbrManager with setCmsdManager function.');
+            this.abrManager_.setCmsdManager = () => {};
+          }
+          if (typeof this.abrManager_.trySuggestStreams != 'function') {
+            shaka.Deprecate.deprecateFeature(5,
+                'AbrManager w/o trySuggestStreams',
+                'Please use an AbrManager with trySuggestStreams function.');
+            this.abrManager_.trySuggestStreams = () => {};
           }
           this.abrManagerFactory_ = abrManagerFactory;
         }

--- a/lib/player.js
+++ b/lib/player.js
@@ -1949,7 +1949,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         // received.
         const abrManagerFactory = preloadManager.getAbrManagerFactory();
         if (abrManagerFactory) {
-          this.abrManager_ = preloadManager.receiveAbrManager();
+          let abrManager = preloadManager.receiveAbrManager();
+          if (this.abrManager_ !== abrManager) {
+            this.abrManager_.release();
+            // HERE log warnings about missing APIs
+          }
+          this.abrManager_ = abrManager;
           if (this.abrManagerFactory_ != abrManagerFactory) {
             if (typeof this.abrManager_.setMediaElement != 'function') {
               shaka.Deprecate.deprecateFeature(5,

--- a/lib/player.js
+++ b/lib/player.js
@@ -1949,10 +1949,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         // received.
         const abrManagerFactory = preloadManager.getAbrManagerFactory();
         if (abrManagerFactory) {
-          if (this.abrManager_ && this.abrManagerFactory_ &&
-              this.abrManagerFactory_ != abrManagerFactory) {
-            this.abrManager_.stop();
-          }
           this.abrManager_ = preloadManager.receiveAbrManager();
           if (this.abrManagerFactory_ != abrManagerFactory) {
             if (typeof this.abrManager_.setMediaElement != 'function') {

--- a/lib/player.js
+++ b/lib/player.js
@@ -820,12 +820,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.abrManager_ = null;
 
     /**
-     * The factory that was used to create the abrManager_ instance.
-     * @private {?shaka.extern.AbrManager.Factory}
-     */
-    this.abrManagerFactory_ = null;
-
-    /**
      * Contains an ID for use with creating streams.  The manifest parser should
      * start with small IDs, so this starts with a large one.
      * @private {number}
@@ -1142,7 +1136,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.adManagerEventManager_ = null;
     }
 
-    this.abrManagerFactory_ = null;
     this.config_ = null;
     this.stats_ = null;
     this.videoContainer_ = null;
@@ -1947,32 +1940,28 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
         // Also get the ABR manager, which has special logic related to being
         // received.
-        const abrManagerFactory = preloadManager.getAbrManagerFactory();
-        if (abrManagerFactory) {
-          const abrManager = preloadManager.receiveAbrManager();
-          if (this.abrManager_ && this.abrManager_ !== abrManager) {
-            this.abrManager_.release();
-          }
-          this.abrManager_ = abrManager;
-          if (typeof this.abrManager_.setMediaElement != 'function') {
-            shaka.Deprecate.deprecateFeature(5,
-                'AbrManager w/o setMediaElement',
-                'Please use an AbrManager with setMediaElement function.');
-            this.abrManager_.setMediaElement = () => {};
-          }
-          if (typeof this.abrManager_.setCmsdManager != 'function') {
-            shaka.Deprecate.deprecateFeature(5,
-                'AbrManager w/o setCmsdManager',
-                'Please use an AbrManager with setCmsdManager function.');
-            this.abrManager_.setCmsdManager = () => {};
-          }
-          if (typeof this.abrManager_.trySuggestStreams != 'function') {
-            shaka.Deprecate.deprecateFeature(5,
-                'AbrManager w/o trySuggestStreams',
-                'Please use an AbrManager with trySuggestStreams function.');
-            this.abrManager_.trySuggestStreams = () => {};
-          }
-          this.abrManagerFactory_ = abrManagerFactory;
+        const abrManager = preloadManager.receiveAbrManager();
+        if (this.abrManager_ && this.abrManager_ !== abrManager) {
+          this.abrManager_.release();
+        }
+        this.abrManager_ = abrManager;
+        if (typeof this.abrManager_.setMediaElement != 'function') {
+          shaka.Deprecate.deprecateFeature(5,
+              'AbrManager w/o setMediaElement',
+              'Please use an AbrManager with setMediaElement function.');
+          this.abrManager_.setMediaElement = () => {};
+        }
+        if (typeof this.abrManager_.setCmsdManager != 'function') {
+          shaka.Deprecate.deprecateFeature(5,
+              'AbrManager w/o setCmsdManager',
+              'Please use an AbrManager with setCmsdManager function.');
+          this.abrManager_.setCmsdManager = () => {};
+        }
+        if (typeof this.abrManager_.trySuggestStreams != 'function') {
+          shaka.Deprecate.deprecateFeature(5,
+              'AbrManager w/o trySuggestStreams',
+              'Please use an AbrManager with trySuggestStreams function.');
+          this.abrManager_.trySuggestStreams = () => {};
         }
 
         // Load the asset.
@@ -2103,10 +2092,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.manifest_ = null;
       this.parser_ = null;
       this.parserFactory_ = null;
-      // Null the abrManager and abrManagerFactory, so that they won't be shut
+      // Null the abrManager, so that they won't be shut
       // down during unload and will continue to live inside the preloadManager.
       this.abrManager_ = null;
-      this.abrManagerFactory_ = null;
     }
     return preloadManager;
   }
@@ -2194,8 +2182,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     let disableVideo = false;
     let allowMakeAbrManager = true;
     if (standardLoad) {
-      if (this.abrManager_ &&
-          this.abrManagerFactory_ == preloadConfig.abrFactory) {
+      if (this.abrManager_) {
         // If there's already an abr manager, don't make a new abr manager at
         // all.
         // In standardLoad mode, the abr manager isn't used for anything anyway,
@@ -2471,8 +2458,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     preloadManager = new shaka.media.PreloadManager(
         assetUri, mimeType, startTime, playerInterface);
     if (!allowMakeAbrManager) {
-      preloadManager.attachAbrManager(
-          this.abrManager_, this.abrManagerFactory_);
+      preloadManager.attachAbrManager(this.abrManager_);
     }
     return preloadManager;
   }

--- a/lib/player.js
+++ b/lib/player.js
@@ -1949,7 +1949,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         // received.
         const abrManagerFactory = preloadManager.getAbrManagerFactory();
         if (abrManagerFactory) {
-          let abrManager = preloadManager.receiveAbrManager();
+          const abrManager = preloadManager.receiveAbrManager();
           if (this.abrManager_ && this.abrManager_ !== abrManager) {
             this.abrManager_.release();
           }

--- a/lib/player.js
+++ b/lib/player.js
@@ -4199,6 +4199,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       onSegmentAppended: (reference, stream, isMuxed) => {
         this.onSegmentAppended_(
             reference.startTime, reference.endTime, stream.type, isMuxed);
+        // When we are in an L3D stream we want to go to a non-L3D stream, for
+        // this we need to inform the ABR that it should suggest new streams.
         if (this.abrManager_ && stream.fastSwitching &&
             reference.isPartial() && reference.isLastPartial()) {
           this.abrManager_.trySuggestStreams();

--- a/lib/player.js
+++ b/lib/player.js
@@ -820,6 +820,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.abrManager_ = null;
 
     /**
+     * The factory that was used to create the abrManager_ instance.
+     * @private {?shaka.extern.AbrManager.Factory}
+     */
+    this.abrManagerFactory_ = null;
+
+    /**
      * Contains an ID for use with creating streams.  The manifest parser should
      * start with small IDs, so this starts with a large one.
      * @private {number}
@@ -1136,6 +1142,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.adManagerEventManager_ = null;
     }
 
+    this.abrManagerFactory_ = null;
     this.config_ = null;
     this.stats_ = null;
     this.videoContainer_ = null;
@@ -1940,28 +1947,32 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
         // Also get the ABR manager, which has special logic related to being
         // received.
-        const abrManager = preloadManager.receiveAbrManager();
-        if (this.abrManager_ && this.abrManager_ !== abrManager) {
-          this.abrManager_.release();
-        }
-        this.abrManager_ = abrManager;
-        if (typeof this.abrManager_.setMediaElement != 'function') {
-          shaka.Deprecate.deprecateFeature(5,
-              'AbrManager w/o setMediaElement',
-              'Please use an AbrManager with setMediaElement function.');
-          this.abrManager_.setMediaElement = () => {};
-        }
-        if (typeof this.abrManager_.setCmsdManager != 'function') {
-          shaka.Deprecate.deprecateFeature(5,
-              'AbrManager w/o setCmsdManager',
-              'Please use an AbrManager with setCmsdManager function.');
-          this.abrManager_.setCmsdManager = () => {};
-        }
-        if (typeof this.abrManager_.trySuggestStreams != 'function') {
-          shaka.Deprecate.deprecateFeature(5,
-              'AbrManager w/o trySuggestStreams',
-              'Please use an AbrManager with trySuggestStreams function.');
-          this.abrManager_.trySuggestStreams = () => {};
+        const abrManagerFactory = preloadManager.getAbrManagerFactory();
+        if (abrManagerFactory) {
+          const abrManager = preloadManager.receiveAbrManager();
+          if (this.abrManager_ && this.abrManager_ !== abrManager) {
+            this.abrManager_.release();
+          }
+          this.abrManager_ = abrManager;
+          if (typeof this.abrManager_.setMediaElement != 'function') {
+            shaka.Deprecate.deprecateFeature(5,
+                'AbrManager w/o setMediaElement',
+                'Please use an AbrManager with setMediaElement function.');
+            this.abrManager_.setMediaElement = () => {};
+          }
+          if (typeof this.abrManager_.setCmsdManager != 'function') {
+            shaka.Deprecate.deprecateFeature(5,
+                'AbrManager w/o setCmsdManager',
+                'Please use an AbrManager with setCmsdManager function.');
+            this.abrManager_.setCmsdManager = () => {};
+          }
+          if (typeof this.abrManager_.trySuggestStreams != 'function') {
+            shaka.Deprecate.deprecateFeature(5,
+                'AbrManager w/o trySuggestStreams',
+                'Please use an AbrManager with trySuggestStreams function.');
+            this.abrManager_.trySuggestStreams = () => {};
+          }
+          this.abrManagerFactory_ = abrManagerFactory;
         }
 
         // Load the asset.
@@ -2092,9 +2103,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.manifest_ = null;
       this.parser_ = null;
       this.parserFactory_ = null;
-      // Null the abrManager, so that they won't be shut
+      // Null the abrManager and abrManagerFactory, so that they won't be shut
       // down during unload and will continue to live inside the preloadManager.
       this.abrManager_ = null;
+      this.abrManagerFactory_ = null;
     }
     return preloadManager;
   }
@@ -2182,7 +2194,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     let disableVideo = false;
     let allowMakeAbrManager = true;
     if (standardLoad) {
-      if (this.abrManager_) {
+      if (this.abrManager_ &&
+          this.abrManagerFactory_ == preloadConfig.abrFactory) {
         // If there's already an abr manager, don't make a new abr manager at
         // all.
         // In standardLoad mode, the abr manager isn't used for anything anyway,
@@ -2458,7 +2471,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     preloadManager = new shaka.media.PreloadManager(
         assetUri, mimeType, startTime, playerInterface);
     if (!allowMakeAbrManager) {
-      preloadManager.attachAbrManager(this.abrManager_);
+      preloadManager.attachAbrManager(
+          this.abrManager_, this.abrManagerFactory_);
     }
     return preloadManager;
   }

--- a/lib/player.js
+++ b/lib/player.js
@@ -1949,10 +1949,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         // received.
         const abrManagerFactory = preloadManager.getAbrManagerFactory();
         if (abrManagerFactory) {
-          if (!this.abrManagerFactory_ ||
+          if (this.abrManagerFactory_ &&
               this.abrManagerFactory_ != abrManagerFactory) {
-            this.abrManager_ = preloadManager.receiveAbrManager();
-            this.abrManagerFactory_ = preloadManager.getAbrManagerFactory();
+            this.abrManager_.stop();
+          }
+          this.abrManager_ = preloadManager.receiveAbrManager();
+          if (this.abrManagerFactory_ != abrManagerFactory) {
             if (typeof this.abrManager_.setMediaElement != 'function') {
               shaka.Deprecate.deprecateFeature(5,
                   'AbrManager w/o setMediaElement',
@@ -1972,6 +1974,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
               this.abrManager_.trySuggestStreams = () => {};
             }
           }
+          this.abrManagerFactory_ = abrManagerFactory;
         }
 
         // Load the asset.
@@ -2890,7 +2893,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     do {
       activeVariant = this.streamingEngine_.getCurrentVariant();
       if (!activeVariant && !initialVariant) {
-        initialVariant = this.chooseVariant_();
+        initialVariant = this.chooseVariant_(/* initialSelection= */ true);
         goog.asserts.assert(initialVariant, 'Must choose an initial variant!');
       }
 
@@ -4196,6 +4199,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       onSegmentAppended: (reference, stream, isMuxed) => {
         this.onSegmentAppended_(
             reference.startTime, reference.endTime, stream.type, isMuxed);
+        if (this.abrManager_ && stream.fastSwitching &&
+            reference.isPartial() && reference.isLastPartial()) {
+          this.abrManager_.trySuggestStreams();
+        }
       },
       onInitSegmentAppended: (position, initSegment) => {
         const mediaQuality = initSegment.getMediaQuality();
@@ -4207,6 +4214,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         return this.drmEngine_.parseInbandPssh(contentType, segment);
       },
       disableStream: (stream, time) => this.disableStream(stream, time),
+      shouldPrefetchNextSegment: (reference, stream) => {
+        if (!this.config_.abr.enabled) {
+          return true;
+        }
+        if (!stream.fastSwitching ||
+            !reference.isPartial() || !reference.isLastPartial()) {
+          return true;
+        }
+        return false;
+      },
     };
 
     return new shaka.media.StreamingEngine(this.manifest_, playerInterface);
@@ -8225,12 +8242,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * On error, this dispatches an error event and returns null.
    *
+   * @param {boolean=} initialSelection
    * @return {?shaka.extern.Variant}
    * @private
    */
-  chooseVariant_() {
+  chooseVariant_(initialSelection = false) {
     if (this.updateAbrManagerVariants_()) {
-      return this.abrManager_.chooseVariant();
+      return this.abrManager_.chooseVariant(initialSelection);
     } else {
       return null;
     }

--- a/lib/player.js
+++ b/lib/player.js
@@ -1949,7 +1949,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         // received.
         const abrManagerFactory = preloadManager.getAbrManagerFactory();
         if (abrManagerFactory) {
-          if (this.abrManagerFactory_ &&
+          if (this.abrManager_ && this.abrManagerFactory_ &&
               this.abrManagerFactory_ != abrManagerFactory) {
             this.abrManager_.stop();
           }

--- a/test/media/segment_prefetch_unit.js
+++ b/test/media/segment_prefetch_unit.js
@@ -46,8 +46,10 @@ describe('SegmentPrefetch', () => {
               bytes,
           ),
         );
+    const shouldPrefetchNextSegment = () => true;
     segmentPrefetch = new shaka.media.SegmentPrefetch(
-        3, stream, Util.spyFunc(fetchDispatcher), /* reverse= */ false);
+        3, stream, Util.spyFunc(fetchDispatcher), /* reverse= */ false,
+        shouldPrefetchNextSegment);
   });
 
   describe('prefetchSegmentsByTime', () => {

--- a/test/media/segment_prefetch_unit.js
+++ b/test/media/segment_prefetch_unit.js
@@ -46,10 +46,8 @@ describe('SegmentPrefetch', () => {
               bytes,
           ),
         );
-    const shouldPrefetchNextSegment = () => true;
     segmentPrefetch = new shaka.media.SegmentPrefetch(
-        3, stream, Util.spyFunc(fetchDispatcher), /* reverse= */ false,
-        shouldPrefetchNextSegment);
+        3, stream, Util.spyFunc(fetchDispatcher), /* reverse= */ false);
   });
 
   describe('prefetchSegmentsByTime', () => {

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -274,6 +274,7 @@ describe('StreamingEngine', () => {
       onInitSegmentAppended: () => {},
       beforeAppendSegment: () => Promise.resolve(),
       disableStream: (stream, time) => false,
+      shouldPrefetchNextSegment: () => true,
     };
     streamingEngine = new shaka.media.StreamingEngine(
         /** @type {shaka.extern.Manifest} */(manifest), playerInterface);

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -482,6 +482,7 @@ describe('StreamingEngine', () => {
       onInitSegmentAppended: () => {},
       beforeAppendSegment: Util.spyFunc(beforeAppendSegment),
       disableStream: Util.spyFunc(disableStream),
+      shouldPrefetchNextSegment: () => true,
     };
     streamingEngine = new shaka.media.StreamingEngine(
         /** @type {shaka.extern.Manifest} */(manifest), playerInterface);


### PR DESCRIPTION
fastSwitching can be used in case there is a need to start linear playback at very low delay (e.g. shortly after the time the client acquired MPD, initialization segments, and DRM license) or to switch from ad content to main content at an arbitrary point in the stream.

As an example, two representations, join6_540p and join6_1080p, have 6-frame GOPs and are used to start playback at a 6-frame boundary. This enables start-up and fine-grain random access at any 6-frame boundary.

fastSwitching are aligned with the “normal” adaptation set. Asa result, it it is possible to switch between “normal” and fastSwitching variant at any segment sequence boundary.