### PR TITLE
fix: Fix getOrInsertComputed is not available at the init, so not used at the init

### DIFF
--- a/lib/metadata/metadata.js
+++ b/lib/metadata/metadata.js
@@ -81,7 +81,10 @@ shaka.metadata.Metadata = class {
    */
   static registerParserByMime(mimeType, parserFactory) {
     const map = shaka.metadata.Metadata.parsersByMime_;
-    map.getOrInsertComputed(mimeType, () => []).push(parserFactory);
+    if (!map.has(mimeType)) {
+      map.set(mimeType, []);
+    }
+    map.get(mimeType).push(parserFactory);
   }
 
   /**


### PR DESCRIPTION
getOrInsertComputed is not available at init, until polyfills are used, but the problem that this PR fixes is that there is a call that uses it before calling the polyfill.