### PR TITLE
chore(Subtitles): Match parseMedia() implementation signatures

### DIFF
--- a/lib/text/mp4_ttml_parser.js
+++ b/lib/text/mp4_ttml_parser.js
@@ -175,7 +175,7 @@ shaka.text.Mp4TtmlParser = class {
         sampleData = contentData;
       }
       payload = payload.concat(
-            this.parser_.parseMedia(sampleData, time, uri, images));
+          this.parser_.parseMedia(sampleData, time, uri, images));
     }
 
     return payload;

--- a/lib/text/mp4_ttml_parser.js
+++ b/lib/text/mp4_ttml_parser.js
@@ -66,7 +66,7 @@ shaka.text.Mp4TtmlParser = class {
    * @override
    * @export
    */
-  parseMedia(data, time, uri) {
+  parseMedia(data, time, uri, images) {
     const Mp4Parser = shaka.util.Mp4Parser;
 
     let payload = [];
@@ -151,17 +151,17 @@ shaka.text.Mp4TtmlParser = class {
 
     let sampleOffset = 0;
     for (let sampleNum = 0; sampleNum < sampleSizes.length; sampleNum++) {
-      const sampleData =
+      let sampleData =
           shaka.util.BufferUtils.toUint8(fullData, sampleOffset,
               sampleSizes[sampleNum]);
       sampleOffset += sampleSizes[sampleNum];
 
       const subSampleSizes = subSampleSizesPerSample.get(sampleNum);
+      const images = [];
 
       if (subSampleSizes && subSampleSizes.length) {
         const contentData =
             shaka.util.BufferUtils.toUint8(sampleData, 0, subSampleSizes[0]);
-        const images = [];
         let subOffset = subSampleSizes[0];
         for (let i = 1; i < subSampleSizes.length; i++) {
           const imageData =
@@ -172,13 +172,10 @@ shaka.text.Mp4TtmlParser = class {
           images.push('data:image/png;base64,' + raw);
           subOffset += subSampleSizes[i];
         }
-        payload = payload.concat(
-            this.parser_.parseMedia(contentData, time, uri, images));
-      } else {
-        payload = payload.concat(
-            this.parser_.parseMedia(sampleData, time, uri,
-                /* images= */ []));
+        sampleData = contentData;
       }
+      payload = payload.concat(
+            this.parser_.parseMedia(sampleData, time, uri, images));
     }
 
     return payload;

--- a/lib/text/mp4_vtt_parser.js
+++ b/lib/text/mp4_vtt_parser.js
@@ -91,7 +91,7 @@ shaka.text.Mp4VttParser = class {
    * @override
    * @export
    */
-  parseMedia(data, time) {
+  parseMedia(data, time, uri, images) {
     if (!data.length) {
       return [];
     }

--- a/lib/text/srt_text_parser.js
+++ b/lib/text/srt_text_parser.js
@@ -6,7 +6,6 @@
 
 goog.provide('shaka.text.SrtTextParser');
 
-goog.require('goog.asserts');
 goog.require('shaka.text.TextEngine');
 goog.require('shaka.text.Utils');
 goog.require('shaka.text.VttTextParser');
@@ -18,47 +17,23 @@ goog.require('shaka.util.StringUtils');
  * @implements {shaka.extern.TextParser}
  * @export
  */
-shaka.text.SrtTextParser = class {
-  constructor() {
-    /**
-     * @type {!shaka.extern.TextParser}
-     * @private
-     */
-    this.parser_ = new shaka.text.VttTextParser();
-  }
-
+shaka.text.SrtTextParser = class extends shaka.text.VttTextParser {
   /**
    * @override
    * @export
    */
-  parseInit(data) {
-    goog.asserts.assert(false, 'SRT does not have init segments');
-  }
-
-  /**
-   * @override
-   * @export
-   */
-  setManifestType(manifestType) {
-    // Unused.
-  }
-
-  /**
-   * @override
-   * @export
-   */
-  parseMedia(data, time, uri) {
+  parseMedia(data, time, uri, images) {
     const BufferUtils = shaka.util.BufferUtils;
     const StringUtils = shaka.util.StringUtils;
 
     // Get the input as a string.
     const str = StringUtils.fromUTF8(data);
 
-    const vvtText = this.srt2webvtt_(str);
+    const vttText = this.srt2webvtt_(str);
 
-    const newData = BufferUtils.toUint8(StringUtils.toUTF8(vvtText));
+    const newData = BufferUtils.toUint8(StringUtils.toUTF8(vttText));
 
-    return this.parser_.parseMedia(newData, time, uri, /* images= */ []);
+    return super.parseMedia(newData, time, uri, images);
   }
 
   /**

--- a/lib/text/vtt_text_parser.js
+++ b/lib/text/vtt_text_parser.js
@@ -48,7 +48,7 @@ shaka.text.VttTextParser = class {
    * @override
    * @export
    */
-  parseMedia(data, time) {
+  parseMedia(data, time, uri, images) {
     const VttTextParser = shaka.text.VttTextParser;
     // Get the input as a string.  Normalize newlines to \n.
     let str = shaka.util.StringUtils.fromUTF8(data);

--- a/test/text/cue_integration.js
+++ b/test/text/cue_integration.js
@@ -58,6 +58,6 @@ describe('Cue', () => {
   function parseVtt(text, time) {
     const data =
         shaka.util.BufferUtils.toUint8(shaka.util.StringUtils.toUTF8(text));
-    return new shaka.text.VttTextParser().parseMedia(data, time);
+    return new shaka.text.VttTextParser().parseMedia(data, time, null, []);
   }
 });

--- a/test/text/mp4_ttml_parser_unit.js
+++ b/test/text/mp4_ttml_parser_unit.js
@@ -66,7 +66,7 @@ describe('Mp4TtmlParser', () => {
       vttOffset: 0,
       isMpegTs: false,
     };
-    const ret = parser.parseMedia(ttmlSegmentMultipleMDAT, time, null);
+    const ret = parser.parseMedia(ttmlSegmentMultipleMDAT, time, null, []);
     // Bodies.
     expect(ret.length).toBe(2);
     // Divs.
@@ -87,7 +87,7 @@ describe('Mp4TtmlParser', () => {
       vttOffset: 0,
       isMpegTs: false,
     };
-    const ret = parser.parseMedia(ttmlSegmentMultipleSample, time, null);
+    const ret = parser.parseMedia(ttmlSegmentMultipleSample, time, null, []);
     // Bodies.
     expect(ret.length).toBe(2);
     // Divs.
@@ -117,10 +117,10 @@ describe('Mp4TtmlParser', () => {
     const parser = new shaka.text.Mp4TtmlParser();
     parser.parseInit(ttmlInitSegment);
 
-    const ret1 = parser.parseMedia(ttmlSegment, time1, null);
+    const ret1 = parser.parseMedia(ttmlSegment, time1, null, []);
     expect(ret1.length).toBeGreaterThan(0);
 
-    const ret2 = parser.parseMedia(ttmlSegment, time2, null);
+    const ret2 = parser.parseMedia(ttmlSegment, time2, null, []);
     expect(ret2.length).toBeGreaterThan(0);
 
     expect(ret2[0].startTime).toBe(ret1[0].startTime + 7);
@@ -224,7 +224,7 @@ describe('Mp4TtmlParser', () => {
       vttOffset: 0,
       isMpegTs: false,
     };
-    const result = parser.parseMedia(ttmlSegment, time, null);
+    const result = parser.parseMedia(ttmlSegment, time, null, []);
     shaka.test.TtmlUtils.verifyHelper(
         cues, result, {startTime: 23, endTime: 53.5});
   });
@@ -239,7 +239,7 @@ describe('Mp4TtmlParser', () => {
       vttOffset: 0,
       isMpegTs: false,
     };
-    const ret = parser.parseMedia(imscImageSegment, time, null);
+    const ret = parser.parseMedia(imscImageSegment, time, null, []);
     // Bodies.
     expect(ret.length).toBe(1);
     // Divs.

--- a/test/text/mp4_vtt_parser_unit.js
+++ b/test/text/mp4_vtt_parser_unit.js
@@ -72,7 +72,7 @@ describe('Mp4VttParser', () => {
       vttOffset: 0,
       isMpegTs: false,
     };
-    const result = parser.parseMedia(vttSegment, time);
+    const result = parser.parseMedia(vttSegment, time, null, []);
     verifyHelper(cues, result);
   });
 
@@ -106,7 +106,7 @@ describe('Mp4VttParser', () => {
       vttOffset: 0,
       isMpegTs: false,
     };
-    const result = parser.parseMedia(vttSegmentMultiPayload, time);
+    const result = parser.parseMedia(vttSegmentMultiPayload, time, null, []);
     verifyHelper(cues, result);
   });
 
@@ -140,7 +140,7 @@ describe('Mp4VttParser', () => {
       vttOffset: 0,
       isMpegTs: false,
     };
-    const result = parser.parseMedia(vttSegSettings, time);
+    const result = parser.parseMedia(vttSegSettings, time, null, []);
     verifyHelper(cues, result);
   });
 
@@ -168,7 +168,7 @@ describe('Mp4VttParser', () => {
       vttOffset: 0,
       isMpegTs: false,
     };
-    const result = parser.parseMedia(vttSegNoDuration, time);
+    const result = parser.parseMedia(vttSegNoDuration, time, null, []);
     verifyHelper(cues, result);
   });
 
@@ -196,7 +196,7 @@ describe('Mp4VttParser', () => {
       vttOffset: 10,
       isMpegTs: false,
     };
-    const result = parser.parseMedia(vttSegment, time);
+    const result = parser.parseMedia(vttSegment, time, null, []);
     verifyHelper(cues, result);
   });
 
@@ -210,7 +210,7 @@ describe('Mp4VttParser', () => {
       vttOffset: 0,
       isMpegTs: false,
     };
-    const result = parser.parseMedia(new Uint8Array(0), time);
+    const result = parser.parseMedia(new Uint8Array(0), time, null, []);
     verifyHelper([], result);
   });
 

--- a/test/text/srt_text_parser_unit.js
+++ b/test/text/srt_text_parser_unit.js
@@ -230,7 +230,7 @@ describe('SrtTextParser', () => {
     const data = BufferUtils.toUint8(StringUtils.toUTF8(text));
 
     const parser = new shaka.text.SrtTextParser();
-    const result = parser.parseMedia(data, time, null);
+    const result = parser.parseMedia(data, time, null, []);
 
     const expected = cues.map((cue) => {
       if (cue.nestedCues) {

--- a/test/text/vtt_text_parser_unit.js
+++ b/test/text/vtt_text_parser_unit.js
@@ -1844,7 +1844,7 @@ describe('VttTextParser', () => {
     const error = shaka.test.Util.jasmineError(shakaError);
     const data =
         shaka.util.BufferUtils.toUint8(shaka.util.StringUtils.toUTF8(text));
-    expect(() => 
+    expect(() =>
       new shaka.text.VttTextParser().parseMedia(data, time, null, []))
         .toThrow(error);
   }

--- a/test/text/vtt_text_parser_unit.js
+++ b/test/text/vtt_text_parser_unit.js
@@ -1811,7 +1811,7 @@ describe('VttTextParser', () => {
       parser.setManifestType(shaka.media.ManifestParser.HLS);
     }
 
-    const result = parser.parseMedia(data, time);
+    const result = parser.parseMedia(data, time, null, []);
 
     const checkCue = (cue) => {
       if (cue.nestedCues) {
@@ -1844,7 +1844,8 @@ describe('VttTextParser', () => {
     const error = shaka.test.Util.jasmineError(shakaError);
     const data =
         shaka.util.BufferUtils.toUint8(shaka.util.StringUtils.toUTF8(text));
-    expect(() => new shaka.text.VttTextParser().parseMedia(data, time))
+    expect(() => 
+      new shaka.text.VttTextParser().parseMedia(data, time, null, []))
         .toThrow(error);
   }
 });

--- a/test/text/web_vtt_layout_integration.js
+++ b/test/text/web_vtt_layout_integration.js
@@ -513,7 +513,7 @@ filterDescribe('WebVTT layout', shaka.test.TextLayoutTests.supported, () => {
       isMpegTs: false,
     };
     const textParser = new shaka.text.VttTextParser();
-    const cues = textParser.parseMedia(data, time);
+    const cues = textParser.parseMedia(data, time, null, []);
     helper.textDisplayer.append(cues);
   }
 });


### PR DESCRIPTION
Our `TextParser` interface has 4-parameters `parseMedia()` signature, but not all implementations follow it, so align it.
Additional small optimizations in `SrtTextParser` (inherit `VttTextParser` instead of using it internally) and `Mp4TtmlParser` (reduce duplication).