### PR TITLE
build: Reduce bundle size by deduplicating license headers

### DIFF
--- a/externs/shaka/metadata_parser.js
+++ b/externs/shaka/metadata_parser.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/metadata/id3v1_utils.js
+++ b/lib/metadata/id3v1_utils.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/metadata/ilst_utils.js
+++ b/lib/metadata/ilst_utils.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/metadata/metadata.js
+++ b/lib/metadata/metadata.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/metadata/vorbis_utils.js
+++ b/lib/metadata/vorbis_utils.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/metadata/ilst_utils_unit.js
+++ b/test/metadata/ilst_utils_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/metadata/vorbis_utils_unit.js
+++ b/test/metadata/vorbis_utils_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
Ensure generated bundles contain a single license header instead of repeating the same notice across bundled modules.

Normalize all copyright years to 2016 and remove
duplicate license headers from generated bundles.

This reduces the final bundle size while preserving license information in the distributed artifacts.

Related to https://github.com/shaka-project/shaka-player/pull/10182