### PR TITLE
perf: Speed up `shaka.Player.probeSupport()`

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -11,6 +11,7 @@ goog.require('shaka.log');
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.device.IDevice');
 goog.require('shaka.drm.DrmUtils');
+goog.require('shaka.media.Capabilities');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.BufferUtils');
@@ -1801,16 +1802,23 @@ shaka.drm.DrmEngine = class {
       'com.microsoft.playready.recommendation': playreadyRobustness,
     };
 
-    const basicVideoCapabilities = [
-      {contentType: 'video/mp4; codecs="avc1.42E01E"'},
-      {contentType: 'video/webm; codecs="vp8"'},
-    ];
+    const basicVideoCapabilities = [];
+    const videoMp4 = 'video/mp4; codecs="avc1.42E01E"';
+    const videoWebm = 'video/webm; codecs="vp8"';
+    if (shaka.media.Capabilities.isTypeSupported(videoMp4)) {
+      basicVideoCapabilities.push(videoMp4);
+    } else {
+      basicVideoCapabilities.push(videoWebm);
+    }
 
-    const basicAudioCapabilities = [
-      {contentType: 'audio/mp4; codecs="mp4a.40.2"'},
-      {contentType: 'audio/webm; codecs="opus"'},
-    ];
-
+    const basicAudioCapabilities = [];
+    const audioMp4 = 'audio/mp4; codecs="mp4a.40.2"';
+    const audioWebm = 'audio/webm; codecs="opus"';
+    if (shaka.media.Capabilities.isTypeSupported(audioMp4)) {
+      basicAudioCapabilities.push(audioMp4);
+    } else {
+      basicAudioCapabilities.push(audioWebm);
+    }
     const basicConfigTemplate = {
       videoCapabilities: basicVideoCapabilities,
       audioCapabilities: basicAudioCapabilities,
@@ -1831,9 +1839,10 @@ shaka.drm.DrmEngine = class {
     /**
      * @param {string} keySystem
      * @param {MediaKeySystemAccess} access
+     * @param {boolean} testHdcp
      * @return {!Promise}
      */
-    const processMediaKeySystemAccess = async (keySystem, access) => {
+    const processMediaKeySystemAccess = async (keySystem, access, testHdcp) => {
       let mediaKeys;
       try {
         // Workaround: Our automated test lab runs Windows browsers under a
@@ -1877,7 +1886,7 @@ shaka.drm.DrmEngine = class {
         audioRobustnessLevels: [],
         minHdcpVersions: [],
       };
-      if (support.has(keySystem) && support.get(keySystem)) {
+      if (support.get(keySystem)) {
         // Update the existing non-null value.
         supportValue = support.get(keySystem);
       } else {
@@ -1906,27 +1915,28 @@ shaka.drm.DrmEngine = class {
         supportValue.audioRobustnessLevels.push(audioRobustness);
       }
 
-      if ('getStatusForPolicy' in mediaKeys) {
-        const promises = [];
+      if (testHdcp && 'getStatusForPolicy' in mediaKeys) {
         for (const hdcpVersion of hdcpVersions) {
           if (supportValue.minHdcpVersions.includes(hdcpVersion)) {
             continue;
           }
-          promises.push(mediaKeys.getStatusForPolicy({
+          // eslint-disable-next-line no-await-in-loop
+          const status = await mediaKeys.getStatusForPolicy({
             minHdcpVersion: hdcpVersion,
-          }).then((status) => {
-            if (status == 'usable' &&
-                !supportValue.minHdcpVersions.includes(hdcpVersion)) {
+          });
+          if (status == 'usable') {
+            if (!supportValue.minHdcpVersions.includes(hdcpVersion)) {
               supportValue.minHdcpVersions.push(hdcpVersion);
             }
-          }));
+          } else {
+            break; // Higher versions won't work either.
+          }
         }
-        await Promise.all(promises);
       }
     };
 
     const testSystemEme = async (keySystem, encryptionScheme,
-        videoRobustness, audioRobustness) => {
+        videoRobustness, audioRobustness, testHdcp = false) => {
       try {
         const basicConfig =
             shaka.util.ObjectUtils.cloneObject(basicConfigTemplate);
@@ -1961,63 +1971,8 @@ shaka.drm.DrmEngine = class {
           access =
               await navigator.requestMediaKeySystemAccess(keySystem, configs);
         }
-        await processMediaKeySystemAccess(keySystem, access);
+        await processMediaKeySystemAccess(keySystem, access, testHdcp);
       } catch (error) {}  // Ignore errors.
-    };
-
-    const testSystemMcap = async (keySystem, encryptionScheme,
-        videoRobustness, audioRobustness) => {
-      try {
-        const decodingConfig = {
-          type: 'media-source',
-          video: {
-            contentType: basicVideoCapabilities[0].contentType,
-            width: 640,
-            height: 480,
-            bitrate: 1,
-            framerate: 1,
-          },
-          audio: {
-            contentType: basicAudioCapabilities[0].contentType,
-            channels: 2,
-            bitrate: 1,
-            samplerate: 1,
-          },
-          keySystemConfiguration: {
-            keySystem,
-            video: {
-              encryptionScheme,
-              robustness: videoRobustness,
-            },
-            audio: {
-              encryptionScheme,
-              robustness: audioRobustness,
-            },
-          },
-        };
-        // On some (Android) WebView environments, decodingInfo will
-        // not resolve or reject, at least if RESOURCE_PROTECTED_MEDIA_ID
-        // is not set.  This is a workaround for that issue.
-        const TIMEOUT_FOR_DECODING_INFO_IN_SECONDS = 5;
-        let decodingInfo;
-        const device = shaka.device.DeviceFactory.getDevice();
-        if (device.getDeviceType() == shaka.device.IDevice.DeviceType.MOBILE) {
-          decodingInfo =
-            await shaka.util.Functional.promiseWithTimeout(
-                TIMEOUT_FOR_DECODING_INFO_IN_SECONDS,
-                navigator.mediaCapabilities.decodingInfo(decodingConfig),
-            );
-        } else {
-          decodingInfo =
-              await navigator.mediaCapabilities.decodingInfo(decodingConfig);
-        }
-
-        const access = decodingInfo.keySystemAccess;
-        await processMediaKeySystemAccess(keySystem, access);
-      } catch (error) {
-        // Ignore errors.
-        shaka.log.v2('Failed to probe support for', keySystem, error);
-      }
     };
 
     // Initialize the support structure for each key system.
@@ -2042,25 +1997,19 @@ shaka.drm.DrmEngine = class {
 
     // Test each key system and encryption scheme.
     const tests = [];
-    for (const encryptionScheme of testEncryptionSchemes) {
-      for (const keySystem of testKeySystems) {
-        if (!checkKeySystem(keySystem)) {
-          continue;
-        }
-        tests.push(testSystemEme(keySystem, encryptionScheme, '', ''));
-        tests.push(testSystemMcap(keySystem, encryptionScheme, '', ''));
-      }
-    }
-
     for (const keySystem of testKeySystems) {
+      if (!checkKeySystem(keySystem)) {
+        continue;
+      }
+      let testHdcp = true;
+      for (const encryptionScheme of testEncryptionSchemes) {
+        tests.push(
+            testSystemEme(keySystem, encryptionScheme, '', '', testHdcp));
+        testHdcp = false;  // We only need to test HDCP once.
+      }
       for (const robustness of (testRobustness[keySystem] || [])) {
-        if (!checkKeySystem(keySystem)) {
-          continue;
-        }
         tests.push(testSystemEme(keySystem, null, robustness, ''));
         tests.push(testSystemEme(keySystem, null, '', robustness));
-        tests.push(testSystemMcap(keySystem, null, robustness, ''));
-        tests.push(testSystemMcap(keySystem, null, '', robustness));
       }
     }
 

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -1802,23 +1802,16 @@ shaka.drm.DrmEngine = class {
       'com.microsoft.playready.recommendation': playreadyRobustness,
     };
 
-    const basicVideoCapabilities = [];
-    const videoMp4 = 'video/mp4; codecs="avc1.42E01E"';
-    const videoWebm = 'video/webm; codecs="vp8"';
-    if (shaka.media.Capabilities.isTypeSupported(videoMp4)) {
-      basicVideoCapabilities.push(videoMp4);
-    } else {
-      basicVideoCapabilities.push(videoWebm);
-    }
+    const basicVideoCapabilities = [
+      {contentType: 'video/mp4; codecs="avc1.42E01E"'},
+      {contentType: 'video/webm; codecs="vp8"'},
+    ];
 
-    const basicAudioCapabilities = [];
-    const audioMp4 = 'audio/mp4; codecs="mp4a.40.2"';
-    const audioWebm = 'audio/webm; codecs="opus"';
-    if (shaka.media.Capabilities.isTypeSupported(audioMp4)) {
-      basicAudioCapabilities.push(audioMp4);
-    } else {
-      basicAudioCapabilities.push(audioWebm);
-    }
+    const basicAudioCapabilities = [
+      {contentType: 'audio/mp4; codecs="mp4a.40.2"'},
+      {contentType: 'audio/webm; codecs="opus"'},
+    ];
+
     const basicConfigTemplate = {
       videoCapabilities: basicVideoCapabilities,
       audioCapabilities: basicAudioCapabilities,

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -11,7 +11,6 @@ goog.require('shaka.log');
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.device.IDevice');
 goog.require('shaka.drm.DrmUtils');
-goog.require('shaka.media.Capabilities');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.BufferUtils');


### PR DESCRIPTION
Speed up execution of `shaka.Player.probeSupport()` which tends to be super slow on Windows with HW DRM. Changes include several tweaks in DRM probing:
- test only using `navigator.requestMediaKeySystemAccess()`, using MediaCapabilities as well was redundant
- test HDCP only once
- drop HDCP tests once we know some version is unsupported

On Windows it speeds up execution from 20s to 0.7-1s.