### PR TITLE
Fix playback rate selection update and skip-previous icon size

### DIFF
--- a/ui/less/containers.less
+++ b/ui/less/containers.less
@@ -199,6 +199,7 @@
     &.shaka-fast-forward-button,
     &.shaka-rewind-button,
     &.shaka-small-play-button,
+    &.shaka-skip-previous-button,
     &.shaka-skip-next-button {
       .material-svg-icon {
         font-size: 32px;

--- a/ui/playback_rate_selection.js
+++ b/ui/playback_rate_selection.js
@@ -86,7 +86,7 @@ shaka.ui.PlaybackRateSelection = class extends shaka.ui.SettingsMenu {
     const rate = this.player.getPlaybackRate();
     // Remove the old checkmark icon and related tags and classes if it exists.
     const checkmarkIcon = shaka.ui.Utils.getDescendantIfExists(
-        this.menu, 'shaka-chosen-item');
+        this.menu, 'material-svg-icon shaka-chosen-item');
     if (checkmarkIcon) {
       const previouslySelectedButton = checkmarkIcon.parentElement;
       previouslySelectedButton.removeAttribute('aria-selected');


### PR DESCRIPTION
* Fixed playback rate selection not updating in the UI due to a mismatched class name query.
* Corrected the icon size for the skip-previous button.


Playback rate selection problem :arrow_down: 
[Screencast From 2025-08-19 22-53-35.webm](https://github.com/user-attachments/assets/38324971-ec39-427c-97da-d13693bae6e9)

