### PR TITLE
feat(CMCDv2): add support for "top playable bitrate"

### DIFF
--- a/externs/cmcd.js
+++ b/externs/cmcd.js
@@ -18,6 +18,7 @@
  *   d: (number|undefined),
  *   ot: (string|undefined),
  *   tb: (number|undefined),
+ *   tpb: (number|undefined),
  *   bl: (number|undefined),
  *   dl: (number|undefined),
  *   mtp: (number|undefined),
@@ -79,6 +80,12 @@
  * @property {number} tb
  *   The highest bitrate rendition in the manifest or playlist that the client
  *   is allowed to play, given current codec, licensing and sizing constraints.
+ *
+ * @property {number} tpb
+ *   The highest bitrate rendition that the player is willing to select given
+ *   current ABR restrictions (bandwidth, resolution limits, etc.). Unlike tb,
+ *   which reports the top bitrate available in the manifest, tpb reflects what
+ *   the player would actually be willing to select.
  *
  * @property {number} bl
  *   The buffer length associated with the media object being requested. This

--- a/lib/player.js
+++ b/lib/player.js
@@ -875,6 +875,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
      */
     this.abrManagerFactory_ = null;
 
+    /** @private {number} */
+    this.topPlayableBandwidth_ = NaN;
+
     /**
      * Contains an ID for use with creating streams.  The manifest parser should
      * start with small IDs, so this starts with a large one.
@@ -4431,6 +4434,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     if (this.abrManager_) {
       this.abrManager_.configure(this.config_.abr);
+      // Recompute top playable bandwidth with the new ABR restrictions.
+      if (this.manifest_) {
+        this.updateAbrManagerVariants_();
+      }
       // Simply enable/disable ABR with each call, since multiple calls to these
       // methods have no effect.
       if (this.config_.abr.enabled) {
@@ -5242,6 +5249,17 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     } else {
       return [];
     }
+  }
+
+  /**
+   * Returns the top bandwidth (in bit/sec) from the variants that pass ABR
+   * restrictions. Returns NaN if unavailable.
+   *
+   * @return {number}
+   * @export
+   */
+  getTopPlayableBandwidth() {
+    return this.topPlayableBandwidth_;
   }
 
   /**
@@ -8016,6 +8034,22 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     const playableVariants = shaka.util.StreamUtils.getPlayableVariants(
         this.manifest_.variants);
+
+    // Compute the top playable bandwidth (for CMCD tpb) while we have
+    // the playable variants at hand.
+    const restrictions = this.config_.abr.restrictions;
+    let topPlayableBandwidth = NaN;
+    for (const variant of playableVariants) {
+      if (shaka.util.StreamUtils.meetsRestrictions(
+          variant, restrictions,
+          /* maxHwRes= */ {width: Infinity, height: Infinity})) {
+        if (isNaN(topPlayableBandwidth) ||
+            variant.bandwidth > topPlayableBandwidth) {
+          topPlayableBandwidth = variant.bandwidth;
+        }
+      }
+    }
+    this.topPlayableBandwidth_ = topPlayableBandwidth;
 
     // Update the abr manager with newly filtered variants.
     const adaptationSet = this.currentAdaptationSetCriteria_.create(

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -1245,6 +1245,53 @@ shaka.util.CmcdManager = class {
   }
 
   /**
+   * Get the top playable bandwidth for the given type, accounting for ABR
+   * restrictions.
+   *
+   * @param {string} type
+   * @return {number}
+   * @private
+   */
+  getTopPlayableBandwidth_(type) {
+    const topBandwidth = this.player_.getTopPlayableBandwidth();
+    if (isNaN(topBandwidth)) {
+      return NaN;
+    }
+
+    const ObjectType = shaka.util.CmcdManager.ObjectType;
+    if (type === ObjectType.VIDEO || type === ObjectType.AUDIO) {
+      const variants = this.player_.getVariantTracks();
+      if (!variants.length) {
+        return NaN;
+      }
+
+      // Find the highest-bandwidth variant that doesn't exceed the top
+      // playable bandwidth.
+      let best = null;
+      for (const variant of variants) {
+        if (variant.type === 'variant' && variant.bandwidth <= topBandwidth) {
+          if (!best || variant.bandwidth > best.bandwidth) {
+            best = variant;
+          }
+        }
+      }
+
+      if (!best) {
+        return NaN;
+      }
+
+      switch (type) {
+        case ObjectType.VIDEO:
+          return best.videoBandwidth || NaN;
+        case ObjectType.AUDIO:
+          return best.audioBandwidth || NaN;
+      }
+    }
+
+    return topBandwidth;
+  }
+
+  /**
    * Get CMCD data for a segment.
    *
    * @param {shaka.extern.RequestContext} context
@@ -1326,6 +1373,7 @@ shaka.util.CmcdManager = class {
 
     if (isMedia && data.ot !== ObjectType.TIMED_TEXT) {
       data.tb = this.getTopBandwidth_(data.ot) / 1000;
+      data.tpb = this.getTopPlayableBandwidth_(data.ot) / 1000;
     }
 
     return data;
@@ -1410,6 +1458,7 @@ shaka.util.CmcdManager = class {
       nor: toUrlSafe,
       rtp: toHundred,
       tb: toRounded,
+      tpb: toRounded,
       ttfb: toRounded,
       ttlb: toRounded,
     };
@@ -1474,7 +1523,7 @@ shaka.util.CmcdManager = class {
     const headerNames = ['Object', 'Request', 'Session', 'Status'];
     const headerGroups = [{}, {}, {}, {}];
     const headerMap = {
-      br: 0, d: 0, ot: 0, tb: 0, url: 0,
+      br: 0, d: 0, ot: 0, tb: 0, tpb: 0, url: 0,
       bl: 1, dl: 1, mtp: 1, nor: 1, nrr: 1, su: 1, ltc: 1, ttfb: 1, ttlb: 1,
       ts: 1, rc: 1, cmsdd: 1, cmsds: 1, sn: 1,
       cid: 2, pr: 2, sf: 2, sid: 2, st: 2, v: 2, msd: 2,


### PR DESCRIPTION
This pull request adds support for the new CMCD v2 `tpb` (top playable bitrate) field, which reports the highest bitrate the player is willing to select given current ABR restrictions, as opposed to the top bitrate in the manifest (`tb`). This involves changes to the player, ABR manager, CMCD manager, and related test coverage to ensure the new field is correctly calculated, reported, and tested.

**CMCD `tpb` (Top Playable Bandwidth) Support:**

* Added `tpb` property to the CMCD externs and documentation to represent the top bitrate the player is willing to select under ABR restrictions. [[1]](diffhunk://#diff-dd79323a2effd02c8c27764ee708fe6b89b085f043f208201d6f71d15ca6a9fdR21) [[2]](diffhunk://#diff-dd79323a2effd02c8c27764ee708fe6b89b085f043f208201d6f71d15ca6a9fdR84-R89)
* Updated the CMCD manager (`cmcd_manager.js`) to calculate and include the `tpb` field in CMCD headers for V2 segment requests, using a new method to determine the top playable bandwidth based on ABR restrictions. [[1]](diffhunk://#diff-f8065b22dd504becf11fd7f24fdb174d6613d57960ab40dfc53cd1ebbb9691efR1247-R1293) [[2]](diffhunk://#diff-f8065b22dd504becf11fd7f24fdb174d6613d57960ab40dfc53cd1ebbb9691efR1376) [[3]](diffhunk://#diff-f8065b22dd504becf11fd7f24fdb174d6613d57960ab40dfc53cd1ebbb9691efR1461) [[4]](diffhunk://#diff-f8065b22dd504becf11fd7f24fdb174d6613d57960ab40dfc53cd1ebbb9691efL1477-R1526)

**ABR and Player Enhancements:**

* Added `getTopBandwidth()` to the ABR manager interface and implemented it in `SimpleAbrManager` to return the highest bandwidth variant that passes ABR restrictions. [[1]](diffhunk://#diff-d381c82ce968f2572669374ea69389fc6f64b0f265665fd0edcc3af93053f0d6R159-R167) [[2]](diffhunk://#diff-002cf7bbd7850fa3dda71c961e3aef88d8014e1e440f32663d2f56943663d8c6R545-R566)
* Added `getTopPlayableBandwidth()` to the player API to expose the top playable bandwidth, delegating to the ABR manager.

**Testing Improvements:**

* Extended CMCD manager unit tests to verify correct calculation and inclusion of the `tpb` field, its absence in V1 mode, and correct handling when ABR restrictions lower the top playable bandwidth. [[1]](diffhunk://#diff-a847c24ffc9e45c94935905116dd83822a26b9d34bfe1754c49e522aa174c1f0R168) [[2]](diffhunk://#diff-a847c24ffc9e45c94935905116dd83822a26b9d34bfe1754c49e522aa174c1f0R912) [[3]](diffhunk://#diff-a847c24ffc9e45c94935905116dd83822a26b9d34bfe1754c49e522aa174c1f0R2924-R2973)