### PR TITLE
perf: Disable ContentWorkarounds on Safari >=26.4

### DIFF
--- a/lib/device/apple_browser.js
+++ b/lib/device/apple_browser.js
@@ -19,23 +19,20 @@ shaka.device.AppleBrowser = class extends shaka.device.AbstractDevice {
   constructor() {
     super();
 
-    /** @private {!shaka.util.Lazy<?number>} */
+    /** @private {!shaka.util.Lazy<!Array<number>>} */
     this.version_ = new shaka.util.Lazy(() => {
       // This works for iOS Safari and desktop Safari, which contain something
-      // like "Version/13.0" indicating the major Safari or iOS version.
-      let match = navigator.userAgent.match(/Version\/(\d+)/);
-      if (match) {
-        return parseInt(match[1], /* base= */ 10);
+      // like "Version/13.0" indicating the major.minor Safari or iOS version.
+      let match = navigator.userAgent.match(/Version\/(\d+)(?:\.(\d+))?/);
+      if (!match) {
+        // This works for all other browsers on iOS, which contain something
+        // like "OS 13_3" indicating the major & minor iOS version.
+        match = navigator.userAgent.match(/OS (\d+)(?:_(\d+))?/);
       }
-
-      // This works for all other browsers on iOS, which contain something like
-      // "OS 13_3" indicating the major & minor iOS version.
-      match = navigator.userAgent.match(/OS (\d+)(?:_\d+)?/);
       if (match) {
-        return parseInt(match[1], /* base= */ 10);
+        return [parseInt(match[1], 10), parseInt(match[2] || '0', 10)];
       }
-
-      return null;
+      return [0, 0];
     });
 
     /** @private {!shaka.util.Lazy<!shaka.device.IDevice.DeviceType>} */
@@ -58,7 +55,7 @@ shaka.device.AppleBrowser = class extends shaka.device.AbstractDevice {
    * @override
    */
   getVersion() {
-    return this.version_.value();
+    return this.version_.value()[0];
   }
 
   /**
@@ -93,21 +90,23 @@ shaka.device.AppleBrowser = class extends shaka.device.AbstractDevice {
    * @override
    */
   requiresEncryptionInfoInAllInitSegments(keySystem, contentType) {
-    return contentType === 'audio';
+    return !this.supportsMixedClearEncryptedContent_() &&
+      contentType === 'audio';
   }
 
   /**
    * @override
    */
   insertEncryptionDataBeforeClear() {
-    return true;
+    return !this.supportsMixedClearEncryptedContent_();
   }
 
   /**
    * @override
    */
   requiresTfhdFix(contentType) {
-    return contentType === 'audio';
+    return !this.supportsMixedClearEncryptedContent_() &&
+      contentType === 'audio';
   }
 
   /**
@@ -131,6 +130,19 @@ shaka.device.AppleBrowser = class extends shaka.device.AbstractDevice {
    */
   supportsContainerChangeType() {
     return false;
+  }
+
+  /**
+   * Apple has fixed the mixed clear/encrypted content issue in Safari 26.4
+   * @return {boolean}
+   * @private
+   */
+  supportsMixedClearEncryptedContent_() {
+    const version = this.version_.value();
+    if (version[0] >= 27) {
+      return true;
+    }
+    return version[0] === 26 && version[1] >= 4;
   }
 
   /**


### PR DESCRIPTION
Since this version we don't need to fake encryption on audio segments.