### PR TITLE
ci: Drop Ubuntu+Edge in VM

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -64,9 +64,6 @@ jobs:
             browser: Firefox
             extra_flags: "--use-xvfb --running_in_vm"
           - os: ubuntu-latest
-            browser: Edge
-            extra_flags: "--use-xvfb --running_in_vm"
-          - os: ubuntu-latest
             browser: Opera
             extra_flags: "--use-xvfb --running_in_vm"
 


### PR DESCRIPTION
The launcher for Edge on Linux no longer works in the GitHub-maintained VMs.  (It still works in our lab.)  Remove this from the test matrix for PRs.