### PR TITLE
fix: Audit all usage of readBytes for memory leaks

### DIFF
--- a/build/conformance.textproto
+++ b/build/conformance.textproto
@@ -138,6 +138,7 @@ requirement: {
     "function template(a) { new Float64Array(a) }"
   error_message: "Use shaka.util.BufferUtils.view* instead."
   whitelist_regexp: "lib/util/buffer_utils.js"
+  whitelist_regexp: "lib/util/data_view_reader.js"
 }
 
 requirement: {

--- a/lib/cea/mp4_cea_parser.js
+++ b/lib/cea/mp4_cea_parser.js
@@ -345,8 +345,11 @@ shaka.cea.Mp4CeaParser = class {
         }
 
         const pts = (time + timeOffset) / timescale;
-        for (const packet of this.seiProcessor_
-            .process(reader.readBytes(naluSize - naluHeaderSize))) {
+        const nalu = reader.readBytes(
+            naluSize - naluHeaderSize,
+            // Don't clone.  The nalu is temporary and is not stored.
+            /* clone= */ false);
+        for (const packet of this.seiProcessor_.process(nalu)) {
           captionPackets.push({
             packet,
             pts,

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -996,8 +996,11 @@ shaka.media.MediaSourceEngine = class {
       schemeId = box.reader.readTerminatedString();
       value = box.reader.readTerminatedString();
     }
-    const messageDataRaw = box.reader.readBytes(
-        box.reader.getLength() - box.reader.getPosition());
+    const messageData = box.reader.readBytes(
+        box.reader.getLength() - box.reader.getPosition(),
+        // The message data gets stored.
+        // Clone the message data so we don't hold the segment in memory.
+        /* clone= */ true);
 
     // See DASH sec. 5.10.3.3.1
     // If a DASH client detects an event message box with a scheme that is not
@@ -1011,10 +1014,6 @@ shaka.media.MediaSourceEngine = class {
       } else {
         // All other schemes are dispatched as a general 'emsg' event.
 
-        // messageDataRaw is a Uint8Array which uses shared ArrayBuffer.
-        // We need to make a copy to not keep whole segment in memory.
-        const messageData = new Uint8Array(messageDataRaw.byteLength);
-        messageData.set(messageDataRaw);
         const endTime = startTime + (eventDuration / timescale);
         /** @type {shaka.extern.EmsgInfo} */
         const emsg = {

--- a/lib/text/mp4_ttml_parser.js
+++ b/lib/text/mp4_ttml_parser.js
@@ -146,8 +146,10 @@ shaka.text.Mp4TtmlParser = class {
         .box('mdat', Mp4Parser.allData((data) => {
           // We collect all of the mdats first, before parsing any of them.
           // This is necessary in case the mp4 has multiple mdats.
+          // They are views on the segment, not cloned, because they will be
+          // concatenated and further parsed soon.
           mdats.push(data);
-        }));
+        }, /* clone= */ false));
     parser.parse(data, /* partialOkay= */ false);
 
     if (mdats.length == 0) {

--- a/lib/text/mp4_vtt_parser.js
+++ b/lib/text/mp4_vtt_parser.js
@@ -173,7 +173,8 @@ shaka.text.Mp4VttParser = class {
               'VTT cues in mp4 with multiple MDAT are not currently supported');
           sawMDAT = true;
           rawPayload = data;
-        }));
+          // Don't clone because this mdat will be further parsed.
+        }, /* clone= */ false));
     parser.parse(data, /* partialOkay= */ false);
 
     if (!sawMDAT && !sawTFDT && !sawTRUN) {
@@ -215,7 +216,11 @@ shaka.text.Mp4VttParser = class {
         let payload = null;
         if (payloadName == 'vttc') {
           if (payloadSize > 8) {
-            payload = reader.readBytes(payloadSize - 8);
+            payload = reader.readBytes(
+                payloadSize - 8,
+                // Don't clone.
+                // The payload is temporary, and is parsed into strings.
+                /* clone= */ false);
           }
         } else if (payloadName == 'vtte') {
           // It's a vtte, which is a vtt cue that is empty. Ignore any data that
@@ -275,16 +280,18 @@ shaka.text.Mp4VttParser = class {
     let id;
     let settings;
 
+    // None of these fields are cloned, because they are immediately parsed
+    // into strings.
     new shaka.util.Mp4Parser()
         .box('payl', shaka.util.Mp4Parser.allData((data) => {
           payload = shaka.util.StringUtils.fromUTF8(data);
-        }))
+        }, /* clone= */ false))
         .box('iden', shaka.util.Mp4Parser.allData((data) => {
           id = shaka.util.StringUtils.fromUTF8(data);
-        }))
+        }, /* clone= */ false))
         .box('sttg', shaka.util.Mp4Parser.allData((data) => {
           settings = shaka.util.StringUtils.fromUTF8(data);
-        }))
+        }, /* clone= */ false))
         .parse(data);
 
     if (payload) {

--- a/lib/util/data_view_reader.js
+++ b/lib/util/data_view_reader.js
@@ -177,10 +177,15 @@ shaka.util.DataViewReader = class {
   /**
    * Reads the specified number of raw bytes.
    * @param {number} bytes The number of bytes to read.
+   * @param {boolean} clone True to clone the data into a new buffer, false to
+   *   create a view on the existing buffer.  Creating a view on the existing
+   *   buffer will keep the entire buffer in memory so long as the view is
+   *   reachable.  Use false for temporary values, and true for values that
+   *   need to outlive the underlying buffer.
    * @return {!Uint8Array}
    * @export
    */
-  readBytes(bytes) {
+  readBytes(bytes, clone) {
     goog.asserts.assert(bytes >= 0, 'Bad call to DataViewReader.readBytes');
     if (this.position_ + bytes > this.dataView_.byteLength) {
       throw this.outOfBounds_();
@@ -189,7 +194,14 @@ shaka.util.DataViewReader = class {
     const value =
         shaka.util.BufferUtils.toUint8(this.dataView_, this.position_, bytes);
     this.position_ += bytes;
-    return value;
+
+    if (clone) {
+      // This creates a new ArrayBuffer to store only this subset of values.
+      return new Uint8Array(value);
+    } else {
+      // This is a new view on the existing buffer of data.
+      return value;
+    }
   }
 
 

--- a/lib/util/mp4_box_parsers.js
+++ b/lib/util/mp4_box_parsers.js
@@ -562,7 +562,11 @@ shaka.util.Mp4BoxParsers = class {
     reader.readUint8();
     reader.readUint8(); // default_isProtected
     reader.readUint8(); // default_Per_Sample_IV_Size
-    const defaultKID = Uint8ArrayUtils.toHex(reader.readBytes(16));
+    const defaultKIDData = reader.readBytes(16,
+        // Don't clone.
+        // The payload is temporary, and is parsed immediately.
+        /* clone= */ false);
+    const defaultKID = Uint8ArrayUtils.toHex(defaultKIDData);
     return {defaultKID};
   }
 
@@ -609,7 +613,10 @@ shaka.util.Mp4BoxParsers = class {
   static parseCOLR(reader) {
     let colorGamut = null;
     let videoRange = null;
-    const data = reader.readBytes(4);
+    const data = reader.readBytes(4,
+        // Don't clone.
+        // The payload is temporary, and is parsed immediately.
+        /* clone= */ false);
     let colorType = '';
     colorType += String.fromCharCode(data[0]);
     colorType += String.fromCharCode(data[1]);
@@ -668,7 +675,10 @@ shaka.util.Mp4BoxParsers = class {
   static updateAV1CodecWithCOLRBox(codec, reader) {
     const Mp4BoxParsers = shaka.util.Mp4BoxParsers;
     const initialPosition = reader.getPosition();
-    const data = reader.readBytes(4);
+    const data = reader.readBytes(4,
+        // Don't clone.
+        // The payload is temporary, and is parsed immediately.
+        /* clone= */ false);
     let colorType = '';
     colorType += String.fromCharCode(data[0]);
     colorType += String.fromCharCode(data[1]);

--- a/lib/util/mp4_parser.js
+++ b/lib/util/mp4_parser.js
@@ -163,8 +163,10 @@ shaka.util.Mp4Parser = class {
         return;
       }
       const payloadSize = end - reader.getPosition();
-      const payload =
-      (payloadSize > 0) ? reader.readBytes(payloadSize) : new Uint8Array(0);
+      const payload = (payloadSize > 0) ?
+          // This is a view made available to the next parser.  Don't clone.
+          reader.readBytes(payloadSize, /* clone= */ false) :
+          new Uint8Array(0);
 
       const payloadReader = new shaka.util.DataViewReader(
           payload, shaka.util.DataViewReader.Endianness.BIG_ENDIAN);
@@ -337,13 +339,18 @@ shaka.util.Mp4Parser = class {
    * binary blob and to parse the body's contents using the provided callback.
    *
    * @param {function(!Uint8Array)} callback
+   * @param {boolean} clone True to clone the data into a new buffer, false to
+   *   create a view on the existing buffer.  Creating a view on the existing
+   *   buffer will keep the entire buffer in memory so long as the view is
+   *   reachable.  Use false for temporary values, and true for values that
+   *   need to outlive the underlying buffer.
    * @return {!shaka.util.Mp4Parser.CallbackType}
    * @export
    */
-  static allData(callback) {
+  static allData(callback, clone) {
     return (box) => {
       const all = box.reader.getLength() - box.reader.getPosition();
-      callback(box.reader.readBytes(all));
+      callback(box.reader.readBytes(all, clone));
     };
   }
 

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -78,13 +78,19 @@ shaka.util.Pssh = class {
     const pssh = shaka.util.BufferUtils.toUint8(dataView, -12, box.size);
     this.data.push(pssh);
 
-    this.systemIds.push(
-        shaka.util.Uint8ArrayUtils.toHex(box.reader.readBytes(16)));
+    const systemIdData = box.reader.readBytes(16,
+        // Don't clone.
+        // The payload is temporary, and is parsed immediately.
+        /* clone= */ false);
+    this.systemIds.push(shaka.util.Uint8ArrayUtils.toHex(systemIdData));
     if (box.version > 0) {
       const numKeyIds = box.reader.readUint32();
       for (let i = 0; i < numKeyIds; i++) {
-        const keyId =
-            shaka.util.Uint8ArrayUtils.toHex(box.reader.readBytes(16));
+        const keyIdData = box.reader.readBytes(16,
+            // Don't clone.
+            // The payload is temporary, and is parsed immediately.
+            /* clone= */ false);
+        const keyId = shaka.util.Uint8ArrayUtils.toHex(keyIdData);
         this.cencKeyIds.push(keyId);
       }
     }

--- a/test/util/data_view_reader_unit.js
+++ b/test/util/data_view_reader_unit.js
@@ -229,7 +229,7 @@ describe('DataViewReader', () => {
     it('detects when reading bytes', () => {
       bigEndianReader.skip(8);
       runTest(() => {
-        bigEndianReader.readBytes(1);
+        bigEndianReader.readBytes(1, /* clone= */ false);
       });
     });
 

--- a/test/util/mp4_parser_unit.js
+++ b/test/util/mp4_parser_unit.js
@@ -231,7 +231,7 @@ describe('Mp4Parser', () => {
           .box('b001', shaka.util.Mp4Parser.allData(
               (data) => {
                 payload = data;
-              })).parse(boxData);
+              }, /* clone= */ false)).parse(boxData);
 
       expect(payload.length).toBe(4);
       expect(payload[0]).toBe(0x00);

--- a/ui/seek_bar.js
+++ b/ui/seek_bar.js
@@ -627,7 +627,8 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
                 .box('mdat', shaka.util.Mp4Parser.allData((data) => {
                   const blob = new Blob([data], {type: 'image/jpeg'});
                   uri = URL.createObjectURL(blob);
-                }));
+                  // Free up the rest of the segment and just clone the mdat.
+                }, /* clone= */ true));
             parser.parse(response.data, /* partialOkay= */ false);
           } else {
             const mimeType = thumbnail.mimeType || 'image/jpeg';


### PR DESCRIPTION
Make cloning buffers (or not) explicit in readBytes.

When we use a range of bytes temporarily for further parsing, we pass clone=false and get a view on the existing memory buffer.  When we want to store the range of bytes, we pass clone=true and avoid holding a reference to an entire segment in memory.

The call for the EMSG parser in MediaSourceEngine had an explicit clone, but now uses the new clone parameter.  This is not a functional change, though.

The only readBytes call that changed in this audit was in the UI seek bar.

The rest all appear to be values for temporary usage, and so are not being cloned.

The new `clone` parameter will require future callers of `readBytes()` to think about their purpose and make a choice.