### PR TITLE
perf(HLS): Optimise manifest text parser

### DIFF
--- a/lib/hls/hls_utils.js
+++ b/lib/hls/hls_utils.js
@@ -147,7 +147,7 @@ shaka.hls.Utils = class {
    * @return {boolean}
    */
   static isComment(line) {
-    return /^#(?!EXT)/m.test(line);
+    return line.startsWith('#') && !line.startsWith('#EXT');
   }
 
   /**

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -80,7 +80,8 @@ shaka.hls.ManifestTextParser = class {
         if (this.mediaPlaylistTags_.has(tag.name)) {
           playlistType = shaka.hls.PlaylistType.MEDIA;
           typeDetected = true;
-        } else if (tag.name == 'EXT-X-STREAM-INF') {
+        } else if (tag.name == 'EXT-X-STREAM-INF' ||
+                   tag.name == 'EXT-X-MEDIA') {
           // Master playlist detected, keep as MASTER
           typeDetected = true;
         } else if (this.segmentTags_.has(tag.name)) {

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -242,7 +242,7 @@ shaka.hls.ManifestTextParser = class {
             2b. Otherwise, items are attributes.
        3. If there is no ":", it's a simple tag with no attributes and no value.
     */
-    const blocks = word.match(/^#(EXT[^:]*)(?::(.*))?$/);
+    const blocks = word.match(shaka.hls.ManifestTextParser.STATIC_PATTERNS.tagBlocks);
     if (!blocks) {
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
@@ -259,39 +259,55 @@ shaka.hls.ManifestTextParser = class {
       const parser = new shaka.util.TextParser(data);
       let blockAttrs;
 
-      // Regex: any number of non-equals-sign characters at the beginning
-      // terminated by comma or end of line
-      const valueRegex = /^([^,=]+)(?:,|$)/g;
-
-      const blockValue = parser.readRegex(valueRegex);
+      // Reset regex lastIndex to ensure proper matching
+      shaka.hls.ManifestTextParser.STATIC_PATTERNS.valueRegex.lastIndex = 0;
+      const blockValue = parser.readRegex(shaka.hls.ManifestTextParser.STATIC_PATTERNS.valueRegex);
 
       if (blockValue) {
         value = blockValue[1];
       }
 
-      // Regex:
-      // 1. Key name ([1])
-      // 2. Equals sign
-      // 3. Either:
-      //   a. A quoted string (everything up to the next quote, [2])
-      //   b. An unquoted string
-      //    (everything up to the next comma or end of line, [3])
-      // 4. Either:
-      //   a. A comma
-      //   b. End of line
-      const attributeRegex = /([^=]+)=(?:"([^"]*)"|([^",]*))(?:,|$)/g;
-
-      while ((blockAttrs = parser.readRegex(attributeRegex))) {
+      // Reset regex lastIndex to ensure proper matching
+      shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex.lastIndex = 0;
+      blockAttrs = parser.readRegex(shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex);
+      while (blockAttrs) {
         const attrName = blockAttrs[1];
         const attrValue = blockAttrs[2] || blockAttrs[3];
         const attribute = new shaka.hls.Attribute(attrName, attrValue);
         attributes.push(attribute);
         parser.skipWhitespace();
+        blockAttrs = parser.readRegex(shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex);
       }
     }
 
     return new shaka.hls.Tag(id, name, attributes, value);
   }
+};
+
+/**
+ * Static pre-compiled regex patterns for maximum performance.
+ * Shared across all parser instances.
+ * Pre-compiled patterns eliminate repeated regex compilation during parsing.
+ * @const {{tagBlocks: !RegExp, valueRegex: !RegExp, attributeRegex: !RegExp}}
+ */
+shaka.hls.ManifestTextParser.STATIC_PATTERNS = {
+  tagBlocks: /^#(EXT[^:]*)(?::(.*))?$/,
+  
+  // Regex: any number of non-equals-sign characters at the beginning
+  // terminated by comma or end of line
+  valueRegex: /^([^,=]+)(?:,|$)/g,
+  
+  // Regex:
+  // 1. Key name ([1])
+  // 2. Equals sign
+  // 3. Either:
+  //   a. A quoted string (everything up to the next quote, [2])
+  //   b. An unquoted string
+  //    (everything up to the next comma or end of line, [3])
+  // 4. Either:
+  //   a. A comma
+  //   b. End of line
+  attributeRegex: /([^=]+)=(?:"([^"]*)"|([^",]*))(?:,|$)/g,
 };
 
 

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -11,7 +11,7 @@ goog.require('shaka.hls.Playlist');
 goog.require('shaka.hls.PlaylistType');
 goog.require('shaka.hls.Segment');
 goog.require('shaka.hls.Tag');
-goog.require('shaka.hls.Utils');
+
 goog.require('shaka.util.Error');
 goog.require('shaka.util.StringUtils');
 goog.require('shaka.util.TextParser');
@@ -24,6 +24,23 @@ shaka.hls.ManifestTextParser = class {
   constructor() {
     /** @private {number} */
     this.globalId_ = 0;
+
+    /**
+     * @private {{comment: !RegExp, extTag: !RegExp, header: !RegExp,
+     *   segmentTag: !RegExp}} Pre-compiled regex patterns for performance
+     */
+    this.patterns_ = {
+      comment: /^#(?!EXT)/m,
+      extTag: /^(#EXT[^:]*)(?::(.*))?$/,
+      header: /^#EXTM3U($|[ \t\n])/m,
+      segmentTag: /^(#EXT)/,
+    };
+
+    /** @private {!Set<string>} O(1) lookup sets for tag classification */
+    this.mediaPlaylistTags_ = new Set(
+        shaka.hls.ManifestTextParser.MEDIA_PLAYLIST_TAGS);
+    this.segmentTags_ = new Set(
+        shaka.hls.ManifestTextParser.SEGMENT_TAGS);
   }
 
   /**
@@ -31,65 +48,52 @@ shaka.hls.ManifestTextParser = class {
    * @return {!shaka.hls.Playlist}
    */
   parsePlaylist(data) {
-    const MEDIA_PLAYLIST_TAGS =
-        shaka.hls.ManifestTextParser.MEDIA_PLAYLIST_TAGS;
-    const SEGMENT_TAGS = shaka.hls.ManifestTextParser.SEGMENT_TAGS;
-
     // Get the input as a string.  Normalize newlines to \n.
     let str = shaka.util.StringUtils.fromUTF8(data);
     str = str.replace(/\r\n|\r(?=[^\n]|$)/gm, '\n').trim();
 
     const lines = str.split(/\n+/m);
 
-    if (!/^#EXTM3U($|[ \t\n])/m.test(lines[0])) {
+    if (!this.patterns_.header.test(lines[0])) {
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MANIFEST,
           shaka.util.Error.Code.HLS_PLAYLIST_HEADER_MISSING);
     }
 
-    /** shaka.hls.PlaylistType */
+    // Single-pass state machine for parsing
     let playlistType = shaka.hls.PlaylistType.MASTER;
-
-    // First, look for media playlist tags, so that we know what the playlist
-    // type really is before we start parsing.
-    // TODO: refactor the for loop for better readability.
-    // Whether to skip the next element; initialize to true to skip first elem.
-    let skip = true;
-    for (const line of lines) {
-      // Ignore comments.
-      if (shaka.hls.Utils.isComment(line) || skip) {
-        skip = false;
-        continue;
-      }
-      const tag = this.parseTag_(line);
-      // These tags won't actually be used, so don't increment the global
-      // id.
-      this.globalId_ -= 1;
-
-      if (MEDIA_PLAYLIST_TAGS.includes(tag.name)) {
-        playlistType = shaka.hls.PlaylistType.MEDIA;
-        break;
-      } else if (tag.name == 'EXT-X-STREAM-INF') {
-        skip = true;
-      }
-    }
-
-    /** {Array<shaka.hls.Tag>} */
+    let typeDetected = false;
     const tags = [];
-    // Initialize to "true" to skip the first element.
-    skip = true;
+    let skip = true;
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       const next = lines[i + 1];
       // Skip comments
-      if (shaka.hls.Utils.isComment(line) || skip) {
+      if (this.patterns_.comment.test(line) || skip) {
         skip = false;
         continue;
       }
 
       const tag = this.parseTag_(line);
-      if (SEGMENT_TAGS.includes(tag.name)) {
+
+      // Detect playlist type on first relevant tag
+      if (!typeDetected) {
+        if (this.mediaPlaylistTags_.has(tag.name)) {
+          playlistType = shaka.hls.PlaylistType.MEDIA;
+          typeDetected = true;
+        } else if (tag.name == 'EXT-X-STREAM-INF') {
+          // Master playlist detected, keep as MASTER
+          typeDetected = true;
+        } else if (this.segmentTags_.has(tag.name)) {
+          // Segment tags also indicate MEDIA playlist
+          playlistType = shaka.hls.PlaylistType.MEDIA;
+          typeDetected = true;
+        }
+      }
+
+      // Transition to segment parsing
+      if (this.segmentTags_.has(tag.name)) {
         if (playlistType != shaka.hls.PlaylistType.MEDIA) {
           // Only media playlists should contain segment tags
           throw new shaka.util.Error(
@@ -139,10 +143,9 @@ shaka.hls.ManifestTextParser = class {
     let currentMapTag = null;
 
     for (const line of lines) {
-      if (/^(#EXT)/.test(line)) {
+      if (this.patterns_.segmentTag.test(line)) {
         const tag = this.parseTag_(line);
-        if (shaka.hls.ManifestTextParser.MEDIA_PLAYLIST_TAGS.includes(
-            tag.name)) {
+        if (this.mediaPlaylistTags_.has(tag.name)) {
           playlistTags.push(tag);
         } else {
           // Mark the the EXT-X-MAP tag, and add it to the segment tags
@@ -163,7 +166,7 @@ shaka.hls.ManifestTextParser = class {
             segmentTags.push(tag);
           }
         }
-      } else if (shaka.hls.Utils.isComment(line)) {
+      } else if (this.patterns_.comment.test(line)) {
         // Skip comments.
       } else {
         const verbatimSegmentUri = line.trim();

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -25,15 +25,6 @@ shaka.hls.ManifestTextParser = class {
     /** @private {number} */
     this.globalId_ = 0;
 
-    /**
-     * @private {{extTag: !RegExp, header: !RegExp}}
-     * Pre-compiled regex patterns for performance
-     */
-    this.patterns_ = {
-      extTag: /^(#EXT[^:]*)(?::(.*))?$/,
-      header: /^#EXTM3U($|[ \t\n])/m,
-    };
-
     /** @private {!Set<string>} O(1) lookup sets for tag classification */
     this.mediaPlaylistTags_ = new Set(
         shaka.hls.ManifestTextParser.MEDIA_PLAYLIST_TAGS);
@@ -52,7 +43,7 @@ shaka.hls.ManifestTextParser = class {
 
     const lines = str.split(/\n+/m);
 
-    if (!this.patterns_.header.test(lines[0])) {
+    if (!shaka.hls.ManifestTextParser.STATIC_PATTERNS.header.test(lines[0])) {
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MANIFEST,
@@ -294,10 +285,12 @@ shaka.hls.ManifestTextParser = class {
  * Static pre-compiled regex patterns for maximum performance.
  * Shared across all parser instances.
  * Pre-compiled patterns eliminate repeated regex compilation during parsing.
- * @const {{tagBlocks: !RegExp, valueRegex: !RegExp, attributeRegex: !RegExp}}
+ * @const {{tagBlocks: !RegExp, valueRegex: !RegExp, attributeRegex: !RegExp,
+ *   header: !RegExp}}
  */
 shaka.hls.ManifestTextParser.STATIC_PATTERNS = {
   tagBlocks: /^#(EXT[^:]*)(?::(.*))?$/,
+  header: /^#EXTM3U($|[ \t\n])/m,
 
   // Regex: any number of non-equals-sign characters at the beginning
   // terminated by comma or end of line

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -247,7 +247,7 @@ shaka.hls.ManifestTextParser = class {
       const parser = new shaka.util.TextParser(data);
       let blockAttrs;
 
-      // Reset regex lastIndex to ensure proper matching
+      // re-using global regex: reset lastIndex
       shaka.hls.ManifestTextParser.STATIC_PATTERNS.valueRegex.lastIndex = 0;
       const blockValue = parser.readRegex(
           shaka.hls.ManifestTextParser.STATIC_PATTERNS.valueRegex);
@@ -256,7 +256,7 @@ shaka.hls.ManifestTextParser = class {
         value = blockValue[1];
       }
 
-      // Reset regex lastIndex to ensure proper matching
+      // re-using global regex: reset lastIndex
       shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex.lastIndex = 0;
       blockAttrs = parser.readRegex(
           shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex);

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -11,7 +11,6 @@ goog.require('shaka.hls.Playlist');
 goog.require('shaka.hls.PlaylistType');
 goog.require('shaka.hls.Segment');
 goog.require('shaka.hls.Tag');
-
 goog.require('shaka.util.Error');
 goog.require('shaka.util.StringUtils');
 goog.require('shaka.util.TextParser');

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -24,12 +24,6 @@ shaka.hls.ManifestTextParser = class {
   constructor() {
     /** @private {number} */
     this.globalId_ = 0;
-
-    /** @private {!Set<string>} O(1) lookup sets for tag classification */
-    this.mediaPlaylistTags_ = new Set(
-        shaka.hls.ManifestTextParser.MEDIA_PLAYLIST_TAGS);
-    this.segmentTags_ = new Set(
-        shaka.hls.ManifestTextParser.SEGMENT_TAGS);
   }
 
   /**
@@ -68,14 +62,14 @@ shaka.hls.ManifestTextParser = class {
 
       // Detect playlist type on first relevant tag
       if (!typeDetected) {
-        if (this.mediaPlaylistTags_.has(tag.name)) {
+        if (shaka.hls.ManifestTextParser.MEDIA_PLAYLIST_TAGS.has(tag.name)) {
           playlistType = shaka.hls.PlaylistType.MEDIA;
           typeDetected = true;
         } else if (tag.name == 'EXT-X-STREAM-INF' ||
                    tag.name == 'EXT-X-MEDIA') {
           // Master playlist detected, keep as MASTER
           typeDetected = true;
-        } else if (this.segmentTags_.has(tag.name)) {
+        } else if (shaka.hls.ManifestTextParser.SEGMENT_TAGS.has(tag.name)) {
           // Segment tags also indicate MEDIA playlist
           playlistType = shaka.hls.PlaylistType.MEDIA;
           typeDetected = true;
@@ -83,7 +77,7 @@ shaka.hls.ManifestTextParser = class {
       }
 
       // Transition to segment parsing
-      if (this.segmentTags_.has(tag.name)) {
+      if (shaka.hls.ManifestTextParser.SEGMENT_TAGS.has(tag.name)) {
         if (playlistType != shaka.hls.PlaylistType.MEDIA) {
           // Only media playlists should contain segment tags
           throw new shaka.util.Error(
@@ -140,7 +134,7 @@ shaka.hls.ManifestTextParser = class {
       const line = lines[lineIndex];
       if (line.startsWith('#EXT')) {
         const tag = this.parseTag_(line);
-        if (this.mediaPlaylistTags_.has(tag.name)) {
+        if (shaka.hls.ManifestTextParser.MEDIA_PLAYLIST_TAGS.has(tag.name)) {
           playlistTags.push(tag);
         } else {
           // Mark the the EXT-X-MAP tag, and add it to the segment tags
@@ -313,10 +307,11 @@ shaka.hls.ManifestTextParser.STATIC_PATTERNS = {
 /**
  * HLS tags that only appear on Media Playlists.
  * Used to determine a playlist type.
+ * O(1) lookup set for tag classification.
  *
- * @const {!Array<string>}
+ * @const {!Set<string>}
  */
-shaka.hls.ManifestTextParser.MEDIA_PLAYLIST_TAGS = [
+shaka.hls.ManifestTextParser.MEDIA_PLAYLIST_TAGS = new Set([
   'EXT-X-TARGETDURATION',
   'EXT-X-MEDIA-SEQUENCE',
   'EXT-X-DISCONTINUITY-SEQUENCE',
@@ -327,16 +322,17 @@ shaka.hls.ManifestTextParser.MEDIA_PLAYLIST_TAGS = [
   'EXT-X-SKIP',
   'EXT-X-PART-INF',
   'EXT-X-DATERANGE',
-];
+]);
 
 
 /**
  * HLS tags that only appear on Segments in a Media Playlists.
  * Used to determine the start of the segments info.
+ * O(1) lookup set for tag classification.
  *
- * @const {!Array<string>}
+ * @const {!Set<string>}
  */
-shaka.hls.ManifestTextParser.SEGMENT_TAGS = [
+shaka.hls.ManifestTextParser.SEGMENT_TAGS = new Set([
   'EXTINF',
   'EXT-X-BYTERANGE',
   'EXT-X-DISCONTINUITY',
@@ -346,4 +342,4 @@ shaka.hls.ManifestTextParser.SEGMENT_TAGS = [
   'EXT-X-MAP',
   'EXT-X-GAP',
   'EXT-X-TILES',
-];
+]);

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -243,7 +243,8 @@ shaka.hls.ManifestTextParser = class {
             2b. Otherwise, items are attributes.
        3. If there is no ":", it's a simple tag with no attributes and no value.
     */
-    const blocks = word.match(shaka.hls.ManifestTextParser.STATIC_PATTERNS.tagBlocks);
+    const blocks = word.match(
+        shaka.hls.ManifestTextParser.STATIC_PATTERNS.tagBlocks);
     if (!blocks) {
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
@@ -262,7 +263,8 @@ shaka.hls.ManifestTextParser = class {
 
       // Reset regex lastIndex to ensure proper matching
       shaka.hls.ManifestTextParser.STATIC_PATTERNS.valueRegex.lastIndex = 0;
-      const blockValue = parser.readRegex(shaka.hls.ManifestTextParser.STATIC_PATTERNS.valueRegex);
+      const blockValue = parser.readRegex(
+          shaka.hls.ManifestTextParser.STATIC_PATTERNS.valueRegex);
 
       if (blockValue) {
         value = blockValue[1];
@@ -270,14 +272,16 @@ shaka.hls.ManifestTextParser = class {
 
       // Reset regex lastIndex to ensure proper matching
       shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex.lastIndex = 0;
-      blockAttrs = parser.readRegex(shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex);
+      blockAttrs = parser.readRegex(
+          shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex);
       while (blockAttrs) {
         const attrName = blockAttrs[1];
         const attrValue = blockAttrs[2] || blockAttrs[3];
         const attribute = new shaka.hls.Attribute(attrName, attrValue);
         attributes.push(attribute);
         parser.skipWhitespace();
-        blockAttrs = parser.readRegex(shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex);
+        blockAttrs = parser.readRegex(
+            shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex);
       }
     }
 
@@ -293,11 +297,11 @@ shaka.hls.ManifestTextParser = class {
  */
 shaka.hls.ManifestTextParser.STATIC_PATTERNS = {
   tagBlocks: /^#(EXT[^:]*)(?::(.*))?$/,
-  
+
   // Regex: any number of non-equals-sign characters at the beginning
   // terminated by comma or end of line
   valueRegex: /^([^,=]+)(?:,|$)/g,
-  
+
   // Regex:
   // 1. Key name ([1])
   // 2. Equals sign

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -11,6 +11,7 @@ goog.require('shaka.hls.Playlist');
 goog.require('shaka.hls.PlaylistType');
 goog.require('shaka.hls.Segment');
 goog.require('shaka.hls.Tag');
+goog.require('shaka.hls.Utils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.StringUtils');
 goog.require('shaka.util.TextParser');
@@ -25,11 +26,10 @@ shaka.hls.ManifestTextParser = class {
     this.globalId_ = 0;
 
     /**
-     * @private {{comment: !RegExp, extTag: !RegExp, header: !RegExp}}
+     * @private {{extTag: !RegExp, header: !RegExp}}
      * Pre-compiled regex patterns for performance
      */
     this.patterns_ = {
-      comment: /^#(?!EXT)/m,
       extTag: /^(#EXT[^:]*)(?::(.*))?$/,
       header: /^#EXTM3U($|[ \t\n])/m,
     };
@@ -68,7 +68,7 @@ shaka.hls.ManifestTextParser = class {
       const line = lines[i];
       const next = lines[i + 1];
       // Skip comments
-      if ((line.startsWith('#') && !line.startsWith('#EXT')) || skip) {
+      if (shaka.hls.Utils.isComment(line) || skip) {
         skip = false;
         continue;
       }
@@ -170,7 +170,7 @@ shaka.hls.ManifestTextParser = class {
             segmentTags.push(tag);
           }
         }
-      } else if (line.startsWith('#') && !line.startsWith('#EXT')) {
+      } else if (shaka.hls.Utils.isComment(line)) {
         // Skip comments.
       } else {
         const verbatimSegmentUri = line.trim();

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -101,8 +101,7 @@ shaka.hls.ManifestTextParser = class {
               shaka.util.Error.Code.HLS_INVALID_PLAYLIST_HIERARCHY);
         }
 
-        const segmentsData = lines.splice(i, lines.length - i);
-        const segments = this.parseSegments_(segmentsData, tags);
+        const segments = this.parseSegments_(lines, i, tags);
         return new shaka.hls.Playlist(playlistType, tags, segments);
       }
 
@@ -124,13 +123,15 @@ shaka.hls.ManifestTextParser = class {
    * Parses an array of strings into an array of HLS Segment objects.
    *
    * @param {!Array<string>} lines
+   * @param {number} startIndex
    * @param {!Array<!shaka.hls.Tag>} playlistTags
    * @return {!Array<shaka.hls.Segment>}
    * @private
    */
-  parseSegments_(lines, playlistTags) {
+  parseSegments_(lines, startIndex, playlistTags) {
     // Pre-allocate segments array for better performance with large playlists
-    const estimatedSegments = Math.max(100, Math.floor(lines.length / 2));
+    const remainingLines = lines.length - startIndex;
+    const estimatedSegments = Math.max(100, Math.floor(remainingLines / 2));
     /** @type {!Array<shaka.hls.Segment>} */
     const segments = new Array(estimatedSegments);
     let segmentIndex = 0;
@@ -144,7 +145,8 @@ shaka.hls.ManifestTextParser = class {
     /** @type {?shaka.hls.Tag} */
     let currentMapTag = null;
 
-    for (const line of lines) {
+    for (let lineIndex = startIndex; lineIndex < lines.length; lineIndex++) {
+      const line = lines[lineIndex];
       if (line.startsWith('#EXT')) {
         const tag = this.parseTag_(line);
         if (this.mediaPlaylistTags_.has(tag.name)) {

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -26,14 +26,13 @@ shaka.hls.ManifestTextParser = class {
     this.globalId_ = 0;
 
     /**
-     * @private {{comment: !RegExp, extTag: !RegExp, header: !RegExp,
-     *   segmentTag: !RegExp}} Pre-compiled regex patterns for performance
+     * @private {{comment: !RegExp, extTag: !RegExp, header: !RegExp}}
+     * Pre-compiled regex patterns for performance
      */
     this.patterns_ = {
       comment: /^#(?!EXT)/m,
       extTag: /^(#EXT[^:]*)(?::(.*))?$/,
       header: /^#EXTM3U($|[ \t\n])/m,
-      segmentTag: /^(#EXT)/,
     };
 
     /** @private {!Set<string>} O(1) lookup sets for tag classification */
@@ -70,7 +69,7 @@ shaka.hls.ManifestTextParser = class {
       const line = lines[i];
       const next = lines[i + 1];
       // Skip comments
-      if (this.patterns_.comment.test(line) || skip) {
+      if ((line.startsWith('#') && !line.startsWith('#EXT')) || skip) {
         skip = false;
         continue;
       }
@@ -130,8 +129,11 @@ shaka.hls.ManifestTextParser = class {
    * @private
    */
   parseSegments_(lines, playlistTags) {
+    // Pre-allocate segments array for better performance with large playlists
+    const estimatedSegments = Math.max(100, Math.floor(lines.length / 2));
     /** @type {!Array<shaka.hls.Segment>} */
-    const segments = [];
+    const segments = new Array(estimatedSegments);
+    let segmentIndex = 0;
     /** @type {!Array<shaka.hls.Tag>} */
     let segmentTags = [];
 
@@ -143,7 +145,7 @@ shaka.hls.ManifestTextParser = class {
     let currentMapTag = null;
 
     for (const line of lines) {
-      if (this.patterns_.segmentTag.test(line)) {
+      if (line.startsWith('#EXT')) {
         const tag = this.parseTag_(line);
         if (this.mediaPlaylistTags_.has(tag.name)) {
           playlistTags.push(tag);
@@ -166,7 +168,7 @@ shaka.hls.ManifestTextParser = class {
             segmentTags.push(tag);
           }
         }
-      } else if (this.patterns_.comment.test(line)) {
+      } else if (line.startsWith('#') && !line.startsWith('#EXT')) {
         // Skip comments.
       } else {
         const verbatimSegmentUri = line.trim();
@@ -177,7 +179,12 @@ shaka.hls.ManifestTextParser = class {
         // The URI appears after all of the tags describing the segment.
         const segment = new shaka.hls.Segment(
             verbatimSegmentUri, segmentTags, partialSegmentTags);
-        segments.push(segment);
+        if (segmentIndex < segments.length) {
+          segments[segmentIndex++] = segment;
+        } else {
+          segments.push(segment);
+          segmentIndex++;
+        }
         segmentTags = [];
         partialSegmentTags = [];
       }
@@ -193,10 +200,17 @@ shaka.hls.ManifestTextParser = class {
       }
       const segment = new shaka.hls.Segment('', segmentTags,
           partialSegmentTags);
-      segments.push(segment);
+      if (segmentIndex < segments.length) {
+        segments[segmentIndex++] = segment;
+      } else {
+        segments.push(segment);
+        segmentIndex++;
+      }
     }
 
-    return segments;
+    // Trim pre-allocated array to actual size
+    return segmentIndex < segments.length ?
+        segments.slice(0, segmentIndex) : segments;
   }
 
   /**


### PR DESCRIPTION
These changes were made in an attempt to address issues with Shaka on Chromecast getting stuck with buffer underruns while parsing large manifests (~7k segments). Instead of parsing once, it gets stuck parsing a manifest over and over on encrypted streams, each manifest parse taking over ~1.2s.

The changes here did not solve the issue, but [I was asked to make a PR](https://github.com/martinstark/shaka-player/commit/786d1370e566e0bdecf3ec8a847b62c6ebc1f7af). While the manifest parsing is slow, it's appears not to be the root cause of the issue we've been seeing.

In synthetic testing, with HLS manifests ranging from 100 to 100,000,000 segments on an AMD processor, Node22, arch linux, the updated  manifest parser uses somewhere between 12-40% less processor time. Assuming my tests were representative.

I don't have enough real world data to say if this makes any significant difference. I haven't run isolated manifest parsing tests on CC hardware (yet, and not sure if I will have time).