### PR TITLE
fix: Fix buffering states when rebuffering goal is 0

### DIFF
--- a/build/types/core
+++ b/build/types/core
@@ -106,6 +106,7 @@
 +../../lib/util/lazy.js
 +../../lib/util/manifest_parser_utils.js
 +../../lib/util/map_utils.js
++../../lib/util/media_element_event.js
 +../../lib/util/media_ready_state_utils.js
 +../../lib/util/mime_utils.js
 +../../lib/util/mp4_box_parsers.js

--- a/lib/media/buffering_observer.js
+++ b/lib/media/buffering_observer.js
@@ -66,33 +66,30 @@ shaka.media.BufferingObserver = class {
      */
     const threshold = this.thresholds_.get(this.previousState_);
 
-    const oldState = this.previousState_;
     const newState =
         (bufferedToEnd || (bufferLead >= threshold && bufferLead > 0)) ?
         (State.SATISFIED) :
         (State.STARVING);
 
-    // Save the new state now so that calls to |getState| from any callbacks
-    // will be accurate.
-    this.previousState_ = newState;
-
-    // Return |true| only when the state has changed.
-    const stateChanged = oldState != newState;
-
-    if (stateChanged && newState === State.SATISFIED) {
-      this.lastRebufferTime_ = Date.now();
-    }
-
-    return stateChanged;
+    return this.setState(newState);
   }
 
   /**
    * Set which state that the observer should think playback was in.
    *
    * @param {shaka.media.BufferingObserver.State} state
+   * @return {boolean}
    */
   setState(state) {
+    const State = shaka.media.BufferingObserver.State;
+
+    // Return |true| only when the state has changed.
+    const stateChanged = this.previousState_ !== state;
     this.previousState_ = state;
+    if (stateChanged && state === State.SATISFIED) {
+      this.lastRebufferTime_ = Date.now();
+    }
+    return stateChanged;
   }
 
   /**
@@ -117,6 +114,26 @@ shaka.media.BufferingObserver = class {
    */
   resetLastRebufferTime() {
     this.lastRebufferTime_ = 0;
+  }
+
+  /**
+   * @param {string} eventName
+   * @return {boolean}
+   */
+  reportEvent(eventName) {
+    let state = undefined;
+    switch (eventName) {
+      case 'seeking':
+      case 'waiting':
+        state = shaka.media.BufferingObserver.State.STARVING;
+        break;
+      case 'canplaythrough':
+      case 'playing':
+      case 'seeked':
+        state = shaka.media.BufferingObserver.State.SATISFIED;
+        break;
+    }
+    return state !== undefined ? this.setState(state) : false;
   }
 };
 

--- a/lib/media/buffering_observer.js
+++ b/lib/media/buffering_observer.js
@@ -6,6 +6,8 @@
 
 goog.provide('shaka.media.BufferingObserver');
 
+goog.require('shaka.util.MediaElementEvent');
+
 
 /**
  * The buffering observer watches how much content has been buffered and raises
@@ -117,19 +119,19 @@ shaka.media.BufferingObserver = class {
   }
 
   /**
-   * @param {string} eventName
+   * @param {!shaka.util.MediaElementEvent} event
    * @return {boolean}
    */
-  reportEvent(eventName) {
+  reportEvent(event) {
     let state = undefined;
-    switch (eventName) {
-      case 'seeking':
-      case 'waiting':
+    switch (event) {
+      case shaka.util.MediaElementEvent.SEEKING:
+      case shaka.util.MediaElementEvent.WAITING:
         state = shaka.media.BufferingObserver.State.STARVING;
         break;
-      case 'canplaythrough':
-      case 'playing':
-      case 'seeked':
+      case shaka.util.MediaElementEvent.CAN_PLAY_THROUGH:
+      case shaka.util.MediaElementEvent.PLAYING:
+      case shaka.util.MediaElementEvent.SEEKED:
         state = shaka.media.BufferingObserver.State.SATISFIED;
         break;
     }

--- a/lib/player.js
+++ b/lib/player.js
@@ -4023,26 +4023,26 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.updateBufferState_();
 
     this.bufferPoller_ = new shaka.util.Timer(() => {
-      this.pollBufferState_();
+      this.pollBufferState_('polling');
     });
     if (this.config_.streaming.rebufferingGoal) {
       this.bufferPoller_.tickEvery(/* seconds= */ 0.25);
     }
     this.loadEventManager_.listen(mediaElement, 'waiting',
-        (e) => this.pollBufferState_());
+        (e) => this.pollBufferState_(e.type));
     this.loadEventManager_.listen(mediaElement, 'canplaythrough',
-        (e) => this.pollBufferState_());
+        (e) => this.pollBufferState_(e.type));
     this.loadEventManager_.listen(mediaElement, 'playing',
-        (e) => this.pollBufferState_());
+        (e) => this.pollBufferState_(e.type));
     this.loadEventManager_.listen(mediaElement, 'seeked',
-        (e) => this.pollBufferState_());
+        (e) => this.pollBufferState_(e.type));
     if (srcEquals) {
       this.loadEventManager_.listen(mediaElement, 'stalled',
-          (e) => this.pollBufferState_());
+          (e) => this.pollBufferState_(e.type));
       this.loadEventManager_.listen(mediaElement, 'progress',
-          (e) => this.pollBufferState_());
+          (e) => this.pollBufferState_(e.type));
       this.loadEventManager_.listen(mediaElement, 'timeupdate',
-          (e) => this.pollBufferState_());
+          (e) => this.pollBufferState_(e.type));
     }
   }
 
@@ -4071,9 +4071,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * This method is called periodically to check what the buffering observer
    * says so that we can update the rest of the buffering behaviours.
    *
+   * @param {string} eventName
    * @private
    */
-  pollBufferState_() {
+  pollBufferState_(eventName) {
     goog.asserts.assert(
         this.video_,
         'Need a media element to update the buffering observer');
@@ -4081,6 +4082,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     goog.asserts.assert(
         this.bufferObserver_,
         'Need a buffering observer to update');
+
+    if (!this.config_.streaming.rebufferingGoal) {
+      const stateChanged = this.bufferObserver_.reportEvent(eventName);
+
+      // If the state changed, we need to surface the event.
+      if (stateChanged) {
+        this.updateBufferState_();
+      }
+      return;
+    }
 
     // This means that MediaSource has buffered the final segment in all
     // SourceBuffers and is no longer accepting additional segments.
@@ -8284,7 +8295,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // If we seek into an unbuffered range, we should fire a 'buffering' event
       // immediately.  If StreamingEngine can buffer fast enough, we may not
       // update our buffering tracking otherwise.
-      this.pollBufferState_();
+      this.pollBufferState_('seeking');
     }
   }
 
@@ -8598,7 +8609,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           this.playhead_.setStartTime(startTime);
         }
       }
-      this.pollBufferState_();
+      this.pollBufferState_('appending');
     }
 
     // Dispatch an event for users to consume, too.

--- a/lib/player.js
+++ b/lib/player.js
@@ -57,6 +57,7 @@ goog.require('shaka.util.IDestroyable');
 goog.require('shaka.util.LanguageUtils');
 goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.MapUtils');
+goog.require('shaka.util.MediaElementEvent');
 goog.require('shaka.util.MediaReadyState');
 goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Mutex');
@@ -4005,6 +4006,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   startBufferManagement_(mediaElement, srcEquals) {
+    const Event = shaka.util.MediaElementEvent;
     goog.asserts.assert(
         !this.bufferObserver_,
         'No buffering observer should exist before initialization.');
@@ -4023,26 +4025,26 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.updateBufferState_();
 
     this.bufferPoller_ = new shaka.util.Timer(() => {
-      this.pollBufferState_('polling');
+      this.pollBufferState_();
     });
     if (this.config_.streaming.rebufferingGoal) {
       this.bufferPoller_.tickEvery(/* seconds= */ 0.25);
     }
-    this.loadEventManager_.listen(mediaElement, 'waiting',
-        (e) => this.pollBufferState_(e.type));
-    this.loadEventManager_.listen(mediaElement, 'canplaythrough',
-        (e) => this.pollBufferState_(e.type));
-    this.loadEventManager_.listen(mediaElement, 'playing',
-        (e) => this.pollBufferState_(e.type));
-    this.loadEventManager_.listen(mediaElement, 'seeked',
-        (e) => this.pollBufferState_(e.type));
+    this.loadEventManager_.listen(mediaElement, Event.WAITING,
+        (e) => this.pollBufferState_(Event.WAITING));
+    this.loadEventManager_.listen(mediaElement, Event.CAN_PLAY_THROUGH,
+        (e) => this.pollBufferState_(Event.CAN_PLAY_THROUGH));
+    this.loadEventManager_.listen(mediaElement, Event.PLAYING,
+        (e) => this.pollBufferState_(Event.PLAYING));
+    this.loadEventManager_.listen(mediaElement, Event.SEEKED,
+        (e) => this.pollBufferState_(Event.SEEKED));
     if (srcEquals) {
-      this.loadEventManager_.listen(mediaElement, 'stalled',
-          (e) => this.pollBufferState_(e.type));
-      this.loadEventManager_.listen(mediaElement, 'progress',
-          (e) => this.pollBufferState_(e.type));
-      this.loadEventManager_.listen(mediaElement, 'timeupdate',
-          (e) => this.pollBufferState_(e.type));
+      this.loadEventManager_.listen(mediaElement, Event.STALLED,
+          (e) => this.pollBufferState_(Event.STALLED));
+      this.loadEventManager_.listen(mediaElement, Event.PROGRESS,
+          (e) => this.pollBufferState_(Event.PROGRESS));
+      this.loadEventManager_.listen(mediaElement, Event.TIME_UPDATE,
+          (e) => this.pollBufferState_(Event.TIME_UPDATE));
     }
   }
 
@@ -4071,10 +4073,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * This method is called periodically to check what the buffering observer
    * says so that we can update the rest of the buffering behaviours.
    *
-   * @param {string} eventName
+   * @param {!shaka.util.MediaElementEvent=} event
    * @private
    */
-  pollBufferState_(eventName) {
+  pollBufferState_(event) {
     goog.asserts.assert(
         this.video_,
         'Need a media element to update the buffering observer');
@@ -4085,11 +4087,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // If rebuffering goal is 0, rely solely on media element events.
     if (!this.config_.streaming.rebufferingGoal) {
-      const stateChanged = this.bufferObserver_.reportEvent(eventName);
+      if (event) {
+        const stateChanged = this.bufferObserver_.reportEvent(event);
 
-      // If the state changed, we need to surface the event.
-      if (stateChanged) {
-        this.updateBufferState_();
+        // If the state changed, we need to surface the event.
+        if (stateChanged) {
+          this.updateBufferState_();
+        }
       }
       return;
     }
@@ -8296,7 +8300,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // If we seek into an unbuffered range, we should fire a 'buffering' event
       // immediately.  If StreamingEngine can buffer fast enough, we may not
       // update our buffering tracking otherwise.
-      this.pollBufferState_('seeking');
+      this.pollBufferState_(shaka.util.MediaElementEvent.SEEKING);
     }
   }
 
@@ -8610,7 +8614,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           this.playhead_.setStartTime(startTime);
         }
       }
-      this.pollBufferState_('appending');
+      this.pollBufferState_();
     }
 
     // Dispatch an event for users to consume, too.

--- a/lib/player.js
+++ b/lib/player.js
@@ -4083,6 +4083,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.bufferObserver_,
         'Need a buffering observer to update');
 
+    // If rebuffering goal is 0, rely solely on media element events.
     if (!this.config_.streaming.rebufferingGoal) {
       const stateChanged = this.bufferObserver_.reportEvent(eventName);
 

--- a/lib/util/media_element_event.js
+++ b/lib/util/media_element_event.js
@@ -1,0 +1,32 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.provide('shaka.util.MediaElementEvent');
+
+/**
+ * Enum for HTMLMediaElement events
+ * @enum {string}
+ */
+shaka.util.MediaElementEvent = {
+  CAN_PLAY: 'canplay',
+  CAN_PLAY_THROUGH: 'canplaythrough',
+  DURATION_CHANGE: 'durationchange',
+  ENCRYPTED: 'encrypted',
+  ENDED: 'ended',
+  LOADED_DATA: 'loadeddata',
+  LOADED_METADATA: 'loadedmetadata',
+  PAUSE: 'pause',
+  PLAY: 'play',
+  PLAYING: 'playing',
+  PROGRESS: 'progress',
+  RATE_CHANGE: 'ratechange',
+  SEEKED: 'seeked',
+  SEEKING: 'seeking',
+  STALLED: 'stalled',
+  TIME_UPDATE: 'timeupdate',
+  VOLUME_CHANGE: 'volumechange',
+  WAITING: 'waiting',
+};

--- a/test/media/buffering_observer_unit.js
+++ b/test/media/buffering_observer_unit.js
@@ -156,4 +156,14 @@ describe('BufferingObserver', () => {
       expect(controller.getLastRebufferTime()).toBe(Date.now());
     });
   });
+
+  it('reports starving state when seeking', () => {
+    controller.reportEvent(shaka.util.MediaElementEvent.SEEKING);
+    expect(controller.getState()).toBe(State.STARVING);
+  });
+
+  it('reports satisfied state when playing', () => {
+    controller.reportEvent(shaka.util.MediaElementEvent.PLAYING);
+    expect(controller.getState()).toBe(State.SATISFIED);
+  });
 });


### PR DESCRIPTION
After #7617, we stopped using the polling mechanism and playback rate to control the buffering state, but the old behavior of checking the buffer was still in place. Moreover, since buffer thresholds were set based on the rebuffering goal value, when that value was 0, the underlying logic tended to underreport buffering.

Now, when the goal is 0, Shaka will rely solely on media element events for buffering reporting.