### PR TITLE
fix: Add Orange STB Back To `requiresEncryptionInfoInAllInitSegments`

### DIFF
--- a/lib/device/webkit_stb.js
+++ b/lib/device/webkit_stb.js
@@ -26,7 +26,7 @@ shaka.device.WebKitSTB = class extends shaka.device.AbstractDevice {
      */
     this.isSkyQ_ = new shaka.util.Lazy(() => {
       return navigator.userAgent.includes('DT_STB_BCM') || 
-        navigator.userAgent.includes('Sky');
+        navigator.userAgent.includes('Sky_STB');
     });
 
     /**
@@ -146,7 +146,7 @@ shaka.device.WebKitSTB = class extends shaka.device.AbstractDevice {
       return true;
     }
     if (navigator.userAgent.includes('DT_STB_BCM') ||
-        navigator.userAgent.includes('Sky')) {
+        navigator.userAgent.includes('Sky_STB')) {
       return true;
     }
     if (!(navigator.vendor || '').includes('Apple')) {

--- a/lib/device/webkit_stb.js
+++ b/lib/device/webkit_stb.js
@@ -25,7 +25,7 @@ shaka.device.WebKitSTB = class extends shaka.device.AbstractDevice {
      * @private {!shaka.util.Lazy<boolean>}
      */
     this.isSkyQ_ = new shaka.util.Lazy(() => {
-      return navigator.userAgent.includes('DT_STB_BCM') || 
+      return navigator.userAgent.includes('DT_STB_BCM') ||
         navigator.userAgent.includes('Sky_STB');
     });
 

--- a/lib/device/webkit_stb.js
+++ b/lib/device/webkit_stb.js
@@ -25,7 +25,8 @@ shaka.device.WebKitSTB = class extends shaka.device.AbstractDevice {
      * @private {!shaka.util.Lazy<boolean>}
      */
     this.isSkyQ_ = new shaka.util.Lazy(() => {
-      return navigator.userAgent.includes('DT_STB_BCM');
+      return navigator.userAgent.includes('DT_STB_BCM') || 
+        navigator.userAgent.includes('Sky');
     });
 
     /**

--- a/lib/device/webkit_stb.js
+++ b/lib/device/webkit_stb.js
@@ -145,7 +145,7 @@ shaka.device.WebKitSTB = class extends shaka.device.AbstractDevice {
       return true;
     }
     if (navigator.userAgent.includes('DT_STB_BCM') ||
-        navigator.userAgent.includes('DT_STB_BCM')) {
+        navigator.userAgent.includes('Sky')) {
       return true;
     }
     if (!(navigator.vendor || '').includes('Apple')) {

--- a/lib/device/webkit_stb.js
+++ b/lib/device/webkit_stb.js
@@ -10,6 +10,7 @@ goog.require('shaka.device.AbstractDevice');
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.device.IDevice');
 goog.require('shaka.util.Lazy');
+goog.require('shaka.log');
 
 
 /**
@@ -26,6 +27,15 @@ shaka.device.WebKitSTB = class extends shaka.device.AbstractDevice {
      */
     this.isSkyQ_ = new shaka.util.Lazy(() => {
       return navigator.userAgent.includes('DT_STB_BCM');
+    });
+
+    /**
+     * Orange STB
+     *
+     * @private {!shaka.util.Lazy<boolean>}
+     */
+    this.isOrange_ = new shaka.util.Lazy(() => {
+      return navigator.userAgent.includes('SOPOpenBrowser');
     });
 
     /** @private {!shaka.util.Lazy<?number>} */
@@ -98,6 +108,13 @@ shaka.device.WebKitSTB = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
+  requiresEncryptionInfoInAllInitSegments(keySystem) {
+    return this.isOrange_.value();
+  }
+
+  /**
+   * @override
+   */
   detectMaxHardwareResolution() {
     const maxResolution = {
       width: window.screen.width * window.devicePixelRatio,
@@ -125,6 +142,9 @@ shaka.device.WebKitSTB = class extends shaka.device.AbstractDevice {
    * @private
    */
   static isWebkitSTB_() {
+    if (navigator.userAgent.includes('SOPOpenBrowser')) {
+      return true;
+    }
     if (navigator.userAgent.includes('DT_STB_BCM') ||
         navigator.userAgent.includes('DT_STB_BCM')) {
       return true;

--- a/lib/device/webkit_stb.js
+++ b/lib/device/webkit_stb.js
@@ -10,7 +10,6 @@ goog.require('shaka.device.AbstractDevice');
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.device.IDevice');
 goog.require('shaka.util.Lazy');
-goog.require('shaka.log');
 
 
 /**


### PR DESCRIPTION
Classifies Orange STB as a Webkit STB device and returns true for `requiresEncryptionInfoInAllInitSegments`

Fixes #8965
