### PR TITLE
fix(DASH): Fix stall on multiperiod streams

### DIFF
--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -765,10 +765,8 @@ shaka.media.MetaSegmentIndex = class extends shaka.media.SegmentIndex {
    * @export
    */
   release() {
-    for (const index of this.indexes_) {
-      index.release();
-    }
-
+    // Drop references to the indexes, but do not release them,
+    // as this MetaSegmentIndex may not be the only owner of them.
     this.indexes_ = [];
   }
 

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -560,7 +560,7 @@ shaka.util.PeriodCombiner = class {
     for (const unusedStreams of unusedStreamsPerPeriod) {
       for (const stream of unusedStreams) {
         // Create a new output stream which includes this input stream.
-        const outputStream = this.createNewOutputStream_(
+        const outputStream = this.createNewOutputStream_(outputStreams,
             stream, streamsPerPeriod, clone, concat,
             unusedStreamsPerPeriod);
         if (outputStream) {
@@ -701,6 +701,7 @@ shaka.util.PeriodCombiner = class {
    * Stream.
    * Templatized to handle both DASH Streams and offline StreamDBs.
    *
+   * @param {!Array<T>} outputStreams A list of existing output streams.
    * @param {T} stream An input stream on which to base the output stream.
    * @param {!Array<!Map<string, T>>} streamsPerPeriod A list of maps of Streams
    *   from each period.
@@ -718,7 +719,7 @@ shaka.util.PeriodCombiner = class {
    *
    * @private
    */
-  createNewOutputStream_(
+  createNewOutputStream_(outputStreams,
       stream, streamsPerPeriod, clone, concat, unusedStreamsPerPeriod) {
     // Check do we want to create output stream from dummy stream
     // and if so, return quickly.
@@ -733,12 +734,30 @@ shaka.util.PeriodCombiner = class {
 
     // This only exists where T == Stream.
     if (outputStream.createSegmentIndex) {
-      // Override the createSegmentIndex function of the outputStream.
+      // Override the createSegmentIndex & closeSegmentIndex functions
+      // of the outputStream.
       outputStream.createSegmentIndex = async () => {
         if (!outputStream.segmentIndex) {
           outputStream.segmentIndex = new shaka.media.MetaSegmentIndex();
           await shaka.util.PeriodCombiner.extendOutputSegmentIndex_(
               outputStream, /* firstNewPeriodIndex= */ 0);
+        }
+      };
+      outputStream.closeSegmentIndex = () => {
+        if (outputStream.segmentIndex) {
+          outputStream.segmentIndex.release();
+          outputStream.segmentIndex = null;
+        }
+        // Close the segment index of the matched streams.
+        if (outputStream.matchedStreams) {
+          for (const match of outputStream.matchedStreams) {
+            if (match.segmentIndex &&
+                !shaka.util.PeriodCombiner.isStreamActivelyUsed_(
+                    match, outputStream, outputStreams)) {
+              match.segmentIndex.release();
+              match.segmentIndex = null;
+            }
+          }
         }
       };
       // For T == Stream, we need to create all the per-period segment indexes
@@ -832,21 +851,7 @@ shaka.util.PeriodCombiner = class {
     // streams that match this output.
     clone.originalId = null;
     clone.createSegmentIndex = () => Promise.resolve();
-    clone.closeSegmentIndex = () => {
-      if (clone.segmentIndex) {
-        clone.segmentIndex.release();
-        clone.segmentIndex = null;
-      }
-      // Close the segment index of the matched streams.
-      if (clone.matchedStreams) {
-        for (const match of clone.matchedStreams) {
-          if (match.segmentIndex) {
-            match.segmentIndex.release();
-            match.segmentIndex = null;
-          }
-        }
-      }
-    };
+    clone.closeSegmentIndex = () => {};
 
     // Clone roles array so this output stream can own it.
     clone.roles = clone.roles.slice();
@@ -1942,6 +1947,32 @@ shaka.util.PeriodCombiner = class {
       shaka.util.PeriodCombiner.memoizedCodecs.set(codecs, normalizedCodec);
     }
     return shaka.util.PeriodCombiner.memoizedCodecs.get(codecs);
+  }
+
+  /**
+   * Checks if the given stream is actively used by any of output streams.
+   * @param {T} stream stream to check
+   * @param {T} parentStream output stream to which the stream belongs
+   * @param {!Array<T>} outputStreams
+   * @return {boolean}
+   * @template T
+   * @private
+   * Accepts either a StreamDB or Stream type.
+   */
+  static isStreamActivelyUsed_(stream, parentStream, outputStreams) {
+    for (const outputStream of outputStreams) {
+      if (outputStream !== parentStream &&
+          outputStream.segmentIndex &&
+          outputStream.matchedStreams &&
+          outputStream.matchedStreams.includes(stream)) {
+        shaka.log.v2(`Stream ${stream.id} is already used in output stream ` +
+            `${outputStream.id}, cannot close it now.`);
+        return true;
+      }
+    }
+    shaka.log.v2(`Stream ${stream.id} not used anywhere else besides ` +
+        `${parentStream.id}, good to close.`);
+    return false;
   }
 };
 


### PR DESCRIPTION
Fixes #8795 

This change is introduced to prevent releasing underlying Stream structures while they might still be needed.
`MetaSegmentIndex` does not release child SegmentIndexes anymore during its release process.
Output Stream's `closeSegmentIndex()` method is now responsible for this. It's also aware about the rest of output streams and it will prevent releasing a particular child stream, if this is used by other output stream.

This scenario can easily happen if DASH manifest have different number of renditions in various periods. Consider following scenario (vx are renditions):

| Period 1 | Period 2 | Periods combined |
| -------- | -------- | ---------------- |
| v1_1     | v2_1     | v1 = v1_1, v2_1  |
| v1_2     | --       | v2 = v1_2, v2_1  |

v2_1 is shared rendition between 2 output streams. If first stream is used but we close 2nd one, we will release shared data and thus affect playback.
This bug was probably introduced by #7217 