### PR TITLE
fix(dash-json): XML-escape text content and attributes in jsonToMpd

### DIFF
--- a/lib/dash/json_utils.js
+++ b/lib/dash/json_utils.js
@@ -8,8 +8,6 @@
 
 goog.provide('shaka.dash.JsonUtils');
 
-goog.require('shaka.util.StringUtils');
-
 
 /**
  * @summary JSON processing utility functions.
@@ -25,6 +23,20 @@ shaka.dash.JsonUtils = class {
     const MPD_NS = 'urn:mpeg:dash:schema:mpd:2011';
 
     /**
+     * XML-escapes a string for safe use in XML text content or attribute values.
+     *
+     * @param {*} s
+     * @return {string}
+     */
+    function xmlEscape(s) {
+      return String(s)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;');
+    }
+
+    /**
      * Emit a tag with attributes and content.
      *
      * @param {string} tagName
@@ -35,7 +47,7 @@ shaka.dash.JsonUtils = class {
     function emit(tagName, attrs, inner) {
       let out = '<' + tagName;
       for (const [k, v] of Object.entries(attrs)) {
-        out += ` ${k}="${shaka.util.StringUtils.htmlUnescape(v)}"`;
+        out += ` ${k}="${xmlEscape(v)}"`;
       }
       if (inner === '') {
         return out + '/>';
@@ -58,7 +70,7 @@ shaka.dash.JsonUtils = class {
 
       // Primitive → <key>value</key>
       if (typeof node !== 'object') {
-        return emit(key, {}, shaka.util.StringUtils.htmlUnescape(String(node)));
+        return emit(key, {}, xmlEscape(String(node)));
       }
 
       // Object case
@@ -117,7 +129,7 @@ shaka.dash.JsonUtils = class {
       }
 
       if (node['$value'] !== undefined && node['$value'] !== null) {
-        textContent = shaka.util.StringUtils.htmlUnescape(node['$value']);
+        textContent = xmlEscape(node['$value']);
       }
 
       return emit(key, attrs, textContent + children.join(''));

--- a/lib/dash/json_utils.js
+++ b/lib/dash/json_utils.js
@@ -23,7 +23,7 @@ shaka.dash.JsonUtils = class {
     const MPD_NS = 'urn:mpeg:dash:schema:mpd:2011';
 
     /**
-     * XML-escapes a string for safe use in XML text content or attribute values.
+     * XML-escapes a string for safe use in XML text or attribute values.
      *
      * @param {*} s
      * @return {string}

--- a/test/dash/json_utils_unit.js
+++ b/test/dash/json_utils_unit.js
@@ -116,6 +116,43 @@ describe('JsonUtils', () => {
       expect(periods[1].attributes['id']).toBe('p2');
     });
 
+    it('XML-escapes text content to prevent XML injection', () => {
+      // A malicious JSON value containing XML metacharacters must not be
+      // interpreted as markup by the XML parser.
+      const json = {
+        BaseURL: [{
+          $value: '</BaseURL><BaseURL>http://attacker.com/segments/',
+        }],
+      };
+
+      const xml = parse(shaka.dash.JsonUtils.jsonToMpd(json));
+
+      // Must have exactly one BaseURL element — not two.
+      const baseUrls = shaka.util.TXml.findChildren(xml, 'BaseURL');
+      expect(baseUrls.length).toBe(1);
+
+      // The text content must be the literal string, not parsed as markup.
+      expect(shaka.util.TXml.getContents(baseUrls[0]))
+          .toBe('</BaseURL><BaseURL>http://attacker.com/segments/');
+    });
+
+    it('XML-escapes attribute values to prevent injection', () => {
+      const json = {
+        Period: [{
+          id: 'p1" injected="yes',
+        }],
+      };
+
+      const xml = parse(shaka.dash.JsonUtils.jsonToMpd(json));
+      const period = shaka.util.TXml.findChild(xml, 'Period');
+      expect(period).not.toBeNull();
+
+      // The attribute must contain the literal string, not break out.
+      expect(period.attributes['id']).toBe('p1" injected="yes');
+      // No spurious 'injected' attribute must exist.
+      expect(period.attributes['injected']).toBeUndefined();
+    });
+
     it('writes namespaced child elements (prefix:Element)', () => {
       const json = {
         $ns: {

--- a/test/dash/json_utils_unit.js
+++ b/test/dash/json_utils_unit.js
@@ -143,13 +143,18 @@ describe('JsonUtils', () => {
         }],
       };
 
-      const xml = parse(shaka.dash.JsonUtils.jsonToMpd(json));
+      const mpd = shaka.dash.JsonUtils.jsonToMpd(json);
+
+      // The double quote must be escaped so it cannot terminate the
+      // attribute value and inject a new attribute.
+      expect(mpd).toContain('id="p1&quot; injected=&quot;yes"');
+      expect(mpd).not.toContain('injected="yes"');
+
+      const xml = parse(mpd);
       const period = shaka.util.TXml.findChild(xml, 'Period');
       expect(period).not.toBeNull();
 
-      // The attribute must contain the literal string, not break out.
-      expect(period.attributes['id']).toBe('p1" injected="yes');
-      // No spurious 'injected' attribute must exist.
+      // No spurious 'injected' attribute must exist after parsing.
       expect(period.attributes['injected']).toBeUndefined();
     });
 


### PR DESCRIPTION
## Problem

`JsonUtils.jsonToMpd()` in `lib/dash/json_utils.js` does not XML-escape string values when building the MPD XML string. The `emit()` helper calls `StringUtils.htmlUnescape()` on both attribute values (line 38) and text content (lines 61, 120) — the wrong direction. `htmlUnescape()` converts HTML entities back to raw characters but does **not** escape raw `<`, `>`, or `"` characters.

This means any JSON string value that contains XML metacharacters is embedded verbatim into the XML output and interpreted as markup by the parser.

**Example — BaseURL injection:**

```json
{
  "Period": [{
    "AdaptationSet": [{
      "BaseURL": "</BaseURL><BaseURL>http://attacker.example/segments/"
    }]
  }]
}
```

`emit('BaseURL', {}, ...)` produces:

```xml
<BaseURL></BaseURL><BaseURL>http://attacker.example/segments/</BaseURL>
```

`dash_parser.js` collects **all** `BaseURL` children via `TXml.findChildren(elem, 'BaseURL')` and adds every resolved URI to `lastCalculatedBaseUris_`. An attacker who controls the manifest URL can redirect segment requests to an arbitrary server.

The same injection path applies to `ContentProtection` and other child elements, and to attribute values containing `"`.

## Fix

Replace the three `htmlUnescape()` calls with a local `xmlEscape()` function that encodes `&`, `<`, `>`, and `"` as XML character references. Remove the now-unused `StringUtils` import.

## Tests

Added two regression tests to `test/dash/json_utils_unit.js`:
- Text content injection: verifies that a `BaseURL` value with `</BaseURL><BaseURL>http://attacker.example/` produces exactly **one** `BaseURL` element with the literal string as content, not two parsed elements.
- Attribute value injection: verifies that a `Period` `id` attribute containing `"` does not break out of the attribute context.