### PR TITLE
fix: Keep TTML subtitles visible until their end time when they extend past a segment

### DIFF
--- a/lib/text/text_utils.js
+++ b/lib/text/text_utils.js
@@ -186,6 +186,28 @@ shaka.text.Utils = class {
   }
 
   /**
+   * Returns true if |subset| is a strict subset of |superset|, with the same
+   * payload.  Used to avoid showing duplicate captions when a TTML cue spans
+   * segment boundaries and is duplicated across segments.
+   *
+   * @param {!shaka.text.Cue} superset
+   * @param {!shaka.text.Cue} subset
+   * @return {boolean}
+   */
+  static isCueStrictSubset(superset, subset) {
+    if (superset.payload != subset.payload) {
+      return false;
+    }
+    const isDiffNegligible = (a, b) => Math.abs(a - b) < 0.001;
+    if (isDiffNegligible(superset.startTime, subset.startTime) &&
+        isDiffNegligible(superset.endTime, subset.endTime)) {
+      return false;
+    }
+    return superset.startTime <= subset.startTime + 0.001 &&
+        superset.endTime >= subset.endTime - 0.001;
+  }
+
+  /**
    * @param {!shaka.text.Cue} shakaCue
    * @return {TextTrackCue}
    */

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -335,10 +335,14 @@ shaka.text.TtmlTextParser = class {
     }
 
     if (this.manifestType_ !== shaka.media.ManifestParser.HLS) {
-      // Clip times to segment boundaries.
+      // Clip the start to the segment boundary when a cue continues from a
+      // previous segment.  Do not clip the end; cues may legitimately extend
+      // past the segment when they are not duplicated in the next one.
       // https://github.com/shaka-project/shaka-player/issues/4631
-      start = Math.max(start, timeContext.segmentStart);
-      end = Math.min(end, timeContext.segmentEnd);
+      // https://github.com/shaka-project/shaka-player/issues/10172
+      if (start < timeContext.segmentStart) {
+        start = timeContext.segmentStart;
+      }
     }
 
     if (!hasTimeAttributes && nestedCues.length > 0) {

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -295,9 +295,18 @@ shaka.text.UITextDisplayer = class {
       // contains the cue, skip it.
       const containsCue = cuesList.some(
           (cueInList) => shaka.text.Cue.equal(cueInList, cue));
-      if (!containsCue) {
-        this.cues_.push(cue);
+      if (containsCue || !cue.payload) {
+        continue;
       }
+      const isSubset = cuesList.some((existingCue) =>
+        shaka.text.Utils.isCueStrictSubset(existingCue, cue));
+      if (isSubset) {
+        continue;
+      }
+      // Drop any existing cues that are strict subsets of this new cue.
+      this.cues_ = this.cues_.filter((existingCue) =>
+        !shaka.text.Utils.isCueStrictSubset(cue, existingCue));
+      this.cues_.push(cue);
     }
     if (this.cues_.length) {
       this.configureCaptionsTimer_();

--- a/test/text/text_utils_unit.js
+++ b/test/text/text_utils_unit.js
@@ -181,4 +181,23 @@ describe('TextUtils', () => {
       expect(cue.positionAlign).toBe(defaultCue.positionAlign);
     });
   });
+
+  describe('isCueStrictSubset', () => {
+    it('detects strict subsets with the same payload', () => {
+      const superset = new shaka.text.Cue(168, 170.92, 'hello');
+      const subset = new shaka.text.Cue(170, 170.92, 'hello');
+      expect(shaka.text.Utils.isCueStrictSubset(superset, subset)).toBe(true);
+    });
+
+    it('returns false for equal cues', () => {
+      const cue = new shaka.text.Cue(168, 170.92, 'hello');
+      expect(shaka.text.Utils.isCueStrictSubset(cue, cue)).toBe(false);
+    });
+
+    it('returns false for different payloads', () => {
+      const superset = new shaka.text.Cue(168, 170.92, 'hello');
+      const subset = new shaka.text.Cue(170, 170.92, 'goodbye');
+      expect(shaka.text.Utils.isCueStrictSubset(superset, subset)).toBe(false);
+    });
+  });
 });

--- a/test/text/ttml_text_parser_unit.js
+++ b/test/text/ttml_text_parser_unit.js
@@ -2681,8 +2681,8 @@ describe('TtmlTextParser', () => {
   it('trims cues to segment boundaries', () => {
     verifyHelper(
         [
-          // Capped to segment end time.
-          {startTime: 168, endTime: 170},
+          // Not capped to segment end time; cue may extend past the segment.
+          {startTime: 168, endTime: Util.closeTo(170.92)},
         ],
         '<tt><body><div>' +
         '  <p begin="00:02:48.00" end="00:02:50.92" xml:id="sub22">' +
@@ -2712,6 +2712,26 @@ describe('TtmlTextParser', () => {
           periodStart: 0,
           segmentStart: 170,
           segmentEnd: 180,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
+        {});
+
+    // Test for https://github.com/shaka-project/shaka-player/issues/10172
+    verifyHelper(
+        [
+          // Cue extends past the segment boundary; end must not be clipped.
+          {startTime: Util.closeTo(699.781), endTime: Util.closeTo(700.700)},
+        ],
+        '<tt><body><div>' +
+        '  <p begin="00:11:39.781" end="00:11:40.700">' +
+        '    subtitle text' +
+        '  </p>' +
+        '</div></body></tt>',
+        {
+          periodStart: 0,
+          segmentStart: 699,
+          segmentEnd: 700,
           vttOffset: 0,
           isMpegTs: false,
         },


### PR DESCRIPTION
### Description

On DASH streams using fragmented MP4 containers for TTML subtitles, cues with an explicit `end` attribute that extends past the current segment boundary were being clipped at `segmentEnd`. This caused subtitles to disappear roughly 0.7 s early in the reported case (and similar for other streams).

ExoPlayer / Media3 handles these cues correctly.

### Root cause and changes

A previous fix for duplicate cues across segments (#4631) applied:

    start = Math.max(start, segmentStart)
    end   = Math.min(end,   segmentEnd)

for non-HLS content. While this eliminated duplicates, it also truncated cues that legitimately continue past the segment and are not repeated in the following segment.

This patch:

* Only clips the *start* time (and only when the cue begins before the current segment — i.e. a continuation).
* Removes the unconditional end clipping for DASH.
* Adds `shaka.text.Utils.isCueStrictSubset` + logic in `UITextDisplayer.append()` so that when the full cue and a tail copy both arrive we only keep the longer one and avoid on-screen duplicates (preserving the #4631 behaviour).
* Leaves the HLS path untouched.

### Testing

* `python3 build/check.py` — clean.
* `python3 build/test.py --quick --filter="trims cues to segment boundaries|isCueStrictSubset" --uncompiled` — 8/8 passing on Chrome & Edge (other browser launcher failures are local env only).
* Red/green: the updated expectations fail against the old clipping logic and pass with this patch.

Fixes #10172