### PR TITLE
fix(TS): Fix timestamps when a segment straddles the 33-bit PTS/DTS rollover

### DIFF
--- a/lib/util/ts_parser.js
+++ b/lib/util/ts_parser.js
@@ -76,9 +76,6 @@ shaka.util.TsParser = class {
     /** @private {?number} */
     this.referencePts_ = null;
 
-    /** @private {?number} */
-    this.referenceDts_ = null;
-
     /** @private {?shaka.util.TsParser.OpusMetadata} */
     this.opusMetadata_ = null;
 
@@ -112,7 +109,6 @@ shaka.util.TsParser = class {
     if (this.discontinuitySequence_ != null &&
         this.discontinuitySequence_ != discontinuitySequence) {
       this.referencePts_ = null;
-      this.referenceDts_ = null;
     }
     this.discontinuitySequence_ = discontinuitySequence;
   }
@@ -566,12 +562,32 @@ shaka.util.TsParser = class {
       // the PTS and DTS are not written out directly. For information
       // on how they are encoded, see
       // http://dvd.sourceforge.net/dvdinfo/pes-hdr.html
-      const pts =
+      let pts =
         (data[9] & 0x0e) * 536870912 + // 1 << 29
         (data[10] & 0xff) * 4194304 + // 1 << 22
         (data[11] & 0xfe) * 16384 + // 1 << 14
         (data[12] & 0xff) * 128 + // 1 << 7
         (data[13] & 0xfe) / 2;
+
+      let dts = null;
+      if (ptsDtsFlags & 0x40) {
+        dts =
+          (data[14] & 0x0e) * 536870912 + // 1 << 29
+          (data[15] & 0xff) * 4194304 + // 1 << 22
+          (data[16] & 0xfe) * 16384 + // 1 << 14
+          (data[17] & 0xff) * 128 + // 1 << 7
+          (data[18] & 0xfe) / 2;
+
+        // A frame's PTS and DTS are always within a few frames of each
+        // other.  Since the DTS never exceeds the PTS, the PTS crosses the
+        // 33-bit rollover point first; a packet can therefore carry a PTS
+        // that has already wrapped around while its DTS has not.  Un-wrap
+        // the PTS against the raw DTS so both sit on the same side of the
+        // rollover; otherwise the wrapped PTS would poison the reference
+        // used to normalize the rest of the stream, and the muxer would see
+        // a wildly inconsistent decode timestamp for this frame.
+        pts = this.handleRollover_(pts, dts);
+      }
 
       if (this.referencePts_ == null) {
         this.referencePts_ = pts;
@@ -581,25 +597,12 @@ shaka.util.TsParser = class {
       this.referencePts_ = pesPts;
 
       pesDts = pesPts;
-      if (ptsDtsFlags & 0x40) {
-        const dts =
-          (data[14] & 0x0e) * 536870912 + // 1 << 29
-          (data[15] & 0xff) * 4194304 + // 1 << 22
-          (data[16] & 0xfe) * 16384 + // 1 << 14
-          (data[17] & 0xff) * 128 + // 1 << 7
-          (data[18] & 0xfe) / 2;
-
-        if (this.referenceDts_ == null) {
-          this.referenceDts_ = dts;
-        }
-
-        if (pesPts != pts) {
-          pesDts = this.handleRollover_(dts, this.referenceDts_);
-        } else {
-          pesDts = dts;
-        }
+      if (dts != null) {
+        // Normalize the DTS against this packet's corrected PTS rather than
+        // an independent reference, which also keeps the pair consistent
+        // when a segment straddles a rollover.
+        pesDts = this.handleRollover_(dts, pesPts);
       }
-      this.referenceDts_ = pesDts;
     }
 
     const pesHdrLen = data[8];


### PR DESCRIPTION
A PES packet can carry a PTS that has already wrapped around the 33-bit rollover point while its DTS has not (the PTS always crosses the boundary first, since the DTS never exceeds the PTS).  parsePESHeader_ took the DTS raw whenever the PTS needed no rollover adjustment, so content whose first frame sits just before the rollover produced a wildly inconsistent PTS/DTS pair (e.g. PTS 0 with DTS 2^33 - 3600).  The transmuxer then used the huge raw DTS as baseMediaDecodeTime (~95443s) while the append-time timestampOffset calculation saw ~0, so the buffered range ended up nowhere near the playhead and playback never started.

Now the PTS is first un-wrapped against the raw DTS of the same packet, keeping the whole segment on the pre-rollover side (and timestamps non-negative for the muxer), and the DTS is always normalized against the corrected PTS instead of an independent reference.

Fixes the "Transmuxer Player for video H.264 in TS with b-frames" integration test timing out on all browsers when playing in segments mode.

Related to https://github.com/shaka-project/shaka-player/issues/9323