### PR TITLE
chore: Update Closure Library to latest + patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "globals": "^15.14.0",
         "google-closure-compiler-java": "^20250723.0.0",
         "google-closure-deps": "^20230802.0.0",
-        "google-closure-library": "^20221102.0.0",
+        "google-closure-library": "github:joeyparrish/closure-library#74db0395",
         "htmlhint": "^1.1.3",
         "jasmine-ajax": "^4.0.0",
         "jimp": "^0.22.12",
@@ -6113,10 +6113,11 @@
       }
     },
     "node_modules/google-closure-library": {
-      "version": "20221102.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-library/-/google-closure-library-20221102.0.0.tgz",
-      "integrity": "sha512-M5+LWPS99tMB9dOGpZjLT9CdIYpnwBZiwB+dCmZFOOvwJiOWytntzJ/a/hoNF6zxD15l3GWwRJiEkL636D6DRQ==",
-      "dev": true
+      "version": "20230206.0.0",
+      "resolved": "git+ssh://git@github.com/joeyparrish/closure-library.git#b12e80d1e0afca4b5c9feeff44ff410e9797fb9a",
+      "integrity": "sha512-Ia3zKwX1geAfVxQEMV7aCWSAVJsCSRQoBcuLS6WyoLxFbB1VIsByHmT7PpXcdKK7aOn9CmyExt3RyT+xhySyFg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -15085,10 +15086,10 @@
       }
     },
     "google-closure-library": {
-      "version": "20221102.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-library/-/google-closure-library-20221102.0.0.tgz",
-      "integrity": "sha512-M5+LWPS99tMB9dOGpZjLT9CdIYpnwBZiwB+dCmZFOOvwJiOWytntzJ/a/hoNF6zxD15l3GWwRJiEkL636D6DRQ==",
-      "dev": true
+      "version": "git+ssh://git@github.com/joeyparrish/closure-library.git#b12e80d1e0afca4b5c9feeff44ff410e9797fb9a",
+      "integrity": "sha512-Ia3zKwX1geAfVxQEMV7aCWSAVJsCSRQoBcuLS6WyoLxFbB1VIsByHmT7PpXcdKK7aOn9CmyExt3RyT+xhySyFg==",
+      "dev": true,
+      "from": "google-closure-library@github:joeyparrish/closure-library#74db0395"
     },
     "gopd": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6113,9 +6113,8 @@
       }
     },
     "node_modules/google-closure-library": {
-      "version": "20230206.0.0",
-      "resolved": "git+ssh://git@github.com/joeyparrish/closure-library.git#b12e80d1e0afca4b5c9feeff44ff410e9797fb9a",
-      "integrity": "sha512-Ia3zKwX1geAfVxQEMV7aCWSAVJsCSRQoBcuLS6WyoLxFbB1VIsByHmT7PpXcdKK7aOn9CmyExt3RyT+xhySyFg==",
+      "version": "20230802.0.0",
+      "resolved": "git+ssh://git@github.com/joeyparrish/closure-library.git#74db0395c2bef5fee6eef754d85ccf824b5fde45",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -15086,8 +15085,7 @@
       }
     },
     "google-closure-library": {
-      "version": "git+ssh://git@github.com/joeyparrish/closure-library.git#b12e80d1e0afca4b5c9feeff44ff410e9797fb9a",
-      "integrity": "sha512-Ia3zKwX1geAfVxQEMV7aCWSAVJsCSRQoBcuLS6WyoLxFbB1VIsByHmT7PpXcdKK7aOn9CmyExt3RyT+xhySyFg==",
+      "version": "git+ssh://git@github.com/joeyparrish/closure-library.git#74db0395c2bef5fee6eef754d85ccf824b5fde45",
       "dev": true,
       "from": "google-closure-library@github:joeyparrish/closure-library#74db0395"
     },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "globals": "^15.14.0",
     "google-closure-compiler-java": "^20250723.0.0",
     "google-closure-deps": "^20230802.0.0",
-    "google-closure-library": "^20221102.0.0",
+    "google-closure-library": "github:joeyparrish/closure-library#74db0395",
     "htmlhint": "^1.1.3",
     "jasmine-ajax": "^4.0.0",
     "jimp": "^0.22.12",


### PR DESCRIPTION
Two patches:
 - Fix warning in base.js triggered by the latest compiler update
 - Revert default setting of ENABLE_DEBUG_LOADER to previous value to fix uncompiled mode