### PR TITLE
fix(HLS): Fix getAudioTracks in some HLS streams

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5947,6 +5947,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         if (!id) {
           continue;
         }
+        id += [
+          track.language,
+          track.label,
+          track.channelsCount,
+          track.spatialAudio,
+        ].join('_');
         /** @type {shaka.extern.AudioTrack} */
         const audioTrack = {
           active: track.active,


### PR DESCRIPTION
Some HLS streams have the same originalAudioId for multiple tracks, so to avoid filtering out the tracks we want, we add the language, label, channelsCount, and spatialAudio to get a more accurate ID.