### PR TITLE
test(UI): Fix caption position test to use localized label

### DIFF
--- a/test/ui/ui_unit.js
+++ b/test/ui/ui_unit.js
@@ -783,6 +783,7 @@ describe('UI', () => {
         usePreviewTextDisplayer(player);
         controls.showUI();
 
+        const localization = controls.getLocalization();
         const menu = UiUtils.getElementByClassName(
             videoContainer, 'shaka-text-positions');
         const button = UiUtils.getElementByClassName(
@@ -792,7 +793,9 @@ describe('UI', () => {
         expect(latestPreviewConfig().positionArea)
             .toBe(shaka.config.PositionArea.DEFAULT);
 
-        const topLeftOption = getStyleOption(menu, 'Top left');
+        const topLeftLabel =
+            localization.resolve(shaka.ui.Locales.Ids.TOP_LEFT);
+        const topLeftOption = getStyleOption(menu, topLeftLabel);
         topLeftOption.dispatchEvent(new Event('focus'));
         expect(latestPreviewConfig().positionArea)
             .toBe(shaka.config.PositionArea.TOP_LEFT);


### PR DESCRIPTION
I discovered this by running the tests in a browser that does not have English set as the default language.