### PR TITLE
perf(DASH): Simplify multiperiod eviction

### DIFF
--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -732,17 +732,6 @@ shaka.media.MetaSegmentIndex = class extends shaka.media.SegmentIndex {
     this.indexes_ = [];
   }
 
-  /** Evicts all old SegmentIndexes in this MetaSegmentIndex that are empty. */
-  evictEmpty() {
-    while (this.indexes_.length > 1 && this.indexes_[0].isEmpty()) {
-      const index = this.indexes_.shift();
-      // In the case of this class, this.numEvicted_ represents the evicted
-      // segments that were in indexes that were entirely evicted.
-      this.numEvicted_ += index.getNumEvicted();
-      index.release();
-    }
-  }
-
   /**
    * Append a SegmentIndex to this MetaSegmentIndex.  This effectively stitches
    * the underlying Stream onto the end of the multi-Period Stream represented
@@ -894,10 +883,17 @@ shaka.media.MetaSegmentIndex = class extends shaka.media.SegmentIndex {
    * @export
    */
   evict(time) {
-    for (const index of this.indexes_) {
-      index.evict(time);
+    if (!this.indexes_.length) {
+      return;
     }
-    this.evictEmpty();
+    const index = this.indexes_[0];
+    index.evict(time);
+    if (index.isEmpty()) {
+      this.indexes_.shift();
+      this.numEvicted_ += index.getNumEvicted();
+      index.release();
+      this.evict(time);
+    }
   }
 
   /**

--- a/test/media/segment_index_unit.js
+++ b/test/media/segment_index_unit.js
@@ -1050,10 +1050,7 @@ describe('SegmentIndex', /** @suppress {accessControls} */ () => {
       expect(Array.from(metaIndex)).toEqual(
           inputRefs0.concat(inputRefs1, inputRefs2));
       expect(metaIndex.getNumEvicted()).toBe(0);
-      index0.evict(75);
-      index1.evict(75);
-      index2.evict(75);
-      metaIndex.evictEmpty();
+      metaIndex.evict(75);
       expect(Array.from(metaIndex)).toEqual(inputRefs2.slice(1));
       expect(release0).toHaveBeenCalled();
       expect(release1).toHaveBeenCalled();


### PR DESCRIPTION
When evicting segments based on time, evict only first period and proceed to next ones only when first is already empty.