### PR TITLE
fix(UI): Respect prefers-reduced-transparency for tooltips and seekbar times

### DIFF
--- a/ui/less/general.less
+++ b/ui/less/general.less
@@ -131,6 +131,7 @@ the control buttons panel. */
 @general-font-color-secondary: #ccc;
 @general-font-size: 14px;
 @general-background-color: rgba(0, 0, 0, 50%);
+@general-background-color-mostly-opaque: rgba(0, 0, 0, 90%);
 @general-background-color-opaque: black;
 
 @quality-mark-color: #fff;

--- a/ui/less/thumbnails.less
+++ b/ui/less/thumbnails.less
@@ -28,6 +28,10 @@
       color: @general-font-color;
       font-size: @general-font-size;
       padding: 0 5px;
+
+      @media (prefers-reduced-transparency) {
+        background-color: @general-background-color-mostly-opaque;
+      }
     }
   }
 
@@ -49,4 +53,8 @@
   position: absolute;
   visibility: hidden;
   z-index: 1;
+
+  @media (prefers-reduced-transparency) {
+    background-color: @general-background-color-mostly-opaque;
+  }
 }

--- a/ui/less/tooltip.less
+++ b/ui/less/tooltip.less
@@ -70,6 +70,10 @@
 
       /* The tooltip is also translated 50% to appear centered */
       .translateX(-0.5);
+
+      @media (prefers-reduced-transparency) {
+        background-color: @general-background-color-mostly-opaque;
+      }
     }
   }
 


### PR DESCRIPTION
This is currently only supported in Chromium browsers (it is behind a feature flag in Firefix and WebKit doesn't have it), if you don't want to enable the setting at the operating system level to test this, you can simulate it in the "Rendering" tab in the Chromium developer tools.

<img width="122" height="39" alt="before-tooltips" src="https://github.com/user-attachments/assets/2656bdbe-cc14-486b-b7fe-dd659eb1d670" />
<img width="123" height="41" alt="after-tooltips" src="https://github.com/user-attachments/assets/a2acc0a2-4e6c-4c2a-9ada-a447886765e3" />
