### PR TITLE
fix: Attach mediaKeys when the device does not force us to wait for the encrypted event

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -608,18 +608,28 @@ shaka.drm.DrmEngine = class {
      *  - In case of an offline session
      */
     if (!needWaitForEncryptedEvent &&
-        (this.manifestInitData_ || this.storedPersistentSessions_.size ||
-        this.config_.parseInbandPsshEnabled)) {
+        (this.manifestInitData_ ||
+        this.currentDrmInfo_.keySystem !== 'com.apple.fps' ||
+        this.storedPersistentSessions_.size)) {
       await this.attachMediaKeys_();
-    } else {
-      this.eventManager_.listen(
-          this.video_, 'encrypted', (e) => this.onEncryptedEvent_(e));
     }
 
     this.createOrLoad().catch(() => {
       // Silence errors
       // createOrLoad will run async, errors are triggered through onError_
     });
+
+    // Explicit init data for any one stream or an offline session is
+    // sufficient to suppress 'encrypted' events for all streams.
+    // Also suppress 'encrypted' events when parsing in-band pssh
+    // from media segments because that serves the same purpose as the
+    // 'encrypted' events.
+    if (needWaitForEncryptedEvent ||
+        (!this.manifestInitData_ && !this.storedPersistentSessions_.size &&
+        !this.config_.parseInbandPsshEnabled)) {
+      this.eventManager_.listen(
+          this.video_, 'encrypted', (e) => this.onEncryptedEvent_(e));
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/9032

Regression introduced in https://github.com/shaka-project/shaka-player/pull/8497