### PR TITLE
fix: Bad init segment size calculation when using byte ranges

### DIFF
--- a/lib/media/segment_reference.js
+++ b/lib/media/segment_reference.js
@@ -101,7 +101,7 @@ shaka.media.InitSegmentReference = class {
    */
   getSize() {
     if (this.endByte) {
-      return this.endByte - this.startByte;
+      return (this.endByte + 1) - this.startByte;
     } else {
       return null;
     }


### PR DESCRIPTION
When calculating the size of a segment when using startByte and endByte, both are inclusive. So the sum should add 1.