### PR TITLE
fix(DASH): Prevent memory leak in uncompiled mode

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -633,21 +633,22 @@ shaka.dash.DashParser = class {
         }
       }
     }
-    this.lastCalculatedBaseUris_ = null;
+    this.lastCalculatedBaseUris_.splice(0);
     if (!someLocationValid || !this.contentSteeringManager_) {
       const uris = uriObjs.map(TXml.getContents);
-      this.lastCalculatedBaseUris_ = shaka.util.ManifestParserUtils.resolveUris(
-          manifestBaseUris, uris);
+      this.lastCalculatedBaseUris_.push(
+          ...shaka.util.ManifestParserUtils.resolveUris(
+              manifestBaseUris, uris));
     }
 
+    const contentSteeringManager = this.contentSteeringManager_;
+    const lastCalculatedBaseUris = this.lastCalculatedBaseUris_;
+
     const getBaseUris = () => {
-      if (this.contentSteeringManager_ && someLocationValid) {
-        return this.contentSteeringManager_.getLocations('BaseURL');
+      if (contentSteeringManager && someLocationValid) {
+        return contentSteeringManager.getLocations('BaseURL');
       }
-      if (this.lastCalculatedBaseUris_) {
-        return this.lastCalculatedBaseUris_;
-      }
-      return [];
+      return lastCalculatedBaseUris.slice();
     };
 
     this.manifestPatchContext_.getBaseUris = getBaseUris;
@@ -2784,12 +2785,14 @@ shaka.dash.DashParser = class {
       calculatedBaseUris = uriObjs.map(TXml.getContents);
     }
 
+    const contentSteeringManager = this.contentSteeringManager_;
+
     const getFrameUris = () => {
       if (!uriObjs.length) {
         return [];
       }
-      if (this.contentSteeringManager_ && someLocationValid) {
-        return this.contentSteeringManager_.getLocations(id);
+      if (contentSteeringManager && someLocationValid) {
+        return contentSteeringManager.getLocations(id);
       }
       if (calculatedBaseUris) {
         return calculatedBaseUris;


### PR DESCRIPTION
Keeping `this` references in DASH uri callbacks leads to keeping DashParser instances in memory after unloading.
Luckily this is only the issue in uncompiled mode, Closure Compiler handles it somehow. It is though better to fix it in case we change tooling some day.