### PR TITLE
test: Add unit tests for Hisense, PlayStation, TitanOS, TiVoOS, Vizio and Xbox

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -228,6 +228,7 @@ Playready
 Quicktime
 svta
 teppeis
+TiVo
 Tizen
 Uplynk
 Verimatrix

--- a/shaka-player.uncompiled.js
+++ b/shaka-player.uncompiled.js
@@ -23,6 +23,7 @@ goog.require('shaka.device.DefaultBrowser');
 goog.require('shaka.device.Hisense');
 goog.require('shaka.device.PlayStation');
 goog.require('shaka.device.TitanOS');
+goog.require('shaka.device.TiVoOS');
 goog.require('shaka.device.Tizen');
 goog.require('shaka.device.Vizio');
 goog.require('shaka.device.WebKitSTB');

--- a/test/device/hisense_unit.js
+++ b/test/device/hisense_unit.js
@@ -1,0 +1,39 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('Hisense', () => {
+  /* eslint-disable @stylistic/max-len */
+  // cspell:disable
+  const hisenseUhd = 'Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Odin/88.4324.2.10 Safari/537.36 Model/Hisense-NT72671D VIDAA/6.0(Hisense;SmartTV;55A66GXVT;NT72671/V0000.06.12X.N1212;UHD;55A6GX;)';
+  const hisenseFhd = 'Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36 OMI/4.20.3.54 Model/Hisense-MSD6886 VIDAA/4.0(Hisense;SmartTV;HE43A6100;mstar6886/V0000.01.00T.K1112;FHD)';
+  // cspell:enable
+  /* eslint-enable @stylistic/max-len */
+
+  const Util = shaka.test.Util;
+  const originalUserAgent = navigator.userAgent;
+
+  afterEach(() => {
+    Util.setUserAgent(originalUserAgent);
+  });
+
+  it('reports the right device name and type', () => {
+    Util.setUserAgent(hisenseUhd);
+    const device = new shaka.device.Hisense();
+    expect(device.getDeviceName()).toBe('Hisense');
+    expect(device.getDeviceType()).toBe(shaka.device.IDevice.DeviceType.TV);
+    expect(device.getVersion()).toBe(null);
+  });
+
+  it('detects max hardware resolution from the user agent', async () => {
+    Util.setUserAgent(hisenseUhd);
+    expect(await new shaka.device.Hisense().detectMaxHardwareResolution())
+        .toEqual({width: 3840, height: 2160});
+
+    Util.setUserAgent(hisenseFhd);
+    expect(await new shaka.device.Hisense().detectMaxHardwareResolution())
+        .toEqual({width: 1920, height: 1080});
+  });
+});

--- a/test/device/playstation_unit.js
+++ b/test/device/playstation_unit.js
@@ -1,0 +1,55 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('PlayStation', () => {
+  /* eslint-disable @stylistic/max-len */
+  // cspell:disable
+  const ps4 = 'Mozilla/5.0 (PlayStation 4 WebMAF) AppleWebKit/538.8 (KHTML, like Gecko) WebMAF/v2.3.0-0-g349b724';
+  const ps4Pro = 'Mozilla/5.0 (PlayStation 4 PRO WebMAF, HEVC) AppleWebKit/605.1.15 (KHTML, like Gecko) WebMAF/v3.2.4-0-g236ca012 SDK: (0x12008011u), Built: Feb  5 2025 14:07:28';
+  const ps5 = 'Mozilla/5.0 (PlayStation; PlayStation 5/10.00) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15';
+  // cspell:enable
+  /* eslint-enable @stylistic/max-len */
+
+  const Util = shaka.test.Util;
+  const originalUserAgent = navigator.userAgent;
+
+  afterEach(() => {
+    Util.setUserAgent(originalUserAgent);
+  });
+
+  it('checks PlayStation version', () => {
+    Util.setUserAgent(ps4);
+    expect(new shaka.device.PlayStation().getVersion()).toBe(4);
+    Util.setUserAgent(ps4Pro);
+    expect(new shaka.device.PlayStation().getVersion()).toBe(4);
+    Util.setUserAgent(ps5);
+    expect(new shaka.device.PlayStation().getVersion()).toBe(5);
+  });
+
+  it('reports the right device name, type and engine', () => {
+    Util.setUserAgent(ps5);
+    const device = new shaka.device.PlayStation();
+    expect(device.getDeviceName()).toBe('PlayStation');
+    expect(device.getDeviceType())
+        .toBe(shaka.device.IDevice.DeviceType.CONSOLE);
+    expect(device.getBrowserEngine())
+        .toBe(shaka.device.IDevice.BrowserEngine.WEBKIT);
+  });
+
+  it('applies PS4-specific quirks only on PlayStation 4', () => {
+    Util.setUserAgent(ps4);
+    const ps4Device = new shaka.device.PlayStation();
+    expect(ps4Device.shouldAvoidUseTextDecoderEncoder()).toBe(true);
+    expect(ps4Device.returnLittleEndianUsingPlayReady()).toBe(true);
+    expect(ps4Device.supportsEncryptionSchemePolyfill()).toBe(false);
+
+    Util.setUserAgent(ps5);
+    const ps5Device = new shaka.device.PlayStation();
+    expect(ps5Device.shouldAvoidUseTextDecoderEncoder()).toBe(false);
+    expect(ps5Device.returnLittleEndianUsingPlayReady()).toBe(false);
+    expect(ps5Device.supportsEncryptionSchemePolyfill()).toBe(true);
+  });
+});

--- a/test/device/titan_os_unit.js
+++ b/test/device/titan_os_unit.js
@@ -1,0 +1,29 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('TitanOS', () => {
+  /* eslint-disable @stylistic/max-len */
+  // See: https://docs.titanos.tv/user-agents
+  // cspell:disable
+  const titanOs = 'Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.128 Safari/537.36 OMI/4.24.3.93.MIKE.227 Model/Vestel-MB190 VSTVB MB100 FVC/9.0 (VESTEL; MB190; ) HbbTV/1.7.1 (+DRM; VESTEL; MB190; 0.9.0.0; ; _TV__2025;) TitanOS/3.0 (Vestel MB190 VESTEL) SmartTvA/3.0.0';
+  // cspell:enable
+  /* eslint-enable @stylistic/max-len */
+
+  const Util = shaka.test.Util;
+  const originalUserAgent = navigator.userAgent;
+
+  afterEach(() => {
+    Util.setUserAgent(originalUserAgent);
+  });
+
+  it('reports the right device name and type', () => {
+    Util.setUserAgent(titanOs);
+    const device = new shaka.device.TitanOS();
+    expect(device.getDeviceName()).toBe('TitanOS');
+    expect(device.getDeviceType()).toBe(shaka.device.IDevice.DeviceType.TV);
+    expect(device.getVersion()).toBe(null);
+  });
+});

--- a/test/device/tivo_os_unit.js
+++ b/test/device/tivo_os_unit.js
@@ -1,0 +1,30 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('TiVoOS', () => {
+  /* eslint-disable @stylistic/max-len */
+  // cspell:disable
+  const tivoOs = 'Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.128 Safari/537.36 OPR/46.0.2207.0 OMI/4.23.2.96.LIMA2.127 Model/Vestel-MB180 VSTVB MB100 HbbTV/1.6.1 (+DRM; VESTEL; MB180; 1.63.0.0; ; _TV_G32_2023;) TiVoOS/1.0.0 (Vestel MB180 VESTEL) SmartTvA/3.0.0';
+  // cspell:enable
+  /* eslint-enable @stylistic/max-len */
+
+  const Util = shaka.test.Util;
+  const originalUserAgent = navigator.userAgent;
+
+  afterEach(() => {
+    Util.setUserAgent(originalUserAgent);
+  });
+
+  it('reports the right device name, type and engine', () => {
+    Util.setUserAgent(tivoOs);
+    const device = new shaka.device.TiVoOS();
+    expect(device.getDeviceName()).toBe('TiVoOS');
+    expect(device.getDeviceType()).toBe(shaka.device.IDevice.DeviceType.TV);
+    expect(device.getBrowserEngine())
+        .toBe(shaka.device.IDevice.BrowserEngine.CHROMIUM);
+    expect(device.getVersion()).toBe(null);
+  });
+});

--- a/test/device/vizio_unit.js
+++ b/test/device/vizio_unit.js
@@ -1,0 +1,28 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('Vizio', () => {
+  /* eslint-disable @stylistic/max-len */
+  // cspell:disable
+  const vizio = 'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36 CrKey/1.0.999999 VIZIO SmartCast(Conjure/MTKF-5.1.516.1 FW/0.6.11.1-2 Model/V50C6-J09)';
+  // cspell:enable
+  /* eslint-enable @stylistic/max-len */
+
+  const Util = shaka.test.Util;
+  const originalUserAgent = navigator.userAgent;
+
+  afterEach(() => {
+    Util.setUserAgent(originalUserAgent);
+  });
+
+  it('reports the right device name and type', () => {
+    Util.setUserAgent(vizio);
+    const device = new shaka.device.Vizio();
+    expect(device.getDeviceName()).toBe('Vizio');
+    expect(device.getDeviceType()).toBe(shaka.device.IDevice.DeviceType.TV);
+    expect(device.getVersion()).toBe(null);
+  });
+});

--- a/test/device/xbox_unit.js
+++ b/test/device/xbox_unit.js
@@ -1,0 +1,44 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('Xbox', () => {
+  /* eslint-disable @stylistic/max-len */
+  // Xbox One ships the legacy EdgeHTML browser (token "Edge/").
+  const xboxOne = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/18.18363';
+  /* eslint-enable @stylistic/max-len */
+
+  const Util = shaka.test.Util;
+  const originalUserAgent = navigator.userAgent;
+
+  afterEach(() => {
+    Util.setUserAgent(originalUserAgent);
+  });
+
+  it('checks Xbox version', () => {
+    Util.setUserAgent(xboxOne);
+    expect(new shaka.device.Xbox().getVersion()).toBe(18);
+  });
+
+  it('detects the legacy Edge browser engine', () => {
+    Util.setUserAgent(xboxOne);
+    expect(new shaka.device.Xbox().getBrowserEngine())
+        .toBe(shaka.device.IDevice.BrowserEngine.EDGE);
+  });
+
+  it('reports the right device name and type', () => {
+    Util.setUserAgent(xboxOne);
+    const device = new shaka.device.Xbox();
+    expect(device.getDeviceName()).toBe('Xbox');
+    expect(device.getDeviceType())
+        .toBe(shaka.device.IDevice.DeviceType.CONSOLE);
+  });
+
+  it('overrides Dolby Vision codecs on legacy Edge', () => {
+    Util.setUserAgent(xboxOne);
+    expect(new shaka.device.Xbox().shouldOverrideDolbyVisionCodecs())
+        .toBe(true);
+  });
+});

--- a/transmuxer_worker.uncompiled.js
+++ b/transmuxer_worker.uncompiled.js
@@ -45,6 +45,7 @@ goog.require('shaka.device.DefaultBrowser');
 goog.require('shaka.device.Hisense');
 goog.require('shaka.device.PlayStation');
 goog.require('shaka.device.TitanOS');
+goog.require('shaka.device.TiVoOS');
 goog.require('shaka.device.Tizen');
 goog.require('shaka.device.Vizio');
 goog.require('shaka.device.WebKitSTB');


### PR DESCRIPTION
Add unit tests covering version parsing, device identity, browser engine and version-specific behavior for the six device classes, using real user agent strings from the vendor specifications.

While adding the TiVoOS test it became apparent that shaka.device.TiVoOS was only listed in build/types/devices, so the device was never required from the uncompiled entry points and therefore never registered in uncompiled/debug builds (nor available to the tests). Add the missing goog.require to shaka-player.uncompiled.js and transmuxer_worker.uncompiled.js.