### PR TITLE
fix: Retry the stall-breaking action when a stall persists

### DIFF
--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -335,7 +335,7 @@ shaka.media.GapJumpingController = class {
     const threshold = this.config_.stallThreshold;
     const skip = this.config_.stallSkip;
 
-    const onStall = async (at, duration) => {
+    const onStall = async (at, duration, retryNumber) => {
       goog.asserts.assert(this.video_, 'Must have video');
       const bufferedInfo =
           shaka.media.TimeRangesUtils.getBufferedInfo(this.video_.buffered);
@@ -343,7 +343,8 @@ shaka.media.GapJumpingController = class {
         // Nothing in the buffer.
         return;
       }
-      shaka.log.debug(`Stall detected at ${at} for ${duration} seconds.`);
+      shaka.log.debug(`Stall detected at ${at} for ${duration} seconds ` +
+          `(attempt ${retryNumber + 1}).`);
 
       if (skip) {
         shaka.log.debug(`Seeking forward ${skip} seconds to break stall.`);
@@ -359,9 +360,13 @@ shaka.media.GapJumpingController = class {
         this.video_.pause();
         this.video_.play();
       }
-      this.stallsDetected_++;
-      this.onEvent_(new shaka.util.FakeEvent(
-          shaka.util.FakeEvent.EventName.StallDetected));
+      // Retries are part of the same stall, so only count the stall and
+      // notify the application on the initial attempt.
+      if (retryNumber == 0) {
+        this.stallsDetected_++;
+        this.onEvent_(new shaka.util.FakeEvent(
+            shaka.util.FakeEvent.EventName.StallDetected));
+      }
     };
 
     // When we see a stall, we will try to "jump-start" playback by moving the
@@ -395,8 +400,10 @@ shaka.media.StallDetector = class {
   /**
    * @param {shaka.media.StallDetector.Implementation} implementation
    * @param {number} stallThresholdSeconds
-   * @param {function(number, number)} onStall
-   *     Callback that should be called when a stall is detected.
+   * @param {function(number, number, number)} onStall
+   *     Callback that should be called when a stall is detected.  Given the
+   *     time the playhead is stalled at, the stall duration in seconds, and
+   *     the retry number (0 for the initial attempt).
    */
   constructor(implementation, stallThresholdSeconds, onStall) {
     /** @private {shaka.media.StallDetector.Implementation} */
@@ -407,8 +414,22 @@ shaka.media.StallDetector = class {
     this.value_ = implementation.getPresentationSeconds();
     /** @private {number} */
     this.lastUpdateSeconds_ = implementation.getWallSeconds();
-    /** @private {boolean} */
-    this.didJump_ = false;
+
+    /**
+     * The number of times |onStall| has been called for the current stall.
+     * Reset when the playhead makes progress again.
+     *
+     * @private {number}
+     */
+    this.stallAttempts_ = 0;
+
+    /**
+     * The wall time, in seconds, at which |onStall| was last called.  Only
+     * meaningful when |stallAttempts_| is greater than zero.
+     *
+     * @private {number}
+     */
+    this.lastAttemptSeconds_ = 0;
 
     /**
      * The amount of time in seconds that we must have the same value of
@@ -418,7 +439,7 @@ shaka.media.StallDetector = class {
      */
     this.stallThresholdSeconds_ = stallThresholdSeconds;
 
-    /** @private {?function(number, number)} */
+    /** @private {?function(number, number, number)} */
     this.onStall_ = onStall;
   }
 
@@ -452,19 +473,27 @@ shaka.media.StallDetector = class {
       this.lastUpdateSeconds_ = wallTimeSeconds;
       this.value_ = value;
       this.wasMakingProgress_ = shouldBeMakingProgress;
-      this.didJump_ = false;
+      this.stallAttempts_ = 0;
     }
 
     const stallSeconds = wallTimeSeconds - this.lastUpdateSeconds_;
 
+    // If the stall persists after an attempt to break it, retry, spacing the
+    // attempts at least one stall threshold apart, up to the retry limit.
+    const maxAttempts = 1 + shaka.media.StallDetector.MAX_STALL_RETRIES;
     const triggerCallback = stallSeconds >= this.stallThresholdSeconds_ &&
-                            shouldBeMakingProgress && !this.didJump_;
+        shouldBeMakingProgress &&
+        this.stallAttempts_ < maxAttempts &&
+        (this.stallAttempts_ == 0 ||
+         wallTimeSeconds - this.lastAttemptSeconds_ >=
+             this.stallThresholdSeconds_);
 
     if (triggerCallback) {
       if (this.onStall_) {
-        this.onStall_(this.value_, stallSeconds);
+        this.onStall_(this.value_, stallSeconds, this.stallAttempts_);
       }
-      this.didJump_ = true;
+      this.stallAttempts_++;
+      this.lastAttemptSeconds_ = wallTimeSeconds;
       // If the onStall_ method updated the current time, update our stored
       // value so we don't think that was an update.
       this.value_ = impl.getPresentationSeconds();
@@ -473,6 +502,19 @@ shaka.media.StallDetector = class {
     return triggerCallback;
   }
 };
+
+
+/**
+ * The maximum number of times the stall detector will retry the
+ * stall-breaking action for the same stall, after the initial attempt,
+ * while the playhead is still making no progress.  This bounds the number
+ * of corrective actions taken on platforms where the action never manages
+ * to resume playback.
+ *
+ * @const {number}
+ */
+shaka.media.StallDetector.MAX_STALL_RETRIES = 2;
+
 
 /**
  * @interface

--- a/test/media/stall_detector_unit.js
+++ b/test/media/stall_detector_unit.js
@@ -88,6 +88,7 @@ describe('StallDetector', () => {
     expect(onStall).toHaveBeenCalledOnceMoreWith([
       /* stalledWith= */ 5,
       /* stallDurationSeconds= */ 1,
+      /* retryNumber= */ 0,
     ]);
   });
 
@@ -103,6 +104,7 @@ describe('StallDetector', () => {
     expect(onStall).toHaveBeenCalledOnceMoreWith([
       /* stalledWith= */ 5,
       /* stallDurationMs= */ 10,
+      /* retryNumber= */ 0,
     ]);
   });
 
@@ -142,29 +144,81 @@ describe('StallDetector', () => {
     expect(onStall).not.toHaveBeenCalled();
   });
 
-  it('does not call onStall multiple times for same stall', () => {
+  it('retries onStall while the stall persists, up to the limit', () => {
     implementation.shouldMakeProgress = true;
-    implementation.presentationSeconds = 0;
+    implementation.presentationSeconds = 5;
     implementation.wallSeconds = 0;
     detector.poll();
     expect(onStall).not.toHaveBeenCalled();
 
-    implementation.wallSeconds = 10;
+    // The initial attempt happens after the stall threshold.
+    implementation.wallSeconds = 1;
     detector.poll();
-    expect(onStall).toHaveBeenCalled();
-    onStall.calls.reset();
+    expect(onStall).toHaveBeenCalledOnceMoreWith([
+      /* stalledWith= */ 5,
+      /* stallDurationSeconds= */ 1,
+      /* retryNumber= */ 0,
+    ]);
 
-    // This is the same stall, should not be called again.
-    implementation.wallSeconds = 20;
+    // Polling again before a full threshold has passed since the last
+    // attempt should not retry yet.
+    detector.poll();
+    implementation.wallSeconds = 1.5;
     detector.poll();
     expect(onStall).not.toHaveBeenCalled();
 
-    // Now that we changed time, we should get another call.
-    implementation.presentationSeconds = 10;
+    // First retry, one threshold after the previous attempt.
+    implementation.wallSeconds = 2;
+    detector.poll();
+    expect(onStall).toHaveBeenCalledOnceMoreWith([
+      /* stalledWith= */ 5,
+      /* stallDurationSeconds= */ 2,
+      /* retryNumber= */ 1,
+    ]);
+
+    // Second and last retry.
+    implementation.wallSeconds = 3;
+    detector.poll();
+    expect(onStall).toHaveBeenCalledOnceMoreWith([
+      /* stalledWith= */ 5,
+      /* stallDurationSeconds= */ 3,
+      /* retryNumber= */ 2,
+    ]);
+
+    // The retry limit has been reached, so the same stall should not
+    // trigger any more attempts.
     implementation.wallSeconds = 30;
     detector.poll();
-    implementation.wallSeconds = 40;
+    expect(onStall).not.toHaveBeenCalled();
+  });
+
+  it('resets the retry limit when progress is made', () => {
+    implementation.shouldMakeProgress = true;
+    implementation.presentationSeconds = 5;
+    implementation.wallSeconds = 0;
     detector.poll();
-    expect(onStall).toHaveBeenCalled();
+
+    // Exhaust all the attempts for the first stall.
+    for (const time of [1, 2, 3, 30]) {
+      implementation.wallSeconds = time;
+      detector.poll();
+    }
+    expect(onStall).toHaveBeenCalledTimes(
+        1 + shaka.media.StallDetector.MAX_STALL_RETRIES);
+    onStall.calls.reset();
+
+    // Progress resets the limit, so a new stall triggers again.
+    implementation.presentationSeconds = 10;
+    implementation.wallSeconds = 31;
+    detector.poll();
+    expect(onStall).not.toHaveBeenCalled();
+
+    implementation.wallSeconds = 32;
+    detector.poll();
+    expect(onStall).toHaveBeenCalledOnceMoreWith([
+      /* stalledWith= */ 10,
+      /* stallDurationSeconds= */ 1,
+      /* retryNumber= */ 0,
+    ]);
   });
 });


### PR DESCRIPTION
Previously, StallDetector fired its stall-breaking action (stallSkip seek or pause/play cycle) only once per stall: if the media pipeline stayed frozen after that single attempt, playback never recovered. This happens in practice on older WebKit versions (e.g. Safari 18.x), which can get permanently stuck after jumping the small gap at an HLS discontinuity in segments mode.

Now the action is retried while the playhead makes no progress, spaced at least one stallThreshold apart, up to a new constant StallDetector.MAX_STALL_RETRIES (2 retries after the initial attempt). Any real progress resets the limit.

The stallsDetected stat and the "stalldetected" event still fire only once per stall, so application-visible behavior is unchanged.

Related to #9323