### PR TITLE
perf(DASH): Do not store duplicated pssh data buffers

### DIFF
--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -11,6 +11,7 @@ goog.require('shaka.log');
 goog.require('shaka.drm.DrmUtils');
 goog.require('shaka.drm.PlayReady');
 goog.require('shaka.util.Error');
+goog.require('shaka.util.IReleasable');
 goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.Pssh');
 goog.require('shaka.util.StringUtils');
@@ -21,8 +22,19 @@ goog.require('shaka.util.Uint8ArrayUtils');
 /**
  * @summary A set of functions for parsing and interpreting ContentProtection
  *   elements.
+ * @implements {shaka.util.IReleasable}
  */
 shaka.dash.ContentProtection = class {
+  constructor() {
+    /** @private {!Map<string, !Uint8Array>} */
+    this.psshToInitData_ = new Map();
+  }
+
+  /** @override */
+  release() {
+    this.psshToInitData_.clear();
+  }
+
   /**
    * Parses info from the ContentProtection elements at the AdaptationSet level.
    *
@@ -31,10 +43,10 @@ shaka.dash.ContentProtection = class {
    * @param {!Object<string, string>} keySystemsByURI
    * @return {shaka.dash.ContentProtection.Context}
    */
-  static parseFromAdaptationSet(elements, ignoreDrmInfo, keySystemsByURI) {
+  parseFromAdaptationSet(elements, ignoreDrmInfo, keySystemsByURI) {
     const ContentProtection = shaka.dash.ContentProtection;
     const ManifestParserUtils = shaka.util.ManifestParserUtils;
-    const parsed = ContentProtection.parseElements_(elements);
+    const parsed = this.parseElements_(elements);
     /** @type {Array<shaka.extern.InitDataOverride>} */
     let defaultInit = null;
     /** @type {!Array<shaka.extern.DrmInfo>} */
@@ -155,10 +167,9 @@ shaka.dash.ContentProtection = class {
    * @param {!Object<string, string>} keySystemsByURI
    * @return {?string} The parsed key ID
    */
-  static parseFromRepresentation(
+  parseFromRepresentation(
       elements, context, ignoreDrmInfo, keySystemsByURI) {
-    const ContentProtection = shaka.dash.ContentProtection;
-    const repContext = ContentProtection.parseFromAdaptationSet(
+    const repContext = this.parseFromAdaptationSet(
         elements, ignoreDrmInfo, keySystemsByURI);
 
     if (context.firstRepresentation) {
@@ -480,12 +491,12 @@ shaka.dash.ContentProtection = class {
    * @return {!Array<shaka.dash.ContentProtection.Element>}
    * @private
    */
-  static parseElements_(elements) {
+  parseElements_(elements) {
     /** @type {!Array<shaka.dash.ContentProtection.Element>} */
     const out = [];
 
     for (const element of elements) {
-      const parsed = shaka.dash.ContentProtection.parseElement_(element);
+      const parsed = this.parseElement_(element);
       if (parsed) {
         out.push(parsed);
       }
@@ -501,7 +512,7 @@ shaka.dash.ContentProtection = class {
    * @return {?shaka.dash.ContentProtection.Element}
    * @private
    */
-  static parseElement_(elem) {
+  parseElement_(elem) {
     const NS = shaka.dash.ContentProtection.CencNamespaceUri_;
     const TXml = shaka.util.TXml;
 
@@ -537,9 +548,13 @@ shaka.dash.ContentProtection = class {
     try {
       // Try parsing PSSH data.
       init = psshs.map((pssh) => {
+        if (!this.psshToInitData_.has(pssh)) {
+          const initData = shaka.util.Uint8ArrayUtils.fromBase64(pssh);
+          this.psshToInitData_.set(pssh, initData);
+        }
         return {
           initDataType: 'cenc',
-          initData: shaka.util.Uint8ArrayUtils.fromBase64(pssh),
+          initData: this.psshToInitData_.get(pssh),
           keyId: null,
         };
       });

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -210,6 +210,9 @@ shaka.dash.DashParser = class {
      * @private {!Set<!shaka.extern.xml.Node>}
      */
     this.parsedPrftNodes_ = new Set();
+
+    /** @private {!shaka.dash.ContentProtection} */
+    this.contentProtection_ = new shaka.dash.ContentProtection();
   }
 
   /**
@@ -320,6 +323,7 @@ shaka.dash.DashParser = class {
       this.eventManager_ = null;
     }
     this.parsedPrftNodes_.clear();
+    this.contentProtection_.release();
 
     return this.operationManager_.destroy();
   }
@@ -1772,7 +1776,6 @@ shaka.dash.DashParser = class {
     const Functional = shaka.util.Functional;
     const ManifestParserUtils = shaka.util.ManifestParserUtils;
     const ContentType = ManifestParserUtils.ContentType;
-    const ContentProtection = shaka.dash.ContentProtection;
 
     context.adaptationSet = this.createFrame_(elem, context.period, null);
     context.adaptationSet.position = position;
@@ -2050,12 +2053,12 @@ shaka.dash.DashParser = class {
 
     const contentProtectionElements =
         TXml.findChildren(elem, 'ContentProtection');
-    const contentProtection = ContentProtection.parseFromAdaptationSet(
+    const contentProtection = this.contentProtection_.parseFromAdaptationSet(
         contentProtectionElements,
         this.config_.ignoreDrmInfo,
         this.config_.dash.keySystemsByURI);
 
-    // We us contentProtectionElements instead of drmInfos as the latter is
+    // We use contentProtectionElements instead of drmInfos as the latter is
     // not populated yet, and we need the encrypted flag for the upcoming
     // parseRepresentation that will set the encrypted flag to the init seg.
     context.adaptationSet.encrypted = contentProtectionElements.length > 0;
@@ -2406,7 +2409,7 @@ shaka.dash.DashParser = class {
       throw error;
     }
 
-    const keyId = shaka.dash.ContentProtection.parseFromRepresentation(
+    const keyId = this.contentProtection_.parseFromRepresentation(
         contentProtectionElements, contentProtection,
         this.config_.ignoreDrmInfo,
         this.config_.dash.keySystemsByURI);


### PR DESCRIPTION
Use PSSH string to cache init data in order to avoid creating duplicated init data buffers. On streams with many periods due to ad insertion it can make a difference - i.e. on stream with 50 periods this change reduces used memory by init data buffers from 40 KB to 1 KB.

In DASH, PSSH can often be a duplicated data between protected periods and/or adaptation sets. 