### PR TITLE
fix(HLS): Fix playback of EVENT playlist when transition from live to vod

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -427,16 +427,7 @@ shaka.hls.HlsParser = class {
     const stillLive = activeStreamInfos.some((s) => s.hasEndList == false);
     if (activeStreamInfos.length && !stillLive) {
       // Convert the presentation to VOD and set the duration.
-      const PresentationType = shaka.hls.HlsParser.PresentationType_;
-      this.setPresentationType_(PresentationType.VOD);
-
-      // The duration is the minimum of the end times of all active streams.
-      // Non-active streams are not guaranteed to have useful maxTimestamp
-      // values, due to the lazy-loading system, so they are ignored.
-      const maxTimestamps = activeStreamInfos.map((s) => s.maxTimestamp);
-      // The duration is the minimum of the end times of all streams.
-      this.presentationTimeline_.setDuration(Math.min(...maxTimestamps));
-      this.playerInterface_.updateDuration();
+      this.setPresentationType_(shaka.hls.HlsParser.PresentationType_.VOD);
     }
     if (stillLive) {
       this.determineDuration_();


### PR DESCRIPTION
We don't want to update the duration when converting from Live to Vod because MSE doesn't properly support changing the duration from Infinity to a finite number.

Fixes https://github.com/shaka-project/shaka-player/issues/9051