### PR TITLE
fix: Avoid minifying AdaptationSetCriteria configuration

### DIFF
--- a/build/types/core
+++ b/build/types/core
@@ -32,7 +32,6 @@
 +../../lib/drm/playready.js
 
 +../../lib/media/adaptation_set.js
-+../../lib/media/adaptation_set_criteria.js
 +../../lib/media/buffering_observer.js
 +../../lib/media/closed_caption_parser.js
 +../../lib/media/content_workarounds.js

--- a/externs/shaka/adaptation_set_criteria.js
+++ b/externs/shaka/adaptation_set_criteria.js
@@ -4,11 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-goog.provide('shaka.media.AdaptationSetCriteria');
-
-goog.require('shaka.media.AdaptationSet');
-goog.require('shaka.config.CodecSwitchingStrategy');
-
+/**
+ * @externs
+ */
 
 /**
  * An adaptation set criteria is a unit of logic that can take a set of
@@ -16,32 +14,32 @@ goog.require('shaka.config.CodecSwitchingStrategy');
  * adapted between.
  *
  * @interface
- * @export
+ * @exportDoc
  */
-shaka.media.AdaptationSetCriteria = class {
+shaka.extern.AdaptationSetCriteria = class {
   /**
    * Take a set of variants, and return a subset of variants that can be
    * adapted between.
    *
    * @param {!Array<shaka.extern.Variant>} variants
    * @return {!shaka.media.AdaptationSet}
-   * @exportInterface
+   * @exportDoc
    */
   create(variants) {}
 
   /**
    * Sets the AdaptationSetCriteria configuration.
    *
-   * @param {shaka.media.AdaptationSetCriteria.Configuration} config
-   * @exportInterface
+   * @param {shaka.extern.AdaptationSetCriteria.Configuration} config
+   * @exportDoc
    */
   configure(config) {}
 
   /**
    * Gets the current AdaptationSetCriteria configuration.
    *
-   * @return {?shaka.media.AdaptationSetCriteria.Configuration}
-   * @exportInterface
+   * @return {?shaka.extern.AdaptationSetCriteria.Configuration}
+   * @exportDoc
    */
   getConfiguration() {}
 };
@@ -49,10 +47,10 @@ shaka.media.AdaptationSetCriteria = class {
 /**
  * A factory for creating the AdaptationSetCriteria.
  *
- * @typedef {function():!shaka.media.AdaptationSetCriteria}
- * @export
+ * @typedef {function():!shaka.extern.AdaptationSetCriteria}
+ * @exportDoc
  */
-shaka.media.AdaptationSetCriteria.Factory;
+shaka.extern.AdaptationSetCriteria.Factory;
 
 /**
  * @typedef {{
@@ -103,6 +101,6 @@ shaka.media.AdaptationSetCriteria.Factory;
  *   The ordered list of audio codecs to filter variants.
  * @property {number} preferredAudioChannelCount
  *   The preferred audio channel count to filter variants.
- * @export
+ * @exportDoc
  */
-shaka.media.AdaptationSetCriteria.Configuration;
+shaka.extern.AdaptationSetCriteria.Configuration;

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2752,7 +2752,7 @@ shaka.extern.TextDisplayerConfiguration;
  *   networking: shaka.extern.NetworkingConfiguration,
  *   mediaSource: shaka.extern.MediaSourceConfiguration,
  *   abrFactory: shaka.extern.AbrManager.Factory,
- *   adaptationSetCriteriaFactory: shaka.media.AdaptationSetCriteria.Factory,
+ *   adaptationSetCriteriaFactory: shaka.extern.AdaptationSetCriteria.Factory,
  *   abr: shaka.extern.AbrConfiguration,
  *   cmcd: shaka.extern.CmcdConfiguration,
  *   cmsd: shaka.extern.CmsdConfiguration,
@@ -2802,7 +2802,7 @@ shaka.extern.TextDisplayerConfiguration;
  *   Media source configuration and settings.
  * @property {shaka.extern.AbrManager.Factory} abrFactory
  *   A factory to construct an abr manager.
- * @property {shaka.media.AdaptationSetCriteria.Factory
+ * @property {shaka.extern.AdaptationSetCriteria.Factory
  *           } adaptationSetCriteriaFactory
  *   A factory to construct an adaptation set criteria.
  * @property {shaka.extern.AbrConfiguration} abr

--- a/lib/media/preference_based_criteria.js
+++ b/lib/media/preference_based_criteria.js
@@ -10,18 +10,17 @@ goog.require('shaka.config.CodecSwitchingStrategy');
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.log');
 goog.require('shaka.media.AdaptationSet');
-goog.require('shaka.media.AdaptationSetCriteria');
 goog.require('shaka.media.Capabilities');
 goog.require('shaka.util.LanguageUtils');
 
 
 /**
- * @implements {shaka.media.AdaptationSetCriteria}
+ * @implements {shaka.extern.AdaptationSetCriteria}
  * @final
  */
 shaka.media.PreferenceBasedCriteria = class {
   constructor() {
-    /** @private {?shaka.media.AdaptationSetCriteria.Configuration} */
+    /** @private {?shaka.extern.AdaptationSetCriteria.Configuration} */
     this.config_ = null;
   }
 

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -10,7 +10,6 @@ goog.require('goog.asserts');
 goog.require('shaka.drm.DrmEngine');
 goog.require('shaka.drm.DrmUtils');
 goog.require('shaka.log');
-goog.require('shaka.media.AdaptationSetCriteria');
 goog.require('shaka.media.ManifestFilterer');
 goog.require('shaka.media.ManifestParser');
 goog.require('shaka.media.QualityObserver');
@@ -62,7 +61,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     /** @private {?number|Date} */
     this.startTime_ = startTime;
 
-    /** @private {?shaka.media.AdaptationSetCriteria} */
+    /** @private {?shaka.extern.AdaptationSetCriteria} */
     this.currentAdaptationSetCriteria_ = null;
 
     /** @private {number} */
@@ -243,7 +242,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
     return this.parserFactory_;
   }
 
-  /** @return {?shaka.media.AdaptationSetCriteria} */
+  /** @return {?shaka.extern.AdaptationSetCriteria} */
   getCurrentAdaptationSetCriteria() {
     return this.currentAdaptationSetCriteria_;
   }
@@ -365,7 +364,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
   }
 
   /**
-   * @param {?shaka.media.AdaptationSetCriteria} adaptationSetCriteria
+   * @param {?shaka.extern.AdaptationSetCriteria} adaptationSetCriteria
    */
   attachAdaptationSetCriteria(adaptationSetCriteria) {
     this.currentAdaptationSetCriteria_ = adaptationSetCriteria;

--- a/lib/player.js
+++ b/lib/player.js
@@ -13,7 +13,6 @@ goog.require('shaka.device.IDevice');
 goog.require('shaka.drm.DrmEngine');
 goog.require('shaka.drm.DrmUtils');
 goog.require('shaka.log');
-goog.require('shaka.media.AdaptationSetCriteria');
 goog.require('shaka.media.BufferingObserver');
 goog.require('shaka.media.ManifestFilterer');
 goog.require('shaka.media.ManifestParser');
@@ -879,7 +878,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @private {shaka.util.Stats} */
     this.stats_ = null;
 
-    /** @private {!shaka.media.AdaptationSetCriteria} */
+    /** @private {!shaka.extern.AdaptationSetCriteria} */
     this.currentAdaptationSetCriteria_ =
         this.config_.adaptationSetCriteriaFactory();
     this.currentAdaptationSetCriteria_.configure({

--- a/shaka-player.uncompiled.js
+++ b/shaka-player.uncompiled.js
@@ -30,7 +30,6 @@ goog.require('shaka.drm.FairPlay');
 goog.require('shaka.hls.HlsParser');
 goog.require('shaka.mss.MssParser');
 goog.require('shaka.log');
-goog.require('shaka.media.AdaptationSetCriteria');
 goog.require('shaka.media.InitSegmentReference');
 goog.require('shaka.media.ManifestParser');
 goog.require('shaka.media.PreferenceBasedCriteria');


### PR DESCRIPTION
When using custom adaptation set criteria, configuration fields might be minified. Move AdaptationSetCriteria definition to externs to avoid that.