### PR TITLE
perf: Remove unnecessary ABR update during load

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -3032,15 +3032,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // done.
     this.onTracksChanged_();
 
-    // Now that we've filtered out variants that aren't compatible with the
-    // active one, update abr manager with filtered variants.
-    // NOTE: This may be unnecessary.  We've already chosen one codec in
-    // chooseCodecsAndFilterManifest_ before we started streaming.  But it
-    // doesn't hurt, and this will all change when we start using
-    // MediaCapabilities and codec switching.
-    // TODO(#1391): Re-evaluate with MediaCapabilities and codec switching.
-    this.updateAbrManagerVariants_();
-
     const hasPrimary = this.manifest_.variants.some((v) => v.primary);
     if (!this.config_.preferredAudioLanguage && !hasPrimary) {
       shaka.log.warning('No preferred audio language set.  ' +


### PR DESCRIPTION
Removed code predates MediaCapabilities. Right now ABR variants are already set during initial variant selection, so this one is just a duplication.