### PR TITLE
fix: Swallow play() rejection in stall handler to avoid unhandled AbortError

### DIFF
--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -351,7 +351,16 @@ shaka.media.GapJumpingController = class {
       } else {
         shaka.log.debug(
             'Wait for play to avoid reject a possible other play call.');
-        await this.video_.play();
+        // play() can be interrupted by a later pause() (the stall-break below,
+        // a media reset, etc.), rejecting with AbortError. The VideoPlayPromise
+        // polyfill silences that on the play() promise itself, but awaiting it
+        // here would still reject this async stall handler, whose rejection is
+        // not consumed by the caller (StallDetector.poll). So swallow it.
+        try {
+          await this.video_.play();
+        } catch (e) {
+          // Ignore errors.
+        }
         if (!this.video_) {
           return;
         }


### PR DESCRIPTION
When breaking a stall, the stall handler awaits video.play() before pausing and playing again to jump-start playback. If that play() request is interrupted by a later pause() (e.g. a media reset, or the stall-break itself), the promise rejects with "AbortError: The play() request was interrupted by a call to pause()".

The VideoPlayPromise polyfill attaches a catch handler to the play() promise, so a plain fire-and-forget play() never surfaces this rejection. Here, however, the rejection is re-thrown by `await` into onStall, an async callback that StallDetector.poll() invokes without awaiting or catching its result, producing an unhandled promise rejection.