### PR TITLE
perf: Simplify region timeline buffer management

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -1838,23 +1838,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.updateBufferState_();
 
       const bufferRange = () => {
-        const bufferedInfo = this.getBufferedInfo();
-        const range = {
-          start: 0,
-          end: 0,
+        const buffered = this.video_ ? this.video_.buffered : null;
+        return {
+          start: shaka.media.TimeRangesUtils.bufferStart(buffered) || 0,
+          end: shaka.media.TimeRangesUtils.bufferEnd(buffered) || 0,
         };
-        if (bufferedInfo.total.length) {
-          range.start = Infinity;
-          for (const buffered of bufferedInfo.total) {
-            if (buffered.start < range.start) {
-              range.start = buffered.start;
-            }
-            if (buffered.end > range.end) {
-              range.end = buffered.end;
-            }
-          }
-        }
-        return range;
       };
 
       this.metadataRegionTimeline_ =


### PR DESCRIPTION
Use `buffered` property directly, as there is no need for us to create ranges from SourceBuffers. Also, just take start and end from frist and last range, respectively, looping is unnecessary.