### PR TITLE
fix: Avoid hang when loading a new asset after DRM playback

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -197,7 +197,7 @@ shaka.drm.DrmEngine = class {
         await this.video_.setMediaKeys(null);
       } catch (error) {
         // Ignore any failures while removing media keys from the video element.
-        shaka.log.debug(`DrmEngine.destroyNow_ exception`, error);
+        shaka.log.alwaysWarn(`DrmEngine.destroyNow_ exception`, error);
       }
 
       this.video_ = null;

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -267,16 +267,15 @@ shaka.media.MediaSourceEngine = class {
 
     // Store the object URL for releasing it later.
     this.url_ = shaka.media.MediaSourceEngine.createObjectURL(mediaSource);
+
+    // Remove all sources.
+    this.removeSources_();
+
+    // Set <source> or .src, depending on config.
     if (this.config_.useSourceElements) {
-      this.video_.removeAttribute('src');
-      if (this.source_?.parentElement === this.video_) {
-        this.video_.removeChild(this.source_);
-      }
-      if (this.secondarySource_?.parentElement === this.video_) {
-        this.video_.removeChild(this.secondarySource_);
-      }
       this.source_ = shaka.util.Dom.createSourceElement(this.url_);
       this.video_.appendChild(this.source_);
+
       if (this.secondarySource_) {
         this.video_.appendChild(this.secondarySource_);
       }
@@ -460,12 +459,9 @@ shaka.media.MediaSourceEngine = class {
       this.eventManager_ = null;
     }
 
-    if (this.video_ && this.secondarySource_?.parentElement === this.video_) {
-      this.video_.removeChild(this.secondarySource_);
-    }
-    if (this.video_ && this.source_?.parentElement === this.video_) {
+    if (this.video_) {
       // "unload" the video element.
-      this.video_.removeChild(this.source_);
+      this.removeSources_();
       this.video_.load();
       this.video_.disableRemotePlayback = false;
     }
@@ -498,6 +494,28 @@ shaka.media.MediaSourceEngine = class {
     this.playerInterface_ = null;
 
     await Promise.all(cleanup);
+  }
+
+  /**
+   * Remove all sources from the video.
+   *
+   * @private
+   */
+  removeSources_() {
+    if (!this.video_) {
+      return;
+    }
+
+    // Both .src and <source> must be gone before load() for the element to
+    // empty to HAVE_NOTHING, which DRM teardown's setMediaKeys(null) depends
+    // on.
+    this.video_.removeAttribute('src');
+    if (this.source_?.parentElement === this.video_) {
+      this.video_.removeChild(this.source_);
+    }
+    if (this.secondarySource_?.parentElement === this.video_) {
+      this.video_.removeChild(this.secondarySource_);
+    }
   }
 
   /**

--- a/test/media/media_source_engine_integration.js
+++ b/test/media/media_source_engine_integration.js
@@ -746,6 +746,28 @@ describe('MediaSourceEngine', () => {
     expect(onMetadata).toHaveBeenCalled();
   });
 
+  describe('destroy', () => {
+    // Regression test for the unload regression introduced by switching the
+    // media element from a src attribute to <source> elements (commit 445b0ce).
+    // destroy() must fully unload the media element: remove any stale src
+    // attribute, remove all <source> elements, and call load().  Otherwise the
+    // element never returns to HAVE_NOTHING, and DRM teardown
+    // (setMediaKeys(null)) throws InvalidStateError, hanging playback on the
+    // next asset.
+    it('fully unloads the media element', async () => {
+      // The MSE <source> element was added by the beforeEach.  Simulate a stale
+      // src attribute left behind by a previous src= playback (e.g. an ad
+      // break) sitting alongside the <source> element.
+      expect(video.getElementsByTagName('source').length).toBe(1);
+      video.setAttribute('src', 'data:,');
+
+      await mediaSourceEngine.destroy();
+
+      expect(video.getAttribute('src')).toBeNull();
+      expect(video.getElementsByTagName('source').length).toBe(0);
+    });
+  });
+
   describe('embedded emsg boxes', () => {
     // V0 box format
     const emsgSegmentV0 = Uint8ArrayUtils.fromHex(


### PR DESCRIPTION
Loading a new asset after a DRM asset (for example the next episode of a show, or content resuming after an ad break) could hang indefinitely, with the player never reaching a playable state.

This was a regression from commit 445b0ce (#7406, "Use source tags instead of src attribute"), first shipped in v4.12. A lot has changed since, but the regression persisted to now.

That change switched MediaSourceEngine from setting video.src to appending a <source> child and calling load(). The teardown path was not updated symmetrically: destroy() removed the <source> element but never removed a leftover src attribute.  As a result, a stale src attribute could survive, so the element was never fully unloaded.

That matters because DRM teardown depends on the element being empty. With the element still holding a resource, DrmEngine.destroyNow_'s setMediaKeys(null) call threw `InvalidStateError`.  The error was caught and logged, but the old CDM stayed bound to the element, so the next setMediaKeys() never resolved and playback froze.

The fix centralizes source cleanup in a single helper used by both createMediaSource and destroy. On teardown the element is now always fully unloaded.

Internal bug reference b/519625442