### PR TITLE
fix: Fix URI encoding with plus characters

### DIFF
--- a/third_party/closure-uri/uri.js
+++ b/third_party/closure-uri/uri.js
@@ -748,9 +748,9 @@ goog.Uri.QueryData.prototype.ensureKeyMapInitialized_ = function() {
         } else {
           name = pairs[i];
         }
-        name = decodeURIComponent(name.replace(/\+/g, ' '));
+        name = decodeURIComponent(name);
         value = value || '';
-        this.add(name, decodeURIComponent(value.replace(/\+/g, ' ')));
+        this.add(name, decodeURIComponent(value));
       }
     }
   }


### PR DESCRIPTION
There's no requirement that "+" characters not be used in URLs.  In fact, if you start up `python3 -m http.server` and point your browser at `http://localhost:8000/foo+bar?bar+baz=baz+bar`, you'll see every one of those "+" symbols sent directly to the server without encoding at all.

There is an old convention in CGI parameters to turn " " into "+", but proper URL encoding turns " " into "%20".

The URI parser we use was assuming that "+" is always an escaped " ".  So it would decode "+" into " " and then later re-encode it into "%20".

By removing the special treatment of "+" in the URI parser, we make requests to the correct URLs when they involve "+".

Fixes #8713