### PR TITLE
feat(player): expose mediaTimestamp on segmentappended

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1177,7 +1177,7 @@ shaka.media.MediaSourceEngine = class {
    *   partial read of the segment.
    * @param {boolean=} fromSplit
    * @param {number=} continuityTimeline an optional continuity timeline
-   * @return {!Promise}
+   * @return {!Promise<!shaka.media.MediaSourceEngine.AppendBufferInfo>}
    */
   async appendBuffer(
       contentType, data, reference, stream, hasClosedCaptions, seeked = false,
@@ -1192,25 +1192,31 @@ shaka.media.MediaSourceEngine = class {
           reference ? reference.endTime : null,
           reference ? reference.getUris()[0] : null,
           reference ? reference.discontinuitySequence : -1);
-      return;
+      return {
+        mediaTimestamp: null,
+      };
     }
 
     if (!fromSplit && this.needSplitMuxedContent_) {
-      await this.appendBuffer(ContentType.AUDIO, data, reference, stream,
-          hasClosedCaptions, seeked, adaptation, isChunkedData,
-          /* fromSplit= */ true);
-      await this.appendBuffer(ContentType.VIDEO, data, reference, stream,
-          hasClosedCaptions, seeked, adaptation, isChunkedData,
-          /* fromSplit= */ true);
-      return;
+      const audioAppendBufferInfo = await this.appendBuffer(
+          ContentType.AUDIO, data, reference, stream, hasClosedCaptions, seeked,
+          adaptation, isChunkedData, /* fromSplit= */ true);
+      const videoAppendBufferInfo = await this.appendBuffer(
+          ContentType.VIDEO, data, reference, stream, hasClosedCaptions, seeked,
+          adaptation, isChunkedData, /* fromSplit= */ true);
+      return videoAppendBufferInfo.mediaTimestamp != null ?
+          videoAppendBufferInfo : audioAppendBufferInfo;
     }
 
     if (!this.sourceBuffers_.has(contentType)) {
       shaka.log.warning('Attempted to restore a non-existent source buffer');
-      return;
+      return {
+        mediaTimestamp: null,
+      };
     }
 
     let timestampOffset = this.sourceBuffers_.get(contentType).timestampOffset;
+    let mediaTimestamp = null;
 
     let mimeType = this.sourceBufferTypes_.get(contentType);
     if (this.transmuxers_.has(contentType)) {
@@ -1220,6 +1226,7 @@ shaka.media.MediaSourceEngine = class {
       const {timestamp, metadata} = this.getTimestampAndDispatchMetadata(
           contentType, data, reference, stream, mimeType, isChunkedData);
       if (timestamp != null) {
+        mediaTimestamp = timestamp;
         if (this.firstVideoTimestamp_ == null &&
             contentType == ContentType.VIDEO) {
           this.firstVideoTimestamp_ = timestamp;
@@ -1408,6 +1415,10 @@ shaka.media.MediaSourceEngine = class {
         }
       }
     }
+
+    return {
+      mediaTimestamp: mediaTimestamp,
+    };
   }
 
   /**
@@ -2737,6 +2748,18 @@ shaka.media.MediaSourceEngine = class {
  * @type {function(?):string}
  */
 shaka.media.MediaSourceEngine.createObjectURL = window.URL.createObjectURL;
+
+
+/**
+ * @typedef {{
+ *   mediaTimestamp: ?number,
+ * }}
+ *
+ * @property {?number} mediaTimestamp
+ *   The segment start timestamp parsed from the media segment, in seconds, or
+ *   null if Shaka could not parse one.
+ */
+shaka.media.MediaSourceEngine.AppendBufferInfo;
 
 
 /**

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1966,6 +1966,9 @@ shaka.media.StreamingEngine = class {
           this.manifest_.isLowLatency;
       // Enable MP4 low latency streaming with ReadableStream chunked data.
       // And only for DASH and HLS with byterange optimization.
+      let appendBufferInfo = {
+        mediaTimestamp: null,
+      };
       if (lowLatencyMode && isReadableStreamSupported && isMP4 &&
           (this.manifest_.type != shaka.media.ManifestParser.HLS ||
           reference.hasByterangeOptimization())) {
@@ -2007,9 +2010,15 @@ shaka.media.StreamingEngine = class {
             if (sawMDAT) {
               const dataToAppend = remaining.subarray(0, offset);
               remaining = remaining.subarray(offset);
-              await this.append_(
+              const nextAppendBufferInfo = await this.append_(
                   mediaState, presentationTime, stream, reference, dataToAppend,
                   /* isChunkedData= */ true, adaptation);
+              // Keep the timestamp from the first chunk that exposes one. In
+              // low-latency mode, segmentappended describes the whole segment,
+              // not the last chunk.
+              if (appendBufferInfo.mediaTimestamp == null) {
+                appendBufferInfo = nextAppendBufferInfo;
+              }
 
               if (mediaState.segmentPrefetch && mediaState.segmentIterator) {
                 mediaState.segmentPrefetch.prefetchSegmentsByTime(
@@ -2048,8 +2057,9 @@ shaka.media.StreamingEngine = class {
             return;
           }
 
-          await this.append_(mediaState, presentationTime, stream, reference,
-              result, /* chunkedData= */ false, adaptation);
+          appendBufferInfo = await this.append_(
+              mediaState, presentationTime, stream, reference, result,
+              /* chunkedData= */ false, adaptation);
         }
 
         if (mediaState.segmentPrefetch && mediaState.segmentIterator) {
@@ -2080,8 +2090,9 @@ shaka.media.StreamingEngine = class {
           return;
         }
 
-        await this.append_(mediaState, presentationTime, stream, reference,
-            result, /* chunkedData= */ false, adaptation);
+        appendBufferInfo = await this.append_(
+            mediaState, presentationTime, stream, reference, result,
+            /* chunkedData= */ false, adaptation);
       }
 
       this.destroyer_.ensureNotDestroyed();
@@ -2113,11 +2124,11 @@ shaka.media.StreamingEngine = class {
         if (otherState && otherState.type == ContentType.AUDIO) {
           this.playerInterface_.onSegmentAppended(reference, mediaState.stream,
               otherState.stream.isAudioMuxedInVideo,
-              /* isDependency= */ false);
+              /* isDependency= */ false, appendBufferInfo.mediaTimestamp);
         } else {
           this.playerInterface_.onSegmentAppended(reference, mediaState.stream,
               mediaState.stream.codecs.includes(','),
-              /* isDependency= */ false);
+              /* isDependency= */ false, appendBufferInfo.mediaTimestamp);
         }
       }
 
@@ -2245,12 +2256,12 @@ shaka.media.StreamingEngine = class {
             this.playerInterface_.onSegmentAppended(
                 reference, mediaState.stream,
                 otherState.stream.isAudioMuxedInVideo,
-                /* isDependency= */ true);
+                /* isDependency= */ true, /* mediaTimestamp= */ null);
           } else {
             this.playerInterface_.onSegmentAppended(
                 reference, mediaState.stream,
                 mediaState.stream.codecs.includes(','),
-                /* isDependency= */ true);
+                /* isDependency= */ true, /* mediaTimestamp= */ null);
           }
         }
 
@@ -2745,7 +2756,7 @@ shaka.media.StreamingEngine = class {
    * @param {BufferSource} segment
    * @param {boolean=} isChunkedData
    * @param {boolean=} adaptation
-   * @return {!Promise}
+   * @return {!Promise<!shaka.media.MediaSourceEngine.AppendBufferInfo>}
    * @private
    */
   async append_(mediaState, presentationTime, stream, reference, segment,
@@ -2815,17 +2826,19 @@ shaka.media.StreamingEngine = class {
     mediaState.seeked = false;
 
     await this.playerInterface_.beforeAppendSegment(mediaState.type, segment);
-    await this.playerInterface_.mediaSourceEngine.appendBuffer(
-        mediaState.type,
-        segment,
-        reference,
-        stream,
-        hasClosedCaptions,
-        seeked,
-        adaptation,
-        isChunkedData);
+    const appendBufferInfo =
+        await this.playerInterface_.mediaSourceEngine.appendBuffer(
+            mediaState.type,
+            segment,
+            reference,
+            stream,
+            hasClosedCaptions,
+            seeked,
+            adaptation,
+            isChunkedData);
     this.destroyer_.ensureNotDestroyed();
     shaka.log.v2(logPrefix, 'appended media segment');
+    return appendBufferInfo;
   }
 
   /**
@@ -3656,7 +3669,7 @@ shaka.media.StreamingEngine = class {
  *   onError: function(!shaka.util.Error),
  *   onEvent: function(!Event),
  *   onSegmentAppended: function(!shaka.media.SegmentReference,
- *     !shaka.extern.Stream, boolean, boolean),
+ *     !shaka.extern.Stream, boolean, boolean, ?number),
  *   onInitSegmentAppended: function(!number,!shaka.media.InitSegmentReference),
  *   beforeAppendSegment: function(
  *     shaka.util.ManifestParserUtils.ContentType,!BufferSource):Promise,
@@ -3686,7 +3699,7 @@ shaka.media.StreamingEngine = class {
  * @property {function(!Event)} onEvent
  *   Called when an event occurs that should be sent to the app.
  * @property {function(!shaka.media.SegmentReference,
- *     !shaka.extern.Stream, boolean, boolean)} onSegmentAppended
+ *     !shaka.extern.Stream, boolean, boolean, ?number)} onSegmentAppended
  *   Called after a segment is successfully appended to a MediaSource.
  * @property {function(!number,
  *                     !shaka.media.InitSegmentReference)} onInitSegmentAppended

--- a/lib/player.js
+++ b/lib/player.js
@@ -519,6 +519,10 @@ goog.requireType('shaka.media.PresentationTimeline');
  *   Indicates if the segment is muxed (audio + video).
  * @property {boolean} isDependency
  *   Indicates if the segment is from dependency stream.
+ * @property {?number} mediaTimestamp
+ *   The segment start timestamp parsed from the media segment, in seconds, or
+ *   null if Shaka could not parse one. The matching presentation timestamp is
+ *   reported by the event's start field.
  * @exportDoc
  */
 
@@ -4403,9 +4407,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       netEngine: this.networkingEngine_,
       onError: (error) => this.onError_(error),
       onEvent: (event) => this.dispatchEvent(event),
-      onSegmentAppended: (reference, stream, isMuxed, isDependency) => {
+      onSegmentAppended: (reference, stream, isMuxed, isDependency,
+          mediaTimestamp) => {
         this.onSegmentAppended_(reference.startTime, reference.endTime,
-            stream.type, isMuxed, isDependency);
+            stream.type, isMuxed, isDependency, mediaTimestamp);
         // When we are in an L3D stream we want to go to a non-L3D stream, for
         // this we need to inform the ABR that it should suggest new streams.
         if (this.abrManager_ && stream.fastSwitching &&
@@ -8581,10 +8586,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @param {shaka.util.ManifestParserUtils.ContentType} contentType
    * @param {boolean} isMuxed
    * @param {boolean} isDependency
+   * @param {?number} mediaTimestamp
    *
    * @private
    */
-  onSegmentAppended_(start, end, contentType, isMuxed, isDependency) {
+  onSegmentAppended_(
+      start, end, contentType, isMuxed, isDependency, mediaTimestamp) {
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
     const NumberUtils = shaka.util.NumberUtils;
     if (contentType != ContentType.TEXT) {
@@ -8617,7 +8624,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         .set('end', end)
         .set('contentType', contentType)
         .set('isMuxed', isMuxed)
-        .set('isDependency', isDependency);
+        .set('isDependency', isDependency)
+        .set('mediaTimestamp', mediaTimestamp);
     this.dispatchEvent(shaka.Player.makeEvent_(
         shaka.util.FakeEvent.EventName.SegmentAppended, data));
   }

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -613,6 +613,42 @@ describe('MediaSourceEngine', () => {
       await p;
     });
 
+    it('returns parsed media timestamp', async () => {
+      const reference = dummyReference(7, 10);
+      spyOn(mediaSourceEngine, 'getTimestampAndDispatchMetadata')
+          .and.returnValue({
+            timestamp: 5,
+            metadata: [],
+          });
+
+      const p = mediaSourceEngine.appendBuffer(
+          ContentType.AUDIO, buffer, reference, fakeStream,
+          /* hasClosedCaptions= */ false);
+      expect(audioSourceBuffer.appendBuffer).toHaveBeenCalledWith(buffer);
+      audioSourceBuffer.updateend();
+
+      const appendBufferInfo = await p;
+      expect(appendBufferInfo.mediaTimestamp).toBe(5);
+    });
+
+    it('returns null media timestamp when none is parsed', async () => {
+      const reference = dummyReference(7, 10);
+      spyOn(mediaSourceEngine, 'getTimestampAndDispatchMetadata')
+          .and.returnValue({
+            timestamp: null,
+            metadata: [],
+          });
+
+      const p = mediaSourceEngine.appendBuffer(
+          ContentType.AUDIO, buffer, reference, fakeStream,
+          /* hasClosedCaptions= */ false);
+      expect(audioSourceBuffer.appendBuffer).toHaveBeenCalledWith(buffer);
+      audioSourceBuffer.updateend();
+
+      const appendBufferInfo = await p;
+      expect(appendBufferInfo.mediaTimestamp).toBeNull();
+    });
+
     it('rejects promise when operation throws', async () => {
       const reference = dummyReference(0, 1000);
       audioSourceBuffer.appendBuffer.and.throwError('fail!');

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -754,7 +754,9 @@ describe('StreamingEngine', () => {
     const config = shaka.util.PlayerConfiguration.createDefault().streaming;
     config.lowLatencyMode = true;
     mediaSourceEngine = new shaka.test.FakeMediaSourceEngine(segmentData);
-    mediaSourceEngine.appendBuffer.and.stub();
+    mediaSourceEngine.appendBuffer.and.returnValue(Promise.resolve({
+      mediaTimestamp: null,
+    }));
     createStreamingEngine(config);
 
     // Here we go!
@@ -1282,7 +1284,9 @@ describe('StreamingEngine', () => {
       mediaSourceEngine.appendBuffer.and.callFake(
           (type, data, reference) => {
             bufferEnd[type] = reference && reference.endTime;
-            return Promise.resolve();
+            return Promise.resolve({
+              mediaTimestamp: null,
+            });
           });
       mediaSourceEngine.bufferEnd.and.callFake((type) => {
         return bufferEnd[type];
@@ -3408,7 +3412,9 @@ describe('StreamingEngine', () => {
       const bufferEnd = {audio: 0, video: 0, text: 0};
       mediaSourceEngine.appendBuffer.and.callFake((type, data, reference) => {
         bufferEnd[type] = reference && reference.endTime;
-        return Promise.resolve();
+        return Promise.resolve({
+          mediaTimestamp: null,
+        });
       });
       mediaSourceEngine.bufferEnd.and.callFake((type) => bufferEnd[type]);
       mediaSourceEngine.bufferedAheadOf.and.callFake(
@@ -3709,7 +3715,9 @@ describe('StreamingEngine', () => {
       mediaSourceEngine.appendBuffer.and.callFake(
           (type, data, reference) => {
             bufferEnd[type] = reference && reference.endTime;
-            return Promise.resolve();
+            return Promise.resolve({
+              mediaTimestamp: null,
+            });
           });
       mediaSourceEngine.bufferEnd.and.callFake((type) => {
         return bufferEnd[type];

--- a/test/test/util/fake_media_source_engine.js
+++ b/test/test/util/fake_media_source_engine.js
@@ -259,7 +259,7 @@ shaka.test.FakeMediaSourceEngine = class {
    * @param {string} type
    * @param {!ArrayBuffer} data
    * @param {?shaka.media.SegmentReference} reference
-   * @return {!Promise}
+   * @return {!Promise<!shaka.media.MediaSourceEngine.AppendBufferInfo>}
    */
   appendBufferImpl(type, data, reference) {
     if (!this.segments[type]) {
@@ -289,7 +289,9 @@ shaka.test.FakeMediaSourceEngine = class {
       this.initSegments[type] =
           this.segmentData[type].initSegments.map((c) => false);
       this.initSegments[type][i] = true;
-      return Promise.resolve();
+      return Promise.resolve({
+        mediaTimestamp: null,
+      });
     }
 
     // Set media segment.
@@ -323,7 +325,9 @@ shaka.test.FakeMediaSourceEngine = class {
     }
 
     this.segments[type][i] = true;
-    return Promise.resolve();
+    return Promise.resolve({
+      mediaTimestamp: segmentData.segmentStartTimes[i],
+    });
   }
 
   /**


### PR DESCRIPTION
Expose the parsed media segment timestamp through the existing segmentappended event. The media-to-presentation offset is given by (event.start - event.mediaTimestamp). This can be used to map external media timestamps onto the presentation timeline.