### PR TITLE
feat: Export ContentType and use it in Stream & StreamDB types

### DIFF
--- a/externs/shaka/manifest.js
+++ b/externs/shaka/manifest.js
@@ -367,7 +367,7 @@ shaka.extern.SegmentIndex = class {
  *   language: string,
  *   originalLanguage: ?string,
  *   label: ?string,
- *   type: string,
+ *   type: shaka.media.ManifestParser.ContentType,
  *   primary: boolean,
  *   trickModeVideo: ?shaka.extern.Stream,
  *   dependencyStream: ?shaka.extern.Stream,
@@ -479,7 +479,7 @@ shaka.extern.SegmentIndex = class {
  *   The original language, if any, that appeared in the manifest.
  * @property {?string} label
  *   The Stream's label, unique text that should describe the audio/text track.
- * @property {string} type
+ * @property {shaka.media.ManifestParser.ContentType} type
  *   <i>Required.</i> <br>
  *   Content type (e.g. 'video', 'audio' or 'text', 'image')
  * @property {boolean} primary

--- a/externs/shaka/offline.js
+++ b/externs/shaka/offline.js
@@ -116,7 +116,7 @@ shaka.extern.ManifestDB;
  *   originalId: ?string,
  *   groupId: ?string,
  *   primary: boolean,
- *   type: string,
+ *   type: shaka.media.ManifestParser.ContentType,
  *   mimeType: string,
  *   codecs: string,
  *   frameRate: (number|undefined),
@@ -156,7 +156,7 @@ shaka.extern.ManifestDB;
  *   ID that represents the representation's parent adaptation element
  * @property {boolean} primary
  *   Whether the stream set was primary.
- * @property {string} type
+ * @property {shaka.media.ManifestParser.ContentType} type
  *   The type of the stream, 'audio', 'text', or 'video'.
  * @property {string} mimeType
  *   The MIME type of the stream.

--- a/externs/shaka/offline_compat_v1.js
+++ b/externs/shaka/offline_compat_v1.js
@@ -65,7 +65,7 @@ shaka.extern.PeriodDBV1;
  *   id: number,
  *   primary: boolean,
  *   presentationTimeOffset: number,
- *   contentType: string,
+ *   contentType: shaka.media.ManifestParser.ContentType,
  *   mimeType: string,
  *   codecs: string,
  *   frameRate: (number|undefined),
@@ -88,7 +88,7 @@ shaka.extern.PeriodDBV1;
  * @property {number} presentationTimeOffset
  *   The presentation time offset of the stream, in seconds.  Note that this is
  *   the inverse of the timestampOffset as defined in the manifest types.
- * @property {string} contentType
+ * @property {shaka.media.ManifestParser.ContentType} contentType
  *   The type of the stream, 'audio', 'text', or 'video'.
  * @property {string} mimeType
  *   The MIME type of the stream.

--- a/externs/shaka/offline_compat_v2.js
+++ b/externs/shaka/offline_compat_v2.js
@@ -63,7 +63,7 @@ shaka.extern.PeriodDBV2;
  *   originalId: ?string,
  *   primary: boolean,
  *   presentationTimeOffset: number,
- *   contentType: string,
+ *   contentType: shaka.media.ManifestParser.ContentType,
  *   mimeType: string,
  *   codecs: string,
  *   frameRate: (number|undefined),
@@ -90,7 +90,7 @@ shaka.extern.PeriodDBV2;
  * @property {number} presentationTimeOffset
  *   The presentation time offset of the stream, in seconds.  Note that this is
  *   the inverse of the timestampOffset as defined in the manifest types.
- * @property {string} contentType
+ * @property {shaka.media.ManifestParser.ContentType} contentType
  *   The type of the stream, 'audio', 'text', or 'video'.
  * @property {string} mimeType
  *   The MIME type of the stream.

--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -9,6 +9,7 @@ goog.provide('shaka.abr.SimpleAbrManager');
 goog.require('goog.asserts');
 goog.require('shaka.abr.EwmaBandwidthEstimator');
 goog.require('shaka.log');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.EventManager');
 goog.require('shaka.util.IReleasable');
@@ -714,8 +715,9 @@ shaka.abr.SimpleAbrManager = class {
           ' >= ' + droppedFramesThreshold +
           '. Disabling current video stream.');
 
+      const ContentType = shaka.media.ManifestParser.ContentType;
       this.disableStreamCallback_(
-          'video', this.config_.advanced.droppedFramesBanDuration);
+          ContentType.VIDEO, this.config_.advanced.droppedFramesBanDuration);
     }
   }
 

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -1248,7 +1248,7 @@ shaka.dash.DashParser = class {
         }
       };
     } catch (error) {
-      const ContentType = shaka.util.ManifestParserUtils.ContentType;
+      const ContentType = shaka.media.ManifestParser.ContentType;
       const contentType = context.representation.contentType;
       const isText = contentType == ContentType.TEXT ||
             contentType == ContentType.APPLICATION;
@@ -1647,7 +1647,7 @@ shaka.dash.DashParser = class {
   parsePeriod_(context, getBaseUris, periodInfo) {
     const Functional = shaka.util.Functional;
     const TXml = shaka.util.TXml;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     goog.asserts.assert(periodInfo.node, 'periodInfo.node should exist');
     context.period = this.createFrame_(periodInfo.node, null, getBaseUris);
@@ -1867,7 +1867,7 @@ shaka.dash.DashParser = class {
     const TXml = shaka.util.TXml;
     const Functional = shaka.util.Functional;
     const ManifestParserUtils = shaka.util.ManifestParserUtils;
-    const ContentType = ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     context.adaptationSet = this.createFrame_(elem, context.period, null);
     context.adaptationSet.position = position;
@@ -2268,7 +2268,7 @@ shaka.dash.DashParser = class {
       isPrimary, roles, closedCaptions, node, accessibilityPurpose,
       lastSegmentNumber) {
     const TXml = shaka.util.TXml;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     const periodId = context.period.id;
 
@@ -2849,7 +2849,9 @@ shaka.dash.DashParser = class {
       return [];
     };
 
-    let contentType = elem.attributes['contentType'] || parent.contentType;
+    let contentType =
+      /** @type {shaka.media.ManifestParser.ContentType} */ (
+        elem.attributes['contentType'] || parent.contentType);
     const mimeType = elem.attributes['mimeType'] || parent.mimeType;
     const allCodecs = [
       elem.attributes['codecs'] || parent.codecs,
@@ -3104,7 +3106,7 @@ shaka.dash.DashParser = class {
    * @private
    */
   verifyRepresentation_(frame) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     let n = 0;
     n += frame.segmentBase ? 1 : 0;
@@ -3349,7 +3351,7 @@ shaka.dash.DashParser = class {
    *
    * @param {string} mimeType
    * @param {string} codecs
-   * @return {string}
+   * @return {shaka.media.ManifestParser.ContentType}
    * @private
    */
   static guessContentType_(mimeType, codecs) {
@@ -3359,12 +3361,13 @@ shaka.dash.DashParser = class {
       // If it's supported by TextEngine, it's definitely text.
       // We don't check MediaSourceEngine, because that would report support
       // for platform-supported video and audio types as well.
-      return shaka.util.ManifestParserUtils.ContentType.TEXT;
+      return shaka.media.ManifestParser.ContentType.TEXT;
     }
 
     // Otherwise, just split the MIME type.  This handles video and audio
     // types well.
-    return mimeType.split('/')[0];
+    return /** @type {shaka.media.ManifestParser.ContentType} */ (
+      mimeType.split('/')[0]);
   }
 
 
@@ -3527,7 +3530,7 @@ shaka.dash.DashParser.RequestSegmentCallback;
  *   getBaseUris: function():!Array<string>,
  *   width: (number|undefined),
  *   height: (number|undefined),
- *   contentType: string,
+ *   contentType: shaka.media.ManifestParser.ContentType,
  *   mimeType: string,
  *   codecs: string,
  *   supplementalCodecs: string,
@@ -3566,7 +3569,7 @@ shaka.dash.DashParser.RequestSegmentCallback;
  *   The inherited width value.
  * @property {(number|undefined)} height
  *   The inherited height value.
- * @property {string} contentType
+ * @property {shaka.media.ManifestParser.ContentType} contentType
  *   The inherited media type.
  * @property {string} mimeType
  *   The inherited MIME type value.

--- a/lib/dash/segment_base.js
+++ b/lib/dash/segment_base.js
@@ -12,6 +12,7 @@ goog.require('shaka.dash.MpdUtils');
 goog.require('shaka.dash.WebmSegmentIndexParser');
 goog.require('shaka.log');
 goog.require('shaka.media.InitSegmentReference');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.media.SegmentIndex');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.ManifestParserUtils');
@@ -328,7 +329,7 @@ shaka.dash.SegmentBase = class {
    * @param {shaka.media.InitSegmentReference} initSegmentReference
    */
   static checkSegmentIndexSupport(context, initSegmentReference) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     const contentType = context.representation.contentType;
     const containerType = context.representation.mimeType.split('/')[1];

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -11,6 +11,7 @@ goog.require('shaka.dash.MpdUtils');
 goog.require('shaka.dash.SegmentBase');
 goog.require('shaka.log');
 goog.require('shaka.media.InitSegmentReference');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.media.SegmentIndex');
 goog.require('shaka.media.SegmentReference');
 goog.require('shaka.util.ArrayUtils');
@@ -93,9 +94,10 @@ shaka.dash.SegmentTemplate = class {
         timescale: info.timescale,
       };
     } else if (info.segmentDuration) {
+      const ContentType = shaka.media.ManifestParser.ContentType;
       if (!isUpdate &&
-          context.adaptationSet.contentType !== 'image' &&
-          context.adaptationSet.contentType !== 'text') {
+          context.adaptationSet.contentType !== ContentType.IMAGE &&
+          context.adaptationSet.contentType !== ContentType.TEXT) {
         const periodStart = context.periodInfo.start;
         const periodId = context.period.id;
         const initialPeriodDuration = context.periodInfo.duration;
@@ -199,8 +201,10 @@ shaka.dash.SegmentTemplate = class {
       }
 
       if (info.timeline &&
-          context.adaptationSet.contentType !== 'image' &&
-          context.adaptationSet.contentType !== 'text') {
+          context.adaptationSet.contentType !==
+              shaka.media.ManifestParser.ContentType.IMAGE &&
+          context.adaptationSet.contentType !==
+              shaka.media.ManifestParser.ContentType.TEXT) {
         const tsi = /** @type {!TimelineSegmentIndex} */(segmentIndex);
         // getTimeline is the info.timeline but fitted to the period.
         const timeline = tsi.getTimeline();

--- a/lib/device/abstract_device.js
+++ b/lib/device/abstract_device.js
@@ -7,6 +7,7 @@
 goog.provide('shaka.device.AbstractDevice');
 
 goog.require('shaka.device.IDevice');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.util.Dom');
 goog.require('shaka.util.Lazy');
 
@@ -182,7 +183,8 @@ shaka.device.AbstractDevice = class {
     }
 
     const chromeVersion = this.getChromeVersion_();
-    return stream.type === 'video' &&
+    const ContentType = shaka.media.ManifestParser.ContentType;
+    return stream.type === ContentType.VIDEO &&
       chromeVersion != null &&
       chromeVersion < 94 &&
       stream.supplementalCodecs != stream.codecs &&

--- a/lib/device/apple_browser.js
+++ b/lib/device/apple_browser.js
@@ -9,6 +9,7 @@ goog.provide('shaka.device.AppleBrowser');
 goog.require('shaka.device.AbstractDevice');
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.device.IDevice');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.util.Lazy');
 
 
@@ -91,7 +92,7 @@ shaka.device.AppleBrowser = class extends shaka.device.AbstractDevice {
    */
   requiresEncryptionInfoInAllInitSegments(keySystem, contentType) {
     return !this.supportsMixedClearEncryptedContent_() &&
-      contentType === 'audio';
+      contentType === shaka.media.ManifestParser.ContentType.AUDIO;
   }
 
   /**
@@ -106,7 +107,7 @@ shaka.device.AppleBrowser = class extends shaka.device.AbstractDevice {
    */
   requiresTfhdFix(contentType) {
     return !this.supportsMixedClearEncryptedContent_() &&
-      contentType === 'audio';
+      contentType === shaka.media.ManifestParser.ContentType.AUDIO;
   }
 
   /**

--- a/lib/device/i_device.js
+++ b/lib/device/i_device.js
@@ -6,6 +6,8 @@
 
 goog.provide('shaka.device.IDevice');
 
+goog.requireType('shaka.media.ManifestParser');
+
 
 /**
  * @interface
@@ -61,8 +63,8 @@ shaka.device.IDevice = class {
    * around a lack of such info by inserting fake encryption information into
    * initialization segments.
    *
-   * @param {?string} keySystem
-   * @param {?string} contentType
+   * @param {string} keySystem
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @return {boolean}
    * @see https://github.com/shaka-project/shaka-player/issues/2759
    */
@@ -89,7 +91,7 @@ shaka.device.IDevice = class {
   insertEncryptionDataBeforeClear() {}
 
   /**
-   * @param {string} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @return {boolean}
    */
   requiresTfhdFix(contentType) {}

--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -11,6 +11,7 @@ goog.require('shaka.log');
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.device.IDevice');
 goog.require('shaka.drm.DrmUtils');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.BufferUtils');
@@ -2864,7 +2865,7 @@ shaka.drm.DrmEngine = class {
   /**
    * Parse pssh from a media segment and announce new initData.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {!BufferSource} mediaSegment
    * @return {!Promise<void>}
    */
@@ -2873,7 +2874,7 @@ shaka.drm.DrmEngine = class {
       return Promise.resolve();
     }
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (![ContentType.AUDIO, ContentType.VIDEO].includes(contentType)) {
       return Promise.resolve();
     }

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -92,7 +92,7 @@ shaka.hls.HlsParser = class {
     this.mediaSequenceToStartTimeByType_ = new Map();
 
     // Set initial maps.
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     this.mediaSequenceToStartTimeByType_.set(ContentType.VIDEO, new Map());
     this.mediaSequenceToStartTimeByType_.set(ContentType.AUDIO, new Map());
     this.mediaSequenceToStartTimeByType_.set(ContentType.TEXT, new Map());
@@ -887,7 +887,7 @@ shaka.hls.HlsParser = class {
    */
   async parseManifest_(data) {
     const Utils = shaka.hls.Utils;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     goog.asserts.assert(this.masterPlaylistUri_,
         'Master playlist URI must be set before calling parseManifest_!');
@@ -998,9 +998,10 @@ shaka.hls.HlsParser = class {
 
       // Wrap the stream from that stream info with a variant.
       let variantAllowed = true;
-      if (this.config_.disableAudio && streamInfo.type == 'audio') {
+      if (this.config_.disableAudio && streamInfo.type == ContentType.AUDIO) {
         variantAllowed = false;
-      } else if (this.config_.disableVideo && streamInfo.type == 'video' &&
+      } else if (this.config_.disableVideo &&
+          streamInfo.type == ContentType.VIDEO &&
           !streamInfo.stream.codecs.includes(',')) {
         variantAllowed = false;
       }
@@ -1010,8 +1011,10 @@ shaka.hls.HlsParser = class {
           language: this.getLanguage_(languageValue),
           disabledUntilTime: 0,
           primary: true,
-          audio: streamInfo.type == 'audio' ? streamInfo.stream : null,
-          video: streamInfo.type == 'video' ? streamInfo.stream : null,
+          audio: streamInfo.type == ContentType.AUDIO ?
+              streamInfo.stream : null,
+          video: streamInfo.type == ContentType.VIDEO ?
+              streamInfo.stream : null,
           bandwidth: streamInfo.stream.bandwidth || 0,
           allowedByApplication: true,
           allowedByKeySystem: true,
@@ -1073,7 +1076,7 @@ shaka.hls.HlsParser = class {
               if (allCodecs.length > 1) {
                 const audioCodec =
                     shaka.util.ManifestParserUtils.guessCodecsSafe(
-                        shaka.util.ManifestParserUtils.ContentType.AUDIO,
+                        shaka.media.ManifestParser.ContentType.AUDIO,
                         allCodecs);
                 if (audioCodec) {
                   value += ',' + audioCodec;
@@ -1317,12 +1320,14 @@ shaka.hls.HlsParser = class {
       this.presentationTimeline_.setDuration(this.getMinDuration_());
     }
 
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (!this.presentationTimeline_.isStartTimeLocked()) {
       for (const streamInfo of this.uriToStreamInfosMap_.values()) {
         if (!streamInfo.stream.segmentIndex) {
           continue; // Not active.
         }
-        if (streamInfo.type != 'audio' && streamInfo.type != 'video') {
+        if (streamInfo.type != ContentType.AUDIO &&
+            streamInfo.type != ContentType.VIDEO) {
           continue;
         }
         const firstReference =
@@ -1410,7 +1415,7 @@ shaka.hls.HlsParser = class {
    * @private
    */
   parseCodecs_(tags) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     for (const variantTag of tags) {
       const audioGroupId = variantTag.getAttributeValue('AUDIO');
@@ -1550,7 +1555,7 @@ shaka.hls.HlsParser = class {
       }
     }
 
-    const type = shaka.util.ManifestParserUtils.ContentType.TEXT;
+    const type = shaka.media.ManifestParser.ContentType.TEXT;
 
     // Set the codecs for text streams.
     for (const tag of subtitleTags) {
@@ -1621,7 +1626,7 @@ shaka.hls.HlsParser = class {
       }
       try {
         const streamInfo = this.createStreamInfoFromIframeTag_(tag);
-        const ContentType = shaka.util.ManifestParserUtils.ContentType;
+        const ContentType = shaka.media.ManifestParser.ContentType;
         if (streamInfo.stream.type !== ContentType.IMAGE) {
           return null;
         }
@@ -1759,7 +1764,7 @@ shaka.hls.HlsParser = class {
             language: language,
             originalLanguage: language,
             label: null,
-            type: shaka.util.ManifestParserUtils.ContentType.CHAPTER,
+            type: shaka.media.ManifestParser.ContentType.CHAPTER,
             primary: false,
             trickModeVideo: null,
             dependencyStream: null,
@@ -1829,7 +1834,7 @@ shaka.hls.HlsParser = class {
     // Create iFrame stream for each iFrame tag.
     const iFrameStreams = iFrameTags.map((tag) => {
       const streamInfo = this.createStreamInfoFromIframeTag_(tag);
-      const ContentType = shaka.util.ManifestParserUtils.ContentType;
+      const ContentType = shaka.media.ManifestParser.ContentType;
       if (streamInfo.stream.type !== ContentType.VIDEO) {
         return null;
       }
@@ -1980,7 +1985,7 @@ shaka.hls.HlsParser = class {
    * @private
    */
   createStreamInfosForVariantTags_(tags, mediaTags, resolution) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     /** @type {shaka.hls.HlsParser.StreamInfos} */
     const res = {
@@ -2229,7 +2234,7 @@ shaka.hls.HlsParser = class {
    * @private
    */
   getClosedCaptions_(tag, type) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     // The attribute of closed captions is optional, and the value may be
     // 'NONE'.
     const closedCaptionsAttr = tag.getAttributeValue('CLOSED-CAPTIONS');
@@ -2275,15 +2280,15 @@ shaka.hls.HlsParser = class {
    * Shaka recognizes the content types 'audio', 'video', 'text', and 'image'.
    * The HLS 'subtitles' type needs to be mapped to 'text'.
    * @param {!shaka.hls.Tag} tag
-   * @return {string}
+   * @return {shaka.media.ManifestParser.ContentType}
    * @private
    */
   getType_(tag) {
     let type = tag.getRequiredAttrValue('TYPE').toLowerCase();
     if (type == 'subtitles') {
-      type = shaka.util.ManifestParserUtils.ContentType.TEXT;
+      type = shaka.media.ManifestParser.ContentType.TEXT;
     }
-    return type;
+    return /** @type {shaka.media.ManifestParser.ContentType} */ (type);
   }
 
   /**
@@ -2304,7 +2309,7 @@ shaka.hls.HlsParser = class {
   createVariants_(
       audioInfos, videoInfos, bandwidth, width, height, frameRate, videoRange,
       videoLayout, drmInfos, keyIds, iFrameStreams) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const DrmUtils = shaka.drm.DrmUtils;
 
     for (const info of videoInfos) {
@@ -2492,9 +2497,8 @@ shaka.hls.HlsParser = class {
     const globalGroupId = globalGroupIds.sort().join(',');
     const firstTag = tags[0];
     let codecs = '';
-    /** @type {string} */
     const type = this.getType_(firstTag);
-    if (type == shaka.util.ManifestParserUtils.ContentType.TEXT) {
+    if (type == shaka.media.ManifestParser.ContentType.TEXT) {
       codecs = firstTag.getAttributeValue('CODECS') || '';
     }
     if (!codecs) {
@@ -2511,8 +2515,9 @@ shaka.hls.HlsParser = class {
 
     // Check if the stream has already been created as part of another Variant
     // and return it if it has.
+    const ContentType = shaka.media.ManifestParser.ContentType;
     let key = originalId;
-    if (type == 'audio' && globalGroupId) {
+    if (type == ContentType.AUDIO && globalGroupId) {
       key += globalGroupId;
     }
     if (this.uriToStreamInfosMap_.has(key)) {
@@ -2541,14 +2546,15 @@ shaka.hls.HlsParser = class {
     const primary = defaultAttrValue == 'YES';
 
     const channelsCount =
-        type == 'audio' ? this.getChannelsCount_(firstTag) : null;
+        type == ContentType.AUDIO ? this.getChannelsCount_(firstTag) : null;
     const spatialAudio =
-        type == 'audio' ? this.isSpatialAudio_(firstTag) : false;
+        type == ContentType.AUDIO ? this.isSpatialAudio_(firstTag) : false;
     const characteristics = firstTag.getAttributeValue('CHARACTERISTICS');
 
     const forcedAttrValue = firstTag.getAttributeValue('FORCED');
     const forced = forcedAttrValue == 'YES';
-    const sampleRate = type == 'audio' ? this.getSampleRate_(firstTag) : null;
+    const sampleRate =
+        type == ContentType.AUDIO ? this.getSampleRate_(firstTag) : null;
     // TODO: Should we take into account some of the currently ignored
     // attributes: INSTREAM-ID, Attribute descriptions: https://bit.ly/2lpjOhj
     const streamInfo = this.createStreamInfo_(
@@ -2576,8 +2582,7 @@ shaka.hls.HlsParser = class {
   async createStreamInfoFromImageTag_(tag) {
     goog.asserts.assert(tag.name == 'EXT-X-IMAGE-STREAM-INF',
         'Should only be called on image tags!');
-    /** @type {string} */
-    const type = shaka.util.ManifestParserUtils.ContentType.IMAGE;
+    const type = shaka.media.ManifestParser.ContentType.IMAGE;
 
     const verbatimImagePlaylistUri = tag.getRequiredAttrValue('URI');
     const codecs = tag.getAttributeValue('CODECS', 'jpeg') || '';
@@ -2646,15 +2651,14 @@ shaka.hls.HlsParser = class {
   createStreamInfoFromIframeTag_(tag) {
     goog.asserts.assert(tag.name == 'EXT-X-I-FRAME-STREAM-INF',
         'Should only be called on iframe tags!');
-    /** @type {string} */
-    let type = shaka.util.ManifestParserUtils.ContentType.VIDEO;
+    let type = shaka.media.ManifestParser.ContentType.VIDEO;
 
     const verbatimIFramePlaylistUri = tag.getRequiredAttrValue('URI');
     const codecs = tag.getAttributeValue('CODECS') || '';
     const supplementalCodecs = shaka.hls.Utils.getSupplementalCodecs(tag);
 
     if (codecs == 'mjpg') {
-      type = shaka.util.ManifestParserUtils.ContentType.IMAGE;
+      type = shaka.media.ManifestParser.ContentType.IMAGE;
     }
 
     // Check if the stream has already been created as part of another Variant
@@ -2696,7 +2700,7 @@ shaka.hls.HlsParser = class {
    *
    * @param {!Array<!shaka.hls.Tag>} tags
    * @param {!Array<string>} allCodecs
-   * @param {string} type
+   * @param {shaka.media.ManifestParser.ContentType} type
    * @param {!string} supplementalCodecs
    * @return {!shaka.hls.HlsParser.StreamInfo}
    * @private
@@ -2741,7 +2745,7 @@ shaka.hls.HlsParser = class {
    * @param {number} streamId
    * @param {!Array<string>} verbatimMediaPlaylistUris
    * @param {string} codecs
-   * @param {string} type
+   * @param {shaka.media.ManifestParser.ContentType} type
    * @param {?string} languageValue
    * @param {boolean} primary
    * @param {?string} name
@@ -2813,7 +2817,7 @@ shaka.hls.HlsParser = class {
 
     /** @param {!shaka.net.NetworkingEngine.PendingRequest} pendingRequest */
     const downloadSegmentIndex = async (pendingRequest) => {
-      const ContentType = shaka.util.ManifestParserUtils.ContentType;
+      const ContentType = shaka.media.ManifestParser.ContentType;
 
       try {
         // Download the actual manifest.
@@ -3061,9 +3065,11 @@ shaka.hls.HlsParser = class {
    * @private
    */
   getMinDuration_() {
+    const ContentType = shaka.media.ManifestParser.ContentType;
     let minDuration = Infinity;
     for (const streamInfo of this.uriToStreamInfosMap_.values()) {
-      if (streamInfo.stream.segmentIndex && streamInfo.stream.type != 'text' &&
+      if (streamInfo.stream.segmentIndex &&
+          streamInfo.stream.type != ContentType.TEXT &&
           !streamInfo.stream.isAudioMuxedInVideo) {
         // Since everything is already offset to 0 (either by sync or by being
         // VOD), only maxTimestamp is necessary to compute the duration.
@@ -3078,10 +3084,12 @@ shaka.hls.HlsParser = class {
    * @private
    */
   getLiveDuration_() {
+    const ContentType = shaka.media.ManifestParser.ContentType;
     let maxTimestamp = Infinity;
     let minTimestamp = Infinity;
     for (const streamInfo of this.uriToStreamInfosMap_.values()) {
-      if (streamInfo.stream.segmentIndex && streamInfo.stream.type != 'text' &&
+      if (streamInfo.stream.segmentIndex &&
+          streamInfo.stream.type != ContentType.TEXT &&
           !streamInfo.stream.isAudioMuxedInVideo) {
         maxTimestamp = Math.min(maxTimestamp, streamInfo.maxTimestamp);
         minTimestamp = Math.min(minTimestamp, streamInfo.minTimestamp);
@@ -3123,7 +3131,7 @@ shaka.hls.HlsParser = class {
 
     const activeStreamInfos = Array.from(this.uriToStreamInfosMap_.values())
         .filter((s) => s.stream.segmentIndex);
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const hasAudio =
         activeStreamInfos.some((s) => s.stream.type == ContentType.AUDIO);
     const hasVideo =
@@ -3196,7 +3204,7 @@ shaka.hls.HlsParser = class {
    * @param {!shaka.hls.Playlist} playlist
    * @param {function(): !Array<string>} getUris
    * @param {string} codecs
-   * @param {string} type
+   * @param {shaka.media.ManifestParser.ContentType} type
    * @param {?string} languageValue
    * @param {boolean} primary
    * @param {?string} name
@@ -3247,7 +3255,7 @@ shaka.hls.HlsParser = class {
         playlist, mediaSequenceToStartTime, variables, getUris, type,
         /* isNewStream= */ true, /* existingSegmentIndex= */ null);
 
-    if (!mimeType && type == shaka.util.ManifestParserUtils.ContentType.TEXT) {
+    if (!mimeType && type === shaka.media.ManifestParser.ContentType.TEXT) {
       mimeType = await this.guessMimeType_(type, codecs, segments);
 
       // Some manifests don't say what text codec they use, this is a problem
@@ -3275,7 +3283,7 @@ shaka.hls.HlsParser = class {
     if (segments.length > 0 && requestBasicInfo) {
       const basicInfo = await this.getBasicInfoFromSegments_(segments);
 
-      if (type != basicInfo.type && this.isLive_()) {
+      if (type !== basicInfo.type && this.isLive_()) {
         this.mediaSequenceToStartTimeByType_.set(
             basicInfo.type, this.mediaSequenceToStartTimeByType_.get(type));
         this.mediaSequenceToStartTimeByType_.set(type, new Map());
@@ -3327,7 +3335,7 @@ shaka.hls.HlsParser = class {
     }
     this.setFullTypeForStream_(stream);
 
-    if (type == shaka.util.ManifestParserUtils.ContentType.VIDEO &&
+    if (type === shaka.media.ManifestParser.ContentType.VIDEO &&
         (width || height || videoRange || colorGamut)) {
       this.addVideoAttributes_(stream, width, height,
           frameRate, videoRange, /* videoLayout= */ null, colorGamut);
@@ -3459,7 +3467,7 @@ shaka.hls.HlsParser = class {
    * manually on the object after creation.
    * @param {number} id
    * @param {string} codecs
-   * @param {string} type
+   * @param {shaka.media.ManifestParser.ContentType} type
    * @param {?string} languageValue
    * @param {boolean} primary
    * @param {?string} name
@@ -3490,7 +3498,7 @@ shaka.hls.HlsParser = class {
 
     let kind = undefined;
     let accessibilityPurpose = null;
-    if (type == shaka.util.ManifestParserUtils.ContentType.TEXT) {
+    if (type == shaka.media.ManifestParser.ContentType.TEXT) {
       if (roles.includes('public.accessibility.transcribes-spoken-dialog') &&
           roles.includes('public.accessibility.describes-music-and-sound')) {
         kind = shaka.util.ManifestParserUtils.TextStreamKind.CLOSED_CAPTION;
@@ -3512,7 +3520,7 @@ shaka.hls.HlsParser = class {
     }
 
     let label = null;
-    if (type != shaka.util.ManifestParserUtils.ContentType.VIDEO) {
+    if (type != shaka.media.ManifestParser.ContentType.VIDEO) {
       label = name;
     }
 
@@ -3525,7 +3533,7 @@ shaka.hls.HlsParser = class {
       mimeType,
       codecs,
       supplementalCodecs,
-      kind: (type == shaka.util.ManifestParserUtils.ContentType.TEXT) ?
+      kind: (type == shaka.media.ManifestParser.ContentType.TEXT) ?
           shaka.util.ManifestParserUtils.TextStreamKind.SUBTITLE : undefined,
       encrypted: false,
       drmInfos: [],
@@ -4301,7 +4309,7 @@ shaka.hls.HlsParser = class {
 
     let tilesLayout = '';
     let tileDuration = null;
-    if (type == shaka.util.ManifestParserUtils.ContentType.IMAGE) {
+    if (type == shaka.media.ManifestParser.ContentType.IMAGE) {
       // By default in HLS the tilesLayout is 1x1
       tilesLayout = '1x1';
       const tilesTag =
@@ -4405,7 +4413,7 @@ shaka.hls.HlsParser = class {
    * @private
    */
   async processDateRangeTags_(tags, contentType, variables, getUris) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (contentType != ContentType.VIDEO && contentType != ContentType.AUDIO) {
       // DATE-RANGE should only appear in AUDIO or VIDEO playlists.
       // We ignore those that appear in other playlists.
@@ -4975,13 +4983,13 @@ shaka.hls.HlsParser = class {
   /**
    * Attempts to guess stream's mime type based on content type and URI.
    *
-   * @param {string} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {string} codecs
    * @return {?string}
    * @private
    */
   guessMimeTypeBeforeLoading_(contentType, codecs) {
-    if (contentType == shaka.util.ManifestParserUtils.ContentType.TEXT) {
+    if (contentType == shaka.media.ManifestParser.ContentType.TEXT) {
       if (codecs == 'vtt' || codecs == 'wvtt') {
         // If codecs is 'vtt', it's WebVTT.
         return 'text/vtt';
@@ -4992,13 +5000,13 @@ shaka.hls.HlsParser = class {
       }
     }
 
-    if (contentType == shaka.util.ManifestParserUtils.ContentType.IMAGE) {
+    if (contentType == shaka.media.ManifestParser.ContentType.IMAGE) {
       if (!codecs || codecs == 'jpeg') {
         return 'image/jpeg';
       }
     }
 
-    if (contentType == shaka.util.ManifestParserUtils.ContentType.AUDIO) {
+    if (contentType == shaka.media.ManifestParser.ContentType.AUDIO) {
       // See: https://bugs.chromium.org/p/chromium/issues/detail?id=489520
       if (codecs == 'mp4a.40.34') {
         return 'audio/mpeg';
@@ -5017,12 +5025,12 @@ shaka.hls.HlsParser = class {
    * Get a fallback mime type for the content. Used if all the better methods
    * for determining the mime type have failed.
    *
-   * @param {string} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @return {string}
    * @private
    */
   guessMimeTypeFallback_(contentType) {
-    if (contentType == shaka.util.ManifestParserUtils.ContentType.TEXT) {
+    if (contentType == shaka.media.ManifestParser.ContentType.TEXT) {
       // If there was no codecs string and no content-type, assume HLS text
       // streams are WebVTT.
       return 'text/vtt';
@@ -5059,7 +5067,7 @@ shaka.hls.HlsParser = class {
   /**
    * Attempts to guess stream's mime type.
    *
-   * @param {string} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {string} codecs
    * @param {!Array<!shaka.media.SegmentReference>} segments
    * @return {!Promise<string>}
@@ -5730,7 +5738,7 @@ shaka.hls.HlsParser = class {
 /**
  * @typedef {{
  *   stream: !shaka.extern.Stream,
- *   type: string,
+ *   type: shaka.media.ManifestParser.ContentType,
  *   redirectUris: !Array<string>,
  *   getUris: function():!Array<string>,
  *   minTimestamp: number,
@@ -5750,7 +5758,7 @@ shaka.hls.HlsParser = class {
  *
  * @property {!shaka.extern.Stream} stream
  *   The Stream itself.
- * @property {string} type
+ * @property {shaka.media.ManifestParser.ContentType} type
  *   The type value. Could be 'video', 'audio', 'text', or 'image'.
  * @property {!Array<string>} redirectUris
  *   The redirect URIs.
@@ -5879,10 +5887,14 @@ shaka.hls.HlsParser.IMAGE_EXTENSIONS_TO_MIME_TYPES_ = new Map()
  * @private
  */
 shaka.hls.HlsParser.EXTENSION_MAP_BY_CONTENT_TYPE_ = new Map()
-    .set('audio', shaka.hls.HlsParser.AUDIO_EXTENSIONS_TO_MIME_TYPES_)
-    .set('video', shaka.hls.HlsParser.VIDEO_EXTENSIONS_TO_MIME_TYPES_)
-    .set('text', shaka.hls.HlsParser.TEXT_EXTENSIONS_TO_MIME_TYPES_)
-    .set('image', shaka.hls.HlsParser.IMAGE_EXTENSIONS_TO_MIME_TYPES_);
+    .set(shaka.media.ManifestParser.ContentType.AUDIO,
+        shaka.hls.HlsParser.AUDIO_EXTENSIONS_TO_MIME_TYPES_)
+    .set(shaka.media.ManifestParser.ContentType.VIDEO,
+        shaka.hls.HlsParser.VIDEO_EXTENSIONS_TO_MIME_TYPES_)
+    .set(shaka.media.ManifestParser.ContentType.TEXT,
+        shaka.hls.HlsParser.TEXT_EXTENSIONS_TO_MIME_TYPES_)
+    .set(shaka.media.ManifestParser.ContentType.IMAGE,
+        shaka.hls.HlsParser.IMAGE_EXTENSIONS_TO_MIME_TYPES_);
 
 
 /**

--- a/lib/lcevc/lcevc_dec.js
+++ b/lib/lcevc/lcevc_dec.js
@@ -6,8 +6,8 @@
 
 goog.provide('shaka.lcevc.Dec');
 goog.require('shaka.log');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.util.IReleasable');
-goog.require('shaka.util.ManifestParserUtils');
 
 /**
  * @summary
@@ -60,7 +60,7 @@ shaka.lcevc.Dec = class {
    * @param {shaka.extern.Stream} stream
    */
   appendBuffer(data, timestampOffset, stream) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     // LCEVC only supports VIDEO.
     if (stream.type !== ContentType.VIDEO ||
         (this.isDualTrack_ && !shaka.lcevc.Dec.isStreamSupported(stream))) {
@@ -70,19 +70,20 @@ shaka.lcevc.Dec = class {
       // Timestamp offset describes how much offset should be applied to the
       // LCEVC enhancement to match the decoded video frame, as such it needs
       // to be negated.
-      this.dec_.appendBuffer(data, 'video', stream.id, -timestampOffset,
+      this.dec_.appendBuffer(data, ContentType.VIDEO, stream.id,
+          -timestampOffset,
           !this.isDualTrack_);
     }
   }
 
   /**
    * Remove data from the LCEVC Dec.
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {number} startTime relative to the start of the presentation
    * @param {number} endTime relative to the start of the presentation
    */
   removeBuffer(contentType, startTime, endTime) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     // LCEVC only supports VIDEO.
     if (contentType !== ContentType.VIDEO) {
       return;

--- a/lib/media/manifest_parser.js
+++ b/lib/media/manifest_parser.js
@@ -164,9 +164,9 @@ shaka.media.ManifestParser.UNKNOWN = 'UNKNOWN';
  * @export
  */
 shaka.media.ManifestParser.AccessibilityPurpose = {
-  VISUALLY_IMPAIRED: 'visually impaired',
-  HARD_OF_HEARING: 'hard of hearing',
-  SPOKEN_SUBTITLES: 'spoken subtitles',
+  'VISUALLY_IMPAIRED': 'visually impaired',
+  'HARD_OF_HEARING': 'hard of hearing',
+  'SPOKEN_SUBTITLES': 'spoken subtitles',
 };
 
 
@@ -175,12 +175,12 @@ shaka.media.ManifestParser.AccessibilityPurpose = {
  * @export
  */
 shaka.media.ManifestParser.ContentType = {
-  VIDEO: 'video',
-  AUDIO: 'audio',
-  TEXT: 'text',
-  IMAGE: 'image',
-  APPLICATION: 'application',
-  CHAPTER: 'chapter',
+  'VIDEO': 'video',
+  'AUDIO': 'audio',
+  'TEXT': 'text',
+  'IMAGE': 'image',
+  'APPLICATION': 'application',
+  'CHAPTER': 'chapter',
 };
 
 

--- a/lib/media/manifest_parser.js
+++ b/lib/media/manifest_parser.js
@@ -171,6 +171,20 @@ shaka.media.ManifestParser.AccessibilityPurpose = {
 
 
 /**
+ * @enum {string}
+ * @export
+ */
+shaka.media.ManifestParser.ContentType = {
+  VIDEO: 'video',
+  AUDIO: 'audio',
+  TEXT: 'text',
+  IMAGE: 'image',
+  APPLICATION: 'application',
+  CHAPTER: 'chapter',
+};
+
+
+/**
  * Contains the parser factory functions indexed by MIME type.
  *
  * @type {!Map<string, shaka.extern.ManifestParser.Factory>}

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -75,18 +75,18 @@ shaka.media.MediaSourceEngine = class {
     this.textDisplayer_ = textDisplayer;
 
     /**
-     * @private {!Map<shaka.util.ManifestParserUtils.ContentType, SourceBuffer>}
+     * @private {!Map<shaka.media.ManifestParser.ContentType, SourceBuffer>}
      */
     this.sourceBuffers_ = new Map();
 
     /**
-     * @private {!Map<shaka.util.ManifestParserUtils.ContentType, string>}
+     * @private {!Map<shaka.media.ManifestParser.ContentType, string>}
      */
     this.sourceBufferTypes_ = new Map();
 
 
     /**
-     * @private {!Map<shaka.util.ManifestParserUtils.ContentType,
+     * @private {!Map<shaka.media.ManifestParser.ContentType,
      *                    boolean>}
      */
     this.expectedEncryption_ = new Map();
@@ -109,7 +109,7 @@ shaka.media.MediaSourceEngine = class {
     this.eventManager_ = new shaka.util.EventManager();
 
     /**
-     * @private {!Map<shaka.util.ManifestParserUtils.ContentType,
+     * @private {!Map<shaka.media.ManifestParser.ContentType,
                          !shaka.extern.Transmuxer>} */
     this.transmuxers_ = new Map();
 
@@ -172,7 +172,7 @@ shaka.media.MediaSourceEngine = class {
     this.lastDuration_ = null;
 
     /**
-     * @private {!Map<shaka.util.ManifestParserUtils.ContentType,
+     * @private {!Map<shaka.media.ManifestParser.ContentType,
      *                    !shaka.util.TsParser>}
      */
     this.tsParsers_ = new Map();
@@ -499,7 +499,7 @@ shaka.media.MediaSourceEngine = class {
    * Note that it is not valid to call this multiple times, except to add or
    * reinitialize text streams.
    *
-   * @param {!Map<shaka.util.ManifestParserUtils.ContentType,
+   * @param {!Map<shaka.media.ManifestParser.ContentType,
    *               shaka.extern.Stream>} streamsByType
    *   A map of content types to streams.
    * @param {boolean=} sequenceMode
@@ -519,7 +519,7 @@ shaka.media.MediaSourceEngine = class {
   async init(streamsByType, sequenceMode=false,
       manifestType=shaka.media.ManifestParser.UNKNOWN,
       ignoreManifestTimestampsInSegmentsMode=false) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     await this.mediaSourceOpen_.promise;
     if (this.ended() || this.closed()) {
@@ -565,13 +565,13 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Initialize a specific SourceBuffer.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {shaka.extern.Stream} stream
    * @param {string} codecs
    * @private
    */
   initSourceBuffer_(contentType, stream, codecs) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     if (contentType == ContentType.AUDIO && codecs) {
       codecs = shaka.util.MimeUtils.getCorrectAudioCodecs(
@@ -720,14 +720,14 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Gets the first timestamp in buffer for the given content type.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @return {?number} The timestamp in seconds, or null if nothing is buffered.
    */
   bufferStart(contentType) {
     if (!this.sourceBuffers_.size) {
       return null;
     }
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (contentType == ContentType.TEXT) {
       return this.textEngine_.bufferStart();
     }
@@ -738,14 +738,14 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Gets the last timestamp in buffer for the given content type.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @return {?number} The timestamp in seconds, or null if nothing is buffered.
    */
   bufferEnd(contentType) {
     if (!this.sourceBuffers_.size) {
       return null;
     }
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (contentType == ContentType.TEXT) {
       return this.textEngine_.bufferEnd();
     }
@@ -757,12 +757,12 @@ shaka.media.MediaSourceEngine = class {
    * Determines if the given time is inside the buffered range of the given
    * content type.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {number} time Playhead time
    * @return {boolean}
    */
   isBuffered(contentType, time) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (contentType == ContentType.TEXT) {
       return this.textEngine_.isBuffered(time);
     } else {
@@ -775,12 +775,12 @@ shaka.media.MediaSourceEngine = class {
    * Computes how far ahead of the given timestamp is buffered for the given
    * content type.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {number} time
    * @return {number} The amount of time buffered ahead in seconds.
    */
   bufferedAheadOf(contentType, time) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (contentType == ContentType.TEXT) {
       return this.textEngine_.bufferedAheadOf(time);
     } else {
@@ -794,7 +794,7 @@ shaka.media.MediaSourceEngine = class {
    * @return {shaka.extern.BufferedInfo}
    */
   getBufferedInfo() {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const TimeRangesUtils = shaka.media.TimeRangesUtils;
 
     const info = {
@@ -819,7 +819,7 @@ shaka.media.MediaSourceEngine = class {
   }
 
   /**
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @return {TimeRanges} The buffered ranges for the given content type, or
    *   null if the buffered ranges could not be obtained.
    * @private
@@ -855,7 +855,7 @@ shaka.media.MediaSourceEngine = class {
   /**
    * This method is only public for testing.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {!BufferSource} data
    * @param {!shaka.media.SegmentReference} reference The segment reference
    *   we are appending
@@ -1164,7 +1164,7 @@ shaka.media.MediaSourceEngine = class {
    * Start and end times may be null for initialization segments; if present
    * they are relative to the presentation timeline.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {!BufferSource} data
    * @param {?shaka.media.SegmentReference} reference The segment reference
    *   we are appending, or null for init segments
@@ -1184,7 +1184,7 @@ shaka.media.MediaSourceEngine = class {
       contentType, data, reference, stream, hasClosedCaptions, seeked = false,
       adaptation = false, isChunkedData = false, fromSplit = false,
       continuityTimeline) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     if (contentType == ContentType.TEXT) {
       await this.textEngine_.appendBuffer(
@@ -1417,7 +1417,7 @@ shaka.media.MediaSourceEngine = class {
    * @param {string} id
    */
   setSelectedClosedCaptionId(id) {
-    const VIDEO = shaka.util.ManifestParserUtils.ContentType.VIDEO;
+    const VIDEO = shaka.media.ManifestParser.ContentType.VIDEO;
     const videoBufferEndTime = this.bufferEnd(VIDEO) || 0;
     this.textEngine_.setSelectedClosedCaptionId(id, videoBufferEndTime);
   }
@@ -1432,7 +1432,7 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Enqueue an operation to remove data from the SourceBuffer.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {number} startTime relative to the start of the presentation
    * @param {number} endTime relative to the start of the presentation
    * @param {Array<number>=} continuityTimelines a list of continuity timelines
@@ -1440,7 +1440,7 @@ shaka.media.MediaSourceEngine = class {
    * @return {!Promise}
    */
   async remove(contentType, startTime, endTime, continuityTimelines) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (contentType == ContentType.VIDEO && this.captionParser_) {
       this.captionParser_.remove(continuityTimelines);
       // Get actual TextEngine buffer start, as it's not the same as video
@@ -1467,11 +1467,11 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Enqueue an operation to clear the SourceBuffer.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @return {!Promise}
    */
   async clear(contentType) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (contentType == ContentType.TEXT) {
       if (!this.textEngine_) {
         return;
@@ -1511,13 +1511,13 @@ shaka.media.MediaSourceEngine = class {
    * Enqueue an operation to flush the SourceBuffer.
    * This is a workaround for what we believe is a Chromecast bug.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @return {!Promise}
    */
   async flush(contentType) {
     // Flush the pipeline.  Necessary on Chromecast, even though we have removed
     // everything.
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (contentType == ContentType.TEXT) {
       // Nothing to flush for text.
       return;
@@ -1537,7 +1537,7 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Sets the timestamp offset and append window end for the given content type.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {number} timestampOffset The timestamp offset.  Segments which start
    *   at time t will be inserted at time t + timestampOffset instead.  This
    *   value does not affect segments which have already been inserted.
@@ -1551,7 +1551,7 @@ shaka.media.MediaSourceEngine = class {
    *   not be applied in this step.
    * @param {string} mimeType
    * @param {string} codecs
-   * @param {!Map<shaka.util.ManifestParserUtils.ContentType,
+   * @param {!Map<shaka.media.ManifestParser.ContentType,
    *               shaka.extern.Stream>} streamsByType
    *   A map of content types to streams.
    *
@@ -1560,7 +1560,7 @@ shaka.media.MediaSourceEngine = class {
   async setStreamProperties(
       contentType, timestampOffset, appendWindowStart, appendWindowEnd,
       ignoreTimestampOffset, mimeType, codecs, streamsByType) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (contentType == ContentType.TEXT) {
       if (!ignoreTimestampOffset) {
         this.textEngine_.setTimestampOffset(timestampOffset);
@@ -1629,12 +1629,12 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Adjust timestamp offset to maintain AV sync across discontinuities.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {number} timestampOffset
    * @return {!Promise}
    */
   async resync(contentType, timestampOffset) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     if (contentType == ContentType.TEXT) {
       // This operation is for audio and video only.
@@ -1810,7 +1810,7 @@ shaka.media.MediaSourceEngine = class {
 
   /**
    * Remove dependency data.
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {number} startTime relative to the start of the presentation
    * @param {number} endTime relative to the start of the presentation
    */
@@ -1823,7 +1823,7 @@ shaka.media.MediaSourceEngine = class {
 
   /**
    * Append data to the SourceBuffer.
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {BufferSource} data
    * @param {number} timestampOffset
    * @param {shaka.extern.Stream} stream
@@ -1840,7 +1840,7 @@ shaka.media.MediaSourceEngine = class {
 
   /**
    * Remove data from the SourceBuffer.
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {number} startTime relative to the start of the presentation
    * @param {number} endTime relative to the start of the presentation
    * @private
@@ -1862,7 +1862,7 @@ shaka.media.MediaSourceEngine = class {
    * Call abort() on the SourceBuffer.
    * This resets MSE's last_decode_timestamp on all track buffers, which should
    * trigger the splicing logic for overlapping segments.
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @private
    */
   abort_(contentType) {
@@ -1887,7 +1887,7 @@ shaka.media.MediaSourceEngine = class {
    * Nudge the playhead to force the media pipeline to be flushed.
    * This seems to be necessary on Chromecast to get new content to replace old
    * content.
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @private
    */
   flush_(contentType) {
@@ -1905,7 +1905,7 @@ shaka.media.MediaSourceEngine = class {
 
   /**
    * Set the SourceBuffer's timestamp offset.
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {number} timestampOffset
    * @private
    */
@@ -1927,7 +1927,7 @@ shaka.media.MediaSourceEngine = class {
 
   /**
    * Set the SourceBuffer's append window end.
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {number} appendWindowStart
    * @param {number} appendWindowEnd
    * @private
@@ -1949,7 +1949,7 @@ shaka.media.MediaSourceEngine = class {
   }
 
   /**
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @private
    */
   onError_(contentType) {
@@ -1971,7 +1971,7 @@ shaka.media.MediaSourceEngine = class {
   }
 
   /**
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @private
    */
   onUpdateEnd_(contentType) {
@@ -2005,7 +2005,7 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Enqueue an operation and start it if appropriate.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {function()} start
    * @param {?string} uri
    * @return {!Promise}
@@ -2039,7 +2039,7 @@ shaka.media.MediaSourceEngine = class {
 
     /** @type {!Array<!Promise>} */
     const allWaiters = [];
-    /** @type {!Array<!shaka.util.ManifestParserUtils.ContentType>} */
+    /** @type {!Array<!shaka.media.ManifestParser.ContentType>} */
     const contentTypes = Array.from(this.sourceBuffers_.keys());
 
     const blockOperations = new Map();
@@ -2117,7 +2117,7 @@ shaka.media.MediaSourceEngine = class {
 
   /**
    * Pop from the front of the queue and start a new operation.
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @private
    */
   popFromQueue_(contentType) {
@@ -2129,7 +2129,7 @@ shaka.media.MediaSourceEngine = class {
 
   /**
    * Starts the next operation in the queue.
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @private
    */
   startOperation_(contentType) {
@@ -2203,12 +2203,12 @@ shaka.media.MediaSourceEngine = class {
    * @param {shaka.extern.Stream} stream
    * @param {!BufferSource} segment
    * @param {?shaka.media.SegmentReference} reference
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @return {!BufferSource}
    * @private
    */
   workAroundBrokenPlatforms_(stream, segment, reference, contentType) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     const isMp4 = shaka.util.MimeUtils.getContainerType(
         this.sourceBufferTypes_.get(contentType)) == 'mp4';
@@ -2271,13 +2271,13 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Prepare the SourceBuffer to parse a potentially new type or codec.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {string} mimeType
    * @param {?shaka.extern.Transmuxer} transmuxer
    * @private
    */
   change_(contentType, mimeType, transmuxer) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (contentType === ContentType.TEXT) {
       shaka.log.debug(`Change not supported for ${contentType}`);
       return;
@@ -2310,7 +2310,7 @@ shaka.media.MediaSourceEngine = class {
    * Enqueue an operation to prepare the SourceBuffer to parse a potentially new
    * type or codec.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {string} mimeType
    * @param {?shaka.extern.Transmuxer} transmuxer
    * @return {!Promise}
@@ -2325,7 +2325,7 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Resets the MediaSource and re-adds source buffers due to codec mismatch
    *
-   * @param {!Map<shaka.util.ManifestParserUtils.ContentType,
+   * @param {!Map<shaka.media.ManifestParser.ContentType,
    *               shaka.extern.Stream>} streamsByType
    * @private
    */
@@ -2333,7 +2333,7 @@ shaka.media.MediaSourceEngine = class {
     if (this.reloadingMediaSource_ || this.usingRemotePlayback_) {
       return;
     }
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     this.reloadingMediaSource_ = true;
     this.needSplitMuxedContent_ = false;
     const currentTime = this.video_.currentTime;
@@ -2446,7 +2446,7 @@ shaka.media.MediaSourceEngine = class {
 
   /**
    * Resets the Media Source
-   * @param {!Map<shaka.util.ManifestParserUtils.ContentType,
+   * @param {!Map<shaka.media.ManifestParser.ContentType,
    *               shaka.extern.Stream>} streamsByType
    * @return {!Promise}
    */
@@ -2456,7 +2456,7 @@ shaka.media.MediaSourceEngine = class {
   }
 
   /**
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {string} mimeType
    * @param {string} codecs
    * @return {{
@@ -2469,7 +2469,7 @@ shaka.media.MediaSourceEngine = class {
    * @private
    */
   getRealInfo_(contentType, mimeType, codecs) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const MimeUtils = shaka.util.MimeUtils;
     /** @type {?shaka.extern.Transmuxer} */
     let transmuxer;
@@ -2535,10 +2535,10 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Codec switch if necessary, this will not resolve until the codec
    * switch is over.
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {string} mimeType
    * @param {string} codecs
-   * @param {!Map<shaka.util.ManifestParserUtils.ContentType,
+   * @param {!Map<shaka.media.ManifestParser.ContentType,
    *               shaka.extern.Stream>} streamsByType
    * @return {{
    *   type: string,
@@ -2548,7 +2548,7 @@ shaka.media.MediaSourceEngine = class {
    * @private
    */
   getInfoAboutResetOrChangeType_(contentType, mimeType, codecs, streamsByType) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (contentType == ContentType.TEXT) {
       return {
         type: shaka.media.MediaSourceEngine.ResetMode_.NONE,
@@ -2627,17 +2627,17 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Codec switch if necessary, this will not resolve until the codec
    * switch is over.
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {string} mimeType
    * @param {string} codecs
-   * @param {!Map<shaka.util.ManifestParserUtils.ContentType,
+   * @param {!Map<shaka.media.ManifestParser.ContentType,
    *               shaka.extern.Stream>} streamsByType
    * @return {!Promise<boolean>} true if there was a codec switch,
    *                              false otherwise.
    * @private
    */
   async codecSwitchIfNecessary_(contentType, mimeType, codecs, streamsByType) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const {type, transmuxer, newMimeType} = this.getInfoAboutResetOrChangeType_(
         contentType, mimeType, codecs, streamsByType);
 
@@ -2681,7 +2681,7 @@ shaka.media.MediaSourceEngine = class {
    * Returns true if it's necessary reset the media source to load the
    * new stream.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {string} mimeType
    * @param {string} codecs
    * @return {boolean}

--- a/lib/media/quality_observer.js
+++ b/lib/media/quality_observer.js
@@ -8,10 +8,10 @@ goog.provide('shaka.media.QualityObserver');
 
 goog.require('shaka.media.IPlayheadObserver');
 goog.require('shaka.log');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.FakeEventTarget');
-goog.require('shaka.util.ManifestParserUtils');
 
 /**
  * Monitors the quality of content being appended to the source buffers and
@@ -284,13 +284,13 @@ shaka.media.QualityObserver = class extends shaka.util.FakeEventTarget {
       roles: stream.roles,
       language: null,
     };
-    if (stream.type == shaka.util.ManifestParserUtils.ContentType.VIDEO) {
+    if (stream.type == shaka.media.ManifestParser.ContentType.VIDEO) {
       basicQuality.frameRate = stream.frameRate || null;
       basicQuality.height = stream.height || null;
       basicQuality.pixelAspectRatio = stream.pixelAspectRatio || null;
       basicQuality.width = stream.width || null;
     }
-    if (stream.type == shaka.util.ManifestParserUtils.ContentType.AUDIO) {
+    if (stream.type == shaka.media.ManifestParser.ContentType.AUDIO) {
       basicQuality.audioSamplingRate = stream.audioSamplingRate;
       basicQuality.channelsCount = stream.channelsCount;
       basicQuality.label = stream.label || null;

--- a/lib/media/segment_utils.js
+++ b/lib/media/segment_utils.js
@@ -12,6 +12,7 @@ goog.require('shaka.drm.DrmUtils');
 goog.require('shaka.drm.PlayReady');
 goog.require('shaka.media.Capabilities');
 goog.require('shaka.media.ClosedCaptionParser');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.ManifestParserUtils');
@@ -35,7 +36,7 @@ shaka.media.SegmentUtils = class {
     const type = baseMimeType.split('/')[0];
     const codecs = shaka.util.MimeUtils.getCodecs(mimeType);
     return {
-      type: type,
+      type: /** @type {shaka.media.ManifestParser.ContentType} */ (type),
       mimeType: baseMimeType,
       codecs: codecs,
       language: null,
@@ -140,7 +141,9 @@ shaka.media.SegmentUtils = class {
       captionParser.reset();
     }
     return {
-      type: onlyAudio ? 'audio' : 'video',
+      type: onlyAudio ?
+          shaka.media.ManifestParser.ContentType.AUDIO :
+          shaka.media.ManifestParser.ContentType.VIDEO,
       mimeType: 'video/mp2t',
       codecs: codecs.join(', '),
       language: null,
@@ -649,17 +652,18 @@ shaka.media.SegmentUtils = class {
         drmInfo.keyIds.add(/** @type {string} */(defaultKID));
       }
     }
-    let type = 'video';
+    const ContentType = shaka.media.ManifestParser.ContentType;
+    let type = ContentType.VIDEO;
     let mimeType = 'video/mp4';
     if (hasText) {
-      type = 'text';
+      type = ContentType.TEXT;
       mimeType = 'application/mp4';
     } else if (onlyAudio) {
-      type = 'audio';
+      type = ContentType.AUDIO;
       mimeType = 'audio/mp4';
     }
 
-    if (type === 'video' && timescale != null && sampleData.length) {
+    if (type === ContentType.VIDEO && timescale != null && sampleData.length) {
       const ts = timescale;
 
       let totalDuration = 0;
@@ -695,7 +699,7 @@ shaka.media.SegmentUtils = class {
    * @return {!Array<string>} codecs
    */
   static codecsFiltering(codecs) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const ManifestParserUtils = shaka.util.ManifestParserUtils;
     const SegmentUtils = shaka.media.SegmentUtils;
     const allCodecs = SegmentUtils.filterDuplicateCodecs_(codecs);
@@ -918,7 +922,7 @@ shaka.media.SegmentUtils = class {
 
 /**
  * @typedef {{
- *   type: string,
+ *   type: shaka.media.ManifestParser.ContentType,
  *   mimeType: string,
  *   codecs: string,
  *   language: ?string,
@@ -934,7 +938,7 @@ shaka.media.SegmentUtils = class {
  *   drmInfos: !Array<shaka.extern.DrmInfo>,
  * }}
  *
- * @property {string} type
+ * @property {shaka.media.ManifestParser.ContentType} type
  * @property {string} mimeType
  * @property {string} codecs
  * @property {?string} language

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -32,7 +32,6 @@ goog.require('shaka.util.EventManager');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.IDestroyable');
 goog.require('shaka.util.LanguageUtils');
-goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Mp4BoxParsers');
 goog.require('shaka.util.Mp4Parser');
@@ -101,7 +100,7 @@ shaka.media.StreamingEngine = class {
     /**
      * Maps a content type, e.g., 'audio', 'video', or 'text', to a MediaState.
      *
-     * @private {!Map<shaka.util.ManifestParserUtils.ContentType,
+     * @private {!Map<shaka.media.ManifestParser.ContentType,
      *                 !shaka.media.StreamingEngine.MediaState_>}
      */
     this.mediaStates_ = new Map();
@@ -285,7 +284,7 @@ shaka.media.StreamingEngine = class {
     this.failureCallbackBackoff_ =
         new shaka.net.Backoff(failureRetryParams, autoReset);
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     // disable audio segment prefetch if this is now set
     if (config.disableAudioPrefetch) {
@@ -406,7 +405,7 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   async loadNewTextStream_(stream) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     goog.asserts.assert(!this.mediaStates_.has(ContentType.TEXT),
         'Should not call loadNewTextStream_ while streaming text!');
     this.textStreamSequenceId_++;
@@ -444,7 +443,7 @@ shaka.media.StreamingEngine = class {
    * Stop fetching text stream when the user chooses to hide the captions.
    */
   unloadTextStream() {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     const state = this.mediaStates_.get(ContentType.TEXT);
     if (state) {
@@ -466,7 +465,7 @@ shaka.media.StreamingEngine = class {
    * @param {boolean} on
    */
   setTrickPlay(on) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     this.updateSegmentIteratorReverse_();
 
@@ -559,7 +558,7 @@ shaka.media.StreamingEngine = class {
       return;
     }
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     goog.asserts.assert(textStream && textStream.type == ContentType.TEXT,
         'Wrong stream type passed to switchTextStream!');
 
@@ -578,7 +577,7 @@ shaka.media.StreamingEngine = class {
 
   /** Reload the current text stream. */
   reloadTextStream() {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const mediaState = this.mediaStates_.get(ContentType.TEXT);
     if (mediaState) { // Don't reload if there's no text to begin with.
       this.switchInternal_(
@@ -621,7 +620,7 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   switchInternal_(stream, clearBuffer, safeMargin, force, adaptation) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const type = /** @type {!ContentType} */(stream.type);
     const mediaState = this.mediaStates_.get(type);
 
@@ -940,7 +939,7 @@ shaka.media.StreamingEngine = class {
     }
 
     const presentationTime = this.playerInterface_.getPresentationTime();
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const newTimeIsBuffered = (type) => {
       return this.playerInterface_.mediaSourceEngine.isBuffered(
           type, presentationTime);
@@ -1092,7 +1091,7 @@ shaka.media.StreamingEngine = class {
     }
 
     /**
-     * @type {!Map<shaka.util.ManifestParserUtils.ContentType,
+     * @type {!Map<shaka.media.ManifestParser.ContentType,
      *              shaka.extern.Stream>}
      */
     const streamsByType = this.getStreamsByType_(/* includeText= */ true);
@@ -1143,7 +1142,7 @@ shaka.media.StreamingEngine = class {
     /** @type {!shaka.media.StreamingEngine.MediaState_} */
     const mediaState = {
       stream,
-      type: /** @type {shaka.util.ManifestParserUtils.ContentType} */(
+      type: /** @type {shaka.media.ManifestParser.ContentType} */(
         stream.type),
       segmentIterator: null,
       segmentPrefetch: this.createSegmentPrefetch_(stream),
@@ -1186,7 +1185,7 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   createSegmentPrefetch_(stream) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (this.manifest_.type == shaka.media.ManifestParser.MSF) {
       return null;
     }
@@ -1212,7 +1211,7 @@ shaka.media.StreamingEngine = class {
     if (this.audioPrefetchMap_.has(stream)) {
       return this.audioPrefetchMap_.get(stream);
     }
-    const type = /** @type {!shaka.util.ManifestParserUtils.ContentType} */
+    const type = /** @type {!shaka.media.ManifestParser.ContentType} */
         (stream.type);
     const mediaState = this.mediaStates_.get(type);
     const currentSegmentPrefetch = mediaState && mediaState.segmentPrefetch;
@@ -1260,7 +1259,7 @@ shaka.media.StreamingEngine = class {
                 (lang) => LanguageUtils.areLanguageCompatible(
                     variant.audio.language, lang))
         ) {
-          const type = /** @type {!shaka.util.ManifestParserUtils.ContentType}*/
+          const type = /** @type {!shaka.media.ManifestParser.ContentType}*/
             (variant.audio.type);
           const mediaState = this.mediaStates_.get(type);
           const currentSegmentPrefetch = mediaState &&
@@ -1354,7 +1353,7 @@ shaka.media.StreamingEngine = class {
   async onUpdate_(mediaState) {
     this.destroyer_.ensureNotDestroyed();
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const logPrefix = shaka.media.StreamingEngine.logPrefix_(mediaState);
 
     // Sanity check.
@@ -1513,7 +1512,7 @@ shaka.media.StreamingEngine = class {
     goog.asserts.assert(this.manifest_, 'manifest_ should not be null');
     goog.asserts.assert(this.config_, 'config_ should not be null');
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     // Do not schedule update for closed captions text mediaState, since closed
     // captions are embedded in video streams.
@@ -1924,7 +1923,7 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   async fetchAndAppend_(mediaState, presentationTime, reference, adaptation) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const StreamingEngine = shaka.media.StreamingEngine;
     const logPrefix = StreamingEngine.logPrefix_(mediaState);
 
@@ -2179,7 +2178,7 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   async fetchAndAppendDependency_(mediaState, segmentTime, bufferingGoal) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     const dependencyStream = mediaState.stream;
     const segmentIndex = dependencyStream.segmentIndex;
@@ -2417,7 +2416,7 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   async initSourceBuffer_(mediaState, reference, adaptation) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const MimeUtils = shaka.util.MimeUtils;
     const StreamingEngine = shaka.media.StreamingEngine;
     const logPrefix = StreamingEngine.logPrefix_(mediaState);
@@ -2682,10 +2681,10 @@ shaka.media.StreamingEngine = class {
    */
   async setProperties_(mediaState, timestampOffset, appendWindowStart,
       appendWindowEnd, reference, codecs, mimeType) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     /**
-     * @type {!Map<shaka.util.ManifestParserUtils.ContentType,
+     * @type {!Map<shaka.media.ManifestParser.ContentType,
      *              shaka.extern.Stream>}
      */
     const streamsByType = this.getStreamsByType_();
@@ -2763,7 +2762,7 @@ shaka.media.StreamingEngine = class {
         timescale = reference.initSegmentReference.timescale;
       }
       const shouldFixTimestampOffset = isMP4 && timescale &&
-          stream.type === shaka.util.ManifestParserUtils.ContentType.VIDEO &&
+          stream.type === shaka.media.ManifestParser.ContentType.VIDEO &&
           this.manifest_.type == shaka.media.ManifestParser.DASH;
 
       if (shouldFixTimestampOffset) {
@@ -2930,7 +2929,7 @@ shaka.media.StreamingEngine = class {
     const CEA608_MIME = MimeUtils.CEA608_CLOSED_CAPTION_MIMETYPE;
     const CEA708_MIME = MimeUtils.CEA708_CLOSED_CAPTION_MIMETYPE;
     return mediaState &&
-        mediaState.type == shaka.util.ManifestParserUtils.ContentType.TEXT &&
+        mediaState.type == shaka.media.ManifestParser.ContentType.TEXT &&
         (mediaState.stream.mimeType == CEA608_MIME ||
          mediaState.stream.mimeType == CEA708_MIME);
   }
@@ -3106,7 +3105,7 @@ shaka.media.StreamingEngine = class {
     // If the text's update is canceled and its mediaState is deleted, stop
     // scheduling another update.
     const type = mediaState.type;
-    if (type == shaka.util.ManifestParserUtils.ContentType.TEXT &&
+    if (type == shaka.media.ManifestParser.ContentType.TEXT &&
           !this.mediaStates_.has(type)) {
       shaka.log.v1(logPrefix, 'Text stream is unloaded. No update is needed.');
       return;
@@ -3282,7 +3281,7 @@ shaka.media.StreamingEngine = class {
       }
     }
     this.lastMediaSourceReset_ = now;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const audioMediaState = this.mediaStates_.get(ContentType.AUDIO);
     if (audioMediaState) {
       this.cancelUpdate_(audioMediaState);
@@ -3400,7 +3399,7 @@ shaka.media.StreamingEngine = class {
     if (!device.supportsSmoothCodecSwitching(keySystem)) {
       for (const type of this.mediaStates_.keys()) {
         const mediaState = this.mediaStates_.get(type);
-        const ContentType = shaka.util.ManifestParserUtils.ContentType;
+        const ContentType = shaka.media.ManifestParser.ContentType;
         if (mediaState.type === ContentType.TEXT) {
           continue;
         }
@@ -3412,7 +3411,7 @@ shaka.media.StreamingEngine = class {
     } else if (!device.supportsContainerChangeType()) {
       for (const type of this.mediaStates_.keys()) {
         const mediaState = this.mediaStates_.get(type);
-        const ContentType = shaka.util.ManifestParserUtils.ContentType;
+        const ContentType = shaka.media.ManifestParser.ContentType;
         if (mediaState.type === ContentType.TEXT) {
           continue;
         }
@@ -3466,7 +3465,7 @@ shaka.media.StreamingEngine = class {
 
     const presentationTime = this.playerInterface_.getPresentationTime();
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const mediaState = this.mediaStates_.get(ContentType.VIDEO) ||
       this.mediaStates_.get(ContentType.AUDIO);
     if (!mediaState) {
@@ -3504,7 +3503,7 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   discardReferenceByBoundary_(mediaState, reference) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     if (mediaState.type === ContentType.TEXT) {
       return false;
     }
@@ -3588,12 +3587,12 @@ shaka.media.StreamingEngine = class {
 
   /**
    * @param {boolean=} includeText
-   * @return {!Map<shaka.util.ManifestParserUtils.ContentType,
+   * @return {!Map<shaka.media.ManifestParser.ContentType,
    *               shaka.extern.Stream>}
    * @private
    */
   getStreamsByType_(includeText = false) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     const updateCodecsAndMimeType = (stream) => {
       if (stream.fullMimeTypes && stream.fullMimeTypes.size > 1) {
@@ -3613,7 +3612,7 @@ shaka.media.StreamingEngine = class {
     };
 
     /**
-     * @type {!Map<shaka.util.ManifestParserUtils.ContentType,
+     * @type {!Map<shaka.media.ManifestParser.ContentType,
      *              shaka.extern.Stream>}
      */
     const streamsByType = new Map();
@@ -3659,7 +3658,7 @@ shaka.media.StreamingEngine = class {
  *     !shaka.extern.Stream, boolean, boolean),
  *   onInitSegmentAppended: function(!number,!shaka.media.InitSegmentReference),
  *   beforeAppendSegment: function(
- *     shaka.util.ManifestParserUtils.ContentType,!BufferSource):Promise,
+ *     shaka.media.ManifestParser.ContentType,!BufferSource):Promise,
  *   disableStream: function(!shaka.extern.Stream, number):boolean,
  *   shouldPrefetchNextSegment: function(!shaka.media.SegmentReference,
  *     !shaka.extern.Stream):boolean,
@@ -3691,7 +3690,7 @@ shaka.media.StreamingEngine = class {
  * @property {function(!number,
  *                     !shaka.media.InitSegmentReference)} onInitSegmentAppended
  *   Called when an init segment is appended to a MediaSource.
- * @property {!function(shaka.util.ManifestParserUtils.ContentType,
+ * @property {!function(shaka.media.ManifestParser.ContentType,
  *   !BufferSource):Promise} beforeAppendSegment
  *   A function called just before appending to the source buffer.
  * @property {function(!shaka.extern.Stream, number):boolean} disableStream
@@ -3707,7 +3706,7 @@ shaka.media.StreamingEngine.PlayerInterface;
 
 /**
  * @typedef {{
- *   type: shaka.util.ManifestParserUtils.ContentType,
+ *   type: shaka.media.ManifestParser.ContentType,
  *   stream: shaka.extern.Stream,
  *   segmentIterator: shaka.media.SegmentIterator,
  *   lastSegmentReference: shaka.media.SegmentReference,
@@ -3739,7 +3738,7 @@ shaka.media.StreamingEngine.PlayerInterface;
  * for a particular content type. At any given time there is a Stream object
  * associated with the state of the logical stream.
  *
- * @property {shaka.util.ManifestParserUtils.ContentType} type
+ * @property {shaka.media.ManifestParser.ContentType} type
  *   The stream's content type, e.g., 'audio', 'video', or 'text'.
  * @property {shaka.extern.Stream} stream
  *   The current Stream.

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -102,7 +102,7 @@ shaka.msf.MSFParser = class {
      * Tracks whether the first segment has been received for each content type.
      * Used to delay locking the presentation timeline until all expected
      * stream types have started producing data.
-     * @private {!Set<shaka.util.ManifestParserUtils.ContentType>}
+     * @private {!Set<shaka.media.ManifestParser.ContentType>}
      */
     this.receivedFirstSegment_ = new Set();
   }
@@ -646,7 +646,7 @@ shaka.msf.MSFParser = class {
    * @private
    */
   processTrack_(track, contentProtections, initDataList) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const ManifestParserUtils = shaka.util.ManifestParserUtils;
 
     let initData = new Uint8Array([]);
@@ -973,7 +973,7 @@ shaka.msf.MSFParser = class {
    * @private
    */
   createVariants_() {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     // Create variants for all audio/video combinations.
     let nextVariantId = 0;

--- a/lib/offline/indexeddb/v1_storage_cell.js
+++ b/lib/offline/indexeddb/v1_storage_cell.js
@@ -8,9 +8,9 @@ goog.provide('shaka.offline.indexeddb.V1StorageCell');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.offline.indexeddb.BaseStorageCell');
 goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.PeriodCombiner');
 
 
@@ -267,8 +267,8 @@ shaka.offline.indexeddb.V1StorageCell = class
    * @private
    */
   static fillMissingVariants_(period) {
-    const AUDIO = shaka.util.ManifestParserUtils.ContentType.AUDIO;
-    const VIDEO = shaka.util.ManifestParserUtils.ContentType.VIDEO;
+    const AUDIO = shaka.media.ManifestParser.ContentType.AUDIO;
+    const VIDEO = shaka.media.ManifestParser.ContentType.VIDEO;
 
     // There are three cases:
     //  1. All streams' variant ids are null

--- a/lib/offline/manifest_converter.js
+++ b/lib/offline/manifest_converter.js
@@ -13,7 +13,6 @@ goog.require('shaka.media.PresentationTimeline');
 goog.require('shaka.media.SegmentIndex');
 goog.require('shaka.media.SegmentReference');
 goog.require('shaka.offline.OfflineUri');
-goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.MimeUtils');
 
 
@@ -301,7 +300,7 @@ shaka.offline.ManifestConverter = class {
    * @private
    */
   isAudio_(streamDB) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     return streamDB.type == ContentType.AUDIO;
   }
 
@@ -311,7 +310,7 @@ shaka.offline.ManifestConverter = class {
    * @private
    */
   isVideo_(streamDB) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     return streamDB.type == ContentType.VIDEO;
   }
 
@@ -321,7 +320,7 @@ shaka.offline.ManifestConverter = class {
    * @private
    */
   isText_(streamDB) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     return streamDB.type == ContentType.TEXT;
   }
 
@@ -331,7 +330,7 @@ shaka.offline.ManifestConverter = class {
    * @private
    */
   isImage_(streamDB) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     return streamDB.type == ContentType.IMAGE;
   }
 
@@ -341,7 +340,7 @@ shaka.offline.ManifestConverter = class {
    * @private
    */
   isChapter_(streamDB) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     return streamDB.type == ContentType.CHAPTER;
   }
 

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -685,7 +685,7 @@ shaka.offline.Storage = class {
       // Assign the stored data to the manifest.
       let complete = true;
       for (const stream of manifestDB.streams) {
-        if (stream.type == shaka.util.ManifestParserUtils.ContentType.CHAPTER) {
+        if (stream.type == shaka.media.ManifestParser.ContentType.CHAPTER) {
           continue;
         }
         for (const segment of stream.segments) {
@@ -844,18 +844,18 @@ shaka.offline.Storage = class {
     /** @type {!Set<number>} */
     const chapterIds = new Set();
 
+    const ContentType = shaka.media.ManifestParser.ContentType;
+
     // Collect the IDs of the chosen tracks.
     for (const track of chosenTracks) {
       if (track.type == 'variant') {
         variantIds.add(track.id);
       }
-      if (track.type == 'text') {
+      if (track.type === ContentType.TEXT) {
         textIds.add(track.id);
-      }
-      if (track.type == 'image') {
+      } else if (track.type === ContentType.IMAGE) {
         imageIds.add(track.id);
-      }
-      if (track.type == 'chapter') {
+      } else if (track.type === ContentType.CHAPTER) {
         chapterIds.add(track.id);
       }
     }
@@ -1079,15 +1079,16 @@ shaka.offline.Storage = class {
    */
   static getCapabilities_(manifestDb, isVideo) {
     const MimeUtils = shaka.util.MimeUtils;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     const ret = [];
     for (const stream of manifestDb.streams) {
-      if (isVideo && stream.type == 'video') {
+      if (isVideo && stream.type === ContentType.VIDEO) {
         ret.push({
           contentType: MimeUtils.getFullType(stream.mimeType, stream.codecs),
           robustness: manifestDb.drmInfo.videoRobustness,
         });
-      } else if (!isVideo && stream.type == 'audio') {
+      } else if (!isVideo && stream.type === ContentType.AUDIO) {
         ret.push({
           contentType: MimeUtils.getFullType(stream.mimeType, stream.codecs),
           robustness: manifestDb.drmInfo.audioRobustness,
@@ -1450,7 +1451,7 @@ shaka.offline.Storage = class {
       language: 'und',
       originalLanguage: null,
       label: null,
-      type: shaka.util.ManifestParserUtils.ContentType.IMAGE,
+      type: shaka.media.ManifestParser.ContentType.IMAGE,
       primary: false,
       trickModeVideo: null,
       dependencyStream: null,
@@ -1507,7 +1508,7 @@ shaka.offline.Storage = class {
       language: language,
       originalLanguage: language,
       label: null,
-      type: shaka.util.ManifestParserUtils.ContentType.TEXT,
+      type: shaka.media.ManifestParser.ContentType.TEXT,
       primary: false,
       trickModeVideo: null,
       dependencyStream: null,
@@ -1730,7 +1731,7 @@ shaka.offline.Storage = class {
       let pendingInitSegmentRefId = undefined;
 
       let chapterTitle = null;
-      if (stream.type == shaka.util.ManifestParserUtils.ContentType.CHAPTER) {
+      if (stream.type == shaka.media.ManifestParser.ContentType.CHAPTER) {
         const metadata = segment.getMetadata();
         if (metadata) {
           chapterTitle = metadata.title;

--- a/lib/player.js
+++ b/lib/player.js
@@ -7065,7 +7065,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             shaka.util.Error.Code.CANNOT_ADD_EXTERNAL_TEXT_TO_SRC_EQUALS);
       }
 
-      const ContentType = shaka.util.ManifestParserUtils.ContentType;
+      const ContentType = shaka.media.ManifestParser.ContentType;
 
       const seekRange = this.seekRange();
       let duration = seekRange.end - seekRange.start;
@@ -7189,7 +7189,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             uri);
       }
 
-      const ContentType = shaka.util.ManifestParserUtils.ContentType;
+      const ContentType = shaka.media.ManifestParser.ContentType;
       const seekRange = this.seekRange();
       let duration = seekRange.end - seekRange.start;
       if (this.manifest_) {
@@ -7348,7 +7348,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         mimeType = await this.getTextMimetype_(uri);
       }
 
-      const ContentType = shaka.util.ManifestParserUtils.ContentType;
+      const ContentType = shaka.media.ManifestParser.ContentType;
       const seekRange = this.seekRange();
       let duration = seekRange.end - seekRange.start;
       if (this.manifest_) {
@@ -7669,7 +7669,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (this.loadMode_ != shaka.Player.LoadMode.MEDIA_SOURCE) {
       return output;
     }
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const variant = this.streamingEngine_.getCurrentVariant();
     const textStream = this.streamingEngine_.getCurrentTextStream();
     const currentTime = this.video_.currentTime;
@@ -7827,7 +7827,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   makeTextStreamsForClosedCaptions_(manifest) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const TextStreamKind = shaka.util.ManifestParserUtils.TextStreamKind;
     const CEA608_MIME = shaka.util.MimeUtils.CEA608_CLOSED_CAPTION_MIMETYPE;
     const CEA708_MIME = shaka.util.MimeUtils.CEA708_CLOSED_CAPTION_MIMETYPE;
@@ -8721,14 +8721,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * @param {number} start
    * @param {number} end
-   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {shaka.media.ManifestParser.ContentType} contentType
    * @param {boolean} isMuxed
    * @param {boolean} isDependency
    *
    * @private
    */
   onSegmentAppended_(start, end, contentType, isMuxed, isDependency) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const NumberUtils = shaka.util.NumberUtils;
     if (contentType != ContentType.TEXT) {
       // When we append a segment to media source (via streaming engine) we are

--- a/lib/text/speech_to_text.js
+++ b/lib/text/speech_to_text.js
@@ -8,12 +8,12 @@ goog.provide('shaka.text.SpeechToText');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.Dom');
 goog.require('shaka.util.EventManager');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.IReleasable');
-goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.Lazy');
 goog.require('shaka.util.Timer');
 goog.requireType('shaka.Player');
@@ -434,7 +434,7 @@ shaka.text.SpeechToText = class {
     return {
       id: this.nextTextTrackId_++,
       active: false,
-      type: shaka.util.ManifestParserUtils.ContentType.TEXT,
+      type: shaka.media.ManifestParser.ContentType.TEXT,
       bandwidth: 0,
       language: '',
       label: null,

--- a/lib/transmuxer/aac_transmuxer.js
+++ b/lib/transmuxer/aac_transmuxer.js
@@ -7,13 +7,13 @@
 goog.provide('shaka.transmuxer.AacTransmuxer');
 
 goog.require('shaka.media.Capabilities');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.metadata.Id3Utils');
 goog.require('shaka.transmuxer.ADTS');
 goog.require('shaka.transmuxer.TransmuxerEngine');
 goog.require('shaka.transmuxer.TransmuxerUtils');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Mp4Generator');
 
@@ -64,7 +64,7 @@ shaka.transmuxer.AacTransmuxer = class {
     if (!this.isAacContainer_(mimeType)) {
       return false;
     }
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     return Capabilities.isTypeSupported(
         this.convertCodecs(ContentType.AUDIO, mimeType));
   }
@@ -184,7 +184,7 @@ shaka.transmuxer.AacTransmuxer = class {
     /** @type {shaka.util.Mp4Generator.StreamInfo} */
     const streamInfo = {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      type: shaka.media.ManifestParser.ContentType.AUDIO,
       codecs: info.codec,
       timescale: sampleRate,
       duration: duration,

--- a/lib/transmuxer/ac3_transmuxer.js
+++ b/lib/transmuxer/ac3_transmuxer.js
@@ -8,13 +8,13 @@ goog.provide('shaka.transmuxer.Ac3Transmuxer');
 
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.media.Capabilities');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.metadata.Id3Utils');
 goog.require('shaka.transmuxer.Ac3');
 goog.require('shaka.transmuxer.TransmuxerEngine');
 goog.require('shaka.transmuxer.TransmuxerUtils');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.Mp4Generator');
 
 
@@ -64,7 +64,7 @@ shaka.transmuxer.Ac3Transmuxer = class {
     if (!this.isAc3Container_(mimeType)) {
       return false;
     }
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     return Capabilities.isTypeSupported(
         this.convertCodecs(ContentType.AUDIO, mimeType));
   }
@@ -186,7 +186,7 @@ shaka.transmuxer.Ac3Transmuxer = class {
     /** @type {shaka.util.Mp4Generator.StreamInfo} */
     const streamInfo = {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      type: shaka.media.ManifestParser.ContentType.AUDIO,
       codecs: 'ac-3',
       timescale: sampleRate,
       duration: duration,

--- a/lib/transmuxer/ec3_transmuxer.js
+++ b/lib/transmuxer/ec3_transmuxer.js
@@ -7,13 +7,13 @@
 goog.provide('shaka.transmuxer.Ec3Transmuxer');
 
 goog.require('shaka.media.Capabilities');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.metadata.Id3Utils');
 goog.require('shaka.transmuxer.Ec3');
 goog.require('shaka.transmuxer.TransmuxerEngine');
 goog.require('shaka.transmuxer.TransmuxerUtils');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.Mp4Generator');
 
 
@@ -63,7 +63,7 @@ shaka.transmuxer.Ec3Transmuxer = class {
     if (!this.isEc3Container_(mimeType)) {
       return false;
     }
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     return Capabilities.isTypeSupported(
         this.convertCodecs(ContentType.AUDIO, mimeType));
   }
@@ -180,7 +180,7 @@ shaka.transmuxer.Ec3Transmuxer = class {
     /** @type {shaka.util.Mp4Generator.StreamInfo} */
     const streamInfo = {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      type: shaka.media.ManifestParser.ContentType.AUDIO,
       codecs: 'ec-3',
       timescale: sampleRate,
       duration: duration,

--- a/lib/transmuxer/loc_transmuxer.js
+++ b/lib/transmuxer/loc_transmuxer.js
@@ -8,6 +8,7 @@ goog.provide('shaka.transmuxer.LocTransmuxer');
 
 goog.require('goog.asserts');
 goog.require('shaka.media.Capabilities');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.transmuxer.H264');
 goog.require('shaka.transmuxer.H265');
 goog.require('shaka.transmuxer.Opus');
@@ -85,7 +86,7 @@ shaka.transmuxer.LocTransmuxer = class {
       return false;
     }
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const MimeUtils = shaka.util.MimeUtils;
 
     let convertedMimeType = mimeType;
@@ -144,7 +145,7 @@ shaka.transmuxer.LocTransmuxer = class {
    */
   convertCodecs(contentType, mimeType) {
     if (this.isLocContainer_(mimeType)) {
-      const ContentType = shaka.util.ManifestParserUtils.ContentType;
+      const ContentType = shaka.media.ManifestParser.ContentType;
       const MimeUtils = shaka.util.MimeUtils;
       const codecs = MimeUtils.getCodecs(mimeType).split(',')
           .map((codecs) => {
@@ -174,7 +175,7 @@ shaka.transmuxer.LocTransmuxer = class {
    * @export
    */
   transmux(data, stream, reference, duration, contentType) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const MimeUtils = shaka.util.MimeUtils;
 
     const uint8ArrayData = shaka.util.BufferUtils.toUint8(data);
@@ -386,7 +387,7 @@ shaka.transmuxer.LocTransmuxer = class {
 
     return {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      type: shaka.media.ManifestParser.ContentType.VIDEO,
       codecs: 'avc1',
       timescale,
       duration,
@@ -464,7 +465,7 @@ shaka.transmuxer.LocTransmuxer = class {
 
     return {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      type: shaka.media.ManifestParser.ContentType.VIDEO,
       codecs: 'hvc1',
       timescale,
       duration,
@@ -512,7 +513,7 @@ shaka.transmuxer.LocTransmuxer = class {
 
     return {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      type: shaka.media.ManifestParser.ContentType.AUDIO,
       codecs: stream.codecs,
       timescale,
       duration,
@@ -573,7 +574,7 @@ shaka.transmuxer.LocTransmuxer = class {
 
     return {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      type: shaka.media.ManifestParser.ContentType.AUDIO,
       codecs: stream.codecs,
       timescale,
       duration,

--- a/lib/transmuxer/mp3_transmuxer.js
+++ b/lib/transmuxer/mp3_transmuxer.js
@@ -7,13 +7,13 @@
 goog.provide('shaka.transmuxer.Mp3Transmuxer');
 
 goog.require('shaka.media.Capabilities');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.metadata.Id3Utils');
 goog.require('shaka.transmuxer.MpegAudio');
 goog.require('shaka.transmuxer.TransmuxerEngine');
 goog.require('shaka.transmuxer.TransmuxerUtils');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
-goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.Mp4Generator');
 
 
@@ -63,7 +63,7 @@ shaka.transmuxer.Mp3Transmuxer = class {
     if (!this.isMpegContainer_(mimeType)) {
       return false;
     }
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     return Capabilities.isTypeSupported(
         this.convertCodecs(ContentType.AUDIO, mimeType));
   }
@@ -165,7 +165,7 @@ shaka.transmuxer.Mp3Transmuxer = class {
     /** @type {shaka.util.Mp4Generator.StreamInfo} */
     const streamInfo = {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      type: shaka.media.ManifestParser.ContentType.AUDIO,
       codecs: 'mp3',
       timescale: sampleRate,
       duration: duration,

--- a/lib/transmuxer/mpeg_ts_transmuxer.js
+++ b/lib/transmuxer/mpeg_ts_transmuxer.js
@@ -7,6 +7,7 @@
 goog.provide('shaka.transmuxer.MpegTsTransmuxer');
 
 goog.require('shaka.media.Capabilities');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.transmuxer.MpegAudio');
 goog.require('shaka.transmuxer.TransmuxerEngine');
 goog.require('shaka.util.BufferUtils');
@@ -67,7 +68,7 @@ shaka.transmuxer.MpegTsTransmuxer = class {
       return false;
     }
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const MimeUtils = shaka.util.MimeUtils;
 
     const codecs = MimeUtils.getCodecs(mimeType);
@@ -130,7 +131,7 @@ shaka.transmuxer.MpegTsTransmuxer = class {
    */
   transmux(data, stream, reference, duration, contentType) {
     const MpegAudio = shaka.transmuxer.MpegAudio;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const Uint8ArrayUtils = shaka.util.Uint8ArrayUtils;
 
     if (!this.tsParser_) {

--- a/lib/transmuxer/ts_transmuxer.js
+++ b/lib/transmuxer/ts_transmuxer.js
@@ -7,6 +7,7 @@
 goog.provide('shaka.transmuxer.TsTransmuxer');
 
 goog.require('shaka.media.Capabilities');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.metadata.Id3Utils');
 goog.require('shaka.transmuxer.AacTransmuxer');
 goog.require('shaka.transmuxer.Ac3');
@@ -86,7 +87,7 @@ shaka.transmuxer.TsTransmuxer = class {
       return false;
     }
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const MimeUtils = shaka.util.MimeUtils;
 
     let convertedMimeType = mimeType;
@@ -146,7 +147,7 @@ shaka.transmuxer.TsTransmuxer = class {
    */
   convertCodecs(contentType, mimeType) {
     if (this.isTsContainer_(mimeType)) {
-      const ContentType = shaka.util.ManifestParserUtils.ContentType;
+      const ContentType = shaka.media.ManifestParser.ContentType;
       const MimeUtils = shaka.util.MimeUtils;
       // The replace it's necessary because Firefox(the only browser that
       // supports MP3 in MP4) only support the MP3 codec with the mp3 string.
@@ -181,7 +182,7 @@ shaka.transmuxer.TsTransmuxer = class {
    * @export
    */
   transmux(data, stream, reference, duration, contentType) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     const uint8ArrayData = shaka.util.BufferUtils.toUint8(data);
 
@@ -396,7 +397,7 @@ shaka.transmuxer.TsTransmuxer = class {
 
       const allCodecs = shaka.util.MimeUtils.splitCodecs(stream.codecs);
       const audioCodec = shaka.util.ManifestParserUtils.guessCodecsSafe(
-          shaka.util.ManifestParserUtils.ContentType.AUDIO, allCodecs);
+          shaka.media.ManifestParser.ContentType.AUDIO, allCodecs);
       if (!audioCodec || !stream.channelsCount || !stream.audioSamplingRate) {
         throw new shaka.util.Error(
             shaka.util.Error.Severity.CRITICAL,
@@ -441,7 +442,7 @@ shaka.transmuxer.TsTransmuxer = class {
 
     return {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      type: shaka.media.ManifestParser.ContentType.AUDIO,
       codecs: info.codec,
       timescale: sampleRate,
       duration: duration,
@@ -532,7 +533,7 @@ shaka.transmuxer.TsTransmuxer = class {
 
     return {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      type: shaka.media.ManifestParser.ContentType.AUDIO,
       codecs: 'ac-3',
       timescale: sampleRate,
       duration: duration,
@@ -623,7 +624,7 @@ shaka.transmuxer.TsTransmuxer = class {
 
     return {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      type: shaka.media.ManifestParser.ContentType.AUDIO,
       codecs: 'ec-3',
       timescale: sampleRate,
       duration: duration,
@@ -701,7 +702,7 @@ shaka.transmuxer.TsTransmuxer = class {
 
     return {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      type: shaka.media.ManifestParser.ContentType.AUDIO,
       codecs: 'mp3',
       timescale: sampleRate,
       duration: duration,
@@ -801,7 +802,7 @@ shaka.transmuxer.TsTransmuxer = class {
 
     return {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+      type: shaka.media.ManifestParser.ContentType.AUDIO,
       codecs: 'opus',
       timescale: sampleRate,
       duration: duration,
@@ -885,7 +886,7 @@ shaka.transmuxer.TsTransmuxer = class {
 
     return {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      type: shaka.media.ManifestParser.ContentType.VIDEO,
       codecs: 'avc1',
       timescale: timescale,
       duration: duration,
@@ -980,7 +981,7 @@ shaka.transmuxer.TsTransmuxer = class {
 
     return {
       id: stream.id,
-      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      type: shaka.media.ManifestParser.ContentType.VIDEO,
       codecs: 'hvc1',
       timescale: timescale,
       duration: duration,

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -9,6 +9,7 @@ goog.provide('shaka.util.CmcdManager');
 goog.require('goog.Uri');
 
 goog.require('shaka.log');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.EventManager');
@@ -996,18 +997,19 @@ shaka.util.CmcdManager = class {
 
     const type = stream.type;
 
-    if (type == 'video') {
+    const ContentType = shaka.media.ManifestParser.ContentType;
+    if (type === ContentType.VIDEO) {
       if (stream.codecs && stream.codecs.includes(',')) {
         return shaka.util.CmcdManager.ObjectType.MUXED;
       }
       return shaka.util.CmcdManager.ObjectType.VIDEO;
     }
 
-    if (type == 'audio') {
+    if (type === ContentType.AUDIO) {
       return shaka.util.CmcdManager.ObjectType.AUDIO;
     }
 
-    if (type == 'text') {
+    if (type === ContentType.TEXT) {
       if (stream.mimeType === 'application/mp4') {
         return shaka.util.CmcdManager.ObjectType.TIMED_TEXT;
       }

--- a/lib/util/manifest_parser_utils.js
+++ b/lib/util/manifest_parser_utils.js
@@ -8,6 +8,7 @@ goog.provide('shaka.util.ManifestParserUtils');
 
 goog.require('goog.Uri');
 goog.require('shaka.drm.DrmUtils');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.LanguageUtils');
@@ -229,7 +230,7 @@ shaka.util.ManifestParserUtils = class {
     }
 
     // Text does not require a codec string.
-    if (contentType == shaka.util.ManifestParserUtils.ContentType.TEXT) {
+    if (contentType == shaka.media.ManifestParser.ContentType.TEXT) {
       return '';
     }
 
@@ -367,19 +368,6 @@ shaka.util.ManifestParserUtils = class {
 /**
  * @enum {string}
  */
-shaka.util.ManifestParserUtils.ContentType = {
-  VIDEO: 'video',
-  AUDIO: 'audio',
-  TEXT: 'text',
-  IMAGE: 'image',
-  APPLICATION: 'application',
-  CHAPTER: 'chapter',
-};
-
-
-/**
- * @enum {string}
- */
 shaka.util.ManifestParserUtils.TextStreamKind = {
   SUBTITLE: 'subtitle',
   CLOSED_CAPTION: 'caption',
@@ -457,6 +445,9 @@ shaka.util.ManifestParserUtils.TEXT_CODEC_REGEXPS = [
  * @const {!Map<string, !Array<!RegExp>>}
  */
 shaka.util.ManifestParserUtils.CODEC_REGEXPS_BY_CONTENT_TYPE_ = new Map()
-    .set('audio', shaka.util.ManifestParserUtils.AUDIO_CODEC_REGEXPS)
-    .set('video', shaka.util.ManifestParserUtils.VIDEO_CODEC_REGEXPS)
-    .set('text', shaka.util.ManifestParserUtils.TEXT_CODEC_REGEXPS);
+    .set(shaka.media.ManifestParser.ContentType.AUDIO,
+        shaka.util.ManifestParserUtils.AUDIO_CODEC_REGEXPS)
+    .set(shaka.media.ManifestParser.ContentType.VIDEO,
+        shaka.util.ManifestParserUtils.VIDEO_CODEC_REGEXPS)
+    .set(shaka.media.ManifestParser.ContentType.TEXT,
+        shaka.util.ManifestParserUtils.TEXT_CODEC_REGEXPS);

--- a/lib/util/mime_utils.js
+++ b/lib/util/mime_utils.js
@@ -8,8 +8,8 @@ goog.provide('shaka.util.MimeUtils');
 
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.device.IDevice');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.transmuxer.TransmuxerEngine');
-goog.require('shaka.util.ManifestParserUtils');
 
 /**
  * @summary A set of utility functions for dealing with MIME types.
@@ -66,7 +66,7 @@ shaka.util.MimeUtils = class {
     const fullMimeType = MimeUtils.getFullType(mimeType, codecs);
     const fullMimeTypeWithAllCodecs = MimeUtils.getFullTypeWithAllCodecs(
         mimeType, codecs);
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const TransmuxerEngine = shaka.transmuxer.TransmuxerEngine;
 
     if (TransmuxerEngine.isSupported(fullMimeTypeWithAllCodecs, contentType)) {

--- a/lib/util/mp4_generator.js
+++ b/lib/util/mp4_generator.js
@@ -8,6 +8,7 @@ goog.provide('shaka.util.Mp4Generator');
 
 goog.require('goog.asserts');
 goog.require('shaka.device.DeviceFactory');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Lazy');
 goog.require('shaka.util.ManifestParserUtils');
@@ -105,7 +106,7 @@ shaka.util.Mp4Generator = class {
    */
   tkhd_(streamInfo) {
     const Mp4Generator = shaka.util.Mp4Generator;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const id = streamInfo.id + 1;
     let width = streamInfo.stream.width || 0;
     let height = streamInfo.stream.height || 0;
@@ -175,7 +176,7 @@ shaka.util.Mp4Generator = class {
    */
   hdlr_(streamInfo) {
     const Mp4Generator = shaka.util.Mp4Generator;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     let bytes = new Uint8Array([]);
     switch (streamInfo.type) {
       case ContentType.VIDEO:
@@ -197,7 +198,7 @@ shaka.util.Mp4Generator = class {
    */
   minf_(streamInfo) {
     const Mp4Generator = shaka.util.Mp4Generator;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     switch (streamInfo.type) {
       case ContentType.VIDEO:
         return Mp4Generator.box(
@@ -238,7 +239,7 @@ shaka.util.Mp4Generator = class {
    */
   stsd_(streamInfo) {
     const Mp4Generator = shaka.util.Mp4Generator;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     let audioCodec = 'aac';
     if (streamInfo.codecs.includes('mp3')) {
       audioCodec = 'mp3';
@@ -482,7 +483,7 @@ shaka.util.Mp4Generator = class {
    * @private
    */
   esds_(streamInfo) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     const id = streamInfo.id + 1;
     const channelsCount = streamInfo.stream.channelsCount || 2;
@@ -835,7 +836,7 @@ shaka.util.Mp4Generator = class {
    * @private
    */
   trun_(streamInfo, offset) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const Mp4Generator = shaka.util.Mp4Generator;
 
     const samples = streamInfo.data ? streamInfo.data.samples : [];
@@ -1388,7 +1389,7 @@ shaka.util.Mp4Generator.STCO_BOX_ = new shaka.util.Lazy(
 /**
  * @typedef {{
  *   id: number,
- *   type: string,
+ *   type: shaka.media.ManifestParser.ContentType,
  *   codecs: string,
  *   timescale: number,
  *   duration: number,
@@ -1401,7 +1402,7 @@ shaka.util.Mp4Generator.STCO_BOX_ = new shaka.util.Lazy(
  *
  * @property {number} id
  *   A unique ID
- * @property {string} type
+ * @property {shaka.media.ManifestParser.ContentType} type
  *   Indicate the content type: 'video' or 'audio'.
  * @property {string} codecs
  *   <i>Defaults to '' (i.e., unknown / not needed).</i> <br>

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -9,12 +9,12 @@ goog.provide('shaka.util.PeriodCombiner');
 goog.require('goog.asserts');
 goog.require('shaka.drm.DrmUtils');
 goog.require('shaka.log');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.media.MetaSegmentIndex');
 goog.require('shaka.media.SegmentIndex');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.IReleasable');
 goog.require('shaka.util.LanguageUtils');
-goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.MimeUtils');
 
 /**
@@ -53,7 +53,7 @@ shaka.util.PeriodCombiner = class {
      */
     this.usedPeriodIds_ = new Set();
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     /** @private {Map<string, !Array<shaka.extern.Stream>>} */
     this.streamCollections_ = new Map()
@@ -180,7 +180,7 @@ shaka.util.PeriodCombiner = class {
    * @private
    */
   getStreamsPerPeriod_(periods, addDummy) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const PeriodCombiner = shaka.util.PeriodCombiner;
 
     const audioStreamsPerPeriod = [];
@@ -232,7 +232,7 @@ shaka.util.PeriodCombiner = class {
    * @export
    */
   async combinePeriods(periods, isDynamic, isPatchUpdate = false) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     // Optimization: for single-period VOD, do nothing.  This makes sure
     // single-period DASH content will be 100% accurately represented in the
@@ -398,7 +398,7 @@ shaka.util.PeriodCombiner = class {
    * @return {!Promise<!Array<shaka.extern.StreamDB>>}
    */
   static async combineDbStreams(streamDbsPerPeriod) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const PeriodCombiner = shaka.util.PeriodCombiner;
 
     // Optimization: for single-period content, do nothing.  This makes sure
@@ -788,7 +788,7 @@ shaka.util.PeriodCombiner = class {
   static extendOutputStream_(
       outputStream, firstNewPeriodIndex, concat, unusedStreamsPerPeriod,
       periodsMissing) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const LanguageUtils = shaka.util.LanguageUtils;
     const matches = outputStream.matchedStreams;
 
@@ -1103,11 +1103,12 @@ shaka.util.PeriodCombiner = class {
    * @private
    */
   findBestMatchInPeriod_(streams, outputStream) {
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const getKey = {
-      'audio': shaka.util.PeriodCombiner.generateAudioKey_,
-      'video': shaka.util.PeriodCombiner.generateVideoKey_,
-      'text': shaka.util.PeriodCombiner.generateTextKey_,
-      'image': shaka.util.PeriodCombiner.generateImageKey_,
+      [ContentType.AUDIO]: shaka.util.PeriodCombiner.generateAudioKey_,
+      [ContentType.VIDEO]: shaka.util.PeriodCombiner.generateVideoKey_,
+      [ContentType.TEXT]: shaka.util.PeriodCombiner.generateTextKey_,
+      [ContentType.IMAGE]: shaka.util.PeriodCombiner.generateImageKey_,
     }[outputStream.type];
 
     let best = null;
@@ -1118,17 +1119,26 @@ shaka.util.PeriodCombiner = class {
     } else {
       // We haven't found exact match, try to find the best one via
       // linear search.
+      const PeriodCombiner = shaka.util.PeriodCombiner;
       const areCompatible = {
-        'audio': (os, s) => this.areAVStreamsCompatible_(os, s),
-        'video': (os, s) => this.areAVStreamsCompatible_(os, s),
-        'text': shaka.util.PeriodCombiner.areTextStreamsCompatible_,
-        'image': shaka.util.PeriodCombiner.areImageStreamsCompatible_,
+        [ContentType.AUDIO]:
+            (os, s) => this.areAVStreamsCompatible_(os, s),
+        [ContentType.VIDEO]:
+            (os, s) => this.areAVStreamsCompatible_(os, s),
+        [ContentType.TEXT]:
+            PeriodCombiner.areTextStreamsCompatible_,
+        [ContentType.IMAGE]:
+            PeriodCombiner.areImageStreamsCompatible_,
       }[outputStream.type];
       const isBetterMatch = {
-        'audio': shaka.util.PeriodCombiner.isAudioStreamBetterMatch_,
-        'video': shaka.util.PeriodCombiner.isVideoStreamBetterMatch_,
-        'text': shaka.util.PeriodCombiner.isTextStreamBetterMatch_,
-        'image': shaka.util.PeriodCombiner.isImageStreamBetterMatch_,
+        [ContentType.AUDIO]:
+            PeriodCombiner.isAudioStreamBetterMatch_,
+        [ContentType.VIDEO]:
+            PeriodCombiner.isVideoStreamBetterMatch_,
+        [ContentType.TEXT]:
+            PeriodCombiner.isTextStreamBetterMatch_,
+        [ContentType.IMAGE]:
+            PeriodCombiner.isImageStreamBetterMatch_,
       }[outputStream.type];
 
       for (const stream of streams.values()) {
@@ -1607,7 +1617,7 @@ shaka.util.PeriodCombiner = class {
    * audio or video, since those are strictly required in all periods if they
    * exist in any period.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} type
+   * @param {shaka.media.ManifestParser.ContentType} type
    * @return {shaka.extern.StreamDB}
    * @private
    */
@@ -1649,7 +1659,7 @@ shaka.util.PeriodCombiner = class {
    * audio or video, since those are strictly required in all periods if they
    * exist in any period.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} type
+   * @param {shaka.media.ManifestParser.ContentType} type
    * @return {shaka.extern.Stream}
    * @private
    */
@@ -1820,7 +1830,7 @@ shaka.util.PeriodCombiner = class {
    * @private
    */
   static isDummy_(stream) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     switch (stream.type) {
       case ContentType.TEXT:
         return !stream.language;

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -18,11 +18,11 @@ goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.drm.DrmUtils');
 goog.require('shaka.drm.FairPlay');
 goog.require('shaka.log');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.media.PreferenceBasedCriteria');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.ConfigUtils');
 goog.require('shaka.util.LanguageUtils');
-goog.require('shaka.util.ManifestParserUtils');
 
 
 /**
@@ -600,7 +600,7 @@ shaka.util.PlayerConfiguration = class {
    */
   static defaultTrackSelect(
       tracks, preferredAudioLanguages, preferredVideoHdrLevel) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const LanguageUtils = shaka.util.LanguageUtils;
 
     let hdrLevel = preferredVideoHdrLevel;

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -775,7 +775,7 @@ shaka.util.StreamUtils = class {
     const audio = variant.audio;
     const video = variant.video;
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const ManifestParserUtils = shaka.util.ManifestParserUtils;
     const MimeUtils = shaka.util.MimeUtils;
 
@@ -1191,7 +1191,7 @@ shaka.util.StreamUtils = class {
    */
   static variantToTrack(variant) {
     const ManifestParserUtils = shaka.util.ManifestParserUtils;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     /** @type {?shaka.extern.Stream} */
     const audio = variant.audio;
@@ -1395,7 +1395,7 @@ shaka.util.StreamUtils = class {
    * @return {shaka.extern.TextTrack}
    */
   static textStreamToTrack(stream) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     /** @type {shaka.extern.TextTrack} */
     const track = {
@@ -1425,7 +1425,7 @@ shaka.util.StreamUtils = class {
    * @return {shaka.extern.ImageTrack}
    */
   static imageStreamToTrack(stream) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     let width = stream.width || null;
     let height = stream.height || null;
@@ -1474,7 +1474,7 @@ shaka.util.StreamUtils = class {
    * @return {shaka.extern.ChapterTrack}
    */
   static chapterStreamToTrack(stream) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     /** @type {shaka.extern.ChapterTrack} */
     const track = {
@@ -1508,7 +1508,7 @@ shaka.util.StreamUtils = class {
    * @return {shaka.extern.TextTrack}
    */
   static html5TextTrackToTrack(textTrack, textVisibility = false) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     /** @type {shaka.extern.TextTrack} */
     const track = {
       id: shaka.util.StreamUtils.html5TrackId(textTrack),
@@ -1547,7 +1547,7 @@ shaka.util.StreamUtils = class {
    * @return {shaka.extern.ChapterTrack}
    */
   static html5TextTrackToChapterTrack(textTrack) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     /** @type {shaka.extern.ChapterTrack} */
     const track = {
@@ -1876,7 +1876,7 @@ shaka.util.StreamUtils = class {
    * @return {boolean}
    */
   static isAudio(stream) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     return stream.type == ContentType.AUDIO;
   }
 
@@ -1888,7 +1888,7 @@ shaka.util.StreamUtils = class {
    * @return {boolean}
    */
   static isVideo(stream) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     return stream.type == ContentType.VIDEO;
   }
 
@@ -2025,7 +2025,7 @@ shaka.util.StreamUtils = class {
    * @return {!shaka.extern.Variant}
    */
   static createEmptyVariant(mimeTypes) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     /** @type {shaka.extern.Variant} */
     const variant = {

--- a/lib/util/switch_history.js
+++ b/lib/util/switch_history.js
@@ -6,6 +6,8 @@
 
 goog.provide('shaka.util.SwitchHistory');
 
+goog.require('shaka.media.ManifestParser');
+
 
 /**
  * This class is used to track changes in variant and text selections. This
@@ -63,7 +65,7 @@ shaka.util.SwitchHistory = class {
     this.history_.push({
       timestamp: this.getNowInSeconds_(),
       id: newText.id,
-      type: 'text',
+      type: shaka.media.ManifestParser.ContentType.TEXT,
       fromAdaptation: fromAdaptation,
       bandwidth: null,
     });

--- a/lib/util/ts_parser.js
+++ b/lib/util/ts_parser.js
@@ -8,6 +8,7 @@ goog.provide('shaka.util.TsParser');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.metadata.Id3Utils');
 goog.require('shaka.util.ExpGolomb');
 goog.require('shaka.util.Uint8ArrayUtils');
@@ -844,7 +845,8 @@ shaka.util.TsParser = class {
    */
   getStartTime(contentType) {
     const timescale = shaka.util.TsParser.Timescale;
-    if (contentType == 'audio') {
+    const ContentType = shaka.media.ManifestParser.ContentType;
+    if (contentType === ContentType.AUDIO) {
       let audioStartTime = null;
       const audioData = this.getAudioData();
       if (audioData.length) {
@@ -852,7 +854,7 @@ shaka.util.TsParser = class {
         audioStartTime = Math.min(pes.dts, pes.pts) / timescale;
       }
       return audioStartTime;
-    } else if (contentType == 'video') {
+    } else if (contentType === ContentType.VIDEO) {
       let videoStartTime = null;
       const videoData = this.getVideoData(/* naluProcessing= */ false);
       if (videoData.length) {

--- a/test/abr/simple_abr_manager_integration.js
+++ b/test/abr/simple_abr_manager_integration.js
@@ -5,7 +5,7 @@
  */
 
 describe('SimpleAbrManager (integration)', () => {
-  const ContentType = shaka.util.ManifestParserUtils.ContentType;
+  const ContentType = shaka.media.ManifestParser.ContentType;
   const Util = shaka.test.Util;
   const TEST_SCHEME = 'abrtest';
 

--- a/test/cast/cast_utils_unit.js
+++ b/test/cast/cast_utils_unit.js
@@ -300,7 +300,7 @@ describe('CastUtils', () => {
             },
             config);
 
-        const ContentType = shaka.util.ManifestParserUtils.ContentType;
+        const ContentType = shaka.media.ManifestParser.ContentType;
         const initObject = new Map();
         initObject.set(ContentType.VIDEO, fakeVideoStream);
 

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -6,7 +6,7 @@
 
 // Test basic manifest parsing functionality.
 describe('DashParser Manifest', () => {
-  const ContentType = shaka.util.ManifestParserUtils.ContentType;
+  const ContentType = shaka.media.ManifestParser.ContentType;
   const Dash = shaka.test.Dash;
   const mp4IndexSegmentUri = '/base/test/test/assets/index-segment.mp4';
 
@@ -1066,7 +1066,7 @@ describe('DashParser Manifest', () => {
     let video = variant && variant.video;
     expect(video).toEqual(jasmine.objectContaining({
       originalId: 'main',
-      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      type: shaka.media.ManifestParser.ContentType.VIDEO,
       bandwidth: 2,
     }));
     let dependencyStream = video && video.dependencyStream;
@@ -1077,13 +1077,13 @@ describe('DashParser Manifest', () => {
     video = variant && variant.video;
     expect(video).toEqual(jasmine.objectContaining({
       originalId: 'mainenhance',
-      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      type: shaka.media.ManifestParser.ContentType.VIDEO,
       bandwidth: 2,
     }));
     dependencyStream = video && video.dependencyStream;
     expect(dependencyStream).toEqual(jasmine.objectContaining({
       originalId: 'enhance',
-      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      type: shaka.media.ManifestParser.ContentType.VIDEO,
       bandwidth: 1,
       baseOriginalId: 'main',
     }));
@@ -1120,7 +1120,7 @@ describe('DashParser Manifest', () => {
                          variant.video.trickModeVideo;
     expect(trickModeVideo).toEqual(jasmine.objectContaining({
       id: 2,
-      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      type: shaka.media.ManifestParser.ContentType.VIDEO,
     }));
   });
 
@@ -1160,7 +1160,7 @@ describe('DashParser Manifest', () => {
                          variant.video.trickModeVideo;
     expect(trickModeVideo).toEqual(jasmine.objectContaining({
       id: 3,
-      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      type: shaka.media.ManifestParser.ContentType.VIDEO,
     }));
 
     const variant2 = manifest.variants[1];
@@ -1168,7 +1168,7 @@ describe('DashParser Manifest', () => {
                          variant2.video.trickModeVideo;
     expect(trickModeVideo2).toEqual(jasmine.objectContaining({
       id: 3,
-      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      type: shaka.media.ManifestParser.ContentType.VIDEO,
     }));
   });
 
@@ -1213,7 +1213,7 @@ describe('DashParser Manifest', () => {
                          variant.video.trickModeVideo;
     expect(trickModeVideo).toEqual(jasmine.objectContaining({
       id: 3,
-      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      type: shaka.media.ManifestParser.ContentType.VIDEO,
     }));
     expect(trickModeVideo.bandwidth).toBe(1);
 
@@ -1222,7 +1222,7 @@ describe('DashParser Manifest', () => {
                          variant2.video.trickModeVideo;
     expect(trickModeVideo2).toEqual(jasmine.objectContaining({
       id: 4,
-      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      type: shaka.media.ManifestParser.ContentType.VIDEO,
     }));
     expect(trickModeVideo2.bandwidth).toBe(2);
   });
@@ -1395,7 +1395,7 @@ describe('DashParser Manifest', () => {
     const manifest = await parser.start('dummy://foo', playerInterface);
     expect(manifest.textStreams.length).toBe(2);
     // At one time, these came out as 'application' rather than 'text'.
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     expect(manifest.textStreams[0].type).toBe(ContentType.TEXT);
     expect(manifest.textStreams[1].type).toBe(ContentType.TEXT);
   });
@@ -1426,7 +1426,7 @@ describe('DashParser Manifest', () => {
     // In #875, this was an empty list.
     expect(manifest.textStreams.length).toBe(1);
     if (manifest.textStreams.length) {
-      const ContentType = shaka.util.ManifestParserUtils.ContentType;
+      const ContentType = shaka.media.ManifestParser.ContentType;
       expect(manifest.textStreams[0].type).toBe(ContentType.TEXT);
     }
   });

--- a/test/drm/drm_engine_integration.js
+++ b/test/drm/drm_engine_integration.js
@@ -5,7 +5,7 @@
  */
 
 describe('DrmEngine', () => {
-  const ContentType = shaka.util.ManifestParserUtils.ContentType;
+  const ContentType = shaka.media.ManifestParser.ContentType;
 
   // These come from Axinom.
   const videoInitSegmentUri = '/base/test/test/assets/multidrm-video-init.mp4';

--- a/test/drm/drm_engine_unit.js
+++ b/test/drm/drm_engine_unit.js
@@ -2978,7 +2978,7 @@ describe('DrmEngine', () => {
       drmEngine.newInitData = shaka.test.Util.spyFunc(newInitDataSpy);
 
       await drmEngine.parseInbandPssh(
-          shaka.util.ManifestParserUtils.ContentType.VIDEO, binarySegment);
+          shaka.media.ManifestParser.ContentType.VIDEO, binarySegment);
       const expectedInitData = shaka.util.Uint8ArrayUtils.fromHex(
           WIDEVINE_PSSH + PLAYREADY_PSSH);
       expect(newInitDataSpy).toHaveBeenCalledWith('cenc', expectedInitData);
@@ -2992,7 +2992,7 @@ describe('DrmEngine', () => {
       const newInitDataSpy = jasmine.createSpy('newInitData');
       drmEngine.newInitData = shaka.test.Util.spyFunc(newInitDataSpy);
       await drmEngine.parseInbandPssh(
-          shaka.util.ManifestParserUtils.ContentType.VIDEO, binarySegment);
+          shaka.media.ManifestParser.ContentType.VIDEO, binarySegment);
       expect(newInitDataSpy).not.toHaveBeenCalled();
     });
   });

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -7,7 +7,7 @@
 // cspell:ignore FBQUFBQUFBQUFBQUFBQUFBQUFBQU Gxhe Ijpb Ijpbey AAEC
 
 describe('HlsParser', () => {
-  const ContentType = shaka.util.ManifestParserUtils.ContentType;
+  const ContentType = shaka.media.ManifestParser.ContentType;
   const TextStreamKind = shaka.util.ManifestParserUtils.TextStreamKind;
   const Util = shaka.test.Util;
   const originalAlwaysWarn = shaka.log.alwaysWarn;

--- a/test/media/adaptation_set_unit.js
+++ b/test/media/adaptation_set_unit.js
@@ -238,7 +238,8 @@ describe('AdaptationSet', () => {
       forced: false,
       trickModeVideo: null,
       dependencyStream: null,
-      type: '',
+      type: /** @type {shaka.media.ManifestParser.ContentType} */ (
+        mimeType.split('/')[0]),
       accessibilityPurpose: null,
       external: false,
       groupId: null,

--- a/test/media/media_source_engine_integration.js
+++ b/test/media/media_source_engine_integration.js
@@ -7,7 +7,7 @@
 // cspell:ignore customdatascheme
 
 describe('MediaSourceEngine', () => {
-  const ContentType = shaka.util.ManifestParserUtils.ContentType;
+  const ContentType = shaka.media.ManifestParser.ContentType;
   const Uint8ArrayUtils = shaka.util.Uint8ArrayUtils;
   const Cue = shaka.text.Cue;
   const Util = shaka.test.Util;

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -36,7 +36,7 @@ let MockSourceBuffer;
 
 describe('MediaSourceEngine', () => {
   const Util = shaka.test.Util;
-  const ContentType = shaka.util.ManifestParserUtils.ContentType;
+  const ContentType = shaka.media.ManifestParser.ContentType;
 
   const originalIsTypeSupported = window.MediaSource.isTypeSupported;
   let originalIsTypeSupportedManaged;
@@ -1437,7 +1437,7 @@ describe('MediaSourceEngine', () => {
     initObject.set(ContentType.AUDIO, fakeAudioStream);
 
     /**
-     * @param {!Map<shaka.util.ManifestParserUtils.ContentType,
+     * @param {!Map<shaka.media.ManifestParser.ContentType,
      *              shaka.extern.Stream>} initObject
      * @suppress {visibility}
      */

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -5,7 +5,7 @@
  */
 
 describe('StreamingEngine', () => {
-  const ContentType = shaka.util.ManifestParserUtils.ContentType;
+  const ContentType = shaka.media.ManifestParser.ContentType;
   const Util = shaka.test.Util;
 
   let metadata;
@@ -642,7 +642,7 @@ describe('StreamingEngine', () => {
             bandwidth: 5000000,
             width: 600,
             height: 400,
-            type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+            type: shaka.media.ManifestParser.ContentType.VIDEO,
             drmInfos: [],
           },
           audio: {
@@ -652,7 +652,7 @@ describe('StreamingEngine', () => {
             mimeType: 'audio/mp4',
             codecs: 'mp4a.40.2',
             bandwidth: 192000,
-            type: shaka.util.ManifestParserUtils.ContentType.AUDIO,
+            type: shaka.media.ManifestParser.ContentType.AUDIO,
             drmInfos: [],
           },
         }],

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -6,20 +6,20 @@
 
 describe('StreamingEngine', () => {
   const Util = shaka.test.Util;
-  const ContentType = shaka.util.ManifestParserUtils.ContentType;
+  const ContentType = shaka.media.ManifestParser.ContentType;
 
   // Dummy byte ranges and sizes for initialization and media segments.
   // Create empty object first and initialize the fields through
   // [] to allow field names to be expressions.
   /**
-   * @type {!Object<shaka.util.ManifestParserUtils.ContentType,
+   * @type {!Object<shaka.media.ManifestParser.ContentType,
    *                 !Array<number>>}
    */
   const initSegmentRanges = {};
   initSegmentRanges[ContentType.AUDIO] = [100, 1000];
   initSegmentRanges[ContentType.VIDEO] = [200, 2000];
 
-  /** @type {!Object<shaka.util.ManifestParserUtils.ContentType, number>} */
+  /** @type {!Object<shaka.media.ManifestParser.ContentType, number>} */
   const segmentSizes = {};
   segmentSizes[ContentType.AUDIO] = 1000;
   segmentSizes[ContentType.VIDEO] = 10000;

--- a/test/offline/manifest_convert_unit.js
+++ b/test/offline/manifest_convert_unit.js
@@ -6,8 +6,8 @@
 
 describe('ManifestConverter', () => {
   describe('createVariants', () => {
-    const audioType = 'audio';
-    const videoType = 'video';
+    const audioType = shaka.media.ManifestParser.ContentType.AUDIO;
+    const videoType = shaka.media.ManifestParser.ContentType.VIDEO;
 
     it('will create variants with variant ids', () => {
       /** @type {!Array<shaka.extern.StreamDB>} */
@@ -290,7 +290,7 @@ describe('ManifestConverter', () => {
 
   /**
    * @param {number} id
-   * @param {string} type
+   * @param {shaka.media.ManifestParser.ContentType} type
    * @param {!Array<number>} variantIds
    * @return {shaka.extern.StreamDB}
    */
@@ -362,7 +362,7 @@ describe('ManifestConverter', () => {
    * @return {shaka.extern.StreamDB}
    */
   function createVideoStreamDB(id, variantIds) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const mimeType = 'video/mp4';
     const codecs = 'avc1.42c01e';
     return {
@@ -424,7 +424,7 @@ describe('ManifestConverter', () => {
    * @return {shaka.extern.StreamDB}
    */
   function createAudioStreamDB(id, variantIds) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const mimeType = 'audio/mp4';
     const codecs = 'mp4a.40.2';
     return {
@@ -485,7 +485,7 @@ describe('ManifestConverter', () => {
    * @return {shaka.extern.StreamDB}
    */
   function createTextStreamDB(id) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const mimeType = 'text/vtt';
     const codecs = '';
     return {

--- a/test/offline/storage_compatibility_unit.js
+++ b/test/offline/storage_compatibility_unit.js
@@ -100,7 +100,7 @@ filterDescribe('Storage Compatibility', offlineSupported, () => {
 
   function makeTests(metadata) {
     const CannedIDB = shaka.test.CannedIDB;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const Util = shaka.test.Util;
 
     /** @type {?shaka.extern.StorageCell} */

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -5,7 +5,7 @@
  */
 
 describe('Player', () => {
-  const ContentType = shaka.util.ManifestParserUtils.ContentType;
+  const ContentType = shaka.media.ManifestParser.ContentType;
   const Util = shaka.test.Util;
 
   const originalLogError = shaka.log.error;

--- a/test/test/util/fake_media_source_engine.js
+++ b/test/test/util/fake_media_source_engine.js
@@ -232,7 +232,7 @@ shaka.test.FakeMediaSourceEngine = class {
       throw new Error('unexpected type');
     }
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const hasSegment = (i) => {
       return this.segments[type][i] ||
           (type == ContentType.VIDEO && this.segments['trickvideo'] &&
@@ -268,7 +268,7 @@ shaka.test.FakeMediaSourceEngine = class {
 
     // Remains 'video' even when we detect a 'trickvideo' segment.
     const originalType = type;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     // Set init segment.
     let i = this.segmentData[type].initSegments.indexOf(data);
@@ -279,7 +279,7 @@ shaka.test.FakeMediaSourceEngine = class {
       if (i >= 0) {
         // 'trickvideo' value is only used for testing.
         // Cast to the ContentType enum for compatibility.
-        type = /** @type {shaka.util.ManifestParserUtils.ContentType} */(
+        type = /** @type {shaka.media.ManifestParser.ContentType} */(
           'trickvideo');
       }
     }
@@ -301,7 +301,7 @@ shaka.test.FakeMediaSourceEngine = class {
       if (i >= 0) {
         // 'trickvideo' value is only used for testing.
         // Cast to the ContentType enum for compatibility.
-        type = /** @type {shaka.util.ManifestParserUtils.ContentType} */(
+        type = /** @type {shaka.media.ManifestParser.ContentType} */(
           'trickvideo');
       }
     }
@@ -378,14 +378,14 @@ shaka.test.FakeMediaSourceEngine = class {
 
     this.segments[type] = this.segments[type].map((c) => false);
 
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     // If we're clearing video, clear the segment list for 'trickvideo', too.
     if (type == ContentType.VIDEO && this.segments['trickvideo']) {
       // 'trickvideo' value is only used for testing.
       // Cast to the ContentType enum for compatibility.
       this.clearImpl_(
-          /** @type {shaka.util.ManifestParserUtils.ContentType} */(
+          /** @type {shaka.media.ManifestParser.ContentType} */(
             'trickvideo'));
     }
 

--- a/test/test/util/manifest_generator.js
+++ b/test/test/util/manifest_generator.js
@@ -212,7 +212,7 @@ shaka.test.ManifestGenerator.Manifest = class {
    * @param {function(!shaka.test.ManifestGenerator.Stream)=} func
    */
   addTextStream(id, func) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const stream = new shaka.test.ManifestGenerator.Stream(
         this, /* isPartial= */ false, id, ContentType.TEXT, 'und');
     if (func) {
@@ -228,7 +228,7 @@ shaka.test.ManifestGenerator.Manifest = class {
    * @param {function(!shaka.test.ManifestGenerator.Stream)=} func
    */
   addImageStream(id, func) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const stream = new shaka.test.ManifestGenerator.Stream(
         this, /* isPartial= */ false, id, ContentType.IMAGE, 'und');
     if (func) {
@@ -245,7 +245,7 @@ shaka.test.ManifestGenerator.Manifest = class {
    * @param {function(!shaka.test.ManifestGenerator.Stream)} func
    */
   addPartialTextStream(func) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     const stream = new shaka.test.ManifestGenerator.Stream(
         this, /* isPartial= */ true, null, ContentType.TEXT);
@@ -317,7 +317,7 @@ shaka.test.ManifestGenerator.Variant = class {
    * @param {function(!shaka.test.ManifestGenerator.Stream)=} func
    */
   addVideo(id, func) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const stream = new shaka.test.ManifestGenerator.Stream(
         this.manifest_, /* isPartial= */ false, id, ContentType.VIDEO, 'und');
     if (func) {
@@ -333,7 +333,7 @@ shaka.test.ManifestGenerator.Variant = class {
    * @param {function(!shaka.test.ManifestGenerator.Stream)=} func
    */
   addAudio(id, func) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const stream = new shaka.test.ManifestGenerator.Stream(
         this.manifest_, /* isPartial= */ false, id, ContentType.AUDIO,
         this.language, this.label);
@@ -350,7 +350,7 @@ shaka.test.ManifestGenerator.Variant = class {
    */
   addExistingStream(id) {
     const stream = this.manifest_.findExistingStream_(id);
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     goog.asserts.assert(stream, 'Must list an existing stream ID');
     if (stream.type == ContentType.AUDIO) {
       this.audio = stream;
@@ -366,11 +366,11 @@ shaka.test.ManifestGenerator.Variant = class {
    * the properties that were explicitly given to it.  All other properties will
    * be ignored.
    *
-   * @param {shaka.util.ManifestParserUtils.ContentType} type
+   * @param {shaka.media.ManifestParser.ContentType} type
    * @param {function(!shaka.test.ManifestGenerator.Stream)=} func
    */
   addPartialStream(type, func) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     const stream = new shaka.test.ManifestGenerator.Stream(
         this.manifest_, /* isPartial= */ true, null, type);
@@ -503,7 +503,7 @@ shaka.test.ManifestGenerator.Stream = class {
    * @param {shaka.test.ManifestGenerator.Manifest} manifest
    * @param {boolean} isPartial
    * @param {?number} id
-   * @param {shaka.util.ManifestParserUtils.ContentType} type
+   * @param {shaka.media.ManifestParser.ContentType} type
    * @param {?string=} lang
    * @param {string=} label
    */
@@ -513,7 +513,7 @@ shaka.test.ManifestGenerator.Stream = class {
     // goog.asserts.assert(
     //     !manifest || !manifest.isIdUsed_(id),
     //     'Streams should have unique ids!');
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     /** @const {shaka.test.ManifestGenerator.Manifest} */
     this.manifest_ = manifest;
@@ -521,7 +521,7 @@ shaka.test.ManifestGenerator.Stream = class {
     /** @type {shaka.media.InitSegmentReference} */
     this.initSegmentReference_ = null;
 
-    /** @type {string} */
+    /** @type {shaka.media.ManifestParser.ContentType} */
     this.type = type;
     if (id != null) {
       /** @type {number} */
@@ -530,13 +530,13 @@ shaka.test.ManifestGenerator.Stream = class {
 
     let defaultMimeType = 'text/plain';
     let defaultCodecs = '';
-    if (type == ContentType.AUDIO) {
+    if (type === ContentType.AUDIO) {
       defaultMimeType = 'audio/mp4';
       defaultCodecs = 'mp4a.40.2';
-    } else if (type == ContentType.VIDEO) {
+    } else if (type === ContentType.VIDEO) {
       defaultMimeType = 'video/mp4';
       defaultCodecs = 'avc1.4d401f';
-    } else if (type == ContentType.TEXT) {
+    } else if (type === ContentType.TEXT) {
       defaultMimeType = 'text/vtt';
     }
 

--- a/test/test/util/offline_utils.js
+++ b/test/test/util/offline_utils.js
@@ -26,7 +26,7 @@ shaka.test.OfflineUtils = class {
 
   /**
    * @param {number} id
-   * @param {string} type
+   * @param {shaka.media.ManifestParser.ContentType} type
    * @return {shaka.extern.StreamDB}
    */
   static createStream(id, type) {

--- a/test/test/util/streaming_engine_util.js
+++ b/test/test/util/streaming_engine_util.js
@@ -315,7 +315,7 @@ shaka.test.StreamingEngineUtil = class {
             appendWindowEnd);
         ref.mimeType = mimeType;
         ref.codecs = codecs;
-        const ContentType = shaka.util.ManifestParserUtils.ContentType;
+        const ContentType = shaka.media.ManifestParser.ContentType;
         if (aesKey &&
             (type == ContentType.AUDIO || type == ContentType.VIDEO)) {
           ref.aesKey = aesKey;
@@ -390,7 +390,7 @@ shaka.test.StreamingEngineUtil = class {
         variant2.audio = /** @type {shaka.extern.Stream} */ (
           shaka.test.StreamingEngineUtil.createMockStream('audio', 11));
 
-        const ContentType = shaka.util.ManifestParserUtils.ContentType;
+        const ContentType = shaka.media.ManifestParser.ContentType;
         const segmentIndex = new shaka.test.FakeSegmentIndex();
         segmentIndex.getNumReferences.and.callFake(
             () => getNumReferences(ContentType.AUDIO));
@@ -434,7 +434,7 @@ shaka.test.StreamingEngineUtil = class {
 
     // Populate the Manifest.
     for (const type in segmentDurations) {
-      const ContentType = shaka.util.ManifestParserUtils.ContentType;
+      const ContentType = shaka.media.ManifestParser.ContentType;
       let stream;
       if (type == ContentType.TEXT) {
         stream = textStream;
@@ -505,7 +505,7 @@ shaka.test.StreamingEngineUtil = class {
    * @return {shaka.extern.Stream}
    */
   static createMockAudioStream(id) {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const Util = shaka.test.Util;
 
     const mimeType = 'audio/mp4';
@@ -554,7 +554,7 @@ shaka.test.StreamingEngineUtil = class {
    * @return {shaka.extern.Stream}
    */
   static createMockVideoStream(id, mimeType='video/mp4') {
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     const Util = shaka.test.Util;
 
     const codecs = 'avc1.42c01e';
@@ -619,7 +619,7 @@ shaka.test.StreamingEngineUtil = class {
       codecs,
       supplementalCodecs: '',
       kind: ManifestParserUtils.TextStreamKind.SUBTITLE,
-      type: ManifestParserUtils.ContentType.TEXT,
+      type: shaka.media.ManifestParser.ContentType.TEXT,
       label: '',
       language: 'und',
       originalLanguage: null,

--- a/test/test/util/test_scheme.js
+++ b/test/test/util/test_scheme.js
@@ -198,7 +198,7 @@ shaka.test.TestScheme = class {
      * @param {!shaka.test.ManifestGenerator.Stream} stream
      * @param {!shaka.test.ManifestGenerator.Variant} variant
      * @param {MetadataType} data
-     * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+     * @param {shaka.media.ManifestParser.ContentType} contentType
      * @param {string} name
      */
     function addStreamInfo(stream, variant, data, contentType, name) {
@@ -282,7 +282,7 @@ shaka.test.TestScheme = class {
     const DATA = shaka.test.TestScheme.DATA;
     const GENERATORS = shaka.test.TestScheme.GENERATORS;
     const MANIFESTS = shaka.test.TestScheme.MANIFESTS;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     for (const name in DATA) {
       GENERATORS[name + suffix] = GENERATORS[name + suffix] || {};

--- a/test/test/util/util.js
+++ b/test/test/util/util.js
@@ -378,7 +378,7 @@ shaka.test.Util = class {
    */
   static async isTypeSupported(mimetype, width, height) {
     const MimeUtils = shaka.util.MimeUtils;
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
 
     /** @type {!MediaDecodingConfiguration} */
     const mediaDecodingConfig = {

--- a/test/transmuxer/transmuxer_engine_integration.js
+++ b/test/transmuxer/transmuxer_engine_integration.js
@@ -5,7 +5,7 @@
  */
 
 describe('TransmuxerEngine', () => {
-  const ContentType = shaka.util.ManifestParserUtils.ContentType;
+  const ContentType = shaka.media.ManifestParser.ContentType;
 
   const mp4MimeType = 'video/mp4; codecs="avc1.42E01E"';
   const transportStreamVideoMimeType = 'video/mp2t; codecs="avc1.42E01E"';

--- a/test/util/language_utils_unit.js
+++ b/test/util/language_utils_unit.js
@@ -145,7 +145,7 @@ describe('LanguageUtils', () => {
      */
     function makeTextStream(language) {
       const sparse = {
-        type: shaka.util.ManifestParserUtils.ContentType.TEXT,
+        type: shaka.media.ManifestParser.ContentType.TEXT,
         language: language,
       };
 

--- a/test/util/periods_unit.js
+++ b/test/util/periods_unit.js
@@ -2003,7 +2003,7 @@ describe('PeriodCombiner', () => {
         /* manifest= */ null,
         /* isPartial= */ false,
         /* id= */ nextId++,
-        /* type= */ shaka.util.ManifestParserUtils.ContentType.VIDEO,
+        /* type= */ shaka.media.ManifestParser.ContentType.VIDEO,
         /* lang= */ 'und');
     streamGenerator.size(width, height);
     streamGenerator.originalId = height.toString();
@@ -2022,7 +2022,7 @@ describe('PeriodCombiner', () => {
         /* manifest= */ null,
         /* isPartial= */ false,
         /* id= */ nextId++,
-        /* type= */ shaka.util.ManifestParserUtils.ContentType.AUDIO,
+        /* type= */ shaka.media.ManifestParser.ContentType.AUDIO,
         language);
     streamGenerator.primary = primary;
     streamGenerator.channelsCount = channels;
@@ -2045,7 +2045,7 @@ describe('PeriodCombiner', () => {
         /* manifest= */ null,
         /* isPartial= */ false,
         /* id= */ nextId++,
-        /* type= */ shaka.util.ManifestParserUtils.ContentType.TEXT,
+        /* type= */ shaka.media.ManifestParser.ContentType.TEXT,
         language);
     streamGenerator.primary = primary;
     streamGenerator.originalId = primary ?
@@ -2065,7 +2065,7 @@ describe('PeriodCombiner', () => {
         /* manifest= */ null,
         /* isPartial= */ false,
         /* id= */ nextId++,
-        /* type= */ shaka.util.ManifestParserUtils.ContentType.IMAGE);
+        /* type= */ shaka.media.ManifestParser.ContentType.IMAGE);
     streamGenerator.size(width, height);
     streamGenerator.originalId = height.toString();
     streamGenerator.mime('image/jpeg');

--- a/test/util/string_utils_unit.js
+++ b/test/util/string_utils_unit.js
@@ -65,7 +65,7 @@ function defineStringUtilTests() {
     // This is 4 Unicode characters, the last will be split into a surrogate
     // pair.
     const arr = [0xef, 0xbb, 0xbf, 0x74, 0x65, 0x78, 0x74];
-    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const ContentType = shaka.media.ManifestParser.ContentType;
     expect(StringUtils.fromUTF8(new Uint8Array(arr))).toBe(ContentType.TEXT);
   });
 

--- a/test/util/ts_parser_unit.js
+++ b/test/util/ts_parser_unit.js
@@ -7,7 +7,7 @@
 describe('TsParser', () => {
   const Util = shaka.test.Util;
   const BufferUtils = shaka.util.BufferUtils;
-  const ContentType = shaka.util.ManifestParserUtils.ContentType;
+  const ContentType = shaka.media.ManifestParser.ContentType;
 
   it('probes a TS segment', async () => {
     const responses = await Promise.all([


### PR DESCRIPTION
Update `shaka.extern.Stream` and `shaka.extern.StreamDB` objects to use `shaka.media.ManifestParser.ContentType` as a type instead of string. Actual values do not change, as we were referring to this enum internally anyway.
Move `shaka.util.ManifestParserUtils.ContentType` to `shaka.media.ManifestParser.ContentType` and export it.