### PR TITLE
refactor(Ads): Reduce duplication in InterstitialAdManager

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -78,6 +78,14 @@ shaka.ads.InterstitialAdManager = class {
     this.interstitials_ = new Set();
 
     /**
+     * Cache of interstitials_ sorted by descending start time, invalidated
+     * (set to null) whenever interstitials_ changes. Avoids re-sorting on every
+     * getCurrentInterstitial_ call (which runs per frame).
+     * @private {?Array<shaka.extern.AdInterstitial>}
+     */
+    this.sortedInterstitials_ = null;
+
+    /**
      * Asset lists (HLS X-ASSET-LIST) whose resolution has been deferred until
      * playback approaches them. This avoids resolving every ad decision at
      * parse time, which would otherwise create a burst of concurrent requests.
@@ -435,6 +443,7 @@ shaka.ads.InterstitialAdManager = class {
     this.hlsMetadataIds_.clear();
     this.interstitialIds_.clear();
     this.interstitials_.clear();
+    this.sortedInterstitials_ = null;
     this.unresolvedAssetLists_.clear();
     this.preloadOffsets_.clear();
     this.player_.destroyAllPreloads();
@@ -503,11 +512,7 @@ shaka.ads.InterstitialAdManager = class {
    * @param {shaka.extern.HLSMetadata} hlsMetadata
    */
   async addMetadata(hlsMetadata) {
-    let id = null;
-    const hlsMetadataId = hlsMetadata.values.find((v) => v.key == 'ID');
-    if (hlsMetadataId) {
-      id = /** @type {string} */(hlsMetadataId.data);
-    }
+    const id = this.getMetadataValue_(hlsMetadata, 'ID');
     if (id) {
       if (this.hlsMetadataIds_.has(id)) {
         // A subsequent EXT-X-DATERANGE with the same ID augments the existing
@@ -520,8 +525,7 @@ shaka.ads.InterstitialAdManager = class {
     }
     this.updatePlayerConfig_();
     let adInterstitials = [];
-    if (hlsMetadata &&
-        hlsMetadata.values.find((v) => v.key == 'X-OVERLAY-ID')) {
+    if (this.getMetadataValue_(hlsMetadata, 'X-OVERLAY-ID') != null) {
       adInterstitials = this.getOverlaysInfo_(hlsMetadata);
     } else {
       adInterstitials = await this.getInterstitialsInfo_(hlsMetadata);
@@ -544,11 +548,11 @@ shaka.ads.InterstitialAdManager = class {
    * @private
    */
   updateInterstitials_(hlsMetadata, id) {
-    const playout = hlsMetadata.values.find((v) => v.key == 'X-PLAYOUT-LIMIT');
-    if (!playout) {
+    const playout = this.getMetadataValue_(hlsMetadata, 'X-PLAYOUT-LIMIT');
+    if (playout == null) {
       return;
     }
-    const playoutLimit = parseFloat(/** @type {string} */ (playout.data));
+    const playoutLimit = parseFloat(playout);
     if (isNaN(playoutLimit)) {
       return;
     }
@@ -625,18 +629,14 @@ shaka.ads.InterstitialAdManager = class {
    * @param {shaka.extern.HLSMetadata} hlsMetadata
    */
   addPreloadMetadata(hlsMetadata) {
-    const findValue = (key) => {
-      const frame = hlsMetadata.values.find((v) => v.key == key);
-      return frame ? /** @type {string} */ (frame.data) : null;
-    };
-    const id = findValue('ID');
+    const id = this.getMetadataValue_(hlsMetadata, 'ID');
     if (id) {
       if (this.hlsMetadataIds_.has(id)) {
         return;
       }
       this.hlsMetadataIds_.add(id);
     }
-    const targetId = findValue('X-TARGET-ID');
+    const targetId = this.getMetadataValue_(hlsMetadata, 'X-TARGET-ID');
     if (!targetId) {
       return;
     }
@@ -845,30 +845,13 @@ shaka.ads.InterstitialAdManager = class {
       const topLeft = TXml.findChild(overlayElement, 'TopLeft');
       const size = TXml.findChild(overlayElement, 'Size');
       if (topLeft && size) {
-        const topLeftX = TXml.parseAttr(topLeft, 'x', TXml.parseInt);
-        if (topLeftX == null) {
+        const parsed = this.parseTopLeftSize_(topLeft, size);
+        if (!parsed) {
           shaka.log.warning('Unsupported OverlayEvent', region);
           return;
         }
-        const topLeftY = TXml.parseAttr(topLeft, 'y', TXml.parseInt);
-        if (topLeftY == null) {
-          shaka.log.warning('Unsupported OverlayEvent', region);
-          return;
-        }
-        const sizeX = TXml.parseAttr(size, 'x', TXml.parseInt);
-        if (sizeX == null) {
-          shaka.log.warning('Unsupported OverlayEvent', region);
-          return;
-        }
-        const sizeY = TXml.parseAttr(size, 'y', TXml.parseInt);
-        if (sizeY == null) {
-          shaka.log.warning('Unsupported OverlayEvent', region);
-          return;
-        }
-        overlay.topLeft.x = topLeftX;
-        overlay.topLeft.y = topLeftY;
-        overlay.size.x = sizeX;
-        overlay.size.y = sizeY;
+        overlay.topLeft = parsed.topLeft;
+        overlay.size = parsed.size;
       }
     }
     let currentVideo = null;
@@ -877,23 +860,8 @@ shaka.ads.InterstitialAdManager = class {
       const topLeft = TXml.findChild(squeezeElement, 'TopLeft');
       const size = TXml.findChild(squeezeElement, 'Size');
       if (topLeft && size) {
-        const topLeftX = TXml.parseAttr(topLeft, 'x', TXml.parseInt);
-        if (topLeftX == null) {
-          shaka.log.warning('Unsupported OverlayEvent', region);
-          return;
-        }
-        const topLeftY = TXml.parseAttr(topLeft, 'y', TXml.parseInt);
-        if (topLeftY == null) {
-          shaka.log.warning('Unsupported OverlayEvent', region);
-          return;
-        }
-        const sizeX = TXml.parseAttr(size, 'x', TXml.parseInt);
-        if (sizeX == null) {
-          shaka.log.warning('Unsupported OverlayEvent', region);
-          return;
-        }
-        const sizeY = TXml.parseAttr(size, 'y', TXml.parseInt);
-        if (sizeY == null) {
+        const parsed = this.parseTopLeftSize_(topLeft, size);
+        if (!parsed) {
           shaka.log.warning('Unsupported OverlayEvent', region);
           return;
         }
@@ -902,14 +870,8 @@ shaka.ads.InterstitialAdManager = class {
             x: viewport.x,
             y: viewport.y,
           },
-          topLeft: {
-            x: topLeftX,
-            y: topLeftY,
-          },
-          size: {
-            x: sizeX,
-            y: sizeY,
-          },
+          topLeft: parsed.topLeft,
+          size: parsed.size,
         };
       }
     }
@@ -941,6 +903,31 @@ shaka.ads.InterstitialAdManager = class {
       tracking: null,
     };
     this.addInterstitials([interstitial]);
+  }
+
+  /**
+   * Parses the integer x/y attributes of TopLeft and Size nodes (used by DASH
+   * overlay events). Returns null if any coordinate is missing or invalid.
+   *
+   * @param {!shaka.extern.xml.Node} topLeft
+   * @param {!shaka.extern.xml.Node} size
+   * @return {?{topLeft: {x: number, y: number}, size: {x: number, y: number}}}
+   * @private
+   */
+  parseTopLeftSize_(topLeft, size) {
+    const TXml = shaka.util.TXml;
+    const topLeftX = TXml.parseAttr(topLeft, 'x', TXml.parseInt);
+    const topLeftY = TXml.parseAttr(topLeft, 'y', TXml.parseInt);
+    const sizeX = TXml.parseAttr(size, 'x', TXml.parseInt);
+    const sizeY = TXml.parseAttr(size, 'y', TXml.parseInt);
+    if (topLeftX == null || topLeftY == null ||
+        sizeX == null || sizeY == null) {
+      return null;
+    }
+    return {
+      topLeft: {x: topLeftX, y: topLeftY},
+      size: {x: sizeX, y: sizeY},
+    };
   }
 
   /**
@@ -1010,7 +997,7 @@ shaka.ads.InterstitialAdManager = class {
               this.basePlayer_.getConfiguration().streaming.retryParameters);
         } catch (error) {}
       }
-      const interstitialId = interstitial.id || JSON.stringify(interstitial);
+      const interstitialId = this.interstitialId_(interstitial);
       if (this.interstitialIds_.has(interstitialId)) {
         continue;
       }
@@ -1023,6 +1010,7 @@ shaka.ads.InterstitialAdManager = class {
       }
       this.interstitialIds_.add(interstitialId);
       this.interstitials_.add(interstitial);
+      this.sortedInterstitials_ = null;
       this.applyPreloadOffset_(interstitial);
       if (this.isWithinPreloadWindow_(interstitial)) {
         if (!this.preloadTasks_.has(interstitial) &&
@@ -1063,6 +1051,21 @@ shaka.ads.InterstitialAdManager = class {
 
 
   /**
+   * Returns interstitials_ sorted by descending start time, using a cache that
+   * is invalidated whenever interstitials_ changes.
+   *
+   * @return {!Array<shaka.extern.AdInterstitial>}
+   * @private
+   */
+  getSortedInterstitials_() {
+    if (!this.sortedInterstitials_) {
+      this.sortedInterstitials_ = Array.from(this.interstitials_).sort(
+          (a, b) => b.startTime - a.startTime);
+    }
+    return this.sortedInterstitials_;
+  }
+
+  /**
    * @param {boolean=} needPreRoll
    * @param {?number=} numberToSkip
    * @return {?shaka.extern.AdInterstitial}
@@ -1072,9 +1075,7 @@ shaka.ads.InterstitialAdManager = class {
     let skipped = 0;
     let currentInterstitial = null;
     if (this.interstitials_.size && this.lastTime_ != null) {
-      const interstitials = Array.from(this.interstitials_).sort((a, b) => {
-        return b.startTime - a.startTime;
-      });
+      const interstitials = this.getSortedInterstitials_();
       const roundDecimals = (number) => {
         return Math.round(number * 1000) / 1000;
       };
@@ -1170,6 +1171,7 @@ shaka.ads.InterstitialAdManager = class {
     if (interstitial.once) {
       oncePlayed++;
       this.interstitials_.delete(interstitial);
+      this.sortedInterstitials_ = null;
       this.removeEventListeners_();
       if (!interstitial.overlay) {
         this.cuepointsChanged_();
@@ -1207,12 +1209,7 @@ shaka.ads.InterstitialAdManager = class {
    * @private
    */
   setupStaticAd_(interstitial, sequenceLength, adPosition, oncePlayed) {
-    let timeOffset = interstitial.startTime;
-    if (interstitial.pre) {
-      timeOffset = 0;
-    } else if (interstitial.post) {
-      timeOffset = -1;
-    }
+    const timeOffset = this.getTimeOffset_(interstitial);
 
     if (!this.playingAd_) {
       this.playingAdStartTime_ = Date.now();
@@ -1278,25 +1275,19 @@ shaka.ads.InterstitialAdManager = class {
       };
     }
 
-    const viewport = overlay.viewport;
-    const topLeft = overlay.topLeft;
-    const size = overlay.size;
     // Special case for VAST non-linear ads
-    if (viewport.x == 0 && viewport.y == 0) {
-      htmlElement.width = interstitial.overlay.size.x;
-      htmlElement.height = interstitial.overlay.size.y;
+    if (overlay.viewport.x == 0 && overlay.viewport.y == 0) {
+      htmlElement.width = overlay.size.x;
+      htmlElement.height = overlay.size.y;
       htmlElement.style.bottom = '10%';
       htmlElement.style.left = '0';
       htmlElement.style.right = '0';
       htmlElement.style.width = '100%';
-      if (!interstitial.overlay.size.y && tagName == 'iframe') {
+      if (!overlay.size.y && tagName == 'iframe') {
         htmlElement.style.height = 'auto';
       }
     } else {
-      htmlElement.style.height = (size.y / viewport.y * 100) + '%';
-      htmlElement.style.left = (topLeft.x / viewport.x * 100) + '%';
-      htmlElement.style.top = (topLeft.y / viewport.y * 100) + '%';
-      htmlElement.style.width = (size.x / viewport.x * 100) + '%';
+      this.applyOverlayPosition_(htmlElement, overlay);
     }
     this.adContainer_.appendChild(htmlElement);
 
@@ -1359,12 +1350,7 @@ shaka.ads.InterstitialAdManager = class {
     goog.asserts.assert(this.video_, 'Must have video');
     const startTime = Date.now();
 
-    let timeOffset = interstitial.startTime;
-    if (interstitial.pre) {
-      timeOffset = 0;
-    } else if (interstitial.post) {
-      timeOffset = -1;
-    }
+    const timeOffset = this.getTimeOffset_(interstitial);
 
     if (!this.playingAd_) {
       this.playingAdStartTime_ = Date.now();
@@ -1644,13 +1630,8 @@ shaka.ads.InterstitialAdManager = class {
       this.video_.style.display = '';
       if (interstitial.overlay) {
         this.video_.loop = interstitial.loop;
-        const viewport = interstitial.overlay.viewport;
-        const topLeft = interstitial.overlay.topLeft;
-        const size = interstitial.overlay.size;
-        this.video_.style.height = (size.y / viewport.y * 100) + '%';
-        this.video_.style.left = (topLeft.x / viewport.x * 100) + '%';
-        this.video_.style.top = (topLeft.y / viewport.y * 100) + '%';
-        this.video_.style.width = (size.x / viewport.x * 100) + '%';
+        this.applyOverlayPosition_(
+            /** @type {!HTMLElement} */ (this.video_), interstitial.overlay);
       } else {
         this.baseVideo_.pause();
         if (!this.basePlayer_.isLive()) {
@@ -1779,6 +1760,24 @@ shaka.ads.InterstitialAdManager = class {
   }
 
   /**
+   * Positions an element within the ad container according to an overlay's
+   * viewport/topLeft/size, expressed as CSS percentages.
+   *
+   * @param {!HTMLElement} element
+   * @param {!shaka.extern.AdPositionInfo} overlay
+   * @private
+   */
+  applyOverlayPosition_(element, overlay) {
+    const viewport = overlay.viewport;
+    const topLeft = overlay.topLeft;
+    const size = overlay.size;
+    element.style.height = (size.y / viewport.y * 100) + '%';
+    element.style.left = (topLeft.x / viewport.x * 100) + '%';
+    element.style.top = (topLeft.y / viewport.y * 100) + '%';
+    element.style.width = (size.x / viewport.x * 100) + '%';
+  }
+
+  /**
    * @param {shaka.extern.AdInterstitial} interstitial
    * @private
    */
@@ -1875,63 +1874,42 @@ shaka.ads.InterstitialAdManager = class {
     if (!hlsMetadata) {
       return interstitialsAd;
     }
-    const assetUri = hlsMetadata.values.find((v) => v.key == 'X-ASSET-URI');
-    const assetList =
-        hlsMetadata.values.find((v) => v.key == 'X-ASSET-LIST');
+    const assetUri = this.getMetadataValue_(hlsMetadata, 'X-ASSET-URI');
+    const assetList = this.getMetadataValue_(hlsMetadata, 'X-ASSET-LIST');
     if (!assetUri && !assetList) {
       return interstitialsAd;
     }
-    let id = null;
-    const hlsMetadataId = hlsMetadata.values.find((v) => v.key == 'ID');
-    if (hlsMetadataId) {
-      id = /** @type {string} */(hlsMetadataId.data);
-    }
-    const startTime = id == null ?
-        Math.floor(hlsMetadata.startTime * 10) / 10:
-        hlsMetadata.startTime;
-    let endTime = hlsMetadata.endTime;
-    if (hlsMetadata.endTime && hlsMetadata.endTime != Infinity &&
-        typeof(hlsMetadata.endTime) == 'number') {
-      endTime = id == null ?
-          Math.floor(hlsMetadata.endTime * 10) / 10:
-          hlsMetadata.endTime;
-    }
-    const restrict = hlsMetadata.values.find((v) => v.key == 'X-RESTRICT');
+    const id = this.getMetadataValue_(hlsMetadata, 'ID');
+    const {startTime, endTime} = this.getInterstitialTimes_(hlsMetadata, id);
+    const restrict = this.getMetadataValue_(hlsMetadata, 'X-RESTRICT');
     let isSkippable = true;
     let canJump = true;
-    if (restrict && restrict.data) {
-      const data = /** @type {string} */(restrict.data);
-      isSkippable = !data.includes('SKIP');
-      canJump = !data.includes('JUMP');
+    if (restrict != null) {
+      isSkippable = !restrict.includes('SKIP');
+      canJump = !restrict.includes('JUMP');
     }
     let skipOffset = isSkippable ? 0 : null;
     const skipControlOffset =
-        hlsMetadata.values.find((v) => v.key == 'X-SKIP-CONTROL-OFFSET');
-    if (skipControlOffset) {
-      const skipControlOffsetString =
-      /** @type {string} */(skipControlOffset.data);
-      skipOffset = parseFloat(skipControlOffsetString);
+        this.getMetadataValue_(hlsMetadata, 'X-SKIP-CONTROL-OFFSET');
+    if (skipControlOffset != null) {
+      skipOffset = parseFloat(skipControlOffset);
       if (isNaN(skipOffset)) {
         skipOffset = isSkippable ? 0 : null;
       }
     }
     let skipFor = null;
     const skipControlDuration =
-        hlsMetadata.values.find((v) => v.key == 'X-SKIP-CONTROL-DURATION');
-    if (skipControlDuration) {
-      const skipControlDurationString =
-      /** @type {string} */(skipControlDuration.data);
-      skipFor = parseFloat(skipControlDurationString);
+        this.getMetadataValue_(hlsMetadata, 'X-SKIP-CONTROL-DURATION');
+    if (skipControlDuration != null) {
+      skipFor = parseFloat(skipControlDuration);
       if (isNaN(skipOffset)) {
         skipFor = null;
       }
     }
     let resumeOffset = null;
-    const resume =
-        hlsMetadata.values.find((v) => v.key == 'X-RESUME-OFFSET');
-    if (resume) {
-      const resumeOffsetString = /** @type {string} */(resume.data);
-      resumeOffset = parseFloat(resumeOffsetString);
+    const resume = this.getMetadataValue_(hlsMetadata, 'X-RESUME-OFFSET');
+    if (resume != null) {
+      resumeOffset = parseFloat(resume);
       if (isNaN(resumeOffset)) {
         resumeOffset = null;
       }
@@ -1942,37 +1920,24 @@ shaka.ads.InterstitialAdManager = class {
       resumeOffset = null;
     }
     let playoutLimit = null;
-    const playout =
-        hlsMetadata.values.find((v) => v.key == 'X-PLAYOUT-LIMIT');
-    if (playout) {
-      const playoutLimitString = /** @type {string} */(playout.data);
-      playoutLimit = parseFloat(playoutLimitString);
+    const playout = this.getMetadataValue_(hlsMetadata, 'X-PLAYOUT-LIMIT');
+    if (playout != null) {
+      playoutLimit = parseFloat(playout);
       if (isNaN(playoutLimit)) {
         playoutLimit = null;
       }
     }
-    let once = false;
-    let pre = false;
-    let post = false;
-    const cue = hlsMetadata.values.find((v) => v.key == 'CUE');
-    if (cue) {
-      const data = /** @type {string} */(cue.data);
-      once = data.includes('ONCE');
-      pre = data.includes('PRE');
-      post = data.includes('POST');
-    }
+    const {once, pre, post} = this.parseCue_(hlsMetadata);
     let timelineRange = false;
     const timelineOccupies =
-        hlsMetadata.values.find((v) => v.key == 'X-TIMELINE-OCCUPIES');
-    if (timelineOccupies) {
-      const data = /** @type {string} */(timelineOccupies.data);
-      timelineRange = data.includes('RANGE');
-    } else if (!resume && this.basePlayer_.isLive()) {
+        this.getMetadataValue_(hlsMetadata, 'X-TIMELINE-OCCUPIES');
+    if (timelineOccupies != null) {
+      timelineRange = timelineOccupies.includes('RANGE');
+    } else if (resume == null && this.basePlayer_.isLive()) {
       timelineRange = !pre && !post;
     }
-    if (assetUri) {
-      const uri = /** @type {string} */(assetUri.data);
-      if (!uri) {
+    if (assetUri != null) {
+      if (!assetUri) {
         return interstitialsAd;
       }
       interstitialsAd.push({
@@ -1980,7 +1945,7 @@ shaka.ads.InterstitialAdManager = class {
         groupId: null,
         startTime,
         endTime,
-        uri: this.getUriWithHlsParams_(uri),
+        uri: this.getUriWithHlsParams_(assetUri),
         mimeType: null,
         isSkippable,
         skipOffset,
@@ -2000,9 +1965,8 @@ shaka.ads.InterstitialAdManager = class {
         clickThroughUrl: null,
         tracking: null,
       });
-    } else if (assetList) {
-      const uri = /** @type {string} */(assetList.data);
-      if (!uri) {
+    } else if (assetList != null) {
+      if (!assetList) {
         return interstitialsAd;
       }
       /** @type {shaka.ads.InterstitialAdManager.AssetListDescriptor} */
@@ -2011,7 +1975,7 @@ shaka.ads.InterstitialAdManager = class {
         groupId: null,
         startTime,
         endTime,
-        assetListUri: uri,
+        assetListUri: assetList,
         isSkippable,
         skipOffset,
         skipFor,
@@ -2302,9 +2266,10 @@ shaka.ads.InterstitialAdManager = class {
       this.preloadTasks_.delete(interstitial);
     }
     this.removePreloadOnDomElements_(interstitial);
-    const interstitialId = interstitial.id || JSON.stringify(interstitial);
+    const interstitialId = this.interstitialId_(interstitial);
     this.interstitialIds_.delete(interstitialId);
     this.interstitials_.delete(interstitial);
+    this.sortedInterstitials_ = null;
     if (this.lastPlayedAd_ === interstitial) {
       this.lastPlayedAd_ = null;
     }
@@ -2377,78 +2342,33 @@ shaka.ads.InterstitialAdManager = class {
     if (!hlsMetadata) {
       return interstitialsAd;
     }
-    const assetUri = hlsMetadata.values.find((v) => v.key == 'X-ASSET-URI');
-    if (!assetUri) {
-      return interstitialsAd;
-    }
-    const uri = /** @type {string} */(assetUri.data);
+    const uri = this.getMetadataValue_(hlsMetadata, 'X-ASSET-URI');
     if (!uri) {
       return interstitialsAd;
     }
-    let id = null;
-    const hlsMetadataId =
-        hlsMetadata.values.find((v) => v.key == 'X-OVERLAY-ID');
-    if (hlsMetadataId) {
-      id = /** @type {string} */(hlsMetadataId.data);
-    }
-    const startTime = id == null ?
-        Math.floor(hlsMetadata.startTime * 10) / 10:
-        hlsMetadata.startTime;
-    let endTime = hlsMetadata.endTime;
-    if (hlsMetadata.endTime && hlsMetadata.endTime != Infinity &&
-        typeof(hlsMetadata.endTime) == 'number') {
-      endTime = id == null ?
-          Math.floor(hlsMetadata.endTime * 10) / 10:
-          hlsMetadata.endTime;
-    }
-    let once = false;
-    let pre = false;
-    let post = false;
-    const cue = hlsMetadata.values.find((v) => v.key == 'CUE');
-    if (cue) {
-      const data = /** @type {string} */(cue.data);
-      once = data.includes('ONCE');
-      pre = data.includes('PRE');
-      post = data.includes('POST');
-    }
-    let mimeType = null;
-    const mimeTypeTag = hlsMetadata.values.find(
-        (v) => v.key == 'X-ASSET-MIMETYPE');
-    if (mimeTypeTag) {
-      mimeType = /** @type {string} */(mimeTypeTag.data);
-    }
-    let loop = false;
-    const loopTag = hlsMetadata.values.find((v) => v.key == 'X-LOOP');
-    if (loopTag) {
-      const data = /** @type {string} */(loopTag.data);
-      loop = data == 'YES';
-    }
+    const id = this.getMetadataValue_(hlsMetadata, 'X-OVERLAY-ID');
+    const {startTime, endTime} = this.getInterstitialTimes_(hlsMetadata, id);
+    const {once, pre, post} = this.parseCue_(hlsMetadata);
+    const mimeType = this.getMetadataValue_(hlsMetadata, 'X-ASSET-MIMETYPE');
+    const loop = this.getMetadataValue_(hlsMetadata, 'X-LOOP') == 'YES';
     let z = 1;
-    const depth = hlsMetadata.values.find((v) => v.key == 'X-DEPTH');
-    if (depth) {
-      const data = /** @type {string} */(depth.data);
-      z = parseFloat(data);
+    const depth = this.getMetadataValue_(hlsMetadata, 'X-DEPTH');
+    if (depth != null) {
+      z = parseFloat(depth);
       if (isNaN(z)) {
         z = 1;
       }
     }
-    let background = null;
-    const backgroundTag = hlsMetadata.values.find(
-        (v) => v.key == 'X-BACKGROUND');
-    if (backgroundTag) {
-      background = /** @type {string} */(backgroundTag.data);
-    }
+    const background = this.getMetadataValue_(hlsMetadata, 'X-BACKGROUND');
 
     const viewport = {
       x: 1920,
       y: 1080,
     };
 
-    const viewportElement = hlsMetadata.values.find(
-        (v) => v.key == 'X-VIEWPORT');
-    if (viewportElement) {
-      const data = /** @type {string} */(viewportElement.data);
-      const size = data.split('x');
+    const viewportValue = this.getMetadataValue_(hlsMetadata, 'X-VIEWPORT');
+    if (viewportValue != null) {
+      const size = viewportValue.split('x');
       if (size.length != 2) {
         return interstitialsAd;
       }
@@ -2472,11 +2392,10 @@ shaka.ads.InterstitialAdManager = class {
       },
     };
 
-    const overlayPosition = hlsMetadata.values.find(
-        (v) => v.key == 'X-OVERLAY-POSITION');
-    if (overlayPosition) {
-      const data = /** @type {string} */(overlayPosition.data);
-      const position = data.split('x');
+    const overlayPosition =
+        this.getMetadataValue_(hlsMetadata, 'X-OVERLAY-POSITION');
+    if (overlayPosition != null) {
+      const position = overlayPosition.split('x');
       if (position.length != 2) {
         return interstitialsAd;
       }
@@ -2484,11 +2403,9 @@ shaka.ads.InterstitialAdManager = class {
       overlay.topLeft.y = parseFloat(position[1]);
     }
 
-    const overlaySize = hlsMetadata.values.find(
-        (v) => v.key == 'X-OVERLAY-SIZE');
-    if (overlaySize) {
-      const data = /** @type {string} */(overlaySize.data);
-      const size = data.split('x');
+    const overlaySize = this.getMetadataValue_(hlsMetadata, 'X-OVERLAY-SIZE');
+    if (overlaySize != null) {
+      const size = overlaySize.split('x');
       if (size.length != 2) {
         return interstitialsAd;
       }
@@ -2498,11 +2415,10 @@ shaka.ads.InterstitialAdManager = class {
 
     /** @type {?shaka.extern.AdPositionInfo} */
     let currentVideo = null;
-    const squeezeCurrent = hlsMetadata.values.find(
-        (v) => v.key == 'X-SQUEEZECURRENT');
-    if (squeezeCurrent) {
-      const data = /** @type {string} */(squeezeCurrent.data);
-      let percentage = parseFloat(data);
+    const squeezeCurrent =
+        this.getMetadataValue_(hlsMetadata, 'X-SQUEEZECURRENT');
+    if (squeezeCurrent != null) {
+      let percentage = parseFloat(squeezeCurrent);
       if (isNaN(percentage)) {
         percentage = 1;
       }
@@ -2520,12 +2436,10 @@ shaka.ads.InterstitialAdManager = class {
           y: 1080 * percentage,
         },
       };
-      const squeezeCurrentPosition = hlsMetadata.values.find(
-          (v) => v.key == 'X-SQUEEZECURRENT-POSITION');
-      if (squeezeCurrentPosition) {
-        const squeezeCurrentPositionData =
-        /** @type {string} */(squeezeCurrentPosition.data);
-        const position = squeezeCurrentPositionData.split('x');
+      const squeezeCurrentPosition =
+          this.getMetadataValue_(hlsMetadata, 'X-SQUEEZECURRENT-POSITION');
+      if (squeezeCurrentPosition != null) {
+        const position = squeezeCurrentPosition.split('x');
         if (position.length != 2) {
           return interstitialsAd;
         }
@@ -2665,6 +2579,86 @@ shaka.ads.InterstitialAdManager = class {
         shaka.net.NetworkingEngine.defaultRetryParameters());
     return this.basePlayer_.getNetworkingEngine()
         .request(type, request, context);
+  }
+
+  /**
+   * Returns the string data of the HLS metadata frame with the given key, or
+   * null if there is no such frame.
+   *
+   * @param {shaka.extern.HLSMetadata} hlsMetadata
+   * @param {string} key
+   * @return {?string}
+   * @private
+   */
+  getMetadataValue_(hlsMetadata, key) {
+    const frame = hlsMetadata.values.find((v) => v.key == key);
+    return frame ? /** @type {string} */ (frame.data) : null;
+  }
+
+  /**
+   * Computes the start/end times of an interstitial from its HLS metadata. When
+   * the Date Range has no ID, the times are floored to a tenth of a second.
+   *
+   * @param {shaka.extern.HLSMetadata} hlsMetadata
+   * @param {?string} id
+   * @return {{startTime: number, endTime: ?number}}
+   * @private
+   */
+  getInterstitialTimes_(hlsMetadata, id) {
+    const startTime = id == null ?
+        Math.floor(hlsMetadata.startTime * 10) / 10 :
+        hlsMetadata.startTime;
+    let endTime = hlsMetadata.endTime;
+    if (hlsMetadata.endTime && hlsMetadata.endTime != Infinity &&
+        typeof(hlsMetadata.endTime) == 'number') {
+      endTime = id == null ?
+          Math.floor(hlsMetadata.endTime * 10) / 10 :
+          hlsMetadata.endTime;
+    }
+    return {startTime, endTime};
+  }
+
+  /**
+   * Parses the CUE attribute (ONCE/PRE/POST) from HLS metadata.
+   *
+   * @param {shaka.extern.HLSMetadata} hlsMetadata
+   * @return {{once: boolean, pre: boolean, post: boolean}}
+   * @private
+   */
+  parseCue_(hlsMetadata) {
+    const cue = this.getMetadataValue_(hlsMetadata, 'CUE');
+    return {
+      once: cue != null && cue.includes('ONCE'),
+      pre: cue != null && cue.includes('PRE'),
+      post: cue != null && cue.includes('POST'),
+    };
+  }
+
+  /**
+   * @param {shaka.extern.AdInterstitial} interstitial
+   * @return {string}
+   * @private
+   */
+  interstitialId_(interstitial) {
+    return interstitial.id || JSON.stringify(interstitial);
+  }
+
+  /**
+   * The AD_BREAK_STARTED/ENDED time offset for an interstitial: 0 for pre-roll,
+   * -1 for post-roll, otherwise its start time.
+   *
+   * @param {shaka.extern.AdInterstitial} interstitial
+   * @return {number}
+   * @private
+   */
+  getTimeOffset_(interstitial) {
+    if (interstitial.pre) {
+      return 0;
+    }
+    if (interstitial.post) {
+      return -1;
+    }
+    return interstitial.startTime;
   }
 
   /**


### PR DESCRIPTION
- Centralize HLS metadata access and parsing (X- attribute lookup, start/end  times, CUE, DASH overlay TopLeft/Size) into shared helpers.
- Extract helpers for the overlay CSS positioning, ad-break time offset and interstitial id, removing duplication between the static/video/overlay paths.
- Cache the start-time-sorted interstitial list (rebuilt only on change) to avoid re-sorting on every getCurrentInterstitial_ call.