### PR TITLE
fix(security): prevent glob expansion in shaka-bot comment command parser

### DIFF
--- a/.github/workflows/shaka-bot-commands/lib.sh
+++ b/.github/workflows/shaka-bot-commands/lib.sh
@@ -79,7 +79,10 @@ function parse_command() {
     echo "Parsing comment.  Line: \"$COMMENT_LINE\""
 
     # Tokenize the line by whitespace.
-    local TOKENS=( $COMMENT_LINE )
+    # Security fix: use read -ra for safe word-splitting to prevent
+    # glob expansion from attacker-controlled comment content.
+    local TOKENS
+    IFS=' ' read -ra TOKENS <<< "$COMMENT_LINE"
 
     local INDEX
     for (( INDEX=0; INDEX < ${#TOKENS[@]}; INDEX++ )); do


### PR DESCRIPTION
## Summary

Fixes unquoted variable expansion in `parse_command()` in `.github/workflows/shaka-bot-commands/lib.sh` that could allow glob characters in PR comments to expand against runner filesystem paths.

## Vulnerability Details

The `parse_command` function tokenized comment lines using unquoted array assignment:
```bash
local TOKENS=( $COMMENT_LINE )
```

In bash, unquoted variable expansion in an array context performs **word-splitting AND pathname (glob) expansion**. If a PR comment contains glob characters like `*`, `?`, or `[abc]`, bash may expand them against files in the runner's working directory (`shaka-player/`).

While the current commands (`help`, `test`) have limited blast radius, this is incorrect handling of untrusted input and could cause issues if:
- New commands are added that use `$SHAKA_BOT_ARGUMENTS` in file operations
- A glob matches unexpected filenames, altering command routing
- Runner CWD is accidentally changed before parse_command runs

**Trigger:** Any GitHub user who can comment on PRs can trigger this (comments containing `@shaka-bot`).

## Fix

Replace unquoted expansion with `read -ra` which performs safe word-splitting without glob expansion:
```bash
IFS=' ' read -ra TOKENS <<< "$COMMENT_LINE"
```

## Testing
Existing bot command tests cover the behavior. The fix is semantically equivalent for all valid commands.