### PR TITLE
fix: Restore correct playhead position after MediaSource reload

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -720,6 +720,16 @@ shaka.media.MediaSourceEngine = class {
   }
 
   /**
+   * Indicate if the MediaSource is currently being reloaded, e.g. because of
+   * a codec switch or an error recovery.
+   *
+   * @return {boolean}
+   */
+  isReloadingMediaSource() {
+    return this.reloadingMediaSource_;
+  }
+
+  /**
    * Reinitialize the TextEngine for a new text type.
    * @param {string} mimeType
    * @param {boolean} external

--- a/lib/media/video_wrapper.js
+++ b/lib/media/video_wrapper.js
@@ -111,6 +111,11 @@ shaka.media.VideoWrapper = class {
     if (this.video_.readyState > 0) {
       this.mover_.moveTo(time);
     } else {
+      // The media element isn't ready to accept changes to current time yet,
+      // so update the cached start time and apply it once the media element
+      // is ready. Otherwise, the delayed call below would ignore |time| and
+      // re-apply the stale start time it was constructed with.
+      this.startTime_ = time;
       shaka.util.MediaReadyState.waitForReadyState(this.video_,
           HTMLMediaElement.HAVE_METADATA,
           this.eventManager_,

--- a/lib/player.js
+++ b/lib/player.js
@@ -8732,6 +8732,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           // If not paused then GapJumpingController will handle this gap.
           this.video_.paused &&
           !this.video_.seeking &&
+          // A codec switch or error recovery reload can also leave the video
+          // paused momentarily; that's not the initial buffer gap, so don't
+          // treat it as a start position.
+          !this.mediaSourceEngine_.isReloadingMediaSource() &&
           startTime != null &&
           startTime > 0 &&
           this.playhead_.getTime() < startTime &&

--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -410,6 +410,47 @@ describe('Playhead', () => {
     });
   });  // getTime
 
+  // Regression test for https://github.com/shaka-project/shaka-player/issues/10299
+  // A codec-switch (or MSE error recovery) reload briefly drops the video's
+  // readyState back to 0. If the playhead is repositioned while that's
+  // happening, it must end up at the newly requested time once the video
+  // becomes ready again, not at the original startTime it was constructed
+  // with.
+  it('setStartTime applies the requested time if the video becomes ' +
+      'temporarily unready', () => {
+    video.readyState = HTMLMediaElement.HAVE_METADATA;
+    playhead = new shaka.media.MediaSourcePlayhead(
+        video,
+        manifest,
+        config,
+        /* startTime= */ 5,
+        Util.spyFunc(onSeek),
+        Util.spyFunc(onEvent));
+
+    playhead.ready();
+
+    expect(video.currentTime).toBe(5);
+
+    // Simulate normal playback progressing past the initial start time.
+    video.currentTime = 40;
+    video.on['seeking']();
+
+    // Simulate the video element becoming unready, e.g. because
+    // MediaSourceEngine reassigned video.src during a reload.
+    video.readyState = 0;
+
+    // Something (e.g. the "skip initial buffer gap" logic) asks the
+    // playhead to move to a new position while the video isn't ready yet.
+    playhead.setStartTime(42);
+
+    // Once the video becomes ready again, it should end up at the newly
+    // requested position, not the original startTime (5).
+    video.readyState = HTMLMediaElement.HAVE_METADATA;
+    video.on['loadedmetadata']();
+
+    expect(video.currentTime).toBe(42);
+  });
+
   it('clamps playhead after seeking for live', () => {
     video.readyState = HTMLMediaElement.HAVE_METADATA;
 


### PR DESCRIPTION
When the video element briefly becomes unready during a MediaSource reset (codec switch or  MEDIA_SOURCE_OPERATION_FAILED recovery), VideoWrapper.setTime() discarded the requested time and  reapplied the original, stale startTime once the video became ready again. This bug predates PR #9668, but was  masked by a fallback removed there, which is why it started causing playback to rewind to the initial startTime after a  codec-switch reload.

Also guard the "skip initial buffer gap" logic in Player.onSegmentAppended_ against the transient `video.paused`  state that a MediaSource reload produces, since it isn't a real initial-gap scenario.

Fixes https://github.com/shaka-project/shaka-player/issues/10299