### PR TITLE
fix(UI): Hide volume slider on Smart TV and mobile after mute_volume change

### DIFF
--- a/ui/ui.js
+++ b/ui/ui.js
@@ -490,11 +490,15 @@ shaka.ui.Overlay = class {
       config.enableFullscreenOnRotation = device.getBrowserEngine() !==
           shaka.device.IDevice.BrowserEngine.WEBKIT;
       config.forceLandscapeOnFullscreen = true;
+      // On mobile, keep the mute button but hide the volume slider by
+      // replacing the composite mute_volume element with a standalone mute
+      // button.
+      config.controlPanelElements = config.controlPanelElements.map(
+          (name) => name === 'mute_volume' ? 'mute' : name);
       const filterElements = [
         'play_pause',
         'skip_previous',
         'skip_next',
-        'volume',
       ];
       config.controlPanelElements = config.controlPanelElements.filter(
           (name) => !filterElements.includes(name));
@@ -521,11 +525,15 @@ shaka.ui.Overlay = class {
       config.singleClickForPlayAndPause = false;
       config.enableTooltips = false;
       config.doubleClickForFullscreen = false;
+      // Smart TVs adjust volume with the remote, so replace the composite
+      // mute_volume element (mute button + volume slider) with a standalone
+      // mute button: keep the mute control but hide the volume slider.
+      config.controlPanelElements = config.controlPanelElements.map(
+          (name) => name === 'mute_volume' ? 'mute' : name);
       const filterElements = [
         'play_pause',
         'cast',
         'remote',
-        'volume',
         'save_video_frame',
       ];
       config.controlPanelElements = config.controlPanelElements.filter(


### PR DESCRIPTION
The composite `mute_volume` element introduced in #10214 replaced the separate `mute` and `volume` entries in the default controlPanelElements. However, the Smart TV and mobile configs still filtered the now-nonexistent `volume` entry, so the composite element survived and rendered the volume slider on devices where it was previously hidden.

Replace `mute_volume` with the standalone `mute` button on Smart TV and mobile (where volume is controlled by the remote / hardware buttons), keeping the mute control while hiding the volume slider, and drop the dead `volume` filter entry.

Fixes the `UI controls controls-button-panel has default elements` unit test failure on Tizen (deviceType TV).