### PR TITLE
fix: Prevent memory exhaustion from malformed TRUN sample_count

### DIFF
--- a/lib/util/mp4_box_parsers.js
+++ b/lib/util/mp4_box_parsers.js
@@ -7,6 +7,7 @@
 goog.provide('shaka.util.Mp4BoxParsers');
 
 goog.require('shaka.util.DataViewReader');
+goog.require('shaka.util.Error');
 goog.require('shaka.util.Mp4Parser');
 goog.require('shaka.util.Uint8ArrayUtils');
 
@@ -194,6 +195,43 @@ shaka.util.Mp4BoxParsers = class {
     // Skip "first_sample_flags" if present.
     if (flags & 0x000004) {
       reader.skip(4);
+    }
+
+    // Validate sampleCount against the remaining bytes in the box before
+    // iterating.  A malicious or corrupt fragment can declare a sampleCount
+    // (a 32-bit value, up to ~4.29 billion) that is far larger than the box
+    // could actually contain.  When no per-sample fields are present (flags
+    // has none of the per-sample bits set), the loop below reads zero bytes
+    // per iteration, so the reader's own bounds checks never trigger and the
+    // loop would allocate one object per declared sample -- allowing a tiny
+    // input to exhaust memory.  Bound sampleCount by the number of samples
+    // that could possibly fit in the remaining payload.
+    let minBytesPerSample = 0;
+    if (flags & 0x000100) {
+      minBytesPerSample += 4; // sample_duration
+    }
+    if (flags & 0x000200) {
+      minBytesPerSample += 4; // sample_size
+    }
+    if (flags & 0x000400) {
+      minBytesPerSample += 4; // sample_flags
+    }
+    if (flags & 0x000800) {
+      minBytesPerSample += 4; // sample_composition_time_offset
+    }
+    const bytesRemaining = reader.getLength() - reader.getPosition();
+    // When per-sample fields are present, each sample consumes
+    // minBytesPerSample bytes; otherwise a sample consumes no bytes, but a
+    // valid fragment still cannot describe more samples than there are bytes
+    // remaining in the box.
+    const maxPossibleSamples = minBytesPerSample > 0 ?
+        Math.floor(bytesRemaining / minBytesPerSample) :
+        bytesRemaining;
+    if (sampleCount > maxPossibleSamples) {
+      throw new shaka.util.Error(
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.MEDIA,
+          shaka.util.Error.Code.BUFFER_READ_OUT_OF_BOUNDS);
     }
 
     for (let i = 0; i < sampleCount; i++) {

--- a/test/util/mp4_box_parsers_unit.js
+++ b/test/util/mp4_box_parsers_unit.js
@@ -180,6 +180,65 @@ describe('Mp4BoxParsers', () => {
     expect(baseMediaDecodeTime).toBe(expectedBaseMediaDecodeTime);
   });
 
+  describe('parseTRUN sampleCount validation', () => {
+    const DataViewReader = shaka.util.DataViewReader;
+    const Endianness = shaka.util.DataViewReader.Endianness;
+
+    /**
+     * Builds a minimal TRUN payload (the bytes after the box header, version,
+     * and flags) with the given declared sample_count followed by
+     * |extraBytes| additional bytes representing per-sample data.
+     * @param {number} sampleCount
+     * @param {number} extraBytes
+     * @return {!shaka.util.DataViewReader}
+     */
+    function makeTrunReader(sampleCount, extraBytes) {
+      const data = new Uint8Array(4 + extraBytes);
+      new DataView(data.buffer).setUint32(0, sampleCount);
+      return new DataViewReader(data, Endianness.BIG_ENDIAN);
+    }
+
+    it('rejects a sample_count larger than the box can hold (flags=0)', () => {
+      // flags = 0 means the per-sample loop reads no bytes, so without a
+      // bound the parser would allocate ~4.29 billion objects from a tiny
+      // input.  The box has no per-sample bytes, so any non-zero count is
+      // out of bounds.
+      const reader = makeTrunReader(0xFFFFFFFF, 0);
+      expect(() => {
+        shaka.util.Mp4BoxParsers.parseTRUN(reader, /* version= */ 0,
+            /* flags= */ 0);
+      }).toThrow();
+    });
+
+    it('rejects a sample_count larger than the box can hold (flags set)', () => {
+      // flags request sample_duration + sample_size = 8 bytes per sample.
+      // The box only carries 8 extra bytes (room for exactly one sample),
+      // so a declared count of 1,000,000 must be rejected.
+      const reader = makeTrunReader(1000000, /* extraBytes= */ 8);
+      expect(() => {
+        shaka.util.Mp4BoxParsers.parseTRUN(reader, /* version= */ 0,
+            /* flags= */ 0x000300);
+      }).toThrow();
+    });
+
+    it('accepts a valid sample_count backed by enough bytes', () => {
+      // 3 samples * 8 bytes/sample (duration + size) = 24 bytes.
+      const reader = makeTrunReader(3, /* extraBytes= */ 24);
+      const parsed = shaka.util.Mp4BoxParsers.parseTRUN(
+          reader, /* version= */ 0, /* flags= */ 0x000300);
+      expect(parsed.sampleCount).toBe(3);
+      expect(parsed.sampleData.length).toBe(3);
+    });
+
+    it('accepts a zero sample_count', () => {
+      const reader = makeTrunReader(0, /* extraBytes= */ 0);
+      const parsed = shaka.util.Mp4BoxParsers.parseTRUN(
+          reader, /* version= */ 0, /* flags= */ 0);
+      expect(parsed.sampleCount).toBe(0);
+      expect(parsed.sampleData.length).toBe(0);
+    });
+  });
+
   it('parses ESDS box for xHE-AAC segment', () => {
     let channelCount;
     let sampleRate;


### PR DESCRIPTION
## What this fixes

The `parseTRUN` box parser in `lib/util/mp4_box_parsers.js` reads a 32-bit `sample_count` and iterates that many times, allocating one object per declared sample. When a TRUN box sets none of the per-sample flags, the loop body reads zero bytes per iteration, so the `DataViewReader` bounds checks never trigger. A malformed or malicious fragment as small as a few bytes can declare a `sample_count` of up to ~4.29 billion, forcing the parser to allocate billions of objects and exhausting memory — crashing the player.

This code path is reachable from untrusted media and caption segments via the CEA (`mp4_cea_parser.js`), MP4 VTT (`mp4_vtt_parser.js`), and MP4 TTML (`mp4_ttml_parser.js`) parsers, so a crafted stream can trigger it on the client.

## The fix

Bound `sample_count` by the number of samples that could actually fit in the remaining box payload:

- Compute the minimum bytes each sample must consume from the per-sample flags.
- If per-sample fields are present, cap the count at `remaining / minBytesPerSample`.
- If no per-sample fields are present (zero bytes per sample), cap the count at the number of remaining bytes, since a valid fragment cannot describe more samples than there are bytes in the box.
- Throw `BUFFER_READ_OUT_OF_BOUNDS` when the declared count exceeds this bound.

Valid fragments are unaffected — the bound is only reached by counts that could never be backed by real data.

## Tests

Added unit tests in `test/util/mp4_box_parsers_unit.js` covering:
- Rejection of an oversized `sample_count` with `flags = 0`
- Rejection of an oversized `sample_count` with per-sample flags set
- Acceptance of a valid `sample_count` backed by enough bytes
- Acceptance of a zero `sample_count`

## Security note

I have also reported the underlying issue privately via https://g.co/vulnz per the project's SECURITY.md, so the security team can coordinate disclosure.