### PR TITLE
perf(HLS): Optimize mimetype resolution during parsing

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -3738,27 +3738,15 @@ shaka.hls.HlsParser = class {
    * @param {!shaka.hls.Playlist} playlist
    * @param {string} type
    * @param {function(): !Array<string>} getUris
+   * @param {string} mimeType
    * @param {shaka.extern.aesKey=} aesKey
    * @return {shaka.media.SegmentReference}
    * @private
    */
   createSegmentReference_(
       initSegmentReference, previousReference, hlsSegment, startTime,
-      variables, playlist, type, getUris, aesKey) {
+      variables, playlist, type, getUris, mimeType, aesKey) {
     const HlsParser = shaka.hls.HlsParser;
-
-    const getMimeType = (uri) => {
-      const extension = shaka.net.NetworkingUtils.getExtension(uri);
-      if (!extension) {
-        return null;
-      }
-      const map = HlsParser.EXTENSION_MAP_BY_CONTENT_TYPE_.get(type);
-      let mimeType = map.get(extension);
-      if (!mimeType) {
-        mimeType = HlsParser.RAW_FORMATS_TO_MIME_TYPES_.get(extension);
-      }
-      return mimeType;
-    };
 
     const tags = hlsSegment.tags;
     const extinfTag =
@@ -3803,8 +3791,6 @@ shaka.hls.HlsParser = class {
         return null;
       }
     }
-
-    const mimeType = getMimeType(hlsSegment.verbatimSegmentUri);
 
     // Create SegmentReferences for the partial segments.
     let partialSegmentRefs = [];
@@ -3922,10 +3908,17 @@ shaka.hls.HlsParser = class {
 
         let pMimeType = mimeType;
         if (!pMimeType) {
-          if (partialSegmentRefs.length) {
+          if (partialSegmentRefs.length && partialSegmentRefs[0].mimeType) {
             pMimeType = partialSegmentRefs[0].mimeType;
           } else {
-            pMimeType = getMimeType(pUri);
+            // Fallback for the very first partial segment if the parent
+            // segment's mimeType couldn't be determined.
+            if (pUri) {
+              const HlsParser = shaka.hls.HlsParser;
+              const extension = shaka.net.NetworkingUtils.getExtension(pUri);
+              const map = HlsParser.EXTENSION_MAP_BY_CONTENT_TYPE_.get(type);
+              pMimeType = map.get(extension) || null;
+            }
           }
         }
 
@@ -4265,6 +4258,8 @@ shaka.hls.HlsParser = class {
 
     let currentInitSegmentRef = null;
     let lastMapTagId = null;
+    let currentMimeType = null;
+    let lastUriExtension = null;
 
     /** @type {shaka.extern.aesKey|undefined} */
     let aesKey = undefined;
@@ -4302,6 +4297,20 @@ shaka.hls.HlsParser = class {
     /** @type {!Array<{bitrate: number, duration: number}>} */
     const bitrates = [];
 
+    const getMimeType = (uri) => {
+      const HlsParser = shaka.hls.HlsParser;
+      const extension = shaka.net.NetworkingUtils.getExtension(uri);
+      if (!extension) {
+        return null;
+      }
+      const map = HlsParser.EXTENSION_MAP_BY_CONTENT_TYPE_.get(type);
+      let mimeType = map.get(extension);
+      if (!mimeType) {
+        mimeType = HlsParser.RAW_FORMATS_TO_MIME_TYPES_.get(extension);
+      }
+      return mimeType;
+    };
+
     for (let i = 0; i < hlsSegments.length; i++) {
       const item = hlsSegments[i];
 
@@ -4312,6 +4321,18 @@ shaka.hls.HlsParser = class {
         currentInitSegmentRef = this.getInitSegmentReference_(playlist,
             item.tags, getUris, variables);
         lastMapTagId = mapTag.id;
+      }
+
+      // Only re-evaluate the mimetype if the segment's file extension changes.
+      const uri = item.verbatimSegmentUri;
+      let extension = '';
+      if (uri) {
+        extension = shaka.net.NetworkingUtils.getExtension(uri);
+      }
+
+      if (extension !== lastUriExtension) {
+        currentMimeType = getMimeType(uri);
+        lastUriExtension = extension;
       }
 
       const startTime =
@@ -4352,6 +4373,7 @@ shaka.hls.HlsParser = class {
           playlist,
           type,
           getUris,
+          currentMimeType,
           aesKey);
 
       if (reference) {


### PR DESCRIPTION
This PR is a follow-up optimisation to the recent performance improvements for the HLS parser, as discussed in **Issue #9067**.

Following a review of the previous changes, this PR addresses a similar, remaining bottleneck: redundant mimetype calculation. The parser was determining the mimetype from the URI for every segment, which, while less expensive than the init segment lookup, still adds unnecessary overhead in performance-critical loops when parsing large manifests.

### The Fix

This PR applies the same optimisation pattern used for the init segment fix:

-  The `createSegments_` function now tracks the file extension of the last-processed segment in a local variable.
-  The mimetype is recalculated only when a segment's file extension changes. This is more efficient and correctly handles manifests with mixed container types (e.g., switching from `.mp4` to `.ts`), addressing the feedback on the [previous PR](https://github.com/shaka-project/shaka-player/pull/9066#pullrequestreview-3204976655).
-  The pre-calculated mimetype is now passed down into `createSegmentReference_`, simplifying its responsibility and optimising the logic in `createSegments_`.

This change further reduces CPU usage during manifest updates and ensures the parser correctly handles dynamic mimetype changes without performance penalties. I have also added a new unit test to cover this specific mimetype switching scenario.

### Performance Difference

Comparison below is made on a Samsung 2022 (Tizen 6.5) TV.

**Before this change:**
<img width="4978" height="2620" alt="image" src="https://github.com/user-attachments/assets/bdb6b0e0-219d-47a6-b9c1-2505f9e0805b" />

**After this change:**
<img width="2481" height="1257" alt="Screenshot 2025-09-15 at 2 07 14 pm" src="https://github.com/user-attachments/assets/0f1663cb-6d38-4750-9df4-b9c3c4e43974" />

While the primary bottleneck was addressed previously, this change provides an additional, measurable performance gain.

Thanks in advance for taking a look at this. I'm keen on improving this further, so any thoughts or directions on where to focus next in order to further improve the parser's performance would be fantastic.