### PR TITLE
fix(EMSG): Fix memory leak in EMSG handling

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -996,8 +996,6 @@ shaka.media.MediaSourceEngine = class {
       schemeId = box.reader.readTerminatedString();
       value = box.reader.readTerminatedString();
     }
-    const messageData = box.reader.readBytes(
-        box.reader.getLength() - box.reader.getPosition());
 
     // See DASH sec. 5.10.3.3.1
     // If a DASH client detects an event message box with a scheme that is not
@@ -1010,6 +1008,12 @@ shaka.media.MediaSourceEngine = class {
         this.playerInterface_.onManifestUpdate();
       } else {
         // All other schemes are dispatched as a general 'emsg' event.
+        const messageDataRaw = box.reader.readBytes(
+            box.reader.getLength() - box.reader.getPosition());
+        // messageDataRaw is a Uint8Array which uses shared ArrayBuffer.
+        // We need to make a copy to not keep whole segment in memory.
+        const messageData = new Uint8Array(messageDataRaw.byteLength);
+        messageData.set(messageDataRaw);
         const endTime = startTime + (eventDuration / timescale);
         /** @type {shaka.extern.EmsgInfo} */
         const emsg = {

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -996,6 +996,8 @@ shaka.media.MediaSourceEngine = class {
       schemeId = box.reader.readTerminatedString();
       value = box.reader.readTerminatedString();
     }
+    const messageDataRaw = box.reader.readBytes(
+        box.reader.getLength() - box.reader.getPosition());
 
     // See DASH sec. 5.10.3.3.1
     // If a DASH client detects an event message box with a scheme that is not
@@ -1008,8 +1010,7 @@ shaka.media.MediaSourceEngine = class {
         this.playerInterface_.onManifestUpdate();
       } else {
         // All other schemes are dispatched as a general 'emsg' event.
-        const messageDataRaw = box.reader.readBytes(
-            box.reader.getLength() - box.reader.getPosition());
+
         // messageDataRaw is a Uint8Array which uses shared ArrayBuffer.
         // We need to make a copy to not keep whole segment in memory.
         const messageData = new Uint8Array(messageDataRaw.byteLength);


### PR DESCRIPTION
Since `RegionTimeline` is used for storing EMSG events, used memory significantly grew when content extensively uses EMSG.

When creating EMSG region, we’re creating `message_data` by using method `readBytes()` from `DataViewReader`. Internally, it calls `BufferUtils.toUint8(buffer)` which creates new `Uint8Array` on shared `ArrayBuffer`. We need to make a copy with data needed only to not store whole segments in memory.
