### PR TITLE
fix: Set Default robustness on Android for Widevine key system

### DIFF
--- a/lib/device/default_browser.js
+++ b/lib/device/default_browser.js
@@ -161,8 +161,8 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
       }
     }
     if (this.isAndroid_.value()) {
-      config.drm.defaultAudioRobustnessForWidevine = '';
-      config.drm.defaultVideoRobustnessForWidevine = '';
+      config.drm.defaultAudioRobustnessForWidevine = 'SW_SECURE_CRYPTO';
+      config.drm.defaultVideoRobustnessForWidevine = 'SW_SECURE_CRYPTO';
     }
     return config;
   }


### PR DESCRIPTION
In lib/util/player_configuration.js, the default robustness is set to SW_SECURE_DECODE for Video, and SW_SECURE_CRYPTO for Audio. However, Android robustness is unset. This leads to unspecified behavior and is explicitly warned against in Chrome via the console, and unset robustness is also mentioned in the EME spec.

This now sets both audio and video robustness to SW_SECURE_CRYPTO on Android. We don't use DECODE because of the below: 

https://source.chromium.org/chromium/chromium/src/+/main:components/cdm/renderer/widevine_key_system_info.cc;l=182