### PR TITLE
feat(HLS): Allow encrypted MSE playback with legacy Apple MediaKeys

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -5599,14 +5599,6 @@ shaka.hls.HlsParser = class {
           shaka.util.Error.Code.HLS_MSE_ENCRYPTED_MP2T_NOT_SUPPORTED);
     }
 
-    if (shaka.drm.DrmUtils.isMediaKeysPolyfilled('apple')) {
-      throw new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.MANIFEST,
-          shaka.util.Error.Code
-              .HLS_MSE_ENCRYPTED_LEGACY_APPLE_MEDIA_KEYS_NOT_SUPPORTED);
-    }
-
     const method = drmTag.getRequiredAttrValue('METHOD');
     const VALID_METHODS = ['SAMPLE-AES', 'SAMPLE-AES-CTR'];
     if (!VALID_METHODS.includes(method)) {


### PR DESCRIPTION
Removes the HLS_MSE_ENCRYPTED_LEGACY_APPLE_MEDIA_KEYS_NOT_SUPPORTED guard that rejected encrypted SAMPLE-AES content via MSE when the Apple MediaKeys are polyfilled. This is no longer required after the addition of ClearKey playback in Safari through WebCrypto: https://github.com/shaka-project/shaka-player/commit/f349d0a06e583862dff2fe0a5561c6bd4a3f439d