### PR TITLE
fix: Fix Apple Vision Pro integration with some features

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -329,6 +329,8 @@ shaka.ads.InterstitialAdManager = class {
     if (video.webkitPresentationMode &&
         video.webkitPresentationMode !== 'inline') {
       supportsMultipleMediaElements = false;
+    } else if (video.webkitDisplayingFullscreen) {
+      supportsMultipleMediaElements = false;
     }
     if (this.usingBaseVideo_ != supportsMultipleMediaElements) {
       return;

--- a/lib/player.js
+++ b/lib/player.js
@@ -2715,8 +2715,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.loadEventManager_.listen(mediaElement.videoTracks, 'change',
           () => this.onTracksChanged_());
     }
-    if (mediaElement.webkitPresentationMode) {
-      this.loadEventManager_.listen(mediaElement,
+    const video = /** @type {HTMLVideoElement} */(mediaElement);
+    if (video.webkitPresentationMode ||
+        video.webkitSupportsFullscreen) {
+      this.loadEventManager_.listen(video,
           'webkitpresentationmodechanged', () => {
             if (this.videoContainer_) {
               this.createAndConfigureTextDisplayer_(/* force= */ true);
@@ -3227,9 +3229,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             () => setMode(false));
       }
       const video = /** @type {HTMLVideoElement} */(mediaElement);
-      if (video.webkitSupportsFullscreen) {
+      if (video.webkitPresentationMode || video.webkitSupportsFullscreen) {
         this.loadEventManager_.listen(video, 'webkitpresentationmodechanged',
-            () => setMode(video.webkitPresentationMode !== 'inline'));
+            () => {
+              if (video.webkitPresentationMode) {
+                setMode(video.webkitPresentationMode !== 'inline');
+              } else if (video.webkitSupportsFullscreen) {
+                setMode(video.webkitDisplayingFullscreen);
+              }
+            });
       }
     }
     // Add all media element listeners.
@@ -7562,9 +7570,21 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     config.textDisplayFactory = () => {
       // We prefer NativeTextDisplayer when using PiP and Fullscreen API of the
       // video element itself.
-      if (this.videoContainer_ &&
-          (!this.video_.webkitPresentationMode ||
-          this.video_.webkitPresentationMode == 'inline')) {
+      const shouldPreferUITextDisplayer = () => {
+        if (!this.videoContainer_) {
+          return false;
+        }
+        const video = /** @type {HTMLVideoElement} */(this.video_);
+        if (video.webkitDisplayingFullscreen) {
+          return false;
+        }
+        if (video.webkitPresentationMode &&
+            video.webkitPresentationMode != 'inline') {
+          return false;
+        }
+        return true;
+      };
+      if (shouldPreferUITextDisplayer()) {
         return new shaka.text.UITextDisplayer(
             this.video_, this.videoContainer_);
       } else {


### PR DESCRIPTION
Apple Vision Pro supports `webkitSupportsFullscreen` and `webkitDisplayingFullscreen`, but it doesn't suppport `webkitPresentationMode`.