### PR TITLE
fix(HLS): Improve abort decision logic

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -885,13 +885,20 @@ shaka.media.StreamingEngine = class {
     if (newSegment && !newSegmentSize) {
       // compute approximate segment size using stream bandwidth
       const duration = newSegment.getEndTime() - newSegment.getStartTime();
-      const bandwidth = mediaState.stream.bandwidth || 0;
+      const bandwidth = mediaState.stream.bandwidth ||
+        // If we don't have a stream bandwidth (it happens i.e. in HLS)
+        // look into average variant bandwidth instead.
+        // It's not an ideal estimation, but still better than nothing.
+        this.currentVariant_.bandwidth;
       // bandwidth is in bits per second, and the size is in bytes
       newSegmentSize = duration * bandwidth / 8;
     }
 
+    // We don't have enough information about possible new segment size.
+    // It's safer though to abort current request than wishing it will succeed
+    // in reasonable time.
     if (!newSegmentSize) {
-      return false;
+      return true;
     }
 
     // When switching, we'll need to download the init segment.


### PR DESCRIPTION
We often do not know stream bandwidth in HLS, but Streaming Engine relies on this knowledge to calculate new segment size to fetch. It helps in decision shall we abort currently ongoing request when switching rendition due to ABR change.
This PR adjusts this logic and looks into variant bandwidth if we don't know stream bandwidth.
Additionally, if we cannot determine size at all, by default we will abort currently ongoing request to not accidentally block fetching entirely.