### PR TITLE
feat(ABR): ABR Manager Min forward buffer (duration) to increase quality abr.minBufferAheadToUpgrade

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -400,7 +400,11 @@ shakaDemo.Config = class {
             'abr.advanced.droppedFramesInterval',
             /* canBeDecimal= */ true)
         .addNumberInput_('Dropped Frames Ban Duration',
-            'abr.advanced.droppedFramesBanDuration');
+            'abr.advanced.droppedFramesBanDuration')
+        .addNumberInput_('Dropped Frames Ban Duration',
+            'abr.minBufferAheadToUpgrade',
+            /* canBeDecimal= */ true,
+            /* canBeZero= */ true);
     this.addRestrictionsSection_('abr', 'Adaptation Restrictions');
   }
 

--- a/externs/shaka/abr_manager.js
+++ b/externs/shaka/abr_manager.js
@@ -178,7 +178,7 @@ shaka.extern.AbrManager = class {
  * a fast switch that doesn't involve a buffering event. A minimum of two video
  * segments should always be kept buffered to avoid temporary hiccups.
  *
- * @typedef {function(shaka.extern.Variant, boolean=, number=)}
+ * @typedef {function(shaka.extern.Variant, boolean=, number=, number=)}
  * @exportDoc
  */
 shaka.extern.AbrManager.SwitchCallback;

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2596,6 +2596,7 @@ shaka.extern.AdsConfiguration;
  *   minTimeToSwitch: number,
  *   preferNetworkInformationBandwidth: boolean,
  *   droppedFrames: boolean,
+ *   minBufferAheadToUpgrade: number,
  * }}
  *
  * @property {boolean} enabled
@@ -2694,7 +2695,11 @@ shaka.extern.AdsConfiguration;
  * @property {boolean} droppedFrames
  *   Enable or disable dropped frames protection.
  *   <br>
- *   Defaults to <code>true</code>.
+ * @property {number} minBufferAheadToUpgrade
+ *   The minimum amount of buffer, in seconds, required ahead of the current
+ *   playback position before upgrading to a higher bandwidth rendition.
+ *   The recommended value should be defined according to the segment length.
+ *   Defaults to <code>0</code>.
  * @exportDoc
  */
 shaka.extern.AbrConfiguration;

--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -533,7 +533,7 @@ shaka.abr.SimpleAbrManager = class {
       // If any of these chosen streams are already chosen, Player will filter
       // them out before passing the choices on to StreamingEngine.
       this.switch_(chosenVariant, this.config_.clearBufferSwitch,
-          this.config_.safeMarginSwitch);
+          this.config_.safeMarginSwitch, this.config_.minBufferAheadToUpgrade);
       this.updateFramesInfo_();
     }
   }

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -524,7 +524,56 @@ shaka.media.StreamingEngine = class {
    */
   switchVariant(
       variant, clearBuffer = false, safeMargin = 0, force = false,
-      adaptation = false) {
+      adaptation = false, minBufferAheadToUpgrade = 0) {
+    if (this.currentVariant_) {
+      let currentBandwidth = 0;
+      let nextBandwidth = 0;
+
+      if (this.currentVariant_.video) {
+        currentBandwidth += this.currentVariant_.video.bandwidth;
+      }
+      if (this.currentVariant_.audio) {
+        currentBandwidth += this.currentVariant_.audio.bandwidth;
+      }
+      if (variant.video) {
+        nextBandwidth += variant.video.bandwidth;
+      }
+      if (variant.audio) {
+        nextBandwidth += variant.audio.bandwidth;
+      }
+      if (nextBandwidth > currentBandwidth) {
+        const presentationTime = this.playerInterface_.getPresentationTime();
+        let aHeadDuration = 0;
+        const buffers =
+            this.playerInterface_.mediaSourceEngine.getBufferedInfo().total;
+        for (const buffer of buffers) {
+          aHeadDuration += Math.max(0, buffer.end - presentationTime);
+        }
+        let manifestEndTime = this.manifest_.presentationTimeline.getDuration();
+        if (manifestEndTime == Infinity) {
+          manifestEndTime =
+              this.manifest_.presentationTimeline.getMaxSegmentEndTime() ||
+              presentationTime;
+        }
+        const durationToEndManifest = manifestEndTime - presentationTime;
+        shaka.log.debug(
+            'switchVariant:',
+            'durationToEndManifest=' + durationToEndManifest,
+            'aHeadDuration=' + (aHeadDuration ),
+        );
+        // check if the manifest end time is not too closed to the current
+        // position. if yes the configuration maybe wrong.
+        if (durationToEndManifest > minBufferAheadToUpgrade) {
+          if (aHeadDuration < minBufferAheadToUpgrade ) {
+            shaka.log.debug('switchVariant: skips switchVariant');
+            return;
+          }
+        }
+      }
+    } else {
+      shaka.log.info('JA no current');
+    }
+
     this.currentVariant_ = variant;
 
     if (!this.startupComplete_) {

--- a/lib/player.js
+++ b/lib/player.js
@@ -3053,15 +3053,17 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.config_.playRangeStart,
         this.config_.playRangeEnd);
 
-    this.abrManager_.init((variant, clearBuffer, safeMargin) => {
-      return this.switch_(variant, clearBuffer, safeMargin);
-    }, (type, banDuration) => {
-      const currentVariant = this.streamingEngine_?.getCurrentVariant();
-      const stream = currentVariant && currentVariant[type];
-      if (stream) {
-        this.disableStream(stream, banDuration);
-      }
-    });
+    this.abrManager_.init(
+        (variant, clearBuffer, safeMargin, minBufferAheadToUpgrade) => {
+          return this.switch_(
+              variant, clearBuffer, safeMargin, minBufferAheadToUpgrade);
+        }, (type, banDuration) => {
+          const currentVariant = this.streamingEngine_?.getCurrentVariant();
+          const stream = currentVariant && currentVariant[type];
+          if (stream) {
+            this.disableStream(stream, banDuration);
+          }
+        });
     this.abrManager_.setMediaElement(mediaElement);
     this.abrManager_.setCmsdManager(this.cmsdManager_);
 
@@ -8506,7 +8508,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   switchVariant_(variant, fromAdaptation, clearBuffer, safeMargin,
-      force = false) {
+      force = false, minBufferAheadToUpgrade = 0) {
     const currentVariant = this.streamingEngine_.getCurrentVariant();
     if (variant == currentVariant) {
       shaka.log.debug('Variant already selected.');
@@ -8515,7 +8517,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // so 'adaptation' isn't passed here.
       if (clearBuffer) {
         this.streamingEngine_.switchVariant(variant, clearBuffer, safeMargin,
-            /* force= */ true);
+            /* force= */ true, /* adaptation= */ false,
+            minBufferAheadToUpgrade);
       }
       return;
     }
@@ -8524,7 +8527,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.addVariantToSwitchHistory_(variant, fromAdaptation);
     this.streamingEngine_.switchVariant(
         variant, clearBuffer, safeMargin, force,
-        /* adaptation= */ fromAdaptation);
+        /* adaptation= */ fromAdaptation, minBufferAheadToUpgrade);
     let oldTrack = null;
     if (currentVariant) {
       oldTrack = shaka.util.StreamUtils.variantToTrack(currentVariant);
@@ -8679,7 +8682,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *   Defaults to 0 if not provided. Ignored if clearBuffer is false.
    * @private
    */
-  switch_(variant, clearBuffer = false, safeMargin = 0) {
+  switch_(variant, clearBuffer = false, safeMargin = 0,
+      minBufferAheadToUpgrade = 0) {
     shaka.log.debug('switch_');
     goog.asserts.assert(this.config_.abr.enabled,
         'AbrManager should not call switch while disabled!');
@@ -8700,7 +8704,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     this.switchVariant_(variant, /* fromAdaptation= */ true,
-        clearBuffer, safeMargin);
+        clearBuffer, safeMargin, false, minBufferAheadToUpgrade);
   }
 
   /**

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -342,6 +342,7 @@ shaka.util.PlayerConfiguration = class {
       minTimeToSwitch: 0,
       preferNetworkInformationBandwidth: false,
       droppedFrames: true,
+      minBufferAheadToUpgrade: 0,
     };
 
     const cmcd = {

--- a/test/abr/simple_abr_manager_unit.js
+++ b/test/abr/simple_abr_manager_unit.js
@@ -163,7 +163,7 @@ describe('SimpleAbrManager', () => {
       // and variant 5 - for bandwidth = 6e5
       const expectedVariant = (bandwidth == 6e5) ? variants[5] : variants[2];
 
-      expect(switchCallback).toHaveBeenCalledWith(expectedVariant, false, 0);
+      expect(switchCallback).toHaveBeenCalledWith(expectedVariant, false, 0, 0);
     });
   }
 
@@ -210,7 +210,7 @@ describe('SimpleAbrManager', () => {
     // Expect variants 4 to be chosen
     const expectedVariant = variants[3];
 
-    expect(switchCallback).toHaveBeenCalledWith(expectedVariant, false, 0);
+    expect(switchCallback).toHaveBeenCalledWith(expectedVariant, false, 0, 0);
   });
 
   it('does not call switchCallback() if not enabled', () => {
@@ -288,7 +288,7 @@ describe('SimpleAbrManager', () => {
 
     // The second parameter is missing to indicate that the buffer should not be
     // cleared.
-    expect(switchCallback).toHaveBeenCalledWith(jasmine.any(Object), false, 0);
+    expect(switchCallback).toHaveBeenCalledWith(jasmine.any(Object), false, 0, 0);
   });
 
   it('does clear the buffer on upgrade with safeMargin to 4', () => {
@@ -316,7 +316,7 @@ describe('SimpleAbrManager', () => {
 
     // The second parameter is missing to indicate that the buffer should not be
     // cleared.
-    expect(switchCallback).toHaveBeenCalledWith(jasmine.any(Object), true, 4);
+    expect(switchCallback).toHaveBeenCalledWith(jasmine.any(Object), true, 4, 0);
   });
 
   it('does not clear the buffer on downgrade', () => {
@@ -343,7 +343,7 @@ describe('SimpleAbrManager', () => {
 
     // The second parameter is missing to indicate that the buffer should not be
     // cleared.
-    expect(switchCallback).toHaveBeenCalledWith(jasmine.any(Object), false, 0);
+    expect(switchCallback).toHaveBeenCalledWith(jasmine.any(Object), false, 0, 0);
   });
 
   it('will respect restrictions', () => {


### PR DESCRIPTION
I would like to have a parameter in the ABR configuration that will not allow the variant change to an higher quality if the filled buffer is below a threshold.

By default this should be set to 0, more over to some low latency setup. if the next variant has an equal or higher (>=) bandwidth and the forward buffer is not filled, we just not jump to the next quality. if the buffer is fill with this X duration we can change variant. If the new variant is lower (<) in term of bandwidth we switch. (this is to protect the going down situation where we are already in bad shape with that current variant) if no current variant we switch.
if the duration of the current playback till the end of the manifest is smaller to that value we allow the switch. it clearly a bad configuration. (TBD it can be the manifest that has delay and i'm not sure we should do that...)