### PR TITLE
feat: cmcdv2/rc-key

### DIFF
--- a/externs/cmcd.js
+++ b/externs/cmcd.js
@@ -34,6 +34,7 @@
  *   rtp: (number|undefined),
  *   msd: (number|undefined),
  *   ltc: (number|undefined),
+ *   rc: (number|undefined),
  * }}
  *
  * @description
@@ -197,5 +198,12 @@
  *   the origin and when it was rendered by the client. The accuracy of this
  *   estimate is dependent on synchronization between the packager and the
  *   player clocks.
+ *
+ * @property {number} rc
+ *   Response code
+ *
+ *   The response code received when requesting a media object.
+ *   In a redirect scenario, this would be the final response code received.
+ *   A value of 0 SHOULD be used to indicate that a response was not received.
  */
 var CmcdData;

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -518,11 +518,7 @@ shaka.util.CmcdManager = class {
         ])) :
         shaka.util.CmcdManager.CmcdKeys.V1Keys;
 
-    if (response.status) {
-      data.rc = response.status;
-    } else {
-      data.rc = 0;
-    }
+    data.rc = response.status || 0;
 
     const rawOutput = this.getGenericData_(
         data,

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -518,6 +518,12 @@ shaka.util.CmcdManager = class {
         ])) :
         shaka.util.CmcdManager.CmcdKeys.V1Keys;
 
+    if (response.status) {
+      data.rc = response.status;
+    } else {
+      data.rc = 0;
+    }
+
     const rawOutput = this.getGenericData_(
         data,
         shaka.util.CmcdManager.CmcdMode.RESPONSE,
@@ -1159,7 +1165,7 @@ shaka.util.CmcdManager = class {
     const headerGroups = [{}, {}, {}, {}];
     const headerMap = {
       br: 0, d: 0, ot: 0, tb: 0,
-      bl: 1, dl: 1, mtp: 1, nor: 1, nrr: 1, su: 1, ltc: 1,
+      bl: 1, dl: 1, mtp: 1, nor: 1, nrr: 1, su: 1, ltc: 1, rc: 1,
       cid: 2, pr: 2, sf: 2, sid: 2, st: 2, v: 2, msd: 2,
       bs: 3, rtp: 3,
     };


### PR DESCRIPTION
- Extended the CmcdData type definition to include a new rc (response code) property, along with its detailed description, in externs/cmcd.js
- Implemented the logic within CmcdManager to extract the HTTP response status from network responses and assign it to the rc key. If no status is available, it defaults to 0
- rc key has been integrated into the CMCD header mapping
- Added new unit tests to cmcd_manager_unit.js to validate that the rc key is correctly included in CMCD data, both when sent via query parameters and HTTP headers, and that the default value of 0 is used when the response status is not provided.