### PR TITLE
fix(text): use valid CSS value 'line-through' for LINE_THROUGH

### DIFF
--- a/lib/text/cue.js
+++ b/lib/text/cue.js
@@ -950,7 +950,7 @@ shaka.text.Cue.fontStyle = {
  */
 shaka.text.Cue.textDecoration = {
   'UNDERLINE': 'underline',
-  'LINE_THROUGH': 'lineThrough',
+  'LINE_THROUGH': 'line-through',
   'OVERLINE': 'overline',
 };
 

--- a/test/text/ttml_text_parser_unit.js
+++ b/test/text/ttml_text_parser_unit.js
@@ -2177,6 +2177,41 @@ describe('TtmlTextParser', () => {
         {startTime: 62.05, endTime: 3723.2});
   });
 
+  it('parses lineThrough text decoration', () => {
+    // Regression test: ensure tts:textDecoration="lineThrough" produces a cue
+    // whose textDecoration array contains the LINE_THROUGH enum value.  The
+    // existing 'parses text decoration' test combined lineThrough with
+    // noLineThrough to test removal, so it never asserted the positive case.
+    verifyHelper(
+        [
+          {
+            startTime: 62.05,
+            endTime: 3723.2,
+            payload: 'Test',
+            textDecoration: [Cue.textDecoration.LINE_THROUGH],
+          },
+        ],
+        '<tt xmlns:tts="http://www.w3.org/ns/ttml#styling">' +
+        '<styling>' +
+        '<style xml:id="s1" tts:textDecoration="lineThrough"/>' +
+        '</styling>' +
+        '<layout>' +
+        '<region xml:id="subtitleArea" style="s1"/>' +
+        '</layout>' +
+        '<body region="subtitleArea"><div>' +
+        '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
+        '</div></body></tt>',
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
+        {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
+        {startTime: 62.05, endTime: 3723.2});
+  });
+
   it('cues should have default cellResolution', () => {
     verifyHelper(
         [

--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -132,6 +132,33 @@ describe('UITextDisplayer', () => {
         .toEqual(jasmine.objectContaining({'background-color': 'black'}));
   });
 
+  it('renders LINE_THROUGH text decoration as a valid CSS value',
+      async () => {
+        // Regression test: previously LINE_THROUGH was 'lineThrough', which
+        // is not a valid CSS text-decoration value, so browsers ignored it
+        // and no strikethrough was drawn.  After the fix the value is the
+        // valid CSS token 'line-through'.
+        /** @type {!shaka.text.Cue} */
+        const cue = new shaka.text.Cue(0, 100, 'deleted text');
+        cue.textDecoration.push(shaka.text.Cue.textDecoration.LINE_THROUGH);
+        cue.nestedCues = [];
+
+        textDisplayer.setTextVisibility(true);
+        textDisplayer.append([cue]);
+        await updateCaptions();
+
+        const textContainer =
+            videoContainer.querySelector('.shaka-text-container');
+        const captions = textContainer.querySelector('div');
+        // Browsers expose the parsed value via the longhand
+        // text-decoration-line; fall back to the shorthand for older engines.
+        const decoration =
+            captions.style.textDecorationLine ||
+            captions.style.textDecoration;
+        expect(decoration).toContain('line-through');
+        expect(decoration).not.toContain('lineThrough');
+      });
+
   it('correctly displays styles for nested cues', async () => {
     /** @type {!shaka.text.Cue} */
     const cue = new shaka.text.Cue(0, 100, '');


### PR DESCRIPTION
Fixes #10247.

`shaka.text.Cue.textDecoration.LINE_THROUGH` was `'lineThrough'`, but its sibling
values `UNDERLINE`/`OVERLINE` are valid CSS tokens and `UITextDisplayer` renders
the array directly into `style.textDecoration`. Browsers reject the invalid
`'lineThrough'` value, so strikethrough never renders, even when produced by
TTML's `tts:textDecoration="lineThrough"`.

This is Option B from the issue: change the enum value to the valid CSS token
`'line-through'`. The TTML parser is unaffected because its `case 'lineThrough'`
matches the input string, not the enum value.

### Test coverage

- `test/text/ui_text_displayer_unit.js`: new test verifies `LINE_THROUGH`
  renders as a valid CSS `text-decoration` value (no test previously exercised
  this rendering path).
- `test/text/ttml_text_parser_unit.js`: new test asserts a positive
  `tts:textDecoration="lineThrough"` case (the existing test only combined it
  with `noLineThrough`, so it never asserted the positive case).
