### PR TITLE
feat: cmcdv2/url-key

### DIFF
--- a/externs/cmcd.js
+++ b/externs/cmcd.js
@@ -34,6 +34,7 @@
  *   rtp: (number|undefined),
  *   msd: (number|undefined),
  *   ltc: (number|undefined),
+ *   url: (string|undefined)
  * }}
  *
  * @description
@@ -197,5 +198,13 @@
  *   the origin and when it was rendered by the client. The accuracy of this
  *   estimate is dependent on synchronization between the packager and the
  *   player clocks.
+ *
+ * @property {string} url
+ *  url
+ *
+ *  The URL used to request the media object.
+ *  This key MUST NOT be used with Request Modereporting mode #1.
+ *  If the request is redirected, this key MUST report the initial
+ *  requested URL.
  */
 var CmcdData;

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -7,6 +7,7 @@
 goog.provide('shaka.util.CmcdManager');
 
 goog.require('goog.Uri');
+
 goog.require('shaka.log');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.ArrayUtils');
@@ -297,7 +298,11 @@ shaka.util.CmcdManager = class {
       const data = this.getDataForSegment_(context, response.uri);
 
       if (this.config_.version === shaka.util.CmcdManager.Version.VERSION_2) {
-        data.url = response.originalUri || response.uri;
+        const originalRequestUrl = response.originalUri || response.uri;
+
+        data.url = this.removeCmcdQueryFromUri_(
+            originalRequestUrl,
+        );
       }
 
       this.applyResponse_(response, data);
@@ -352,6 +357,26 @@ shaka.util.CmcdManager = class {
       shaka.log.warnOnce('CMCD_TEXT_ERROR',
           'Could not generate text CMCD data.', error);
     }
+  }
+
+  /**
+   * Removes the CMCD query parameter from a URI.
+   *
+   * @param {string} uri
+   * @return {string}
+   * @private
+   */
+  removeCmcdQueryFromUri_(uri) {
+    if (!uri || !uri.includes('CMCD=')) {
+      return uri;
+    }
+
+    const url = new goog.Uri(uri);
+    const queryData = url.getQueryData();
+
+    queryData.remove('CMCD');
+
+    return url.toString();
   }
 
   /**

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -297,13 +297,11 @@ shaka.util.CmcdManager = class {
     try {
       const data = this.getDataForSegment_(context, response.uri);
 
-      if (this.config_.version === shaka.util.CmcdManager.Version.VERSION_2) {
-        const originalRequestUrl = response.originalUri || response.uri;
+      const originalRequestUrl = response.originalUri || response.uri;
 
-        data.url = this.removeCmcdQueryFromUri_(
-            originalRequestUrl,
-        );
-      }
+      data.url = this.removeCmcdQueryFromUri_(
+          originalRequestUrl,
+      );
 
       this.applyResponse_(response, data);
     } catch (error) {

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -371,12 +371,15 @@ shaka.util.CmcdManager = class {
       return uri;
     }
 
-    const url = new goog.Uri(uri);
-    const queryData = url.getQueryData();
+    try {
+      const url = new URL(uri);
+      url.searchParams.delete('CMCD');
 
-    queryData.remove('CMCD');
-
-    return url.toString();
+      return url.toString();
+    } catch (error) {
+      shaka.log.error('Failed to parse URI for CMCD removal:', uri, error);
+      return uri;
+    }
   }
 
   /**

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -295,6 +295,11 @@ shaka.util.CmcdManager = class {
   applyResponseSegmentData(response, context) {
     try {
       const data = this.getDataForSegment_(context, response.uri);
+
+      if (this.config_.version === shaka.util.CmcdManager.Version.VERSION_2) {
+        data.url = response.originalUri || response.uri;
+      }
+
       this.applyResponse_(response, data);
     } catch (error) {
       shaka.log.warnOnce(
@@ -1158,7 +1163,7 @@ shaka.util.CmcdManager = class {
     const headerNames = ['Object', 'Request', 'Session', 'Status'];
     const headerGroups = [{}, {}, {}, {}];
     const headerMap = {
-      br: 0, d: 0, ot: 0, tb: 0,
+      br: 0, d: 0, ot: 0, tb: 0, url: 0,
       bl: 1, dl: 1, mtp: 1, nor: 1, nrr: 1, su: 1, ltc: 1,
       cid: 2, pr: 2, sf: 2, sid: 2, st: 2, v: 2, msd: 2,
       bs: 3, rtp: 3,

--- a/test/util/cmcd_manager_unit.js
+++ b/test/util/cmcd_manager_unit.js
@@ -1356,7 +1356,7 @@ describe('CmcdManager Setup', () => {
         expect(decodedUri).not.toContain('nrr=');
       });
 
-      it('includes the original request URL in response mode', () => {
+      it('includes the request URL, without CMCD in response mode', () => {
         const cmcdManager = createCmcdManager(
             playerInterface,
             {
@@ -1372,7 +1372,7 @@ describe('CmcdManager Setup', () => {
 
         const response = createResponse();
         response.uri = 'https://redirected.com/v2seg.mp4';
-        response.originalUri = 'https://initial.com/v2seg.mp4';
+        response.originalUri = 'https://initial.com/v2seg.mp4?CMCD=br%3D5234%2Cot%3Dv';
 
         cmcdManager.applyResponseData(
             shaka.net.NetworkingEngine.RequestType.SEGMENT,
@@ -1380,14 +1380,14 @@ describe('CmcdManager Setup', () => {
             createSegmentContext(),
         );
 
-        // The response.uri is modified by applyResponseData to become the
-        // beacon URL. We decode it to check the CMCD payload.
         const decodedUri = decodeURIComponent(response.uri);
 
-        // The spec requires the URL to be a string, which gets quoted.
-        const expectedUrlParam = `url="${response.originalUri}"`;
+        const expectedCleanUrl = 'https://initial.com/v2seg.mp4';
+        const expectedUrlParam = `url="${expectedCleanUrl}"`;
+        const unexpectedUrlParam = `url="${response.originalUri}"`;
 
         expect(decodedUri).toContain(expectedUrlParam);
+        expect(decodedUri).not.toContain(unexpectedUrlParam);
       });
 
       it('response excludes `nrr` key for v2, even if requested', () => {

--- a/test/util/cmcd_manager_unit.js
+++ b/test/util/cmcd_manager_unit.js
@@ -1555,6 +1555,35 @@ describe('CmcdManager Setup', () => {
         expect(decodedUri).not.toContain('msd=');
         expect(decodedUri).not.toContain('ltc=');
       });
+
+      it('cmcd does not include the url parameter for CMCD v1', () => {
+        const cmcdManager = createCmcdManager(
+            playerInterface, {
+              // Explicitly set version to 1
+              version: 1,
+              targets: [{
+                mode: 'response',
+                enabled: true,
+                url: 'https://example.com/cmcd',
+                useHeaders: false,
+              }],
+            },
+        );
+
+        const response = createResponse();
+        response.uri = 'https://redirected.com/v2seg.mp4';
+        response.originalUri = 'https://initial.com/v2seg.mp4?CMCD=br%3D5234';
+
+        cmcdManager.applyResponseData(
+            shaka.net.NetworkingEngine.RequestType.SEGMENT,
+            response,
+            createSegmentContext(),
+        );
+
+        const decodedUri = decodeURIComponent(response.uri);
+
+        expect(decodedUri).not.toContain('url=');
+      });
     });
   });
 });

--- a/test/util/cmcd_manager_unit.js
+++ b/test/util/cmcd_manager_unit.js
@@ -1390,6 +1390,121 @@ describe('CmcdManager Setup', () => {
         expect(decodedUri).not.toContain(unexpectedUrlParam);
       });
 
+      it('cmcd url key preserves other query parameters', () => {
+        const cmcdManager = createCmcdManager(playerInterface, {
+          version: 2,
+          targets: [{
+            mode: 'response',
+            enabled: true,
+            url: 'https://example.com/cmcd',
+            useHeaders: false,
+          }]},
+        );
+
+        const response = createResponse();
+        response.uri = 'https://redirected.com/v2seg.mp4';
+
+        response.originalUri = 'https://initial.com/v2seg.mp4?foo=bar&CMCD=br%3D5234&baz=qux';
+
+        cmcdManager.applyResponseData(
+            shaka.net.NetworkingEngine.RequestType.SEGMENT,
+            response,
+            createSegmentContext(),
+        );
+
+        const decodedUri = decodeURIComponent(response.uri);
+
+        const expectedCleanUrl = 'https://initial.com/v2seg.mp4?foo=bar&baz=qux';
+        const expectedUrlParam = `url="${expectedCleanUrl}"`;
+
+        expect(decodedUri).toContain(expectedUrlParam);
+      });
+
+      it('cmcd url key does not modify URL if no CMCD param is present', () => {
+        const cmcdManager = createCmcdManager(playerInterface, {
+          version: 2,
+          targets: [{
+            mode: 'response',
+            enabled: true,
+            url: 'https://example.com/cmcd',
+            useHeaders: false,
+          }]},
+        );
+
+        const response = createResponse();
+        const originalUrl = 'https://initial.com/v2seg.mp4?foo=bar';
+        response.uri = 'https://redirected.com/v2seg.mp4';
+        response.originalUri = originalUrl;
+
+        cmcdManager.applyResponseData(
+            shaka.net.NetworkingEngine.RequestType.SEGMENT,
+            response,
+            createSegmentContext(),
+        );
+
+        const decodedUri = decodeURIComponent(response.uri);
+        const expectedUrlParam = `url="${originalUrl}"`;
+
+        expect(decodedUri).toContain(expectedUrlParam);
+      });
+
+      it('cmcd url key preserves URL fragments (hash)', () => {
+        const cmcdManager = createCmcdManager(playerInterface, {
+          version: 2,
+          targets: [{
+            mode: 'response',
+            enabled: true,
+            url: 'https://example.com/cmcd',
+            useHeaders: false,
+          }]},
+        );
+
+        const response = createResponse();
+        response.uri = 'https://redirected.com/v2seg.mp4';
+        response.originalUri = 'https://initial.com/v2seg.mp4?CMCD=br%3D5234#t=10';
+
+        cmcdManager.applyResponseData(
+            shaka.net.NetworkingEngine.RequestType.SEGMENT,
+            response,
+            createSegmentContext(),
+        );
+
+        const decodedUri = decodeURIComponent(response.uri);
+
+        const expectedCleanUrl = 'https://initial.com/v2seg.mp4#t=10';
+        const expectedUrlParam = `url="${expectedCleanUrl}"`;
+
+        expect(decodedUri).toContain(expectedUrlParam);
+      });
+
+      it('cmcd url key handles an empty CMCD parameter', () => {
+        const cmcdManager = createCmcdManager(playerInterface, {
+          version: 2,
+          targets: [{
+            mode: 'response',
+            enabled: true,
+            url: 'https://example.com/cmcd',
+            useHeaders: false,
+          }]},
+        );
+
+        const response = createResponse();
+        response.uri = 'https://redirected.com/v2seg.mp4';
+        response.originalUri = 'https://initial.com/v2seg.mp4?CMCD=';
+
+        cmcdManager.applyResponseData(
+            shaka.net.NetworkingEngine.RequestType.SEGMENT,
+            response,
+            createSegmentContext(),
+        );
+
+        const decodedUri = decodeURIComponent(response.uri);
+        const expectedCleanUrl = 'https://initial.com/v2seg.mp4';
+        const expectedUrlParam = `url="${expectedCleanUrl}"`;
+
+        expect(decodedUri).toContain(expectedUrlParam);
+      });
+
       it('response excludes `nrr` key for v2, even if requested', () => {
         const cmcdManager = createCmcdManager(
             playerInterface,


### PR DESCRIPTION
-  extended the CmcdData type definition to include an optional url property of type string
- added logic to the CmcdManager to capture and include the url in CMCD data when operating in version 2, prioritizing the original requested URL if a redirect occurred
- updated the internal header mapping to include the new url parameter within the CMCD 'Object' header group.
- added unit test to verify that the url parameter is correctly included in CMCD response mode requests