### PR TITLE
fix(UI): apply background color only for configured icons

### DIFF
--- a/ui/icon.js
+++ b/ui/icon.js
@@ -62,7 +62,7 @@ shaka.ui.Icon = class {
 
       if (url) {
         // let handle the background-color (icon color) by CSS
-        this.svg_.style.setProperty('background-color', '');
+        this.svg_.style.setProperty('background-color', 'currentColor');
         this.svg_.style.setProperty('mask-image', `url("${url}")`);
       } else if (path) {
         this.applyInlinedSVG_(path, viewBox);

--- a/ui/less/material_svg_icon.less
+++ b/ui/less/material_svg_icon.less
@@ -1,6 +1,5 @@
 .shaka-ui-icon {
   display: inline-block;
-  background-color: currentcolor;
   fill: currentcolor;
   mask-position: left top;
   mask-repeat: no-repeat;


### PR DESCRIPTION
Previously, `currentcolor` was applied to the background even for unconfigured icons, causing a black square to appear in place of the icon.

Now, the background color is applied only when the icon is configured.