### PR TITLE
feat(DASH): Support Essential/SupplementalProperty at MPD and Period level

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -1366,7 +1366,7 @@ shaka.dash.DashParser = class {
    */
   checkMpdEssentialProperties_(mpd) {
     const supported = shaka.dash.DashParser.SUPPORTED_ESSENTIAL_PROPERTIES_;
-    const {essentials} = shaka.dash.MpdUtils.parseDescriptors(mpd);
+    const essentials = shaka.dash.MpdUtils.parseEssentialProperties(mpd);
     if (!essentials.length) {
       return;
     }
@@ -1401,7 +1401,7 @@ shaka.dash.DashParser = class {
    * @private
    */
   parseMpdChaining_(mpd) {
-    const {supplementals} = shaka.dash.MpdUtils.parseDescriptors(mpd);
+    const supplementals = shaka.dash.MpdUtils.parseSupplementalProperties(mpd);
     const chaining = shaka.dash.MpdUtils.getDescriptor(
         supplementals, 'urn:mpeg:dash:chaining:2016');
     if (!chaining || !chaining.value) {
@@ -1743,8 +1743,8 @@ shaka.dash.DashParser = class {
     }
 
 
-    const {supplementals} =
-        shaka.dash.MpdUtils.parseDescriptors(periodInfo.node);
+    const supplementals =
+        shaka.dash.MpdUtils.parseSupplementalProperties(periodInfo.node);
     for (const prop of supplementals) {
       if (prop.schemeIdUri == 'urn:mpeg:dash:urlparam:2014') {
         const urlParams = this.getURLParametersFunction_(prop.element);
@@ -2039,10 +2039,10 @@ shaka.dash.DashParser = class {
       }
     };
 
-    const {
-      essentials: essentialProperties,
-      supplementals: supplementalProperties,
-    } = shaka.dash.MpdUtils.parseDescriptors(elem);
+    const essentialProperties =
+        shaka.dash.MpdUtils.parseEssentialProperties(elem);
+    const supplementalProperties =
+        shaka.dash.MpdUtils.parseSupplementalProperties(elem);
     // ID of real AdaptationSet if this is a trick mode set:
     let trickModeFor = null;
     let isFastSwitching = false;
@@ -2466,10 +2466,10 @@ shaka.dash.DashParser = class {
 
     context.roles = roles;
 
-    const {
-      essentials: essentialProperties,
-      supplementals: supplementalProperties,
-    } = shaka.dash.MpdUtils.parseDescriptors(node);
+    const essentialProperties =
+        shaka.dash.MpdUtils.parseEssentialProperties(node);
+    const supplementalProperties =
+        shaka.dash.MpdUtils.parseSupplementalProperties(node);
     const contentProtectionElements =
         TXml.findChildren(node, 'ContentProtection');
 

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -563,6 +563,10 @@ shaka.dash.DashParser = class {
       this.contentSteeringManager_.clearPreviousLocations();
     }
 
+    // Enforce the MPD-level EssentialProperty conformance rule before doing any
+    // heavy processing (ISO/IEC 23009-1 clause 5.8.4.8).
+    this.checkMpdEssentialProperties_(mpd);
+
     // Get any Location elements.  This will update the manifest location and
     // the base URI.
     /** @type {!Array<string>} */
@@ -1351,6 +1355,50 @@ shaka.dash.DashParser = class {
   }
 
   /**
+   * Enforces the EssentialProperty conformance rule at MPD level
+   * (ISO/IEC 23009-1 clause 5.8.4.8).  EssentialProperty descriptors are
+   * grouped by their id attribute, and for each group at least one scheme must
+   * be recognized by the parser.  If a whole group is unrecognized, the content
+   * cannot be presented and parsing fails.
+   *
+   * @param {!shaka.extern.xml.Node} mpd
+   * @private
+   */
+  checkMpdEssentialProperties_(mpd) {
+    const supported = shaka.dash.DashParser.SUPPORTED_ESSENTIAL_PROPERTIES_;
+    const {essentials} = shaka.dash.MpdUtils.parseDescriptors(mpd);
+    if (!essentials.length) {
+      return;
+    }
+    // Group EssentialProperty descriptors by @id.  Descriptors without an @id
+    // do not share an @id with any other, so each is its own group and must be
+    // recognized on its own.
+    /** @type {!Map<string, !Array<shaka.dash.MpdUtils.Descriptor>>} */
+    const groups = new Map();
+    let noIdCounter = 0;
+    for (const descriptor of essentials) {
+      const key = descriptor.id != null ?
+          'id:' + descriptor.id : 'no-id:' + (noIdCounter++);
+      let group = groups.get(key);
+      if (!group) {
+        group = [];
+        groups.set(key, group);
+      }
+      group.push(descriptor);
+    }
+    for (const group of groups.values()) {
+      const recognized = group.some((d) => supported.has(d.schemeIdUri));
+      if (!recognized) {
+        throw new shaka.util.Error(
+            shaka.util.Error.Severity.CRITICAL,
+            shaka.util.Error.Category.MANIFEST,
+            shaka.util.Error.Code.DASH_UNSUPPORTED_ESSENTIAL_PROPERTY,
+            group.map((d) => d.schemeIdUri));
+      }
+    }
+  }
+
+  /**
    * Reads chaining url.
    *
    * @param {!shaka.extern.xml.Node} mpd
@@ -1358,27 +1406,14 @@ shaka.dash.DashParser = class {
    * @private
    */
   parseMpdChaining_(mpd) {
-    const TXml = shaka.util.TXml;
-    const supplementalProperties =
-        TXml.findChildren(mpd, 'SupplementalProperty');
-
-    if (!supplementalProperties.length) {
+    const {supplementals} = shaka.dash.MpdUtils.parseDescriptors(mpd);
+    const chaining = shaka.dash.MpdUtils.getDescriptor(
+        supplementals, 'urn:mpeg:dash:chaining:2016');
+    if (!chaining || !chaining.value) {
       return null;
     }
-
-    for (const prop of supplementalProperties) {
-      const schemeId = prop.attributes['schemeIdUri'];
-      if (schemeId == 'urn:mpeg:dash:chaining:2016') {
-        const url = prop.attributes['value'];
-        if (!url) {
-          return null;
-        }
-        return shaka.util.URL.applyUrlParams(
-            url, this.findRequestParamFn_(mpd, 'chaining'));
-      }
-    }
-
-    return null;
+    return shaka.util.URL.applyUrlParams(
+        chaining.value, this.findRequestParamFn_(mpd, 'chaining'));
   }
 
   /**
@@ -1713,12 +1748,11 @@ shaka.dash.DashParser = class {
     }
 
 
-    const supplementalProperties =
-        TXml.findChildren(periodInfo.node, 'SupplementalProperty');
-    for (const prop of supplementalProperties) {
-      const schemeId = prop.attributes['schemeIdUri'];
-      if (schemeId == 'urn:mpeg:dash:urlparam:2014') {
-        const urlParams = this.getURLParametersFunction_(prop);
+    const {supplementals} =
+        shaka.dash.MpdUtils.parseDescriptors(periodInfo.node);
+    for (const prop of supplementals) {
+      if (prop.schemeIdUri == 'urn:mpeg:dash:urlparam:2014') {
+        const urlParams = this.getURLParametersFunction_(prop.element);
         if (urlParams) {
           context.urlParams = urlParams;
         }
@@ -1966,7 +2000,6 @@ shaka.dash.DashParser = class {
     const scheme = 'urn:mpeg:mpegB:cicp';
     const transferCharacteristicsScheme = `${scheme}:TransferCharacteristics`;
     const colourPrimariesScheme = `${scheme}:ColourPrimaries`;
-    const matrixCoefficientsScheme = `${scheme}:MatrixCoefficients`;
 
     const getVideoRangeFromTransferCharacteristicCICP = (cicp) => {
       switch (cicp) {
@@ -2000,9 +2033,9 @@ shaka.dash.DashParser = class {
       return undefined;
     };
 
-    const parseFont = (prop) => {
-      const fontFamily = prop.attributes['dvb:fontFamily'];
-      const fontUrl = prop.attributes['dvb:url'];
+    const parseFont = (element) => {
+      const fontFamily = element.attributes['dvb:fontFamily'];
+      const fontUrl = element.attributes['dvb:url'];
       if (fontFamily && fontUrl) {
         const uris = shaka.util.URL.resolveUris(
             context.adaptationSet.getBaseUris(), [fontUrl],
@@ -2011,43 +2044,50 @@ shaka.dash.DashParser = class {
       }
     };
 
-    const essentialProperties =
-        TXml.findChildren(elem, 'EssentialProperty');
+    const {
+      essentials: essentialProperties,
+      supplementals: supplementalProperties,
+    } = shaka.dash.MpdUtils.parseDescriptors(elem);
     // ID of real AdaptationSet if this is a trick mode set:
     let trickModeFor = null;
     let isFastSwitching = false;
     let adaptationSetUrlParams = null;
     let unrecognizedEssentialProperty = false;
     for (const prop of essentialProperties) {
-      const schemeId = prop.attributes['schemeIdUri'];
+      const schemeId = prop.schemeIdUri;
+      if (!shaka.dash.DashParser.SUPPORTED_ESSENTIAL_PROPERTIES_.has(
+          schemeId)) {
+        unrecognizedEssentialProperty = true;
+        continue;
+      }
       if (schemeId == 'http://dashif.org/guidelines/trickmode') {
-        trickModeFor = prop.attributes['value'];
+        trickModeFor = prop.value;
       } else if (schemeId == transferCharacteristicsScheme) {
         videoRange = getVideoRangeFromTransferCharacteristicCICP(
-            parseInt(prop.attributes['value'], 10),
+            parseInt(prop.value, 10),
         );
       } else if (schemeId == colourPrimariesScheme) {
         colorGamut = getColorGamutFromColourPrimariesCICP(
-            parseInt(prop.attributes['value'], 10),
+            parseInt(prop.value, 10),
         );
-      } else if (schemeId == matrixCoefficientsScheme) {
-        continue;
-      } else if (schemeId == 'urn:mpeg:dash:ssr:2023' &&
-          this.config_.dash.enableFastSwitching) {
-        isFastSwitching = true;
+      } else if (schemeId == 'urn:mpeg:dash:ssr:2023') {
+        // Fast switching (SSR) is essential: if the client has it disabled, the
+        // containing AdaptationSet cannot be used.
+        if (this.config_.dash.enableFastSwitching) {
+          isFastSwitching = true;
+        } else {
+          unrecognizedEssentialProperty = true;
+        }
       } else if (schemeId == 'urn:dvb:dash:fontdownload:2014') {
-        parseFont(prop);
+        parseFont(prop.element);
       } else if (schemeId == 'urn:mpeg:dash:urlparam:2014') {
-        adaptationSetUrlParams = this.getURLParametersFunction_(prop);
+        adaptationSetUrlParams = this.getURLParametersFunction_(prop.element);
         if (!adaptationSetUrlParams) {
           unrecognizedEssentialProperty = true;
         }
-      } else if (schemeId == 'urn:mpeg:dash:pattern:2024' ||
-          schemeId == 'urn:mpeg:dash:urlparam:2025') {
-        continue;
-      } else {
-        unrecognizedEssentialProperty = true;
       }
+      // Other recognized schemes (MatrixCoefficients, pattern:2024,
+      // urlparam:2025) are intentionally ignored at AdaptationSet level.
     }
 
     // According to DASH spec (2014) section 5.8.4.8, "the successful processing
@@ -2063,24 +2103,22 @@ shaka.dash.DashParser = class {
 
     let lastSegmentNumber = null;
 
-    const supplementalProperties =
-        TXml.findChildren(elem, 'SupplementalProperty');
     for (const prop of supplementalProperties) {
-      const schemeId = prop.attributes['schemeIdUri'];
+      const schemeId = prop.schemeIdUri;
       if (schemeId == 'http://dashif.org/guidelines/last-segment-number') {
-        lastSegmentNumber = parseInt(prop.attributes['value'], 10) - 1;
+        lastSegmentNumber = parseInt(prop.value, 10) - 1;
       } else if (schemeId == transferCharacteristicsScheme) {
         videoRange = getVideoRangeFromTransferCharacteristicCICP(
-            parseInt(prop.attributes['value'], 10),
+            parseInt(prop.value, 10),
         );
       } else if (schemeId == colourPrimariesScheme) {
         colorGamut = getColorGamutFromColourPrimariesCICP(
-            parseInt(prop.attributes['value'], 10),
+            parseInt(prop.value, 10),
         );
       } else if (schemeId == 'urn:dvb:dash:fontdownload:2014') {
-        parseFont(prop);
+        parseFont(prop.element);
       } else if (schemeId == 'urn:mpeg:dash:urlparam:2014') {
-        adaptationSetUrlParams = this.getURLParametersFunction_(prop);
+        adaptationSetUrlParams = this.getURLParametersFunction_(prop.element);
       }
     }
     // Parse AdaptationSet-level RequestParam elements (urlparam:2025 scheme)
@@ -2433,30 +2471,23 @@ shaka.dash.DashParser = class {
 
     context.roles = roles;
 
-    const supplementalPropertyElements =
-        TXml.findChildren(node, 'SupplementalProperty');
-    const essentialPropertyElements =
-        TXml.findChildren(node, 'EssentialProperty');
+    const {
+      essentials: essentialProperties,
+      supplementals: supplementalProperties,
+    } = shaka.dash.MpdUtils.parseDescriptors(node);
     const contentProtectionElements =
         TXml.findChildren(node, 'ContentProtection');
 
+    const urlParamsScheme = 'urn:mpeg:dash:urlparam:2014';
     let representationUrlParams = null;
-    let urlParamsElement = essentialPropertyElements.find((element) => {
-      const schemeId = element.attributes['schemeIdUri'];
-      return schemeId == 'urn:mpeg:dash:urlparam:2014';
-    });
-    if (urlParamsElement) {
+    const urlParamsDescriptor =
+        shaka.dash.MpdUtils.getDescriptor(
+            essentialProperties, urlParamsScheme) ||
+        shaka.dash.MpdUtils.getDescriptor(
+            supplementalProperties, urlParamsScheme);
+    if (urlParamsDescriptor) {
       representationUrlParams =
-          this.getURLParametersFunction_(urlParamsElement);
-    } else {
-      urlParamsElement = supplementalPropertyElements.find((element) => {
-        const schemeId = element.attributes['schemeIdUri'];
-        return schemeId == 'urn:mpeg:dash:urlparam:2014';
-      });
-      if (urlParamsElement) {
-        representationUrlParams =
-            this.getURLParametersFunction_(urlParamsElement);
-      }
+          this.getURLParametersFunction_(urlParamsDescriptor.element);
     }
 
     // Also check RequestParam elements directly (urlparam:2025 scheme)
@@ -2585,21 +2616,13 @@ shaka.dash.DashParser = class {
 
     // Detect the presence of E-AC3 JOC audio content, using DD+JOC signaling.
     // See: ETSI TS 103 420 V1.2.1 (2018-10)
-    const hasJoc = supplementalPropertyElements.some((element) => {
-      const expectedUri = 'tag:dolby.com,2018:dash:EC3_ExtensionType:2018';
-      const expectedValue = 'JOC';
-      return element.attributes['schemeIdUri'] == expectedUri &&
-          element.attributes['value'] == expectedValue;
-    });
+    const hasJoc = shaka.dash.MpdUtils.hasDescriptor(supplementalProperties,
+        'tag:dolby.com,2018:dash:EC3_ExtensionType:2018', 'JOC');
 
     // Dolby AC-4 Online Delivery Kit 1.5 - AC4_DASH spec
     // https://ott.dolby.com/OnDelKits/AC-4/Dolby_AC-4_Online_Delivery_Kit_1.5/Documentation/Specs/AC4_DASH/help_files/topics/MPEG_dynmc_adpt_strmg_c_mpd_for_ims.html
-    const hasAc4Ims = supplementalPropertyElements.some((element) => {
-      const expectedUri = 'tag:dolby.com,2016:dash:virtualized_content:2016';
-      const expectedValue = '1';
-      return element.attributes['schemeIdUri'] == expectedUri &&
-          element.attributes['value'] == expectedValue;
-    });
+    const hasAc4Ims = shaka.dash.MpdUtils.hasDescriptor(supplementalProperties,
+        'tag:dolby.com,2016:dash:virtualized_content:2016', '1');
 
     const spatialAudio = hasJoc || hasAc4Ims;
 
@@ -2613,15 +2636,14 @@ shaka.dash.DashParser = class {
 
     let tilesLayout;
     if (isImage) {
-      const thumbnailTileElem = essentialPropertyElements.find((element) => {
-        const expectedUris = [
-          'http://dashif.org/thumbnail_tile',
-          'http://dashif.org/guidelines/thumbnail_tile',
-        ];
-        return expectedUris.includes(element.attributes['schemeIdUri']);
-      });
-      if (thumbnailTileElem) {
-        tilesLayout = thumbnailTileElem.attributes['value'];
+      const expectedUris = [
+        'http://dashif.org/thumbnail_tile',
+        'http://dashif.org/guidelines/thumbnail_tile',
+      ];
+      const thumbnailTileDescriptor = essentialProperties.find(
+          (d) => expectedUris.includes(d.schemeIdUri));
+      if (thumbnailTileDescriptor) {
+        tilesLayout = thumbnailTileDescriptor.value;
       }
       // Filter image adaptation sets that has no tilesLayout.
       if (!tilesLayout) {
@@ -3658,6 +3680,39 @@ shaka.dash.DashParser.SCTE214_ = 'urn:scte:dash:scte214-extensions';
  * @private
  */
 shaka.dash.DashParser.UP_NAMESPACE_ = 'urn:mpeg:dash:schema:urlparam:2014';
+
+
+/**
+ * The set of EssentialProperty scheme URIs recognized by the parser.  This is
+ * the single source of truth for EssentialProperty support and is used to:
+ *  - enforce the MPD-level conformance rule of ISO/IEC 23009-1 clause 5.8.4.8
+ *    (if an MPD-level EssentialProperty, or a group sharing the same id
+ *    attribute, uses only schemes outside this set, the presentation must be
+ *    terminated); and
+ *  - decide in parseAdaptationSet_ whether an unrecognized EssentialProperty
+ *    makes the containing AdaptationSet unusable.
+ *
+ * Keep this in sync with the scheme handling in parseAdaptationSet_ and
+ * parseRepresentation_.  Schemes that are recognized but intentionally ignored
+ * (e.g. MatrixCoefficients, pattern:2024, urlparam:2025) are listed here
+ * without dedicated handling.
+ *
+ * @const {!Set<string>}
+ * @private
+ */
+shaka.dash.DashParser.SUPPORTED_ESSENTIAL_PROPERTIES_ = new Set([
+  'http://dashif.org/guidelines/trickmode',
+  'http://dashif.org/thumbnail_tile',
+  'http://dashif.org/guidelines/thumbnail_tile',
+  'urn:mpeg:mpegB:cicp:TransferCharacteristics',
+  'urn:mpeg:mpegB:cicp:ColourPrimaries',
+  'urn:mpeg:mpegB:cicp:MatrixCoefficients',
+  'urn:mpeg:dash:ssr:2023',
+  'urn:dvb:dash:fontdownload:2014',
+  'urn:mpeg:dash:urlparam:2014',
+  'urn:mpeg:dash:pattern:2024',
+  'urn:mpeg:dash:urlparam:2025',
+]);
 
 
 /**

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -1379,12 +1379,7 @@ shaka.dash.DashParser = class {
     for (const descriptor of essentials) {
       const key = descriptor.id != null ?
           'id:' + descriptor.id : 'no-id:' + (noIdCounter++);
-      let group = groups.get(key);
-      if (!group) {
-        group = [];
-        groups.set(key, group);
-      }
-      group.push(descriptor);
+      groups.getOrInsert(key, []).push(descriptor);
     }
     for (const group of groups.values()) {
       const recognized = group.some((d) => supported.has(d.schemeIdUri));

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -1067,6 +1067,74 @@ shaka.dash.MpdUtils = class {
       return element;
     });
   }
+
+  /**
+   * Extracts and normalizes the EssentialProperty and SupplementalProperty
+   * descriptors that are direct children of the given element.
+   *
+   * @param {!shaka.extern.xml.Node} node
+   * @return {{
+   *   essentials: !Array<shaka.dash.MpdUtils.Descriptor>,
+   *   supplementals: !Array<shaka.dash.MpdUtils.Descriptor>,
+   * }}
+   * @see ISO/IEC 23009-1:2022 clauses 5.8.4.8 and 5.8.4.9
+   */
+  static parseDescriptors(node) {
+    const TXml = shaka.util.TXml;
+    const MpdUtils = shaka.dash.MpdUtils;
+    return {
+      essentials: TXml.findChildren(node, 'EssentialProperty')
+          .map(MpdUtils.normalizeDescriptor_),
+      supplementals: TXml.findChildren(node, 'SupplementalProperty')
+          .map(MpdUtils.normalizeDescriptor_),
+    };
+  }
+
+  /**
+   * Returns the first descriptor in the list matching the given scheme (and,
+   * when provided, value), or null if there is none.
+   *
+   * @param {!Array<shaka.dash.MpdUtils.Descriptor>} descriptors
+   * @param {string} schemeIdUri
+   * @param {string=} value
+   * @return {?shaka.dash.MpdUtils.Descriptor}
+   */
+  static getDescriptor(descriptors, schemeIdUri, value) {
+    return descriptors.find((d) => d.schemeIdUri == schemeIdUri &&
+        (value == undefined || d.value == value)) || null;
+  }
+
+  /**
+   * Returns true if the list contains a descriptor matching the given scheme
+   * (and, when provided, value).
+   *
+   * @param {!Array<shaka.dash.MpdUtils.Descriptor>} descriptors
+   * @param {string} schemeIdUri
+   * @param {string=} value
+   * @return {boolean}
+   */
+  static hasDescriptor(descriptors, schemeIdUri, value) {
+    return shaka.dash.MpdUtils.getDescriptor(
+        descriptors, schemeIdUri, value) != null;
+  }
+
+  /**
+   * Normalizes a single EssentialProperty/SupplementalProperty element into a
+   * Descriptor, keeping a reference to the underlying XML element for access to
+   * scheme-specific attributes.
+   *
+   * @param {!shaka.extern.xml.Node} element
+   * @return {shaka.dash.MpdUtils.Descriptor}
+   * @private
+   */
+  static normalizeDescriptor_(element) {
+    return {
+      schemeIdUri: element.attributes['schemeIdUri'],
+      value: element.attributes['value'],
+      id: element.attributes['id'],
+      element,
+    };
+  }
 };
 
 
@@ -1100,6 +1168,30 @@ shaka.dash.MpdUtils = class {
  *   The timeline of the representation, if given.  Times in seconds.
  */
 shaka.dash.MpdUtils.SegmentInfo;
+
+
+/**
+ * @typedef {{
+ *   schemeIdUri: string,
+ *   value: string,
+ *   id: string,
+ *   element: !shaka.extern.xml.Node,
+ * }}
+ *
+ * @description
+ * A normalized DASH property descriptor, as carried by EssentialProperty and
+ * SupplementalProperty elements.
+ *
+ * @property {string} schemeIdUri
+ *   The @schemeIdUri attribute identifying the descriptor scheme.
+ * @property {string} value
+ *   The @value attribute, or undefined if not present.
+ * @property {string} id
+ *   The @id attribute, or undefined if not present.
+ * @property {!shaka.extern.xml.Node} element
+ *   The underlying XML element, for access to scheme-specific attributes.
+ */
+shaka.dash.MpdUtils.Descriptor;
 
 
 /**

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -1069,25 +1069,43 @@ shaka.dash.MpdUtils = class {
   }
 
   /**
-   * Extracts and normalizes the EssentialProperty and SupplementalProperty
-   * descriptors that are direct children of the given element.
+   * Extracts and normalizes the EssentialProperty descriptors that are direct
+   * children of the given element.
    *
    * @param {!shaka.extern.xml.Node} node
-   * @return {{
-   *   essentials: !Array<shaka.dash.MpdUtils.Descriptor>,
-   *   supplementals: !Array<shaka.dash.MpdUtils.Descriptor>,
-   * }}
-   * @see ISO/IEC 23009-1:2022 clauses 5.8.4.8 and 5.8.4.9
+   * @return {!Array<shaka.dash.MpdUtils.Descriptor>}
+   * @see ISO/IEC 23009-1:2022 clause 5.8.4.8
    */
-  static parseDescriptors(node) {
-    const TXml = shaka.util.TXml;
-    const MpdUtils = shaka.dash.MpdUtils;
-    return {
-      essentials: TXml.findChildren(node, 'EssentialProperty')
-          .map(MpdUtils.normalizeDescriptor_),
-      supplementals: TXml.findChildren(node, 'SupplementalProperty')
-          .map(MpdUtils.normalizeDescriptor_),
-    };
+  static parseEssentialProperties(node) {
+    return shaka.dash.MpdUtils.parseDescriptorsByTag_(
+        node, 'EssentialProperty');
+  }
+
+  /**
+   * Extracts and normalizes the SupplementalProperty descriptors that are
+   * direct children of the given element.
+   *
+   * @param {!shaka.extern.xml.Node} node
+   * @return {!Array<shaka.dash.MpdUtils.Descriptor>}
+   * @see ISO/IEC 23009-1:2022 clause 5.8.4.9
+   */
+  static parseSupplementalProperties(node) {
+    return shaka.dash.MpdUtils.parseDescriptorsByTag_(
+        node, 'SupplementalProperty');
+  }
+
+  /**
+   * Extracts and normalizes the descriptor elements with the given tag name
+   * that are direct children of the given element.
+   *
+   * @param {!shaka.extern.xml.Node} node
+   * @param {string} tagName
+   * @return {!Array<shaka.dash.MpdUtils.Descriptor>}
+   * @private
+   */
+  static parseDescriptorsByTag_(node, tagName) {
+    return shaka.util.TXml.findChildren(node, tagName)
+        .map(shaka.dash.MpdUtils.normalizeDescriptor_);
   }
 
   /**

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -856,6 +856,15 @@ shaka.util.Error.Code = {
    */
   'MSF_NO_CATALOG': 4062,
 
+  /**
+   * The MPD contained an EssentialProperty descriptor (or a group of
+   * EssentialProperty descriptors sharing the same @id) at MPD level whose
+   * scheme is not supported by the player.  Per ISO/IEC 23009-1 clause 5.8.4.8,
+   * the presentation cannot be played in this case.
+   * <br> error.data[0] is an array with the unsupported scheme URIs.
+   */
+  'DASH_UNSUPPORTED_ESSENTIAL_PROPERTY': 4063,
+
   // RETIRED: 'INCONSISTENT_BUFFER_STATE': 5000,
   // RETIRED: 'INVALID_SEGMENT_INDEX': 5001,
   // RETIRED: 'SEGMENT_DOES_NOT_EXIST': 5002,

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -1033,6 +1033,27 @@ describe('DashParser Manifest', () => {
           shaka.util.Error.Code.DASH_DUPLICATE_REPRESENTATION_ID);
       await Dash.testFails(source, error);
     });
+
+    it('unsupported MPD-level EssentialProperty', async () => {
+      const source = [
+        '<MPD minBufferTime="PT75S">',
+        '  <EssentialProperty schemeIdUri="urn:example:unsupported:2024" />',
+        '  <Period id="1" duration="PT30S">',
+        '    <AdaptationSet mimeType="video/mp4">',
+        '      <Representation bandwidth="1">',
+        '        <SegmentTemplate media="1.mp4" duration="1" />',
+        '      </Representation>',
+        '    </AdaptationSet>',
+        '  </Period>',
+        '</MPD>',
+      ].join('\n');
+      const error = new shaka.util.Error(
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.MANIFEST,
+          shaka.util.Error.Code.DASH_UNSUPPORTED_ESSENTIAL_PROPERTY,
+          ['urn:example:unsupported:2024']);
+      await Dash.testFails(source, error);
+    });
   });
 
   it('parses dependencyStream tracks', async () => {
@@ -1322,6 +1343,51 @@ describe('DashParser Manifest', () => {
     const trickModeVideo = variant && variant.video &&
                          variant.video.trickModeVideo;
     expect(trickModeVideo).toBe(null);
+  });
+
+  it('ignores unsupported MPD-level SupplementalProperty', async () => {
+    const manifestText = [
+      '<MPD minBufferTime="PT75S">',
+      '  <SupplementalProperty schemeIdUri="urn:example:unsupported:2024" />',
+      '  <Period id="1" duration="PT30S">',
+      '    <AdaptationSet id="1" mimeType="video/mp4">',
+      '      <Representation bandwidth="1">',
+      '        <SegmentTemplate media="1.mp4" duration="1" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '  </Period>',
+      '</MPD>',
+    ].join('\n');
+
+    fakeNetEngine.setResponseText('https://foo', manifestText);
+    /** @type {shaka.extern.Manifest} */
+    const manifest = await parser.start('https://foo', playerInterface);
+
+    // A SupplementalProperty is not essential, so it does not block parsing.
+    expect(manifest.variants.length).toBe(1);
+  });
+
+  it('allows supported MPD-level EssentialProperty', async () => {
+    // Regression test: a recognized EssentialProperty scheme at MPD level (e.g.
+    // SGAI manifests carrying urlparam:2025) must not terminate parsing.
+    const manifestText = [
+      '<MPD minBufferTime="PT75S">',
+      '  <Period id="1" duration="PT30S">',
+      '    <AdaptationSet id="1" mimeType="video/mp4">',
+      '      <Representation bandwidth="1">',
+      '        <SegmentTemplate media="1.mp4" duration="1" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '  </Period>',
+      '  <EssentialProperty schemeIdUri="urn:mpeg:dash:urlparam:2025" />',
+      '</MPD>',
+    ].join('\n');
+
+    fakeNetEngine.setResponseText('https://foo', manifestText);
+    /** @type {shaka.extern.Manifest} */
+    const manifest = await parser.start('https://foo', playerInterface);
+
+    expect(manifest.variants.length).toBe(1);
   });
 
   it('populates groupId', async () => {


### PR DESCRIPTION
Read EssentialProperty and SupplementalProperty descriptors at MPD and Period level, and enforce the MPD-level EssentialProperty conformance rule from ISO/IEC 23009-1 clause 5.8.4.8. 

EssentialProperty descriptors at MPD level are grouped by their `@id` and, when a whole group uses only schemes the parser does not recognize, the presentation is terminated with the new error code DASH_UNSUPPORTED_ESSENTIAL_PROPERTY (4063). SupplementalProperty descriptors remain non-essential and are ignored when unrecognized.