### PR TITLE
ci: Check out ref:main explicitly in size workflow

### DIFF
--- a/.github/workflows/measure-bundle-size.yaml
+++ b/.github/workflows/measure-bundle-size.yaml
@@ -91,6 +91,8 @@ jobs:
       - name: Checkout repo (for script access)
         uses: actions/checkout@v4
         with:
+          # The script that generates the table should be run from `main`, not
+          # the PR that triggered the workflow.
           ref: main
           persist-credentials: false
 

--- a/.github/workflows/measure-bundle-size.yaml
+++ b/.github/workflows/measure-bundle-size.yaml
@@ -90,6 +90,9 @@ jobs:
     steps:
       - name: Checkout repo (for script access)
         uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
 
       - name: Download head sizes
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The `compare` job in `measure-bundle-size.yaml` uses actions/checkout without a specific ref, and the workflow defaults to the PR given a pull_request trigger.  The damage is merely injection of content in the comment, since the `compare` job generates part of the comment text, but runs without credentials.  We can fix that by explicitly checking out from `main` in the `compare` job.

See exploit PoC: https://github.com/shaka-project/shaka-player/pull/10209/changes/d138583186b476048b40f8274c765d9995ff1f22

Many thanks to @tranquac for the proof of concept.