### PR TITLE
fix: avoid calling new Date(null * 1000)

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -6670,8 +6670,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const timeline = this.manifest_.presentationTimeline;
       const startTime = timeline.getInitialProgramDateTime() ||
           timeline.getPresentationStartTime();
-      goog.asserts.assert(startTime != null,
-          'Presentation start time should not be null!');
+      if (startTime === null) {
+        shaka.log.warning('Manifest appears to have no PDT or PST');
+        // startTime can be null in scenarios where a manifest has no
+        // PDT or PST
+        return null;
+      }
       return new Date(/* ms= */ startTime * 1000);
     } else if (this.video_ && this.video_.getStartDate) {
       // Apple's native HLS gives us getStartDate(), which is only available if


### PR DESCRIPTION
A manifest does not necessarily have a PDT or PST if it is a basic live or VOD manifest. The caller of the function may not know this before calling `getPresentationStartTimeAsDate`.

There is no good way of checking ahead of calling `player.getPresentationStartTimeAsDate` if calling the method is valid or not. I think the method should be fine to call even if there is no PDT or PST available in the manifest.

`startTime` being `null` here seems like a valid scenario to me. It should not result in a erroneous call to `new Date` with `null` and instead just return `null` and log a warning.