### PR TITLE
perf(ts): derive start time from PES headers

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -995,7 +995,7 @@ shaka.media.MediaSourceEngine = class {
       tsParser.clearData();
       tsParser.setDiscontinuitySequence(reference.discontinuitySequence);
       tsParser.parse(uint8ArrayData);
-      const startTime = tsParser.getStartTime(contentType);
+      const startTime = tsParser.getStartTimeFromPesHeaders(contentType);
       if (startTime != null) {
         timestamp = startTime;
       }

--- a/lib/util/ts_parser.js
+++ b/lib/util/ts_parser.js
@@ -462,20 +462,63 @@ shaka.util.TsParser = class {
    * @private
    */
   concatPesPackets_(packets, pesIndices, pesIdx) {
-    const first = pesIndices[pesIdx];  // inclusive
-    const end = pesIdx + 1 < pesIndices.length ?  // exclusive
-        pesIndices[pesIdx + 1] : packets.length;
-    return shaka.util.Uint8ArrayUtils.concatRange(packets, first, end);
+    const range = this.getPesPacketRange_(packets, pesIndices, pesIdx);
+    return this.concatPesPacketRange_(packets, range);
   }
 
   /**
-   * Parse PES
-   *
-   * @param {Uint8Array} data
-   * @return {?shaka.extern.MPEG_PES}
+   * @param {!Array<!Uint8Array>} packets Flat list of all TS packets for a PID.
+   * @param {{first: number, end: number}} range Packet range to concatenate.
+   * @return {!Uint8Array}
    * @private
    */
-  parsePES_(data) {
+  concatPesPacketRange_(packets, range) {
+    return shaka.util.Uint8ArrayUtils.concatRange(
+        packets, range.first, range.end);
+  }
+
+  /**
+   * @param {!Array<!Uint8Array>} packets Flat list of all TS packets for a PID.
+   * @param {!Array<number>} pesIndices Start index in `packets` for each PES.
+   * @param {number} pesIdx Index into `pesIndices` for the desired PES.
+   * @return {{first: number, end: number}}
+   * @private
+   */
+  getPesPacketRange_(packets, pesIndices, pesIdx) {
+    const first = pesIndices[pesIdx];  // inclusive
+    const end = pesIdx + 1 < pesIndices.length ?  // exclusive
+        pesIndices[pesIdx + 1] : packets.length;
+    return {first, end};
+  }
+
+  /**
+   * Parse the PES header without requiring the full payload.
+   *
+   * This updates PTS/DTS rollover reference state, so callers that depend on
+   * rollover-corrected timestamps across multiple PES packets must parse
+   * headers in PES order.
+   *
+   * @param {!Uint8Array} data PES bytes available to read from. May contain
+   *   only the first TS packet payload, so this can be smaller than the full
+   *   PES. Use `data.byteLength` for bounds checks on readable bytes.
+   * @param {number} fullPesByteLength Total byte length of the complete PES
+   *   (sum of all its TS packet payloads), which may be larger than
+   *   `data.byteLength`. Use this only for reasoning about the full PES, never
+   *   for indexing into `data`.
+   * @return {?{
+   *   packetLength: number,
+   *   payloadStartOffset: number,
+   *   pts: ?number,
+   *   dts: ?number,
+   * }}
+   * @private
+   */
+  parsePESHeader_(data, fullPesByteLength) {
+    // data.byteLength: bounds check on bytes we can actually index here.
+    if (data.byteLength < shaka.util.TsParser.MIN_PES_HEADER_LENGTH_) {
+      return null;
+    }
+
     const startPrefix = (data[0] << 16) | (data[1] << 8) | data[2];
     // In certain live streams, the start of a TS fragment has ts packets
     // that are frame data that is continuing from the previous fragment. This
@@ -487,9 +530,13 @@ shaka.util.TsParser = class {
     // get the packet length, this will be 0 for video
     const packetLength = (data[4] << 8) | data[5];
 
-    // if PES parsed length is not zero and greater than total received length,
-    // stop parsing. PES might be truncated. minus 6 : PES header size
-    if (packetLength && packetLength > data.byteLength - 6) {
+    // If the declared PES length exceeds what we actually received, the PES is
+    // truncated (e.g. a TS fragment that starts mid-PES). minus 6 : PES header
+    // size. This check is preserved from the full parsePES_ path; on the
+    // header-only path returning null is a safe fallback, since the caller
+    // simply skips this PES and tries the next one. Uses fullPesByteLength
+    // (the complete PES size), not data.byteLength.
+    if (packetLength && packetLength > fullPesByteLength - 6) {
       return null;
     }
 
@@ -500,6 +547,12 @@ shaka.util.TsParser = class {
     // and a DTS value. Determine what combination of values is
     // available to work with.
     const ptsDtsFlags = data[7];
+    // We must have the full optional PES header in hand to read PTS/DTS, so
+    // bounds-check against data.byteLength (what we can actually index), not
+    // fullPesByteLength. If the header bytes aren't present, bail.
+    if (data.byteLength < this.getRequiredPesHeaderLength_(data)) {
+      return null;
+    }
 
     // PTS and DTS are normally stored as a 33-bit number.  Javascript
     // performs all bitwise operations on 32-bit integers but javascript
@@ -552,15 +605,41 @@ shaka.util.TsParser = class {
     const pesHdrLen = data[8];
     // 9 bytes : 6 bytes for PES header + 3 bytes for PES extension
     const payloadStartOffset = pesHdrLen + 9;
-    if (data.byteLength <= payloadStartOffset) {
+    // Reject a PES with no payload after the header. This check is preserved
+    // from the full parsePES_ path (which needs payload bytes); on the
+    // header-only path returning null is a safe fallback, since the caller
+    // skips this PES and tries the next one. Uses fullPesByteLength (the
+    // complete PES size), not data.byteLength.
+    if (fullPesByteLength <= payloadStartOffset) {
       return null;
     }
 
     return {
-      data: data.subarray(payloadStartOffset),
       packetLength: packetLength,
+      payloadStartOffset: payloadStartOffset,
       pts: pesPts,
       dts: pesDts,
+    };
+  }
+
+  /**
+   * Parse PES
+   *
+   * @param {!Uint8Array} data
+   * @return {?shaka.extern.MPEG_PES}
+   * @private
+   */
+  parsePES_(data) {
+    const pes = this.parsePESHeader_(data, data.byteLength);
+    if (!pes) {
+      return null;
+    }
+
+    return {
+      data: data.subarray(pes.payloadStartOffset),
+      packetLength: pes.packetLength,
+      pts: pes.pts,
+      dts: pes.dts,
       nalus: [],
     };
   }
@@ -836,6 +915,94 @@ shaka.util.TsParser = class {
   }
 
   /**
+   * Return the start time for the audio or video by parsing only PES headers.
+   * This is intended for append-time timestamp offset calculation, where
+   * callers do not need the parsed PES payloads.
+   *
+   * @param {string} contentType
+   * @return {?number}
+   */
+  getStartTimeFromPesHeaders(contentType) {
+    let packets;
+    let pesIndices;
+    if (contentType == 'audio') {
+      packets = this.audioData_;
+      pesIndices = this.audioDataPesIndices_;
+    } else if (contentType == 'video') {
+      packets = this.videoData_;
+      pesIndices = this.videoDataPesIndices_;
+    } else {
+      return null;
+    }
+
+    for (let pesIdx = 0; pesIdx < pesIndices.length; pesIdx++) {
+      const range = this.getPesPacketRange_(packets, pesIndices, pesIdx);
+      const firstPacket = packets[range.first];
+      if (!firstPacket) {
+        continue;
+      }
+
+      let byteLength = 0;
+      for (let i = range.first; i < range.end; i++) {
+        byteLength += packets[i].byteLength;
+      }
+
+      // Common case: first TS packet payload already contains the full PES
+      // header, so we can parse it without concatenating the rest of the PES.
+      const hasCompleteHeader =
+          firstPacket.byteLength >=
+              shaka.util.TsParser.MIN_PES_HEADER_LENGTH_ &&
+          firstPacket.byteLength >=
+              this.getRequiredPesHeaderLength_(firstPacket);
+      const data = hasCompleteHeader ? firstPacket :
+          this.concatPesPacketRange_(packets, range);
+
+      const pes = this.parsePESHeader_(data, byteLength);
+      if (!pes) {
+        continue;
+      }
+      const startTime = this.getStartTimeFromPes_(pes);
+      if (startTime != null) {
+        return startTime;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @param {!Uint8Array} data PES data with at least
+   *   `MIN_PES_HEADER_LENGTH_` bytes.
+   * @return {number}
+   * @private
+   */
+  getRequiredPesHeaderLength_(data) {
+    const ptsDtsFlags = data[7];
+    // 0x40 = DTS bit; 0xC0 = PTS-or-DTS bit. DTS bit set implies a PTS+DTS
+    // pair (per the MPEG spec, DTS without PTS is reserved/invalid).
+    if (ptsDtsFlags & 0x40) {
+      return shaka.util.TsParser.PES_HEADER_WITH_DTS_LENGTH_;
+    } else if (ptsDtsFlags & 0xC0) {
+      return shaka.util.TsParser.PES_HEADER_WITH_PTS_LENGTH_;
+    }
+    return shaka.util.TsParser.MIN_PES_HEADER_LENGTH_;
+  }
+
+  /**
+   * @param {{
+   *   pts: ?number,
+   *   dts: ?number,
+   * }} pes
+   * @return {?number}
+   * @private
+   */
+  getStartTimeFromPes_(pes) {
+    if (pes.pts == null || pes.dts == null) {
+      return null;
+    }
+    return Math.min(pes.dts, pes.pts) / shaka.util.TsParser.Timescale;
+  }
+
+  /**
    * Return the start time for the audio and video
    *
    * @param {string} contentType
@@ -843,23 +1010,16 @@ shaka.util.TsParser = class {
    * @export
    */
   getStartTime(contentType) {
-    const timescale = shaka.util.TsParser.Timescale;
+    let pesData;
     if (contentType == 'audio') {
-      let audioStartTime = null;
-      const audioData = this.getAudioData();
-      if (audioData.length) {
-        const pes = audioData[0];
-        audioStartTime = Math.min(pes.dts, pes.pts) / timescale;
-      }
-      return audioStartTime;
+      pesData = this.getAudioData();
     } else if (contentType == 'video') {
-      let videoStartTime = null;
-      const videoData = this.getVideoData(/* naluProcessing= */ false);
-      if (videoData.length) {
-        const pes = videoData[0];
-        videoStartTime = Math.min(pes.dts, pes.pts) / timescale;
-      }
-      return videoStartTime;
+      pesData = this.getVideoData(/* naluProcessing= */ false);
+    } else {
+      return null;
+    }
+    if (pesData.length) {
+      return this.getStartTimeFromPes_(pesData[0]);
     }
     return null;
   }
@@ -1329,6 +1489,27 @@ shaka.util.TsParser.PacketLength_ = 188;
 
 
 /**
+ * @const {number}
+ * @private
+ */
+shaka.util.TsParser.MIN_PES_HEADER_LENGTH_ = 9;
+
+
+/**
+ * @const {number}
+ * @private
+ */
+shaka.util.TsParser.PES_HEADER_WITH_PTS_LENGTH_ = 14;
+
+
+/**
+ * @const {number}
+ * @private
+ */
+shaka.util.TsParser.PES_HEADER_WITH_DTS_LENGTH_ = 19;
+
+
+/**
  * NALU type for Sequence Parameter Set (SPS) for H.264.
  * @const {number}
  * @private
@@ -1394,4 +1575,3 @@ shaka.util.TsParser.PMT;
  * @property {number} sampleRate
  */
 shaka.util.TsParser.OpusMetadata;
-

--- a/test/util/ts_parser_unit.js
+++ b/test/util/ts_parser_unit.js
@@ -64,6 +64,27 @@ describe('TsParser', () => {
     expect(starttime).toBeCloseTo(90019.586, 3);
   });
 
+  it('gets the start time from TS PES headers', async () => {
+    const responses = await Promise.all([
+      Util.fetch('/base/test/test/assets/video.ts'),
+      Util.fetch('/base/test/test/assets/audio.ts'),
+    ]);
+    const videoSegment = BufferUtils.toUint8(responses[0]);
+    const audioSegment = BufferUtils.toUint8(responses[1]);
+
+    const videoStartTime = new shaka.util.TsParser().parse(videoSegment)
+        .getStartTime(ContentType.VIDEO);
+    const headerVideoStartTime = new shaka.util.TsParser().parse(videoSegment)
+        .getStartTimeFromPesHeaders(ContentType.VIDEO);
+    expect(headerVideoStartTime).toBe(videoStartTime);
+
+    const audioStartTime = new shaka.util.TsParser().parse(audioSegment)
+        .getStartTime(ContentType.AUDIO);
+    const headerAudioStartTime = new shaka.util.TsParser().parse(audioSegment)
+        .getStartTimeFromPesHeaders(ContentType.AUDIO);
+    expect(headerAudioStartTime).toBe(audioStartTime);
+  });
+
   it('get the codecs from a TS segment', async () => {
     const responses = await Promise.all([
       Util.fetch('/base/test/test/assets/id3-metadata.ts'),


### PR DESCRIPTION
This PR adds a PES header-only method that extracts the first PTS/DTS without concatenating PES payloads in the common case, and switches MediaSourceEngine to use it — avoids the per-PES Uint8Array allocation when the first TS packet already holds the full PES header (falls back to concatenating the PES range otherwise)