### PR TITLE
feat(CEA): Reveal paint-on and roll-up captions character by character

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -422,9 +422,6 @@ shakaDemo.Config = class {
 
     const docLink = this.resolveExternLink_('.TextDisplayerConfiguration');
     this.addSection_('Text displayer', docLink)
-        .addNumberInput_('Captions update period',
-            'textDisplayer.captionsUpdatePeriod',
-            /* canBeDecimal= */ true)
         .addNumberInput_('Font scale factor',
             'textDisplayer.fontScaleFactor',
             /* canBeDecimal= */ true)

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -3002,7 +3002,6 @@ shaka.extern.OfflineConfiguration;
 
 /**
  * @typedef {{
- *   captionsUpdatePeriod: number,
  *   fontScaleFactor: number,
  *   positionArea: shaka.config.PositionArea,
  *   subtitleDelay: number,
@@ -3012,10 +3011,6 @@ shaka.extern.OfflineConfiguration;
  * @description
  *   Text displayer configuration.
  *
- * @property {number} captionsUpdatePeriod
- *   The number of seconds to see if the captions should be updated.
- *   <br>
- *   Defaults to <code>0.25</code>.
  * @property {number} fontScaleFactor
  *   The font scale factor used to increase or decrease the font size.
  *   <br>

--- a/lib/cea/cea608_data_channel.js
+++ b/lib/cea/cea608_data_channel.js
@@ -184,9 +184,10 @@ shaka.cea.Cea608DataChannel = class {
   /**
    * Mid-Row control code handler.
    * @param {number} b2 Byte #2.
+   * @param {number=} time Presentation time (in seconds) of this control code.
    * @private
    */
-  controlMidrow_(b2) {
+  controlMidrow_(b2, time) {
     // Clear all pre-existing midrow style attributes.
     this.curBuf_.setUnderline(false);
     this.curBuf_.setItalics(false);
@@ -194,7 +195,8 @@ shaka.cea.Cea608DataChannel = class {
 
     // Mid-row attrs use a space.
     this.curBuf_.addChar(
-        shaka.cea.Cea608Memory.CharSet.BASIC_NORTH_AMERICAN, ' '.charCodeAt(0));
+        shaka.cea.Cea608Memory.CharSet.BASIC_NORTH_AMERICAN,
+        ' '.charCodeAt(0), time);
 
     let italics = false;
 
@@ -264,7 +266,7 @@ shaka.cea.Cea608DataChannel = class {
         parsedClosedCaption = this.controlRu_(4, pts);
         break;
       case MiscCmd.FON:
-        this.controlFon_();
+        this.controlFon_(pts);
         break;
       case MiscCmd.RDC:
         this.controlRdc_(pts);
@@ -306,8 +308,10 @@ shaka.cea.Cea608DataChannel = class {
     if (this.type_ !== shaka.cea.Cea608DataChannel.CaptionType.ROLLUP) {
       return null;
     }
-    // Force out the scroll window since the top row will cleared.
-    const parsedClosedCaption = buf.forceEmit(this.prevEndTime_, pts);
+    // Force out the scroll window since the top row will cleared. Roll-up is
+    // revealed character by character (progressive).
+    const parsedClosedCaption =
+        buf.forceEmit(this.prevEndTime_, pts, /* progressive= */ true);
 
     // Calculate the top of the scroll window.
     const topRow = (buf.getRow() - buf.getScrollSize()) + 1;
@@ -342,7 +346,10 @@ shaka.cea.Cea608DataChannel = class {
     // and memories cleared.
     if (this.type_ !== shaka.cea.Cea608DataChannel.CaptionType.ROLLUP &&
         this.type_ !== shaka.cea.Cea608DataChannel.CaptionType.TEXT) {
-      parsedClosedCaption = buf.forceEmit(this.prevEndTime_, pts);
+      // Paint-on content was revealed character by character; pop-on was not.
+      const progressive =
+          this.type_ === shaka.cea.Cea608DataChannel.CaptionType.PAINTON;
+      parsedClosedCaption = buf.forceEmit(this.prevEndTime_, pts, progressive);
 
       // Clear both memories.
       this.displayedMemory_.eraseBuffer();
@@ -360,12 +367,13 @@ shaka.cea.Cea608DataChannel = class {
 
   /**
    * Handles flash on.
+   * @param {number=} time Presentation time (in seconds) of this control code.
    * @private
    */
-  controlFon_() {
+  controlFon_(time) {
     this.curBuf_.addChar(
         shaka.cea.Cea608Memory.CharSet.BASIC_NORTH_AMERICAN,
-        ' '.charCodeAt(0));
+        ' '.charCodeAt(0), time);
   }
 
 
@@ -381,9 +389,14 @@ shaka.cea.Cea608DataChannel = class {
     const buf = this.displayedMemory_;
     let parsedClosedCaption = null;
     if (this.type_ !== shaka.cea.Cea608DataChannel.CaptionType.TEXT) {
+      // Paint-on and roll-up paint onto displayed memory, so their contents
+      // were revealed character by character; pop-on appears all at once.
+      const progressive =
+          this.type_ === shaka.cea.Cea608DataChannel.CaptionType.PAINTON ||
+          this.type_ === shaka.cea.Cea608DataChannel.CaptionType.ROLLUP;
       // Clearing displayed memory means we now know how long
       // its contents were displayed, so force it out.
-      parsedClosedCaption = buf.forceEmit(this.prevEndTime_, pts);
+      parsedClosedCaption = buf.forceEmit(this.prevEndTime_, pts, progressive);
     }
     buf.resetAllRows();
     return parsedClosedCaption;
@@ -426,8 +439,15 @@ shaka.cea.Cea608DataChannel = class {
   controlEoc_(pts) {
     let parsedClosedCaption = null;
     if (this.type_ !== shaka.cea.Cea608DataChannel.CaptionType.TEXT) {
+      // Normally EOC flushes a pop-on caption (loaded off-screen, shown all at
+      // once). But if we are switching to pop-on from paint-on or roll-up, the
+      // displayed memory was painted character by character, so reveal it
+      // progressively.
+      const progressive =
+          this.type_ === shaka.cea.Cea608DataChannel.CaptionType.PAINTON ||
+          this.type_ === shaka.cea.Cea608DataChannel.CaptionType.ROLLUP;
       parsedClosedCaption =
-        this.displayedMemory_.forceEmit(this.prevEndTime_, pts);
+        this.displayedMemory_.forceEmit(this.prevEndTime_, pts, progressive);
     }
     // Swap memories
     const buf = this.nonDisplayedMemory_;
@@ -491,27 +511,29 @@ shaka.cea.Cea608DataChannel = class {
    * Handles a Basic North American byte pair.
    * @param {number} b1 Byte 1.
    * @param {number} b2 Byte 2.
+   * @param {number=} time Presentation time (in seconds) of this byte pair.
    */
-  handleBasicNorthAmericanChar(b1, b2) {
+  handleBasicNorthAmericanChar(b1, b2, time) {
     this.curBuf_.addChar(
-        shaka.cea.Cea608Memory.CharSet.BASIC_NORTH_AMERICAN, b1);
+        shaka.cea.Cea608Memory.CharSet.BASIC_NORTH_AMERICAN, b1, time);
     this.curBuf_.addChar(
-        shaka.cea.Cea608Memory.CharSet.BASIC_NORTH_AMERICAN, b2);
+        shaka.cea.Cea608Memory.CharSet.BASIC_NORTH_AMERICAN, b2, time);
   }
 
   /**
    * Handles an Extended Western European byte pair.
    * @param {number} b1 Byte 1.
    * @param {number} b2 Byte 2.
+   * @param {number=} time Presentation time (in seconds) of this byte pair.
    * @private
    */
-  handleExtendedWesternEuropeanChar_(b1, b2) {
+  handleExtendedWesternEuropeanChar_(b1, b2, time) {
     // Get the char set from the LSB, which is the char set toggle bit.
     const charSet = b1 & 0x01 ?
           shaka.cea.Cea608Memory.CharSet.PORTUGUESE_GERMAN:
           shaka.cea.Cea608Memory.CharSet.SPANISH_FRENCH;
 
-    this.curBuf_.addChar(charSet, b2);
+    this.curBuf_.addChar(charSet, b2, time);
   }
 
   /**
@@ -534,6 +556,7 @@ shaka.cea.Cea608DataChannel = class {
   handleControlCode(ccPacket) {
     const b1 = ccPacket.ccData1;
     const b2 = ccPacket.ccData2;
+    const pts = ccPacket.pts;
 
     // FCC wants control codes transmitted twice, and that will often be
     // seen in broadcast captures. If the very next frame has a duplicate
@@ -550,14 +573,14 @@ shaka.cea.Cea608DataChannel = class {
     if (this.isPAC_(b1, b2)) {
       this.controlPac_(b1, b2);
     } else if (this.isMidrowStyleChange_(b1, b2)) {
-      this.controlMidrow_(b2);
+      this.controlMidrow_(b2, pts);
     } else if (this.isBackgroundAttribute_(b1, b2)) {
       this.controlBackgroundAttribute_(b1, b2);
     } else if (this.isSpecialNorthAmericanChar_(b1, b2)) {
       this.curBuf_.addChar(
-          shaka.cea.Cea608Memory.CharSet.SPECIAL_NORTH_AMERICAN, b2);
+          shaka.cea.Cea608Memory.CharSet.SPECIAL_NORTH_AMERICAN, b2, pts);
     } else if (this.isExtendedWesternEuropeanChar_(b1, b2)) {
-      this.handleExtendedWesternEuropeanChar_(b1, b2);
+      this.handleExtendedWesternEuropeanChar_(b1, b2, pts);
     } else if (this.isMiscellaneous_(b1, b2)) {
       return this.controlMiscellaneous_(ccPacket);
     } else if (this.isOffset_(b1, b2)) {

--- a/lib/cea/cea608_memory.js
+++ b/lib/cea/cea608_memory.js
@@ -86,9 +86,11 @@ shaka.cea.Cea608Memory = class {
    * Emits a closed caption based on the state of the buffer.
    * @param {number} startTime Start time of the cue.
    * @param {number} endTime End time of the cue.
+   * @param {boolean=} progressive If true, reveal text character by character
+   *   using each character's decode time (paint-on and roll-up modes).
    * @return {?shaka.extern.ICaptionDecoder.ClosedCaption}
    */
-  forceEmit(startTime, endTime) {
+  forceEmit(startTime, endTime, progressive = false) {
     const Cea608Memory = shaka.cea.Cea608Memory;
     const stream = shaka.cea.CeaUtils.getCea608StreamName(
         this.fieldNum_, this.channelNum_);
@@ -105,7 +107,7 @@ shaka.cea.Cea608Memory = class {
           this.offset_ * 2.5;
     }
     const ret = shaka.cea.CeaUtils.getParsedCaption(
-        topLevelCue, stream, this.rows_, startTime, endTime);
+        topLevelCue, stream, this.rows_, startTime, endTime, progressive);
     // If the text and its lines are larger than what we can show on the
     // screen, we move the lines up so that the text does not come out of the
     // video.
@@ -159,8 +161,11 @@ shaka.cea.Cea608Memory = class {
    * Adds a character to the buffer.
    * @param {!shaka.cea.Cea608Memory.CharSet} set Character set.
    * @param {number} b CC byte to add.
+   * @param {?number=} time Presentation time (in seconds) at which this
+   *   character was decoded. Used for character-by-character reveal in
+   *   paint-on and roll-up modes.
    */
-  addChar(set, b) {
+  addChar(set, b, time = null) {
     // Valid chars are in the range [0x20, 0x7f]
     if (b < 0x20 || b > 0x7f) {
       return;
@@ -197,7 +202,7 @@ shaka.cea.Cea608Memory = class {
     if (char) {
       const styledChar = new shaka.cea.CeaUtils.StyledChar(
           char, this.underline_, this.italics_,
-          this.backgroundColor_, this.textColor_);
+          this.backgroundColor_, this.textColor_, time);
       this.rows_[this.row_].push(styledChar);
     }
   }

--- a/lib/cea/cea_decoder.js
+++ b/lib/cea/cea_decoder.js
@@ -343,7 +343,7 @@ shaka.cea.CeaDecoder = class {
     } else {
       // Handle as a Basic North American Character.
       selectedStream.handleBasicNorthAmericanChar(
-          ccPacket.ccData1, ccPacket.ccData2);
+          ccPacket.ccData1, ccPacket.ccData2, ccPacket.pts);
     }
 
     return parsedClosedCaption;

--- a/lib/cea/cea_utils.js
+++ b/lib/cea/cea_utils.js
@@ -18,9 +18,15 @@ shaka.cea.CeaUtils = class {
    * @param {!Array<!Array<?shaka.cea.CeaUtils.StyledChar>>} memory
    * @param {number} startTime Start time of the cue.
    * @param {number} endTime End time of the cue.
+   * @param {boolean=} progressive If true, each character is revealed at the
+   *   time it was decoded (its {@link StyledChar#getTime}), instead of all at
+   *   once at startTime. This reproduces the native "paint-on" / roll-up look
+   *   where text appears character by character. Characters decoded at or
+   *   before startTime are still revealed immediately.
    * @return {?shaka.extern.ICaptionDecoder.ClosedCaption}
    */
-  static getParsedCaption(topLevelCue, stream, memory, startTime, endTime) {
+  static getParsedCaption(topLevelCue, stream, memory, startTime, endTime,
+      progressive = false) {
     if (startTime >= endTime) {
       return null;
     }
@@ -48,6 +54,11 @@ shaka.cea.CeaUtils = class {
     let currentItalics = false;
     let currentTextColor = shaka.cea.CeaUtils.DEFAULT_TXT_COLOR;
     let currentBackgroundColor = shaka.cea.CeaUtils.DEFAULT_BG_COLOR;
+
+    // Start time of the run currently being built. Kept in sync with
+    // currentCue.startTime so that, in progressive mode, a change in character
+    // timing opens a new nested cue (just like a style change does).
+    let currentTime = startTime;
 
     // Create first cue that will be nested in top level cue. Default styles.
     let currentCue = shaka.cea.CeaUtils.createStyledCue(
@@ -95,22 +106,31 @@ shaka.cea.CeaUtils = class {
         const textColor = styledChar.getTextColor();
         const backgroundColor = styledChar.getBackgroundColor();
 
-        // If any style properties have changed, we need to open a new cue.
+        // In progressive mode, reveal each character at its decode time. Chars
+        // decoded at or before startTime (e.g. already-displayed roll-up rows)
+        // are merged into the startTime run so they appear immediately.
+        const charTime = styledChar.getTime();
+        const time = (progressive && charTime != null && charTime > startTime) ?
+            charTime : startTime;
+
+        // If any style property or the reveal time has changed, open a new cue.
         if (underline != currentUnderline || italics != currentItalics ||
             textColor != currentTextColor ||
-            backgroundColor != currentBackgroundColor) {
+            backgroundColor != currentBackgroundColor ||
+            time != currentTime) {
           // Push the currently built cue and start a new cue, with new styles.
           if (currentCue.payload) {
             topLevelCue.nestedCues.push(currentCue);
           }
           currentCue = shaka.cea.CeaUtils.createStyledCue(
-              startTime, endTime, underline,
+              time, endTime, underline,
               italics, textColor, backgroundColor);
 
           currentUnderline = underline;
           currentItalics = italics;
           currentTextColor = textColor;
           currentBackgroundColor = backgroundColor;
+          currentTime = time;
         }
 
         currentCue.payload += styledChar.getChar();
@@ -127,6 +147,7 @@ shaka.cea.CeaUtils = class {
       }
 
       // Create a new cue.
+      currentTime = startTime;
       currentCue = shaka.cea.CeaUtils.createStyledCue(
           startTime, endTime, currentUnderline, currentItalics,
           currentTextColor, currentBackgroundColor);
@@ -229,8 +250,13 @@ shaka.cea.CeaUtils.StyledChar = class {
    * @param {boolean} italics
    * @param {string} backgroundColor
    * @param {string} textColor
+   * @param {?number=} time The presentation time (in seconds) at which this
+   *   character was decoded. Used by paint-on and roll-up modes to reveal text
+   *   character by character. May be null when timing is irrelevant (e.g.
+   *   pop-on, or CEA-708).
    */
-  constructor(character, underline, italics, backgroundColor, textColor) {
+  constructor(character, underline, italics, backgroundColor, textColor,
+      time = null) {
     /**
      * @private {string}
      */
@@ -255,6 +281,11 @@ shaka.cea.CeaUtils.StyledChar = class {
      * @private {string}
      */
     this.textColor_ = textColor;
+
+    /**
+     * @private {?number}
+     */
+    this.time_ = time;
   }
 
   /**
@@ -262,6 +293,13 @@ shaka.cea.CeaUtils.StyledChar = class {
    */
   getChar() {
     return this.character_;
+  }
+
+  /**
+   * @return {?number}
+   */
+  getTime() {
+    return this.time_;
   }
 
   /**

--- a/lib/player.js
+++ b/lib/player.js
@@ -4622,6 +4622,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       delete config['manifest']['dash']['disableXlinkProcessing'];
     }
 
+    // Deprecate 'textDisplayer.captionsUpdatePeriod' configuration.
+    if (config['textDisplayer'] &&
+        'captionsUpdatePeriod' in config['textDisplayer']) {
+      shaka.Deprecate.deprecateFeature(6,
+          'textDisplayer.captionsUpdatePeriod configuration',
+          'Captions are now updated based on the cue timings, so this ' +
+          'configuration is no longer needed.');
+      delete config['textDisplayer']['captionsUpdatePeriod'];
+    }
+
     // Backward compatibility for old individual preference fields.
     // These were replaced by structured preference arrays in v5.1.
     shaka.Player.convertLegacyPreferences_(config);

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -38,6 +38,9 @@ shaka.text.UITextDisplayer = class {
     /** @private {!Array<!shaka.text.Cue>} */
     this.cues_ = [];
 
+    /** @private {shaka.Player} */
+    this.player_ = player;
+
     /** @private {HTMLMediaElement} */
     this.video_ = player.getMediaElement();
 
@@ -80,11 +83,16 @@ shaka.text.UITextDisplayer = class {
     // Set the captions at the bottom by default.
     this.textContainer_.style.justifyContent = 'flex-end';
 
-    /** @private {shaka.util.Timer} */
+    /**
+     * Drives caption updates. Rather than polling at a fixed rate, this fires
+     * once at the next moment a cue needs to change (see
+     * configureCaptionsTimer_), then reschedules itself.
+     * @private {shaka.util.Timer}
+     */
     this.captionsTimer_ = new shaka.util.Timer(() => {
-      if (!this.video_.paused) {
-        this.updateCaptions_();
-      }
+      this.updateCaptions_();
+      // Schedule the next update at the following cue boundary.
+      this.configureCaptionsTimer_();
     });
     this.configureCaptionsTimer_();
 
@@ -110,9 +118,21 @@ shaka.text.UITextDisplayer = class {
 
     this.eventManager_.listen(this.video_, 'seeking', () => {
       this.updateCaptions_(/* forceUpdate= */ true);
+      // The playhead jumped, so the previously scheduled boundary is stale.
+      this.configureCaptionsTimer_();
     });
 
-    this.eventManager_.listen(this.video_, 'ratechange', () => {
+    // Any of these can change when the next cue boundary will be reached (or
+    // whether playback is progressing at all), so re-evaluate the update
+    // schedule when they fire.
+    this.eventManager_.listenMulti(this.video_,
+        ['play', 'playing', 'pause', 'waiting'], () => {
+          this.configureCaptionsTimer_();
+        });
+
+    // Use the player's rate change event (which also covers trick play) rather
+    // than the media element's, to match getPlaybackRate() below.
+    this.eventManager_.listen(this.player_, 'ratechange', () => {
       this.configureCaptionsTimer_();
     });
 
@@ -176,9 +196,8 @@ shaka.text.UITextDisplayer = class {
           const entry = entries[entries.length - 1];
           this.isContainerActuallyVisible_ =
               entry.isIntersecting && entry.intersectionRatio > 0;
-          const captionsUpdatePeriod =
-              this.config_?.captionsUpdatePeriod || 0.25;
-          this.applyVisibilityTimer_.tickAfter(captionsUpdatePeriod);
+          this.applyVisibilityTimer_.tickAfter(
+              shaka.text.UITextDisplayer.VISIBILITY_DEBOUNCE_);
         }
       }, options);
       goog.asserts.assert(this.videoContainer_,
@@ -412,20 +431,77 @@ shaka.text.UITextDisplayer = class {
   }
 
   /**
+   * Schedules the next caption update to land exactly when the displayed text
+   * next needs to change (a cue or nested-cue start/end boundary), instead of
+   * polling at a fixed rate. This makes character-by-character reveals (CEA-608
+   * paint-on / roll-up) land on time and avoids waking up while nothing is
+   * changing. A safety period bounds the wait so a missed event or a stall can
+   * never freeze the captions.
    * @private
    */
   configureCaptionsTimer_() {
-    if (this.captionsTimer_) {
-      if (this.cues_.length && !this.renderSuspended_) {
-        const captionsUpdatePeriod = this.config_ ?
-            this.config_.captionsUpdatePeriod : 0.25;
-        const updateTime = captionsUpdatePeriod /
-            Math.max(1, Math.abs(this.video_.playbackRate));
-        this.captionsTimer_.tickEvery(updateTime);
-      } else {
-        this.captionsTimer_.stop();
+    if (!this.captionsTimer_) {
+      return;
+    }
+    // Nothing to animate: no cues, rendering suspended, or playback paused (a
+    // paused frame doesn't change, and events such as seeking force their own
+    // update).
+    if (!this.cues_.length || this.renderSuspended_ || this.video_.paused) {
+      this.captionsTimer_.stop();
+      return;
+    }
+
+    const UITextDisplayer = shaka.text.UITextDisplayer;
+    const delay = this.getActiveConfig_()?.subtitleDelay ?? 0;
+    const now = this.video_.currentTime - delay;
+
+    // Default to the safety period; tighten it to the next boundary below.
+    let mediaUntilUpdate = UITextDisplayer.SAFETY_REFRESH_PERIOD_;
+    const nextBoundary = this.getNextBoundary_(this.cues_, now);
+    // Only target the boundary while the media is actually progressing. During
+    // a stall currentTime is frozen, so the boundary never gets closer; fall
+    // back to the safety period to avoid waking repeatedly for nothing.
+    if (nextBoundary != null &&
+        this.video_.readyState >= HTMLMediaElement.HAVE_FUTURE_DATA) {
+      mediaUntilUpdate = Math.min(
+          mediaUntilUpdate, Math.max(0, nextBoundary - now));
+    }
+
+    // Convert from media time to wall-clock time using the playback rate, with
+    // a small floor so dense cues (e.g. per-character reveals) can't spin.
+    const rate = Math.abs(this.player_.getPlaybackRate()) || 1;
+    const wallUntilUpdate = Math.max(
+        UITextDisplayer.MIN_REFRESH_PERIOD_, mediaUntilUpdate / rate);
+    this.captionsTimer_.tickAfter(wallUntilUpdate);
+  }
+
+  /**
+   * Finds the earliest cue or nested-cue time boundary strictly after the given
+   * time. These are the only moments at which the rendered output can change,
+   * so the update timer wakes there.
+   * @param {!Array<!shaka.text.Cue>} cues
+   * @param {number} time
+   * @return {?number} The next boundary time, or null if there is none ahead.
+   * @private
+   */
+  getNextBoundary_(cues, time) {
+    let next = null;
+    const consider = (boundary) => {
+      if (boundary > time && (next == null || boundary < next)) {
+        next = boundary;
+      }
+    };
+    for (const cue of cues) {
+      consider(cue.startTime);
+      consider(cue.endTime);
+      if (cue.nestedCues.length) {
+        const nestedNext = this.getNextBoundary_(cue.nestedCues, time);
+        if (nestedNext != null) {
+          consider(nestedNext);
+        }
       }
     }
+    return next;
   }
 
   /**
@@ -1398,6 +1474,28 @@ shaka.text.UITextDisplayer = class {
  * }}
  */
 shaka.text.UITextDisplayer.CueRegistry_;
+
+/**
+ * Longest the update timer will ever wait, in seconds. Caption updates normally
+ * land exactly on the next cue boundary; this only bounds the wait so a missed
+ * event or a playback stall can never leave the captions stale indefinitely.
+ * @private @const {number}
+ */
+shaka.text.UITextDisplayer.SAFETY_REFRESH_PERIOD_ = 1;
+
+/**
+ * Shortest the update timer will ever wait, in seconds (~one frame at 60fps).
+ * Prevents a hot loop when cue boundaries are very close together, e.g.
+ * character-by-character CEA-608 reveals.
+ * @private @const {number}
+ */
+shaka.text.UITextDisplayer.MIN_REFRESH_PERIOD_ = 1 / 60;
+
+/**
+ * Debounce applied before re-evaluating container visibility, in seconds.
+ * @private @const {number}
+ */
+shaka.text.UITextDisplayer.VISIBILITY_DEBOUNCE_ = 0.25;
 
 /**
  * @private {!shaka.util.Lazy<!shaka.text.CueRegion>}

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -404,7 +404,6 @@ shaka.util.PlayerConfiguration = class {
     };
 
     const textDisplayer = {
-      captionsUpdatePeriod: 0.25,
       fontScaleFactor: 1,
       positionArea: shaka.config.PositionArea.DEFAULT,
       subtitleDelay: 0,

--- a/test/cea/cea608_memory_unit.js
+++ b/test/cea/cea608_memory_unit.js
@@ -411,4 +411,76 @@ describe('Cea608Memory', () => {
       expect(caption).toEqual(expectedCaption);
     });
   });
+
+  describe('progressive reveal', () => {
+    it('reveals characters at their decode times', () => {
+      const startTime = 1;
+      const endTime = 5;
+
+      // Each character is decoded at a later time, as in paint-on / roll-up.
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, 'a'.charCodeAt(0), 2);
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, 'b'.charCodeAt(0), 3);
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, 'c'.charCodeAt(0), 3);
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, 'd'.charCodeAt(0), 4);
+
+      const topLevelCue = new shaka.text.Cue(startTime, endTime, '');
+      topLevelCue.line = 10;
+      topLevelCue.lineInterpretation =
+          shaka.text.Cue.lineInterpretation.PERCENTAGE;
+      // One nested cue per decode time, each ending at the cue's end time.
+      topLevelCue.nestedCues = [
+        CeaUtils.createDefaultCue(/* startTime= */ 2, endTime, 'a'),
+        CeaUtils.createDefaultCue(/* startTime= */ 3, endTime, 'bc'),
+        CeaUtils.createDefaultCue(/* startTime= */ 4, endTime, 'd'),
+      ];
+
+      const caption =
+          memory.forceEmit(startTime, endTime, /* progressive= */ true);
+      expect(caption).toEqual({stream, cue: topLevelCue});
+    });
+
+    it('reveals characters decoded at or before the start immediately', () => {
+      const startTime = 3;
+      const endTime = 5;
+
+      // 'a' and 'b' were decoded at or before the cue start (e.g. a roll-up row
+      // that scrolled up), so they should be revealed immediately; 'c' is new.
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, 'a'.charCodeAt(0), 1);
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, 'b'.charCodeAt(0), 3);
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, 'c'.charCodeAt(0), 4);
+
+      const topLevelCue = new shaka.text.Cue(startTime, endTime, '');
+      topLevelCue.line = 10;
+      topLevelCue.lineInterpretation =
+          shaka.text.Cue.lineInterpretation.PERCENTAGE;
+      topLevelCue.nestedCues = [
+        CeaUtils.createDefaultCue(/* startTime= */ 3, endTime, 'ab'),
+        CeaUtils.createDefaultCue(/* startTime= */ 4, endTime, 'c'),
+      ];
+
+      const caption =
+          memory.forceEmit(startTime, endTime, /* progressive= */ true);
+      expect(caption).toEqual({stream, cue: topLevelCue});
+    });
+
+    it('ignores decode times when not progressive (e.g. pop-on)', () => {
+      const startTime = 1;
+      const endTime = 5;
+
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, 'a'.charCodeAt(0), 2);
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, 'b'.charCodeAt(0), 3);
+
+      const topLevelCue = new shaka.text.Cue(startTime, endTime, '');
+      topLevelCue.line = 10;
+      topLevelCue.lineInterpretation =
+          shaka.text.Cue.lineInterpretation.PERCENTAGE;
+      // Without progressive mode, everything appears at once at the start time.
+      topLevelCue.nestedCues = [
+        CeaUtils.createDefaultCue(startTime, endTime, 'ab'),
+      ];
+
+      const caption = memory.forceEmit(startTime, endTime);
+      expect(caption).toEqual({stream, cue: topLevelCue});
+    });
+  });
 });

--- a/test/cea/cea_decoder_unit.js
+++ b/test/cea/cea_decoder_unit.js
@@ -348,6 +348,12 @@ describe('CeaDecoder', () => {
       }
       decoder.extract(eraseDisplayedMemory, 6);
 
+      // Roll-up is revealed character by character: each row appears at the
+      // time its bytes were decoded. The newest row of every caption was
+      // decoded in the same frame as its carriage return (the end of the
+      // caption's window), so it is revealed at that window's end time, while
+      // older rows that scrolled up from a previous caption show immediately.
+
       // Top level cue corresponding to the first closed caption.
       const topLevelCue1 = new shaka.text.Cue(
           /* startTime= */ time1, /* endTime= */ time2, '');
@@ -356,7 +362,7 @@ describe('CeaDecoder', () => {
           shaka.text.Cue.lineInterpretation.PERCENTAGE;
       topLevelCue1.nestedCues = [
         CeaUtils.createDefaultCue(
-            /* startTime= */ time1, /* endTime= */ time2, /* payload= */ '1.'),
+            /* startTime= */ time2, /* endTime= */ time2, /* payload= */ '1.'),
       ];
 
       // Top level cue corresponding to the second closed caption.
@@ -373,7 +379,7 @@ describe('CeaDecoder', () => {
             /* startTime= */ time2, /* endTime= */ time3),
 
         CeaUtils.createDefaultCue(
-            /* startTime= */ time2, /* endTime= */ time3, /* payload= */ '2.'),
+            /* startTime= */ time3, /* endTime= */ time3, /* payload= */ '2.'),
       ];
 
       // Top level cue corresponding to the third closed caption.
@@ -390,7 +396,7 @@ describe('CeaDecoder', () => {
             /* startTime= */ time3, /* endTime= */ time4),
 
         CeaUtils.createDefaultCue(
-            /* startTime= */ time3, /* endTime= */ time4, /* payload= */ '3.'),
+            /* startTime= */ time4, /* endTime= */ time4, /* payload= */ '3.'),
       ];
 
       // Top level cue corresponding to the fourth closed caption.
@@ -407,7 +413,7 @@ describe('CeaDecoder', () => {
             /* startTime= */ time4, /* endTime= */ time5),
 
         CeaUtils.createDefaultCue(
-            /* startTime= */ time4, /* endTime= */ time5, /* payload= */ '4.'),
+            /* startTime= */ time5, /* endTime= */ time5, /* payload= */ '4.'),
       ];
 
       const expectedCaptions = [
@@ -466,6 +472,11 @@ describe('CeaDecoder', () => {
       }
       decoder.extract(eraseDisplayedMemory, 3);
 
+      // Roll-up reveals each row at its decode time. The newest row of each
+      // caption was decoded in the same frame that ends the caption's window,
+      // so it is revealed at that end time; rows scrolled up from a previous
+      // caption show immediately.
+
       // Top level cue corresponding to the first closed caption.
       const topLevelCue1 = new shaka.text.Cue(/* startTime= */ 1,
           /* endTime= */ 2, '');
@@ -474,7 +485,7 @@ describe('CeaDecoder', () => {
           shaka.text.Cue.lineInterpretation.PERCENTAGE;
       topLevelCue1.nestedCues = [
         CeaUtils.createDefaultCue(
-            /* startTime= */ 1, /* endTime= */ 2, /* payload= */ '1.'),
+            /* startTime= */ 2, /* endTime= */ 2, /* payload= */ '1.'),
       ];
 
       // Top level cue corresponding to the second closed caption.
@@ -490,7 +501,7 @@ describe('CeaDecoder', () => {
         CeaUtils.createLineBreakCue(/* startTime= */ 2, /* endTime= */ 3),
 
         CeaUtils.createDefaultCue(
-            /* startTime= */ 2, /* endTime= */ 3, /* payload= */ '2.'),
+            /* startTime= */ 3, /* endTime= */ 3, /* payload= */ '2.'),
       ];
 
       const expectedCaptions = [

--- a/test/test/util/layout_tests.js
+++ b/test/test/util/layout_tests.js
@@ -276,6 +276,9 @@ shaka.test.DomTextLayoutTests = class extends shaka.test.TextLayoutTests {
     this.player = {
       getMediaElement: () => /** @type {!HTMLMediaElement} */(this.mockVideo),
       getVideoContainer: () => this.videoContainer,
+      getPlaybackRate: () => this.mockVideo ? this.mockVideo.playbackRate : 1,
+      addEventListener: () => {},
+      removeEventListener: () => {},
     };
 
     await this.waitForFont('Roboto');

--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -49,9 +49,15 @@ describe('UITextDisplayer', () => {
     videoContainer.style.height = `${videoContainerHeight}px`;
     document.body.appendChild(videoContainer);
     video = new shaka.test.FakeVideo();
+    // The displayer reads getPlaybackRate() and listens to the player's
+    // 'ratechange' event, so the fake exposes those (the event listener is
+    // never fired in these tests, so addEventListener can be a no-op).
     player = {
       getMediaElement: () => video,
       getVideoContainer: () => videoContainer,
+      getPlaybackRate: () => video.playbackRate,
+      addEventListener: () => {},
+      removeEventListener: () => {},
     };
   });
 
@@ -821,5 +827,47 @@ describe('UITextDisplayer', () => {
 
     // Text content should be present
     expect(cueElement.textContent).toBe('Top-Left');
+  });
+
+  describe('getNextBoundary_', () => {
+    /**
+     * @param {!Array<!shaka.text.Cue>} cues
+     * @param {number} time
+     * @return {?number}
+     * @suppress {visibility}
+     */
+    function getNextBoundary(cues, time) {
+      return textDisplayer.getNextBoundary_(cues, time);
+    }
+
+    it('returns the earliest boundary strictly after the time', () => {
+      const cues = [new shaka.text.Cue(1, 3, 'a')];
+      expect(getNextBoundary(cues, 0)).toBe(1);
+      expect(getNextBoundary(cues, 1)).toBe(3);
+      expect(getNextBoundary(cues, 2)).toBe(3);
+      // No boundary remains after the cue has ended.
+      expect(getNextBoundary(cues, 3)).toBe(null);
+    });
+
+    it('considers all cues', () => {
+      const cues = [
+        new shaka.text.Cue(1, 3, 'a'),
+        new shaka.text.Cue(5, 8, 'b'),
+      ];
+      expect(getNextBoundary(cues, 3)).toBe(5);
+      expect(getNextBoundary(cues, 5)).toBe(8);
+    });
+
+    it('descends into nested cues (character-by-character reveals)', () => {
+      const cue = new shaka.text.Cue(1, 10, '');
+      cue.nestedCues = [
+        new shaka.text.Cue(2, 10, 'a'),
+        new shaka.text.Cue(5, 10, 'b'),
+      ];
+      const cues = [cue];
+      expect(getNextBoundary(cues, 1)).toBe(2);
+      expect(getNextBoundary(cues, 2)).toBe(5);
+      expect(getNextBoundary(cues, 5)).toBe(10);
+    });
   });
 });


### PR DESCRIPTION
CEA-608 paint-on and roll-up captions are painted to the screen as their bytes arrive, one character at a time. Shaka decoded both modes but emitted each caption as a single batch, so the whole line or window appeared at once instead of progressively, unlike a native decoder.

Each decoded character now carries its presentation timestamp, and paint-on and roll-up cues reveal their text character by character using per-nested-cue start times (the same mechanism WebVTT karaoke already relies on). Pop-on is left unchanged, since it is meant to appear all at once.

To make the reveal land on time without polling, the UITextDisplayer now schedules each update at the next cue (or nested-cue) boundary instead of on a fixed interval, bounded by a safety period so a stall or a missed event can never leave the captions stale.

The textDisplayer.captionsUpdatePeriod configuration is no longer needed and is now deprecated and ignored.