### PR TITLE
fix: Avoid download init segments again when not necessary

### DIFF
--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -312,7 +312,8 @@ shaka.media.SegmentPrefetch = class {
 
   /**
    * Remove all init segments that don't have associated segments in
-   * the segment prefetch map.
+   * the segment prefetch map. If we don't have segments, but we have
+   * initialization segments, it is not cleaned.
    * By default, with delete on get, the init segments should get removed as
    * they are used. With deleteOnGet set to false, we need to clear them
    * every so often once the segments that are associated with each init segment
@@ -320,6 +321,12 @@ shaka.media.SegmentPrefetch = class {
    * @private
    */
   clearInitSegments_() {
+    // In the case of Live, it may happen that we are on the Live edge and do
+    // not have segments, but we want to avoid the initialization segment
+    // being downloaded again in the future when it is not necessary.
+    if (!this.segmentPrefetchMap_.size) {
+      return;
+    }
     const segmentReferences = Array.from(this.segmentPrefetchMap_.keys());
     for (const initSegmentReference of this.initSegmentPrefetchMap_.keys()) {
       // if no segment references this init segment, we should remove it.

--- a/test/media/segment_prefetch_unit.js
+++ b/test/media/segment_prefetch_unit.js
@@ -123,6 +123,21 @@ describe('SegmentPrefetch', () => {
       // this is 6 to account for the init segments,
       // which is not part of the prefetch limit
       expect(fetchDispatcher).toHaveBeenCalledTimes(6);
+
+      // When an evict is made and there are no segments, the init segment
+      // must be kept.
+      segmentPrefetch.evict(1000);
+
+      for (let i = 0; i < 3; i++) {
+        const op = segmentPrefetch.getPrefetchedSegment(references[i]);
+        expect(op).toBeNull();
+      }
+
+      for (let i = 0; i < 3; i++) {
+        const op = segmentPrefetch.getPrefetchedSegment(
+            references[i].initSegmentReference);
+        expect(op).not.toBeNull();
+      }
     });
 
     it('changes fetch direction', async () => {


### PR DESCRIPTION
We evict SegmentPrefetched on each streaming engine update, in the case of Live, it may happen that we are on the Live edge and do not have segments, but we want to avoid the initialization segment being downloaded again in the future when it is not necessary.