### PR TITLE
feat(UI): increase interactive area of seek bar and volume bar

### DIFF
--- a/ui/less/containers.less
+++ b/ui/less/containers.less
@@ -166,6 +166,11 @@
   font-weight: normal;
   font-style: normal;
 
+  /* Increase the z-index of controls-button-panel to cover the overflowing
+   * seek-bar because the seek-bar has a larger touchable area than its
+   * visible size */
+  z-index: 1;
+
   /* Make sure contents cannot be selected. */
   .unselectable();
 

--- a/ui/less/range_elements.less
+++ b/ui/less/range_elements.less
@@ -31,6 +31,10 @@
 @thumb-size: 12px;
 @track-height: 4px;
 
+/* The range element has a larger interactive area than its visible size.
+ * This value should always be greater than @thumb-size. */
+@touchable-size: 40px;
+
 /* The range container is the div that contains a range element.
  * This div will act as a virtual track to allow us to style the track space.
  * An actual track still exists inside the range element, but is transparent. */
@@ -106,14 +110,14 @@
   /* Overlay and fill the container div. */
   .overlay-child();
 
-  /* The range element should be big enough to contain the thumb without
-   * clipping it.  It is very tricky to make the thumb show outside the track
-   * on IE 11. */
-  height: @thumb-size;
+  /* The range element should have a minimum touchable height for
+   * accessibility. */
+  height: @touchable-size;
 
   /* Position the top of the range element so that it is centered on the
-   * container. Note that the container is actually smaller than the thumb. */
-  top: calc((@track-height - @thumb-size) / 2);
+   * container. Note that the container is actually smaller than the
+   * touchable-size. */
+  top: calc((@track-height - @touchable-size) / 2);
 
   /* Make sure clicking at the very top of the bar still takes effect and is not
    * confused with clicking the video to play/pause it. */

--- a/ui/less/thumbnails.less
+++ b/ui/less/thumbnails.less
@@ -51,6 +51,7 @@
   overflow: hidden;
   padding: 0 3px;
   position: absolute;
+  pointer-events: none;
   visibility: hidden;
   z-index: 1;
 


### PR DESCRIPTION
- Set `40px` as the touchable size for range elements (seek-bar and volume-bar).
- Increased `z-index` of `controls-button-panel` to `1` to cover the overflowing seek-bar.
- Made `ui-time-container` non-interactive so it can cover the seek-bar without blocking interactions.

Closes: #9120