### PR TITLE
feat: Use content workaround for Tizen 3 / webOS 3 instead of cross boundary

### DIFF
--- a/lib/device/abstract_device.js
+++ b/lib/device/abstract_device.js
@@ -144,13 +144,6 @@ shaka.device.AbstractDevice = class {
   /**
    * @override
    */
-  insertEncryptionDataBeforeClear() {
-    return false;
-  }
-
-  /**
-   * @override
-   */
   requiresTfhdFix(contentType) {
     return false;
   }

--- a/lib/device/apple_browser.js
+++ b/lib/device/apple_browser.js
@@ -99,13 +99,6 @@ shaka.device.AppleBrowser = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
-  insertEncryptionDataBeforeClear() {
-    return true;
-  }
-
-  /**
-   * @override
-   */
   requiresTfhdFix(contentType) {
     return contentType === 'audio';
   }

--- a/lib/device/default_browser.js
+++ b/lib/device/default_browser.js
@@ -107,13 +107,6 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
-  insertEncryptionDataBeforeClear() {
-    return this.deviceName_.value() === 'Edge' && this.isWindows_.value(); ;
-  }
-
-  /**
-   * @override
-   */
   supportsSmoothCodecSwitching() {
     return this.supportsSmoothCodecSwitching_.value();
   }

--- a/lib/device/i_device.js
+++ b/lib/device/i_device.js
@@ -82,13 +82,6 @@ shaka.device.IDevice = class {
   requiresClearAndEncryptedInitSegments() {}
 
   /**
-   * Indicates should the encryption data be inserted before  or after
-   * the clear data in the init segment.
-   * @return {boolean}
-   */
-  insertEncryptionDataBeforeClear() {}
-
-  /**
    * @param {string} contentType
    * @return {boolean}
    */

--- a/lib/device/tizen.js
+++ b/lib/device/tizen.js
@@ -6,7 +6,6 @@
 
 goog.provide('shaka.device.Tizen');
 
-goog.require('shaka.config.CrossBoundaryStrategy');
 goog.require('shaka.device.AbstractDevice');
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.device.IDevice');

--- a/lib/device/tizen.js
+++ b/lib/device/tizen.js
@@ -67,6 +67,13 @@ shaka.device.Tizen = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
+  requiresTfhdFix(contentType) {
+    return this.getVersion() === 3;
+  }
+
+  /**
+   * @override
+   */
   requiresEC3InitSegments() {
     return this.getVersion() === 3;
   }
@@ -149,10 +156,6 @@ shaka.device.Tizen = class extends shaka.device.AbstractDevice {
 
     config.drm.ignoreDuplicateInitData = this.getVersion() !== 2;
 
-    if (this.getVersion() === 3) {
-      config.streaming.crossBoundaryStrategy =
-          shaka.config.CrossBoundaryStrategy.RESET_TO_ENCRYPTED;
-    }
     config.streaming.shouldFixTimestampOffset = true;
     // Tizen has long hardware pipeline that respond slowly to seeking.
     // Therefore we should not seek when we detect a stall on this platform.

--- a/lib/device/webos.js
+++ b/lib/device/webos.js
@@ -82,6 +82,20 @@ shaka.device.WebOS = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
+  requiresEncryptionInfoInAllInitSegments(keySystem, contentType) {
+    return this.getVersion() === 3;
+  }
+
+  /**
+   * @override
+   */
+  requiresTfhdFix(contentType) {
+    return this.getVersion() === 3;
+  }
+
+  /**
+   * @override
+   */
   supportsMediaCapabilities() {
     return false;
   }
@@ -137,10 +151,6 @@ shaka.device.WebOS = class extends shaka.device.AbstractDevice {
   adjustConfig(config) {
     super.adjustConfig(config);
 
-    if (this.getVersion() === 3) {
-      config.streaming.crossBoundaryStrategy =
-          shaka.config.CrossBoundaryStrategy.RESET;
-    }
     config.streaming.shouldFixTimestampOffset = true;
     // WebOS has long hardware pipeline that respond slowly to seeking.
     // Therefore we should not seek when we detect a stall on this platform.

--- a/lib/device/webos.js
+++ b/lib/device/webos.js
@@ -6,7 +6,6 @@
 
 goog.provide('shaka.device.WebOS');
 
-goog.require('shaka.config.CrossBoundaryStrategy');
 goog.require('shaka.device.AbstractDevice');
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.device.IDevice');

--- a/lib/device/xbox.js
+++ b/lib/device/xbox.js
@@ -68,13 +68,6 @@ shaka.device.Xbox = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
-  insertEncryptionDataBeforeClear() {
-    return true;
-  }
-
-  /**
-   * @override
-   */
   shouldOverrideDolbyVisionCodecs() {
     return this.isLegacyEdge_;
   }

--- a/lib/media/content_workarounds.js
+++ b/lib/media/content_workarounds.js
@@ -336,14 +336,7 @@ shaka.media.ContentWorkarounds = class {
     const newInitSegment =
         new Uint8Array(initSegment.byteLength + metadataBoxArray.byteLength);
 
-    // For Xbox One & Edge, we cut and insert at the start of the source box.
-    // For other platforms, we cut and insert at the end of the source box. It's
-    // not clear why this is necessary on Xbox One, but it seems to be evidence
-    // of another bug in the firmware implementation of MediaSource & EME.
-    const device = shaka.device.DeviceFactory.getDevice();
-    const cutPoint = device.insertEncryptionDataBeforeClear() ?
-      sourceBox.start :
-      sourceBox.start + sourceBox.size;
+    const cutPoint = sourceBox.start;
 
     // The data before the cut point will be copied to the same location as
     // before.  The data after that will be appended after the added metadata


### PR DESCRIPTION
The bug report (https://github.com/shaka-project/shaka-player/issues/8048) states that webOS 3 playback fails when transitioning from plain to encrypted. We initially mitigated this by enforcing crossBoundaryStrategy for this particular device.

The changes made in https://github.com/shaka-project/shaka-player/pull/8354 made us revisit playback on legacy devices, with the adjustments to the media segments tfhd box, plain to encrypted no longer requires an MSE reset.

This PR does the following:
- Remove crossBoundaryStrategy for webOS 3 and Tizen 3.
- Apply the proper content workarounds for these devices.
- The cutpoint is always at the start now, I could not find a device that benefits from having the cutpoint at the end. See table in the issue.

Fixes https://github.com/shaka-project/shaka-player/issues/8048.