### PR TITLE
fix: Improve quota exceeded handler

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -2207,16 +2207,16 @@ shaka.media.StreamingEngine = class {
     });
 
     if (!waitingForAnotherStreamToRecover) {
-      const maxDisabledTime = this.getDisabledTime_(error);
-      if (maxDisabledTime) {
-        shaka.log.debug(logPrefix, 'Disabling stream due to quota', error);
-      }
-      const handled = this.playerInterface_.disableStream(
-          mediaState.stream, maxDisabledTime);
-      if (handled) {
-        return;
-      }
       if (this.config_.avoidEvictionOnQuotaExceededError) {
+        const maxDisabledTime = this.getDisabledTime_(error);
+        if (maxDisabledTime) {
+          shaka.log.debug(logPrefix, 'Disabling stream due to quota', error);
+        }
+        const handled = this.playerInterface_.disableStream(
+            mediaState.stream, maxDisabledTime);
+        if (handled) {
+          return;
+        }
         // QuotaExceededError gets thrown if eviction didn't help to make room
         // for a segment. We want to wait for a while (4 seconds is just an
         // arbitrary number) before updating to give the playhead a chance to
@@ -2232,11 +2232,26 @@ shaka.media.StreamingEngine = class {
       } else if (percentBefore > 4) {
         this.bufferingScale_ -= 0.04;
       } else {
-        shaka.log.error(
-            logPrefix, 'MediaSource threw QuotaExceededError too many times');
-        mediaState.hasError = true;
-        this.fatalError_ = true;
-        this.playerInterface_.onError(error);
+        const maxDisabledTime = this.getDisabledTime_(error);
+        if (maxDisabledTime) {
+          shaka.log.debug(logPrefix, 'Disabling stream due to quota', error);
+        }
+        const handled = this.playerInterface_.disableStream(
+            mediaState.stream, maxDisabledTime);
+        if (handled) {
+          // Reset the buffering scale, cause we've switched to another stream.
+          this.bufferingScale_ = 1.0;
+          // Evict the buffer behind current presentation time, to not hit
+          // quota exceeded again right away.
+          const presentationTime = this.playerInterface_.getPresentationTime();
+          await this.evict_(mediaState, presentationTime);
+        } else {
+          shaka.log.error(
+              logPrefix, 'MediaSource threw QuotaExceededError too many times');
+          mediaState.hasError = true;
+          this.fatalError_ = true;
+          this.playerInterface_.onError(error);
+        }
         return;
       }
       const percentAfter = Math.round(100 * this.bufferingScale_);


### PR DESCRIPTION
Fixes #9076 

Now we will try other stream only if reducing buffering goal doesn't help.
Reset buffering scale on changing stream.
Evict buffer ahead always when we see quota has been exceeded.
