### PR TITLE
fix: prevent infinite loop when constructing CMCD relative urls

### DIFF
--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -1172,7 +1172,10 @@ shaka.util.CmcdManager = class {
       toPath.unshift('..');
     }
 
-    return toPath.join('/');
+    const relativePath = toPath.join('/');
+
+    // preserve query parameters and hash of the destination url
+    return relativePath + to.search + to.hash;
   }
 
   /**

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -1136,49 +1136,6 @@ shaka.util.CmcdManager = class {
   }
 
   /**
-   * Constructs a relative path from a URL
-   *
-   * @param {string} url
-   * @param {string} base
-   * @return {string}
-   * @private
-   */
-  urlToRelativePath_(url, base) {
-    const to = new URL(url);
-    const from = new URL(base);
-
-    if (to.origin !== from.origin) {
-      return url;
-    }
-
-    const toPath = to.pathname.split('/').slice(1);
-    const fromPath = from.pathname.split('/').slice(1, -1);
-
-    // remove common parents
-    const length = Math.min(toPath.length, fromPath.length);
-
-    for (let i = 0; i < length; i++) {
-      if (toPath[i] !== fromPath[i]) {
-        break;
-      }
-
-      toPath.shift();
-      fromPath.shift();
-    }
-
-    // add back paths
-    while (fromPath.length) {
-      fromPath.shift();
-      toPath.unshift('..');
-    }
-
-    const relativePath = toPath.join('/');
-
-    // preserve query parameters and hash of the destination url
-    return relativePath + to.search + to.hash;
-  }
-
-  /**
    * Calculate measured start delay
    *
    * @return {number|undefined}
@@ -1362,7 +1319,7 @@ shaka.util.CmcdManager = class {
           if (nextSegment && nextSegment != segment) {
             if (requestUri && !shaka.util.ArrayUtils.equal(
                 segment.getUris(), nextSegment.getUris())) {
-              data.nor = this.urlToRelativePath_(
+              data.nor = shaka.util.CmcdManager.urlToRelativePath(
                   nextSegment.getUris()[0], requestUri);
             }
             if ((nextSegment.startByte || nextSegment.endByte) &&
@@ -1588,8 +1545,49 @@ shaka.util.CmcdManager = class {
     url.getQueryData().set('CMCD', query);
     return url.toString();
   }
-};
 
+  /**
+   * Constructs a relative path from a URL
+   *
+   * @param {string} url
+   * @param {string} base
+   * @return {string}
+   */
+  static urlToRelativePath(url, base) {
+    const to = new URL(url);
+    const from = new URL(base);
+
+    if (to.origin !== from.origin) {
+      return url;
+    }
+
+    const toPath = to.pathname.split('/').slice(1);
+    const fromPath = from.pathname.split('/').slice(1, -1);
+
+    // remove common parents
+    const length = Math.min(toPath.length, fromPath.length);
+
+    for (let i = 0; i < length; i++) {
+      if (toPath[i] !== fromPath[i]) {
+        break;
+      }
+
+      toPath.shift();
+      fromPath.shift();
+    }
+
+    // add back paths
+    while (fromPath.length) {
+      fromPath.shift();
+      toPath.unshift('..');
+    }
+
+    const relativePath = toPath.join('/');
+
+    // preserve query parameters and hash of the destination url
+    return relativePath + to.search + to.hash;
+  }
+};
 
 /**
  * @enum {string}

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -1155,7 +1155,13 @@ shaka.util.CmcdManager = class {
     const fromPath = from.pathname.split('/').slice(1, -1);
 
     // remove common parents
-    while (toPath[0] === fromPath[0]) {
+    const length = Math.min(toPath.length, fromPath.length);
+
+    for (let i = 0; i < length; i++) {
+      if (toPath[i] !== fromPath[i]) {
+        break;
+      }
+
       toPath.shift();
       fromPath.shift();
     }

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -272,10 +272,6 @@ shaka.util.CmcdManager = class {
    *   The request context
    */
   applyResponseData(type, response, context = {}) {
-    if (!this.config_.enabled) {
-      return;
-    }
-
     const RequestType = shaka.net.NetworkingEngine.RequestType;
 
     switch (type) {
@@ -322,10 +318,6 @@ shaka.util.CmcdManager = class {
    */
   applyResponseSegmentData(response, context) {
     try {
-      if (!this.config_.enabled) {
-        return;
-      }
-
       const data = this.getDataForSegment_(context, response.uri);
 
       if (response.originalRequest &&

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -272,6 +272,10 @@ shaka.util.CmcdManager = class {
    *   The request context
    */
   applyResponseData(type, response, context = {}) {
+    if (!this.config_.enabled) {
+      return;
+    }
+
     const RequestType = shaka.net.NetworkingEngine.RequestType;
 
     switch (type) {
@@ -318,6 +322,10 @@ shaka.util.CmcdManager = class {
    */
   applyResponseSegmentData(response, context) {
     try {
+      if (!this.config_.enabled) {
+        return;
+      }
+
       const data = this.getDataForSegment_(context, response.uri);
 
       if (response.originalRequest &&

--- a/test/util/cmcd_manager_unit.js
+++ b/test/util/cmcd_manager_unit.js
@@ -260,6 +260,65 @@ describe('CmcdManager Setup', () => {
       });
     });
 
+    describe('URL to relative path', () => {
+      it('produces a relative path when at root', () => {
+        const from = 'http://test.com/manifest.mpd';
+        const to = 'http://test.com/1.mp4';
+        expect(CmcdManager.urlToRelativePath(to, from)).toBe('1.mp4');
+      });
+
+      it('produces a relative path when at the same folder level', () => {
+        const from = 'http://test.com/base/manifest.mpd';
+        const to = 'http://test.com/base/1.mp4';
+        expect(CmcdManager.urlToRelativePath(to, from)).toBe('1.mp4');
+      });
+
+      it('produces a relative path when base is lower', () => {
+        const from = 'http://test.com/manifest.mpd';
+        const to = 'http://test.com/base/segments/video/1.mp4';
+        const result = 'base/segments/video/1.mp4';
+        expect(CmcdManager.urlToRelativePath(to, from)).toBe(result);
+      });
+
+      it('produces a relative path when base is higher', () => {
+        const from = 'http://test.com/base/manifest/manifest.mpd';
+        const to = 'http://test.com/1.mp4';
+        expect(CmcdManager.urlToRelativePath(to, from)).toBe('../../1.mp4');
+      });
+
+      it('produces a relative path when base and url are different', () => {
+        const from = 'http://test.com/base/manifest/manifest.mpd';
+        const to = 'http://test.com/base/segments/video/1.mp4';
+        const result = '../segments/video/1.mp4';
+        expect(CmcdManager.urlToRelativePath(to, from)).toBe(result);
+      });
+
+      it('returns url when origins are different', () => {
+        const from = 'http://test.com/base/manifest/manifest.mpd';
+        const to = 'http://foo.com/1.mp4';
+        expect(CmcdManager.urlToRelativePath(to, from)).toBe('http://foo.com/1.mp4');
+      });
+
+      it('maintains query parameters and hash in the relative path', () => {
+        const from = 'http://test.com/base/manifest/manifest.mpd';
+        const to = 'http://test.com/base/segments/video/1.mp4?param=foo&another=bar#hash=baz';
+        const result = '../segments/video/1.mp4?param=foo&another=bar#hash=baz';
+        expect(CmcdManager.urlToRelativePath(to, from)).toBe(result);
+      });
+
+      it('produces a relative path when only query params differ', () => {
+        const from = 'http://test.com/file.mp4?i=0';
+        const to = 'http://test.com/file.mp4?i=1';
+        expect(CmcdManager.urlToRelativePath(to, from)).toBe('file.mp4?i=1');
+      });
+
+      it('produces a relative path when only hash params differ', () => {
+        const from = 'http://test.com/file.mp4#i=0';
+        const to = 'http://test.com/file.mp4#i=1';
+        expect(CmcdManager.urlToRelativePath(to, from)).toBe('file.mp4#i=1');
+      });
+    });
+
     describe('CmcdManager instance', () => {
       const ObjectUtils = shaka.util.ObjectUtils;
 


### PR DESCRIPTION
This PR fixes a few issues:
- The infinite loop described in #9050 
- ~~The fact that CMCD functions were executed when the feature was disabled~~
- Query params being stripped in the `nor` field. https://github.com/streaming-video-technology-alliance/common-media-library/issues/239