### PR TITLE
refactor(CEA): dedupe shared logic and simplify decoders

### DIFF
--- a/lib/cea/cea608_data_channel.js
+++ b/lib/cea/cea608_data_channel.js
@@ -196,14 +196,13 @@ shaka.cea.Cea608DataChannel = class {
     this.curBuf_.addChar(
         shaka.cea.Cea608Memory.CharSet.BASIC_NORTH_AMERICAN, ' '.charCodeAt(0));
 
-    let textColor = shaka.cea.CeaUtils.DEFAULT_TXT_COLOR;
     let italics = false;
 
     // Midrow codes set underline on last (LSB) bit.
     const underline = (b2 & 0x01) === 0x01;
 
     // b2 has the form |P|0|1|0|STYLE|U|
-    textColor = shaka.cea.Cea608DataChannel.TEXT_COLORS[(b2 & 0xe) >> 1];
+    let textColor = shaka.cea.Cea608DataChannel.TEXT_COLORS[(b2 & 0xe) >> 1];
     if (textColor === 'white_italics') {
       textColor = 'white';
       italics = true;

--- a/lib/cea/cea608_memory.js
+++ b/lib/cea/cea608_memory.js
@@ -90,7 +90,8 @@ shaka.cea.Cea608Memory = class {
    */
   forceEmit(startTime, endTime) {
     const Cea608Memory = shaka.cea.Cea608Memory;
-    const stream = `CC${((this.fieldNum_<< 1) | this.channelNum_) + 1}`;
+    const stream = shaka.cea.CeaUtils.getCea608StreamName(
+        this.fieldNum_, this.channelNum_);
     const topLevelCue = new shaka.text.Cue(
         startTime, endTime, /* payload= */ '');
     topLevelCue.lineInterpretation =
@@ -322,7 +323,7 @@ shaka.cea.Cea608Memory.CharSet = {
  * @private @const {!Map<number, string>}
  */
 shaka.cea.Cea608Memory.CharSet.BasicNorthAmericanChars = new Map([
-  [0x27, '’'], [0x2a, 'á'], [0x5c, 'é'], [0x5c, 'é'], [0x5e, 'í'], [0x5f, 'ó'],
+  [0x27, '’'], [0x2a, 'á'], [0x5c, 'é'], [0x5e, 'í'], [0x5f, 'ó'],
   [0x60, 'ú'], [0x7b, 'ç'], [0x7c, '÷'], [0x7d, 'Ñ'], [0x7e, 'ñ'], [0x7f, '█'],
 ]);
 

--- a/lib/cea/cea708_service.js
+++ b/lib/cea/cea708_service.js
@@ -60,7 +60,7 @@ shaka.cea.Cea708Service = class {
     }
 
     // Control codes are in 1 of 4 logical groups:
-    // CL (C0, C2), CR (C1, C3), GL (G0, G2), GR (G1, G2).
+    // CL (C0, C2), CR (C1, C3), GL (G0, G2), GR (G1, G3).
     if (controlCode >= 0x00 && controlCode <= 0x1f) {
       return this.handleC0_(dtvccPacket, controlCode, pts);
     } else if (controlCode >= 0x80 && controlCode <= 0x9f) {
@@ -162,24 +162,27 @@ shaka.cea.Cea708Service = class {
    * @private
    */
   handleC0_(dtvccPacket, controlCode, pts) {
-    // All these commands pertain to the current window, so ensure it exists.
-    if (!this.currentWindow_) {
-      return [];
-    }
-
     if (controlCode == 0x18) {
+      // P16 character. This always carries 2 data bytes, so they must be read
+      // even if there is no current window to draw into; otherwise the packet
+      // read position goes out of sync and the rest of the block is
+      // misinterpreted.
       const firstByte = dtvccPacket.readByte().value;
       const secondByte = dtvccPacket.readByte().value;
 
-      const toHexString = (byteArray) => {
-        return byteArray.map((byte) => {
-          return ('0' + (byte & 0xFF).toString(16)).slice(-2);
-        }).join('');
-      };
-      const unicode = toHexString([firstByte, secondByte]);
-      // Takes a unicode hex string and creates a single character.
-      const char = String.fromCharCode(parseInt(unicode, 16));
+      if (!this.currentWindow_) {
+        return [];
+      }
+
+      // The two bytes form a single 16-bit character code.
+      const char = String.fromCharCode((firstByte << 8) | secondByte);
       this.currentWindow_.setCharacter(char);
+      return [];
+    }
+
+    // All the remaining commands pertain to the current window, so ensure it
+    // exists.
+    if (!this.currentWindow_) {
       return [];
     }
 
@@ -316,7 +319,7 @@ shaka.cea.Cea708Service = class {
   }
 
   /**
-   * Yields each non-null window specified in the 8-bit bitmap.
+   * Returns the ids of each non-null window specified in the 8-bit bitmap.
    * @param {number} bitmap 8 bits corresponding to each of the 8 windows.
    * @return {!Array<number>}
    * @private
@@ -525,10 +528,10 @@ shaka.cea.Cea708Service = class {
     const backgroundGreen = (backgroundByte & 0x0c) >> 2;
     const backgroundRed = (backgroundByte & 0x30) >> 4;
 
-    const foregroundColor = this.rgbColorToHex_(
+    const foregroundColor = this.rgbColorToCssColor_(
         foregroundRed, foregroundGreen, foregroundBlue);
 
-    const backgroundColor = this.rgbColorToHex_(
+    const backgroundColor = this.rgbColorToCssColor_(
         backgroundRed, backgroundGreen, backgroundBlue);
 
     this.currentWindow_.setPenTextColor(foregroundColor);
@@ -645,19 +648,16 @@ shaka.cea.Cea708Service = class {
    * @return {string}
    * @private
    */
-  rgbColorToHex_(red, green, blue) {
+  rgbColorToCssColor_(red, green, blue) {
     // Rather than supporting 64 colors, this decoder supports 8 colors and
     // gets the closest color, as per 9.19 of CEA-708-E. This is because some
     // colors on television such as white, are often sent with lower intensity
     // and often appear dull/greyish on the browser, making them hard to read.
 
-    // As per CEA-708-E 9.19, these mappings will map 64 colors to 8 colors.
-    const colorMapping = {0: 0, 1: 0, 2: 1, 3: 1};
-    red = colorMapping[red];
-    green = colorMapping[green];
-    blue = colorMapping[blue];
-
-    const colorCode = (red << 2) | (green << 1) | blue;
+    // As per CEA-708-E 9.19, quantize each 2-bit channel (0-3) to a single
+    // bit: 0,1 -> 0 and 2,3 -> 1, which is exactly a right shift by one.
+    const colorCode =
+        ((red >> 1) << 2) | ((green >> 1) << 1) | (blue >> 1);
     return shaka.cea.Cea708Service.Colors[colorCode];
   }
 };

--- a/lib/cea/cea708_window.js
+++ b/lib/cea/cea708_window.js
@@ -476,7 +476,7 @@ shaka.cea.Cea708Window = class {
 };
 
 /**
- * Caption type.
+ * Text justification.
  * @const @enum {number}
  */
 shaka.cea.Cea708Window.TextJustification = {

--- a/lib/cea/cea_decoder.js
+++ b/lib/cea/cea_decoder.js
@@ -8,6 +8,7 @@ goog.provide('shaka.cea.CeaDecoder');
 
 goog.require('shaka.cea.Cea608DataChannel');
 goog.require('shaka.cea.Cea708Service');
+goog.require('shaka.cea.CeaUtils');
 goog.require('shaka.cea.DtvccPacketBuilder');
 goog.require('shaka.log');
 goog.require('shaka.media.ClosedCaptionParser');
@@ -302,7 +303,8 @@ shaka.cea.CeaDecoder = class {
     // Get the correct stream for this caption packet (CC1, ..., CC4)
     const selectedChannel = fieldNum ?
         this.currentField2Channel_ : this.currentField1Channel_;
-    const selectedMode = `CC${((fieldNum << 1) | selectedChannel) + 1}`;
+    const selectedMode = shaka.cea.CeaUtils.getCea608StreamName(
+        fieldNum, selectedChannel);
     const selectedStream = this.cea608ModeToStream_.get(selectedMode);
 
     // Check for bad frames (bad pairs). This can be two 0xff, two 0x00, or any

--- a/lib/cea/cea_utils.js
+++ b/lib/cea/cea_utils.js
@@ -25,21 +25,16 @@ shaka.cea.CeaUtils = class {
       return null;
     }
 
-    // Find the first and last row that contains characters.
+    // Find the first and last row that contains characters, in a single pass.
     let firstNonEmptyRow = -1;
     let lastNonEmptyRow = -1;
 
     for (let i = 0; i < memory.length; i++) {
       if (memory[i].some((e) => e != null && e.getChar().trim() != '')) {
-        firstNonEmptyRow = i;
-        break;
-      }
-    }
-
-    for (let i = memory.length - 1; i >= 0; i--) {
-      if (memory[i].some((e) => e != null && e.getChar().trim() != '')) {
+        if (firstNonEmptyRow === -1) {
+          firstNonEmptyRow = i;
+        }
         lastNonEmptyRow = i;
-        break;
       }
     }
 
@@ -69,17 +64,13 @@ shaka.cea.CeaUtils = class {
       let firstNonEmptyCol = -1;
       let lastNonEmptyCol = -1;
 
+      // Find the first and last non-empty columns in a single pass.
       for (let j = 0; j < row.length; j++) {
         if (row[j] != null && row[j].getChar().trim() !== '') {
-          firstNonEmptyCol = j;
-          break;
-        }
-      }
-
-      for (let j = row.length - 1; j >= 0; j--) {
-        if (row[j] != null && row[j].getChar().trim() !== '') {
+          if (firstNonEmptyCol === -1) {
+            firstNonEmptyCol = j;
+          }
           lastNonEmptyCol = j;
-          break;
         }
       }
 
@@ -185,6 +176,50 @@ shaka.cea.CeaUtils = class {
     linebreakCue.lineBreak = true;
     return linebreakCue;
   }
+
+  /**
+   * Returns the CEA-608 stream/mode name (e.g. "CC1") for a given field and
+   * channel pair.
+   * @param {number} fieldNum Field number (0 or 1).
+   * @param {number} channelNum Channel number (0 or 1).
+   * @return {string}
+   */
+  static getCea608StreamName(fieldNum, channelNum) {
+    return `CC${((fieldNum << 1) | channelNum) + 1}`;
+  }
+
+  /**
+   * Returns whether the given NALU type is an SEI NALU for the given codec
+   * family.
+   * @param {shaka.cea.CeaUtils.CodecFamily} codecFamily
+   * @param {number} naluType
+   * @return {boolean}
+   */
+  static isSeiNaluType(codecFamily, naluType) {
+    const CeaUtils = shaka.cea.CeaUtils;
+    switch (codecFamily) {
+      case CeaUtils.CodecFamily.H264:
+        return naluType == CeaUtils.H264_NALU_TYPE_SEI;
+      case CeaUtils.CodecFamily.H265:
+        return naluType == CeaUtils.H265_PREFIX_NALU_TYPE_SEI ||
+            naluType == CeaUtils.H265_SUFFIX_NALU_TYPE_SEI;
+      case CeaUtils.CodecFamily.H266:
+        return naluType == CeaUtils.H266_PREFIX_NALU_TYPE_SEI ||
+            naluType == CeaUtils.H266_SUFFIX_NALU_TYPE_SEI;
+      default:
+        return false;
+    }
+  }
+};
+
+/**
+ * Video codec families that can carry CEA captions in SEI NALUs.
+ * @enum {number}
+ */
+shaka.cea.CeaUtils.CodecFamily = {
+  H264: 0,
+  H265: 1,
+  H266: 2,
 };
 
 shaka.cea.CeaUtils.StyledChar = class {

--- a/lib/cea/dtvcc_packet_builder.js
+++ b/lib/cea/dtvcc_packet_builder.js
@@ -93,9 +93,6 @@ shaka.cea.DtvccPacketBuilder = class {
   /** Clear built packets and packets in progress. */
   clear() {
     this.builtPackets_ = [];
-    // null (not []) signals that no packet is currently open, matching the
-    // constructor and the check in addByte(). Using [] here would let a stray
-    // data byte create a spurious empty packet.
     this.currentPacketBeingBuilt_ = null;
     this.bytesLeftToAddInCurrentPacket_ = 0;
   }

--- a/lib/cea/dtvcc_packet_builder.js
+++ b/lib/cea/dtvcc_packet_builder.js
@@ -93,7 +93,10 @@ shaka.cea.DtvccPacketBuilder = class {
   /** Clear built packets and packets in progress. */
   clear() {
     this.builtPackets_ = [];
-    this.currentPacketBeingBuilt_ = [];
+    // null (not []) signals that no packet is currently open, matching the
+    // constructor and the check in addByte(). Using [] here would let a stray
+    // data byte create a spurious empty packet.
+    this.currentPacketBeingBuilt_ = null;
     this.bytesLeftToAddInCurrentPacket_ = 0;
   }
 };
@@ -132,16 +135,13 @@ shaka.cea.DtvccPacket = class {
   }
 
   /**
-   * Reads a byte from the packet. TODO CONSIDER RENAMING THIS TO BLOCK
+   * Reads a byte from the packet.
    * @return {!shaka.cea.Cea708Service.Cea708Byte}
    * @throws {!shaka.util.Error}
    */
   readByte() {
     if (!this.hasMoreData()) {
-      throw new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.TEXT,
-          shaka.util.Error.Code.BUFFER_READ_OUT_OF_BOUNDS);
+      throw this.outOfBoundsError_();
     }
     return this.packetData_[this.pos_++];
   }
@@ -153,10 +153,7 @@ shaka.cea.DtvccPacket = class {
    */
   skip(numBlocks) {
     if (this.pos_ + numBlocks > this.packetData_.length) {
-      throw new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.TEXT,
-          shaka.util.Error.Code.BUFFER_READ_OUT_OF_BOUNDS);
+      throw this.outOfBoundsError_();
     }
     this.pos_ += numBlocks;
   }
@@ -168,12 +165,21 @@ shaka.cea.DtvccPacket = class {
    */
   rewind(numBlocks) {
     if (this.pos_ - numBlocks < 0) {
-      throw new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.TEXT,
-          shaka.util.Error.Code.BUFFER_READ_OUT_OF_BOUNDS);
+      throw this.outOfBoundsError_();
     }
     this.pos_ -= numBlocks;
+  }
+
+  /**
+   * Builds the error thrown when a read would go outside the packet bounds.
+   * @return {!shaka.util.Error}
+   * @private
+   */
+  outOfBoundsError_() {
+    return new shaka.util.Error(
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.TEXT,
+        shaka.util.Error.Code.BUFFER_READ_OUT_OF_BOUNDS);
   }
 };
 

--- a/lib/cea/mp4_cea_parser.js
+++ b/lib/cea/mp4_cea_parser.js
@@ -282,6 +282,23 @@ shaka.cea.Mp4CeaParser = class {
   }
 
   /**
+   * Flattens the per-TRUN sample data into a single array and advances the
+   * reader to the first sample's data offset within the mdat box.
+   * @param {!shaka.util.DataViewReader} reader
+   * @param {number} offset
+   * @param {!Array<shaka.util.ParsedTRUNBox>} parsedTRUNs
+   * @return {!Array<shaka.util.ParsedTRUNSample>}
+   * @private
+   */
+  getSampleData_(reader, offset, parsedTRUNs) {
+    // Combine all sample data. This assumes that the samples described across
+    // multiple trun boxes are still continuous in the mdat box.
+    const sampleData = [].concat(...parsedTRUNs.map((t) => t.sampleData));
+    reader.skip(offset + parsedTRUNs[0].dataOffset);
+    return sampleData;
+  }
+
+  /**
    * Parse MDAT box.
    * @param {!shaka.util.DataViewReader} reader
    * @param {number} time
@@ -305,16 +322,11 @@ shaka.cea.Mp4CeaParser = class {
     // composition time offset, we default to 0.
     let sampleSize = defaultSampleSize;
 
-    // Combine all sample data.  This assumes that the samples described across
-    // multiple trun boxes are still continuous in the mdat box.
-    const sampleDatas = parsedTRUNs.map((t) => t.sampleData);
-    const sampleData = [].concat(...sampleDatas);
+    const sampleData = this.getSampleData_(reader, offset, parsedTRUNs);
 
     if (sampleData.length) {
       sampleSize = sampleData[0].sampleSize || defaultSampleSize;
     }
-
-    reader.skip(offset + parsedTRUNs[0].dataOffset);
 
     while (reader.hasMoreData()) {
       const naluSize = reader.readUint32();
@@ -328,26 +340,22 @@ shaka.cea.Mp4CeaParser = class {
       switch (this.bitstreamFormat_) {
         case BitstreamFormat.H264:
           naluType = naluHeader & 0x1f;
-          isSeiMessage = naluType == CeaUtils.H264_NALU_TYPE_SEI;
+          isSeiMessage =
+              CeaUtils.isSeiNaluType(CeaUtils.CodecFamily.H264, naluType);
           break;
 
+        // H.265 and H.266 share the same NAL unit header parsing and only
+        // differ in which codec family's SEI types to match against.
         case BitstreamFormat.H265:
+        case BitstreamFormat.H266: {
           naluHeaderSize = 2;
           reader.skip(1);
           naluType = (naluHeader >> 1) & 0x3f;
-          isSeiMessage =
-              naluType == CeaUtils.H265_PREFIX_NALU_TYPE_SEI ||
-              naluType == CeaUtils.H265_SUFFIX_NALU_TYPE_SEI;
+          const family = this.bitstreamFormat_ === BitstreamFormat.H265 ?
+              CeaUtils.CodecFamily.H265 : CeaUtils.CodecFamily.H266;
+          isSeiMessage = CeaUtils.isSeiNaluType(family, naluType);
           break;
-
-        case BitstreamFormat.H266:
-          naluHeaderSize = 2;
-          reader.skip(1);
-          naluType = (naluHeader >> 1) & 0x3f;
-          isSeiMessage =
-              naluType == CeaUtils.H266_PREFIX_NALU_TYPE_SEI ||
-              naluType == CeaUtils.H266_SUFFIX_NALU_TYPE_SEI;
-          break;
+        }
 
         default:
           return;
@@ -415,10 +423,7 @@ shaka.cea.Mp4CeaParser = class {
    */
   parseC608Mdat_(reader, time, timescale, defaultSampleDuration,
       defaultSampleSize, offset, parsedTRUNs, captionPackets) {
-    const sampleDatas = parsedTRUNs.map((t) => t.sampleData);
-    const sampleData = [].concat(...sampleDatas);
-
-    reader.skip(offset + parsedTRUNs[0].dataOffset);
+    const sampleData = this.getSampleData_(reader, offset, parsedTRUNs);
 
     let currentTime = time;
 

--- a/lib/cea/sei_processor.js
+++ b/lib/cea/sei_processor.js
@@ -6,9 +6,13 @@
 
 goog.provide('shaka.cea.SeiProcessor');
 
+goog.require('shaka.util.Uint8ArrayUtils');
+
 
 /**
- * H.264 SEI NALU Parser used for extracting 708 closed caption packets.
+ * SEI NALU parser used for extracting closed caption packets. The SEI message
+ * syntax is identical across H.264, H.265 and H.266, so the same parser handles
+ * all three.
  */
 shaka.cea.SeiProcessor = class {
   /**
@@ -18,29 +22,30 @@ shaka.cea.SeiProcessor = class {
    */
   process(naluData) {
     const seiPayloads = [];
-    const naluClone = this.removeEmu(naluData);
+    const naluClone =
+        shaka.util.Uint8ArrayUtils.removeEmulationPreventionBytes(naluData);
 
-    // The following is an implementation of section 7.3.2.3.1
-    // in Rec. ITU-T H.264 (06/2019), the H.264 spec.
+    // The following parses the SEI message syntax, which is identical across
+    // H.264 (Rec. ITU-T H.264 (06/2019), section 7.3.2.3.1), H.265 and H.266.
     let offset = 0;
 
     while (offset < naluClone.length) {
-      let payloadType = 0; // SEI payload type as defined by H.264 spec
+      let payloadType = 0; // SEI payload type as defined by the spec.
       while (naluClone[offset] == 0xFF) {
         payloadType += 255;
         offset++;
       }
       payloadType += naluClone[offset++];
 
-      let payloadSize = 0; // SEI payload size as defined by H.264 spec
+      let payloadSize = 0; // SEI payload size as defined by the spec.
       while (naluClone[offset] == 0xFF) {
         payloadSize += 255;
         offset++;
       }
       payloadSize += naluClone[offset++];
 
-      // Payload type 4 is user_data_registered_itu_t_t35, as per the H.264
-      // spec. This payload type contains caption data.
+      // Payload type 4 is user_data_registered_itu_t_t35, as per the spec.
+      // This payload type contains caption data.
       if (payloadType == 0x04) {
         seiPayloads.push(naluClone.subarray(offset, offset + payloadSize));
       }
@@ -48,40 +53,5 @@ shaka.cea.SeiProcessor = class {
     }
 
     return seiPayloads;
-  }
-
-
-  /**
-   * Removes H.264 emulation prevention bytes from the byte array.
-   *
-   * Note: Remove bytes by shifting will cause Chromium (VDA) to complain
-   * about conformance. Recreating a new array solves it.
-   *
-   * @param {!Uint8Array} naluData NALU from which EMUs should be removed.
-   * @return {!Uint8Array} The NALU with the emulation prevention byte removed.
-   */
-  removeEmu(naluData) {
-    let naluClone = naluData;
-    let zeroCount = 0;
-    let src = 0;
-    while (src < naluClone.length) {
-      if (zeroCount == 2 && naluClone[src] == 0x03) {
-        // 0x00, 0x00, 0x03 pattern detected
-        zeroCount = 0;
-
-        // Splice the array and recreate a new one, instead of shifting bytes
-        const newArr = [...naluClone];
-        newArr.splice(src, 1);
-        naluClone = new Uint8Array(newArr);
-      } else {
-        if (naluClone[src] == 0x00) {
-          zeroCount++;
-        } else {
-          zeroCount = 0;
-        }
-      }
-      src++;
-    }
-    return naluClone;
   }
 };

--- a/lib/cea/ts_cea_parser.js
+++ b/lib/cea/ts_cea_parser.js
@@ -59,21 +59,21 @@ shaka.cea.TsCeaParser = class {
     const tsParser = this.tsParser_.parse(uint8ArrayData);
     const codecs = tsParser.getCodecs();
     const videoNalus = tsParser.getVideoNalus();
-    const validNaluTypes = [];
+    let codecFamily = null;
     switch (codecs.video) {
       case 'avc':
-        validNaluTypes.push(CeaUtils.H264_NALU_TYPE_SEI);
+        codecFamily = CeaUtils.CodecFamily.H264;
         break;
       case 'hvc':
-        validNaluTypes.push(CeaUtils.H265_PREFIX_NALU_TYPE_SEI);
-        validNaluTypes.push(CeaUtils.H265_SUFFIX_NALU_TYPE_SEI);
+        codecFamily = CeaUtils.CodecFamily.H265;
         break;
     }
-    if (!validNaluTypes.length) {
+    if (codecFamily == null) {
       return captionPackets;
     }
     for (const nalu of videoNalus) {
-      if (validNaluTypes.includes(nalu.type) && nalu.time != null) {
+      if (nalu.time != null &&
+          CeaUtils.isSeiNaluType(codecFamily, nalu.type)) {
         for (const packet of this.seiProcessor_.process(nalu.data)) {
           captionPackets.push({
             packet: packet,

--- a/lib/media/closed_caption_parser.js
+++ b/lib/media/closed_caption_parser.js
@@ -23,7 +23,7 @@ shaka.media.ClosedCaptionParser = class {
    * @param {string} mimeType
    */
   constructor(mimeType) {
-    /** @private {Map<number, shaka.extern.ICaptionDecoder>} */
+    /** @private {!Map<number, !shaka.extern.ICaptionDecoder>} */
     this.decoderCache_ = new Map();
     /** @private {number} */
     this.currentContinuityTimeline_ = 0;
@@ -117,19 +117,18 @@ shaka.media.ClosedCaptionParser = class {
    * @private
    */
   updateDecoder_(continuityTimeline) {
-    const decoder = this.decoderCache_.get(continuityTimeline);
-
+    // updateDecoder_ is only ever called when the timeline actually changes, so
+    // continuityTimeline is always different from the current one, and saving
+    // the current decoder here doesn't affect the lookup below.
     this.decoderCache_.set(this.currentContinuityTimeline_, this.ceaDecoder_);
 
-    if (decoder) {
-      this.ceaDecoder_ = decoder;
-    } else {
-      const decoderFactory = shaka.media.ClosedCaptionParser.findDecoder();
-      if (decoderFactory) {
-        this.ceaDecoder_ = decoderFactory();
-      }
-      this.decoderCache_.set(continuityTimeline, this.ceaDecoder_);
-    }
+    // Reuse the cached decoder for this timeline, or create (and cache) one. If
+    // no decoder is registered, keep using the current one.
+    this.ceaDecoder_ = this.decoderCache_.getOrInsertComputed(
+        continuityTimeline, () => {
+          const decoderFactory = shaka.media.ClosedCaptionParser.findDecoder();
+          return decoderFactory ? decoderFactory() : this.ceaDecoder_;
+        });
   }
 
   /**
@@ -150,12 +149,11 @@ shaka.media.ClosedCaptionParser = class {
     const timelines = new Set(timelinesToKeep);
     for (const key of this.decoderCache_.keys()) {
       if (!timelines.has(key)) {
-        let decoder = this.decoderCache_.get(key);
+        const decoder = this.decoderCache_.get(key);
         if (decoder) {
           decoder.clear();
         }
         this.decoderCache_.delete(key);
-        decoder = null;
       }
     }
   }

--- a/lib/util/exp_golomb.js
+++ b/lib/util/exp_golomb.js
@@ -17,7 +17,7 @@
 
 goog.provide('shaka.util.ExpGolomb');
 
-goog.require('shaka.util.BufferUtils');
+goog.require('shaka.util.Uint8ArrayUtils');
 
 
 /**
@@ -37,7 +37,8 @@ shaka.util.ExpGolomb = class {
     /** @private {!Uint8Array} */
     this.data_ = data;
     if (convertEbsp2rbsp) {
-      this.data_ = this.ebsp2rbsp_(data);
+      this.data_ =
+          shaka.util.Uint8ArrayUtils.removeEmulationPreventionBytes(data);
     }
 
     /** @private {number} */
@@ -50,29 +51,6 @@ shaka.util.ExpGolomb = class {
     // the number of bits left to examine in the current word
     /** @private {number} */
     this.workingBitsAvailable_ = 0;
-  }
-
-  /**
-   * @param {!Uint8Array} data
-   * @return {!Uint8Array}
-   * @private
-   */
-  ebsp2rbsp_(data) {
-    const ret = new Uint8Array(data.byteLength);
-    let retIndex = 0;
-
-    for (let i = 0; i < data.byteLength; i++) {
-      if (i >= 2) {
-        // Unescape: Skip 0x03 after 00 00
-        if (data[i] == 0x03 && data[i - 1] == 0x00 && data[i - 2] == 0x00) {
-          continue;
-        }
-      }
-      ret[retIndex] = data[i];
-      retIndex++;
-    }
-
-    return shaka.util.BufferUtils.toUint8(ret, 0, retIndex);
   }
 
   /**

--- a/lib/util/uint8array_utils.js
+++ b/lib/util/uint8array_utils.js
@@ -164,4 +164,37 @@ shaka.util.Uint8ArrayUtils = class {
 
     return result;
   }
+
+  /**
+   * Removes H.264/H.265/H.266 emulation prevention bytes (the 0x03 that follows
+   * a 0x00 0x00 sequence) from a NAL unit, i.e. converts EBSP to RBSP.
+   *
+   * Builds the result in a single pass into a freshly allocated array. Using a
+   * new array (rather than shifting bytes in place) keeps Chromium (VDA) happy
+   * about NAL unit length conformance.
+   *
+   * @param {!Uint8Array} data
+   * @return {!Uint8Array}
+   */
+  static removeEmulationPreventionBytes(data) {
+    const result = new Uint8Array(data.length);
+    let zeroCount = 0;
+    let dst = 0;
+    for (let src = 0; src < data.length; src++) {
+      const byte = data[src];
+      if (zeroCount >= 2 && byte == 0x03) {
+        // 0x00, 0x00, 0x03 pattern detected; drop the emulation prevention
+        // byte and reset the zero run.
+        zeroCount = 0;
+        continue;
+      }
+      result[dst++] = byte;
+      if (byte == 0x00) {
+        zeroCount++;
+      } else {
+        zeroCount = 0;
+      }
+    }
+    return result.subarray(0, dst);
+  }
 };

--- a/test/cea/mp4_cea_parser_unit.js
+++ b/test/cea/mp4_cea_parser_unit.js
@@ -59,32 +59,6 @@ describe('Mp4CeaParser', () => {
     ]);
   });
 
-  /**
-   * Test only the functionality of removing EPB
-   * Expect removeEmu() to return the NALU with correct length
-   *
-   * Chromium VDA has a strict standard on NALU length
-   * It will complain about conformance if the array is malformed
-   *
-   * If EPB is removed by shifting bytes, it will return the original NALU
-   * length, which will fail this test
-   *
-   * Note that the CEA-608 packet in this test is incomplete
-   */
-  it('parses CEA-608 SEI data from MP4 H.264 stream', () => {
-    const seiProcessor = new shaka.cea.SeiProcessor();
-
-    const cea608Packet = new Uint8Array([
-      0x00, 0x00, 0x03, // Emulation prevention byte
-    ]);
-
-    const naluData = seiProcessor.removeEmu(cea608Packet);
-    expect(naluData).toBeDefined();
-
-    // EPB should be removed by returning new array, not by shifting bytes
-    expect(naluData.length).toBe(2);
-  });
-
   it('parses cea data from mp4 stream', () => {
     const cea708Parser = new shaka.cea.Mp4CeaParser();
 

--- a/test/media/closed_caption_parser_unit.js
+++ b/test/media/closed_caption_parser_unit.js
@@ -33,7 +33,7 @@ describe('ClosedCaptionParser', () => {
   /**
    * @suppress {visibility}
    * @param {shaka.media.ClosedCaptionParser} parser
-   * @return {Map<number, shaka.extern.ICaptionDecoder>}
+   * @return {!Map<number, !shaka.extern.ICaptionDecoder>}
    */
   function getDecoderCache(parser) {
     return parser.decoderCache_;

--- a/test/util/uint8array_utils_unit.js
+++ b/test/util/uint8array_utils_unit.js
@@ -90,4 +90,56 @@ describe('Uint8ArrayUtils', () => {
       expect(Uint8ArrayUtils.concatRange([])).toEqual(new Uint8Array([]));
     });
   });
+
+  describe('removeEmulationPreventionBytes', () => {
+    const removeEmu = (/** @type {!Array<number>} */ arr) =>
+      Uint8ArrayUtils.removeEmulationPreventionBytes(new Uint8Array(arr));
+
+    it('removes a single emulation prevention byte', () => {
+      // 0x00, 0x00, 0x03 -> the 0x03 is dropped.
+      expect(removeEmu([0x00, 0x00, 0x03]))
+          .toEqual(new Uint8Array([0x00, 0x00]));
+    });
+
+    it('returns a new array without mutating the input', () => {
+      // Chromium VDA is strict about NAL unit length, so the result must be a
+      // freshly built array (correct, shortened length) and the input must be
+      // left untouched rather than having its bytes shifted in place.
+      const input = new Uint8Array([0x00, 0x00, 0x03]);
+      const result = Uint8ArrayUtils.removeEmulationPreventionBytes(input);
+      expect(result).toEqual(new Uint8Array([0x00, 0x00]));
+      expect(input).toEqual(new Uint8Array([0x00, 0x00, 0x03]));
+    });
+
+    it('removes consecutive emulation prevention bytes', () => {
+      expect(removeEmu([0x00, 0x00, 0x03, 0x00, 0x00, 0x03]))
+          .toEqual(new Uint8Array([0x00, 0x00, 0x00, 0x00]));
+    });
+
+    it('removes an emulation prevention byte after three zeros', () => {
+      expect(removeEmu([0x00, 0x00, 0x00, 0x03]))
+          .toEqual(new Uint8Array([0x00, 0x00, 0x00]));
+    });
+
+    it('keeps a 0x03 not preceded by two zeros', () => {
+      expect(removeEmu([0x00, 0x03])).toEqual(new Uint8Array([0x00, 0x03]));
+      expect(removeEmu([0x01, 0x00, 0x03]))
+          .toEqual(new Uint8Array([0x01, 0x00, 0x03]));
+    });
+
+    it('keeps data without emulation prevention bytes', () => {
+      expect(removeEmu([0x01, 0x02, 0x03, 0x04]))
+          .toEqual(new Uint8Array([0x01, 0x02, 0x03, 0x04]));
+    });
+
+    it('handles a mix of escaped and unescaped bytes', () => {
+      // 0x00 0x00 0x03 (escaped) then 0x01, then 0x00 0x00 0x03 0x04 (escaped).
+      expect(removeEmu([0x00, 0x00, 0x03, 0x01, 0x00, 0x00, 0x03, 0x04]))
+          .toEqual(new Uint8Array([0x00, 0x00, 0x01, 0x00, 0x00, 0x04]));
+    });
+
+    it('handles empty input', () => {
+      expect(removeEmu([])).toEqual(new Uint8Array([]));
+    });
+  });
 });


### PR DESCRIPTION
Centralize NAL emulation-prevention-byte removal in Uint8ArrayUtils (shared with ExpGolomb), unify CEA-608 stream naming and SEI NALU-type detection, and streamline the 608/708 decoders, MP4 parser, and ClosedCaptionParser. Includes correctness fixes, single-pass scans, and comment/typing cleanups.