### PR TITLE
fix(ABR): Removed unused droppedFrameProtection type

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2688,9 +2688,6 @@ shaka.extern.AdsConfiguration;
  *   trust the information provided by the browser.
  *   <br>
  *   Defaults to <code>false</code>.
- * @property {shaka.extern.DroppedFrameProtectionConfig} droppedFrameProtection
- *   Configuration for monitoring dropped frames and temporarily disabling
- *   streams that exceed a threshold.
  * @property {boolean} droppedFrames
  *   Enable or disable dropped frames protection.
  *   <br>


### PR DESCRIPTION
Leftover from a first iteration that had a separate frame drop config typed as `shaka.extern.DroppedFrameProtectionConfig`. This was later added to the ABR config's advanced prop but we accidentally left its type in.