### PR TITLE
chore: Remove JSDoc for empty constructors

### DIFF
--- a/demo/cast_receiver/receiver_app.js
+++ b/demo/cast_receiver/receiver_app.js
@@ -13,7 +13,6 @@ goog.require('ShakaDemoAssetInfo');
  * @suppress {missingProvide}
  */
 class ShakaReceiverApp {
-  /** */
   constructor() {
     /** @private {HTMLVideoElement} */
     this.video_ = null;

--- a/demo/main.js
+++ b/demo/main.js
@@ -21,7 +21,6 @@ goog.require('shakaDemo.VisualizerButton');
  * configuration, etc).
  */
 shakaDemo.Main = class {
-  /** */
   constructor() {
     /** @private {HTMLVideoElement} */
     this.video_ = null;

--- a/lib/abr/ewma_bandwidth_estimator.js
+++ b/lib/abr/ewma_bandwidth_estimator.js
@@ -17,7 +17,6 @@ goog.require('shaka.abr.Ewma');
  *
  */
 shaka.abr.EwmaBandwidthEstimator = class {
-  /** */
   constructor() {
     /**
      * A fast-moving average.

--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -40,7 +40,6 @@ goog.requireType('shaka.util.CmsdManager');
  * @export
  */
 shaka.abr.SimpleAbrManager = class {
-  /** */
   constructor() {
     /** @private {?shaka.extern.AbrManager.SwitchCallback} */
     this.switch_ = null;

--- a/lib/ads/ad_manager.js
+++ b/lib/ads/ad_manager.js
@@ -414,7 +414,6 @@ goog.require('shaka.util.TXml');
  * @export
  */
 shaka.ads.AdManager = class extends shaka.util.FakeEventTarget {
-  /** */
   constructor() {
     super();
     /** @private {shaka.ads.InterstitialAdManager} */

--- a/lib/ads/ads_stats.js
+++ b/lib/ads/ads_stats.js
@@ -14,7 +14,6 @@ goog.provide('shaka.ads.AdsStats');
  * @final
  */
 shaka.ads.AdsStats = class {
-  /** */
   constructor() {
     /** @private {!Array<number>} */
     this.loadTimes_ = [];

--- a/lib/cea/cea_decoder.js
+++ b/lib/cea/cea_decoder.js
@@ -22,7 +22,6 @@ goog.requireType('shaka.cea.DtvccPacket');
  * @export
  */
 shaka.cea.CeaDecoder = class {
-  /** */
   constructor() {
     /**
      * An array of CEA-608 closed caption data extracted for decoding.

--- a/lib/cea/dtvcc_packet_builder.js
+++ b/lib/cea/dtvcc_packet_builder.js
@@ -19,7 +19,6 @@ goog.requireType('shaka.cea.Cea708Service');
  * before the current packet is finished being built.
  */
 shaka.cea.DtvccPacketBuilder = class {
-  /** */
   constructor() {
     /**
      * An array containing built DTVCC packets that are ready to be processed.

--- a/lib/cea/mp4_cea_parser.js
+++ b/lib/cea/mp4_cea_parser.js
@@ -22,7 +22,6 @@ goog.require('shaka.util.Mp4BoxParsers');
  * @export
  */
 shaka.cea.Mp4CeaParser = class {
-  /** */
   constructor() {
     /**
      * SEI data processor.

--- a/lib/cea/ts_cea_parser.js
+++ b/lib/cea/ts_cea_parser.js
@@ -18,7 +18,6 @@ goog.require('shaka.util.TsParser');
  * @export
  */
 shaka.cea.TsCeaParser = class {
-  /** */
   constructor() {
     /**
      * SEI data processor.

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -21,7 +21,6 @@ goog.require('shaka.util.TextParser');
  * HlS manifest text parser.
  */
 shaka.hls.ManifestTextParser = class {
-  /** */
   constructor() {
     /** @private {number} */
     this.globalId_ = 0;

--- a/lib/media/preference_based_criteria.js
+++ b/lib/media/preference_based_criteria.js
@@ -20,7 +20,6 @@ goog.require('shaka.util.LanguageUtils');
  * @final
  */
 shaka.media.PreferenceBasedCriteria = class {
-  /** */
   constructor() {
     /** @private {?shaka.media.AdaptationSetCriteria.Configuration} */
     this.config_ = null;

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -725,7 +725,6 @@ shaka.media.SegmentIterator = class {
  * @export
  */
 shaka.media.MetaSegmentIndex = class extends shaka.media.SegmentIndex {
-  /** */
   constructor() {
     super([]);
 

--- a/lib/offline/download_progress_estimator.js
+++ b/lib/offline/download_progress_estimator.js
@@ -14,7 +14,6 @@ goog.provide('shaka.offline.DownloadProgressEstimator');
  * @final
  */
 shaka.offline.DownloadProgressEstimator = class {
-  /** */
   constructor() {
     /**
      * This is the sum of all estimates passed to |open|. This is used as the

--- a/lib/offline/indexeddb/storage_mechanism.js
+++ b/lib/offline/indexeddb/storage_mechanism.js
@@ -31,7 +31,6 @@ goog.require('shaka.util.Timer');
  * @implements {shaka.extern.StorageMechanism}
  */
 shaka.offline.indexeddb.StorageMechanism = class {
-  /** */
   constructor() {
     /** @private {IDBDatabase} */
     this.db_ = null;

--- a/lib/offline/offline_manifest_parser.js
+++ b/lib/offline/offline_manifest_parser.js
@@ -20,7 +20,6 @@ goog.require('shaka.util.Error');
  * @implements {shaka.extern.ManifestParser}
  */
 shaka.offline.OfflineManifestParser = class {
-  /** */
   constructor() {
     /** @private {shaka.offline.OfflineUri} */
     this.uri_ = null;

--- a/lib/offline/storage_muxer.js
+++ b/lib/offline/storage_muxer.js
@@ -59,7 +59,6 @@ shaka.offline.StorageCellHandle;
  * @export
  */
 shaka.offline.StorageMuxer = class {
-  /** */
   constructor() {
     /**
      * A key in this map is the name given when registering a StorageMechanism.

--- a/lib/offline/stream_bandwidth_estimator.js
+++ b/lib/offline/stream_bandwidth_estimator.js
@@ -17,7 +17,6 @@ goog.requireType('shaka.media.SegmentReference');
  * will have some influence over the progress of the download.
  */
 shaka.offline.StreamBandwidthEstimator = class {
-  /** */
   constructor() {
     /** @private {!Map<number, number>} */
     this.estimateByStreamId_ = new Map();

--- a/lib/polyfill/orientation.js
+++ b/lib/polyfill/orientation.js
@@ -106,7 +106,6 @@ shaka.polyfill.Orientation = class {
 
 shaka.polyfill.Orientation.FakeOrientation =
 class extends shaka.util.FakeEventTarget {
-  /** */
   constructor() {
     super();
 

--- a/lib/polyfill/patchedmediakeys_apple.js
+++ b/lib/polyfill/patchedmediakeys_apple.js
@@ -756,7 +756,6 @@ class extends shaka.util.FakeEventTarget {
  * @implements {MediaKeyStatusMap}
  */
 shaka.polyfill.PatchedMediaKeysApple.MediaKeyStatusMap = class {
-  /** */
   constructor() {
     /**
      * @type {number}

--- a/lib/polyfill/patchedmediakeys_webkit.js
+++ b/lib/polyfill/patchedmediakeys_webkit.js
@@ -898,7 +898,6 @@ class extends shaka.util.FakeEventTarget {
  * @implements {MediaKeyStatusMap}
  */
 shaka.polyfill.PatchedMediaKeysWebkit.MediaKeyStatusMap = class {
-  /** */
   constructor() {
     /**
      * @type {number}

--- a/lib/text/cue_region.js
+++ b/lib/text/cue_region.js
@@ -11,7 +11,6 @@ goog.provide('shaka.text.CueRegion');
  * @export
  */
 shaka.text.CueRegion = class {
-  /** */
   constructor() {
     const CueRegion = shaka.text.CueRegion;
 

--- a/lib/text/mp4_ttml_parser.js
+++ b/lib/text/mp4_ttml_parser.js
@@ -21,7 +21,6 @@ goog.require('shaka.util.Uint8ArrayUtils');
  * @export
  */
 shaka.text.Mp4TtmlParser = class {
-  /** */
   constructor() {
     /**
      * @type {!shaka.extern.TextParser}

--- a/lib/text/mp4_vtt_parser.js
+++ b/lib/text/mp4_vtt_parser.js
@@ -25,7 +25,6 @@ goog.require('shaka.util.TextParser');
  * @export
  */
 shaka.text.Mp4VttParser = class {
-  /** */
   constructor() {
     /**
      * The current time scale used by the VTT parser.

--- a/lib/text/srt_text_parser.js
+++ b/lib/text/srt_text_parser.js
@@ -18,7 +18,6 @@ goog.require('shaka.util.StringUtils');
  * @export
  */
 shaka.text.SrtTextParser = class {
-  /** */
   constructor() {
     /**
      * @type {!shaka.extern.TextParser}

--- a/lib/util/event_manager.js
+++ b/lib/util/event_manager.js
@@ -20,7 +20,6 @@ goog.require('shaka.util.MultiMap');
  * @export
  */
 shaka.util.EventManager = class {
-  /** */
   constructor() {
     /**
      * Maps an event type to an array of event bindings.

--- a/lib/util/fake_event_target.js
+++ b/lib/util/fake_event_target.js
@@ -23,7 +23,6 @@ goog.require('shaka.util.MultiMap');
  * @exportInterface
  */
 shaka.util.FakeEventTarget = class {
-  /** */
   constructor() {
     /**
      * @private {shaka.util.MultiMap<shaka.util.FakeEventTarget.ListenerType>}

--- a/lib/util/mp4_parser.js
+++ b/lib/util/mp4_parser.js
@@ -15,7 +15,6 @@ goog.require('shaka.util.DataViewReader');
  * @export
  */
 shaka.util.Mp4Parser = class {
-  /** */
   constructor() {
     /** @private {!Map<number, shaka.util.Mp4Parser.BoxType_>} */
     this.headers_ = new Map();

--- a/lib/util/multi_map.js
+++ b/lib/util/multi_map.js
@@ -12,7 +12,6 @@ goog.provide('shaka.util.MultiMap');
  * @template T
  */
 shaka.util.MultiMap = class {
-  /** */
   constructor() {
     /** @private {!Map<string, !Array<T>>} */
     this.map_ = new Map();

--- a/lib/util/operation_manager.js
+++ b/lib/util/operation_manager.js
@@ -16,7 +16,6 @@ goog.require('shaka.util.IDestroyable');
  * @implements {shaka.util.IDestroyable}
  */
 shaka.util.OperationManager = class {
-  /** */
   constructor() {
     /** @private {!Array<!shaka.extern.IAbortableOperation>} */
     this.operations_ = [];

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -25,7 +25,6 @@ goog.require('shaka.util.MimeUtils');
  * @export
  */
 shaka.util.PeriodCombiner = class {
-  /** */
   constructor() {
     /** @private {!Array<shaka.extern.Variant>} */
     this.variants_ = [];

--- a/lib/util/state_history.js
+++ b/lib/util/state_history.js
@@ -19,7 +19,6 @@ goog.require('shaka.log');
  * @final
  */
 shaka.util.StateHistory = class {
-  /** */
   constructor() {
     /**
      * The state that we think is still the current change. It is "open" for

--- a/lib/util/stats.js
+++ b/lib/util/stats.js
@@ -17,7 +17,6 @@ goog.require('shaka.util.SwitchHistory');
  * @final
  */
 shaka.util.Stats = class {
-  /** */
   constructor() {
     /** @private {number} */
     this.width_ = NaN;

--- a/lib/util/switch_history.js
+++ b/lib/util/switch_history.js
@@ -14,7 +14,6 @@ goog.provide('shaka.util.SwitchHistory');
  * @final
  */
 shaka.util.SwitchHistory = class {
-  /** */
   constructor() {
     /** @private {?shaka.extern.Variant} */
     this.currentVariant_ = null;

--- a/lib/util/ts_parser.js
+++ b/lib/util/ts_parser.js
@@ -20,7 +20,6 @@ goog.require('shaka.util.Uint8ArrayUtils');
  * @export
  */
 shaka.util.TsParser = class {
-  /** */
   constructor() {
     /** @private {?number} */
     this.pmtId_ = null;


### PR DESCRIPTION
We don't need this anymore with `exemptEmptyConstructors` config added in #8901