### PR TITLE
feat(Ads): Allow replaying already-played linear ads in MediaTailor

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -70,6 +70,7 @@ Giorgio Gamberoni <giorgio.gamberoni@gmail.com>
 Giuseppe Samela <giuseppe.samela@gmail.com>
 Hassan Bashir <has.992.sky@gmail.com>
 Hichem Taoufik <hichem@code-it.fr>
+Hira Tariq <hira.t.shaikh@gmail.com>
 Ivan Kohut <i.kohut@yahoo.com>
 Itay Kinnrot <itay.kinnrot@kaltura.com>
 Isaac Ramirez <isaac.ramirez.herrera@gmail.com>

--- a/demo/config.js
+++ b/demo/config.js
@@ -499,6 +499,10 @@ shakaDemo.Config = class {
             'ads.disableTrackingEvents')
         .addBoolInput_('Disable Snapback',
             'ads.disableSnapback')
+        .addBoolInput_('Disable played linear ad skip (MediaTailor)',
+            'ads.disablePlayedLinearAdSkip')
+        .addBoolInput_('Disable tracking for played linear ads (MediaTailor)',
+            'ads.disableTrackingForPlayedLinearAds')
         .addNumberInput_('Interstitial preload ahead time',
             'ads.interstitialPreloadAheadTime',
             /* canBeDecimal= */ true,

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2496,6 +2496,8 @@ shaka.extern.AccessibilityConfiguration;
  *   disableTrackingEvents: boolean,
  *   disableSnapback: boolean,
  *   interstitialPreloadAheadTime: number,
+ *   disablePlayedLinearAdSkip: boolean,
+ *   disableTrackingForPlayedLinearAds: boolean,
  * }}
  *
  * @description
@@ -2555,6 +2557,22 @@ shaka.extern.AccessibilityConfiguration;
  *   Interstitial preload ahead time, in seconds.
  *   <br>
  *   Defaults to <code>10</code>.
+ * @property {boolean} disablePlayedLinearAdSkip
+ *   If this is true, the MediaTailor SSAI path will not automatically skip
+ *   already-played linear ads, allowing them to replay. By default, played
+ *   linear ads are force-skipped so the app has no opportunity to control
+ *   replay behavior. Enable this to let the application manage skipping.
+ *   Only affects linear ads in MediaTailor SSAI streams.
+ *   <br>
+ *   Defaults to <code>false</code>.
+ * @property {boolean} disableTrackingForPlayedLinearAds
+ *   If this is true, impression and progress tracking beacons are suppressed
+ *   when a previously-played linear ad replays. Player UI lifecycle events
+ *   (e.g. AD_STARTED, AD_COMPLETE) continue to fire normally. Only meaningful
+ *   when <code>disablePlayedLinearAdSkip</code> is also true. Only affects
+ *   linear ads in MediaTailor SSAI streams.
+ *   <br>
+ *   Defaults to <code>false</code>.
  *
  * @exportDoc
  */

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2558,16 +2558,17 @@ shaka.extern.AccessibilityConfiguration;
  *   <br>
  *   Defaults to <code>10</code>.
  * @property {boolean} disablePlayedLinearAdSkip
- *   If this is true, already-played linear ads will not be automatically
- *   skipped, allowing them to replay. By default, played linear ads are
- *   force-skipped so the app has no opportunity to control replay behavior.
+ *   If true, disables automatic skipping of already-played linear ads.
+ *   Normally, played linear ads are force-skipped on replay. When this flag
+ *   is set, they will play through, allowing the app to control skip behavior.
+ *   Only applies to MediaTailor streams.
  *   <br>
  *   Defaults to <code>false</code>.
  * @property {boolean} disableTrackingForPlayedLinearAds
- *   If this is true, impression and progress tracking beacons are suppressed
- *   when a previously-played linear ad replays. Player UI lifecycle events
- *   (e.g. AD_STARTED, AD_COMPLETE) continue to fire normally. Only meaningful
- *   when <code>disablePlayedLinearAdSkip</code> is also true.
+ *   If true, suppresses tracking beacons when a previously-played linear ad
+ *   replays. Only meaningful when
+ *   <code>disablePlayedLinearAdSkip</code> is also true. Only applies to
+ *   MediaTailor streams.
  *   <br>
  *   Defaults to <code>false</code>.
  *

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2558,19 +2558,16 @@ shaka.extern.AccessibilityConfiguration;
  *   <br>
  *   Defaults to <code>10</code>.
  * @property {boolean} disablePlayedLinearAdSkip
- *   If this is true, the MediaTailor SSAI path will not automatically skip
- *   already-played linear ads, allowing them to replay. By default, played
- *   linear ads are force-skipped so the app has no opportunity to control
- *   replay behavior. Enable this to let the application manage skipping.
- *   Only affects linear ads in MediaTailor SSAI streams.
+ *   If this is true, already-played linear ads will not be automatically
+ *   skipped, allowing them to replay. By default, played linear ads are
+ *   force-skipped so the app has no opportunity to control replay behavior.
  *   <br>
  *   Defaults to <code>false</code>.
  * @property {boolean} disableTrackingForPlayedLinearAds
  *   If this is true, impression and progress tracking beacons are suppressed
  *   when a previously-played linear ad replays. Player UI lifecycle events
  *   (e.g. AD_STARTED, AD_COMPLETE) continue to fire normally. Only meaningful
- *   when <code>disablePlayedLinearAdSkip</code> is also true. Only affects
- *   linear ads in MediaTailor SSAI streams.
+ *   when <code>disablePlayedLinearAdSkip</code> is also true.
  *   <br>
  *   Defaults to <code>false</code>.
  *

--- a/lib/ads/media_tailor_ad_manager.js
+++ b/lib/ads/media_tailor_ad_manager.js
@@ -751,7 +751,11 @@ shaka.ads.MediaTailorAdManager = class {
       trackingEvent = this.mediaTailorAdBreak_.adBreakTrackingEvents.find(
           (event) => event.eventType == eventType);
     }
-    if (trackingEvent && this.config_ && !this.config_.disableTrackingEvents) {
+    if (trackingEvent && this.config_ &&
+        !this.config_.disableTrackingEvents &&
+        !(this.config_.disableTrackingForPlayedLinearAds &&
+            this.mediaTailorAd_ &&
+            this.playedAds_.has(this.mediaTailorAd_.adId))) {
       const NetworkingEngine = shaka.net.NetworkingEngine;
       const type = NetworkingEngine.RequestType.ADS;
       const context = {

--- a/lib/ads/media_tailor_ad_manager.js
+++ b/lib/ads/media_tailor_ad_manager.js
@@ -560,7 +560,8 @@ shaka.ads.MediaTailorAdManager = class {
         const startTime = ad.startTimeInSeconds;
         const endTime = ad.startTimeInSeconds + ad.durationInSeconds;
         if (startTime <= currentTime && endTime > currentTime) {
-          if (this.playedAds_.has(ad.adId)) {
+          if (!(this.config_ && this.config_.disablePlayedLinearAdSkip) &&
+              this.playedAds_.has(ad.adId)) {
             if (this.video_.ended) {
               continue;
             }

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -401,6 +401,8 @@ shaka.util.PlayerConfiguration = class {
       disableTrackingEvents: false,
       disableSnapback: false,
       interstitialPreloadAheadTime: 10,
+      disablePlayedLinearAdSkip: false,
+      disableTrackingForPlayedLinearAds: false,
     };
 
     const textDisplayer = {


### PR DESCRIPTION
## Problem

`MediaTailorAdManager.checkLinearAds_` unconditionally force-skips any already-played linear ad (`video.currentTime = endTime`). Apps have no way to replay a linear ad or implement custom skip logic.

Fixes #10265 

## Solution

Two opt-in `AdsConfiguration` boolean configs, both defaulting to `false`:

| Config | Effect |
|--------|--------|
| `disablePlayedLinearAdSkip` | Stops auto-skip of already-played linear ads so they replay normally |
| `disableTrackingForPlayedLinearAds` | Suppresses network tracking beacons on replay |
