### PR TITLE
fix: Reset media source before switching variant on MSE append failure

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3252,12 +3252,26 @@ shaka.media.StreamingEngine = class {
         this.setTrickPlay(/* on= */ false);
         return;
       }
+
+      if (error.code == shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_THREW ||
+          error.code == shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_FAILED) {
+        // A native append operation just failed on this SourceBuffer.  Reset
+        // the media source (recreating the SourceBuffers) before we switch
+        // variants below, so that we don't append into a SourceBuffer that
+        // may already be in a broken state.  Some platforms crash natively,
+        // asynchronously, if they receive another append on a SourceBuffer
+        // that just failed.
+        // See https://github.com/shaka-project/shaka-player/issues/10331
+        error.handled = await this.resetMediaSource();
+        this.destroyer_.ensureNotDestroyed();
+      }
+
       const maxDisabledTime = this.getDisabledTime_(error);
       if (maxDisabledTime) {
         shaka.log.debug(logPrefix, 'Disabling stream due to error', error);
       }
       error.handled = this.playerInterface_.disableStream(
-          mediaState.stream, maxDisabledTime);
+          mediaState.stream, maxDisabledTime) || error.handled;
 
       // Decrease the error severity to recoverable
       if (error.handled) {

--- a/lib/player.js
+++ b/lib/player.js
@@ -9033,7 +9033,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.stats_.addNonFatalError();
     }
 
-    if (this.manifest_ && this.streamingEngine_ &&
+    // If |error.handled| is already true here, StreamingEngine has already
+    // reset the media source for this same error (see handleStreamingError_
+    // in streaming_engine.js), so there is no need to attempt another reset.
+    if (this.manifest_ && this.streamingEngine_ && !error.handled &&
         (error.code == shaka.util.Error.Code.VIDEO_ERROR ||
         error.code == shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_FAILED ||
         error.code == shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_THREW ||


### PR DESCRIPTION
On MEDIA_SOURCE_OPERATION_FAILED/THREW, StreamingEngine was disabling the stream and switching variants before Player.onError_ got a chance to reset the MediaSource, so the next segment was appended into the same SourceBuffer that had just failed. On some platforms (e.g. embedded WebKit) this triggers an asynchronous native crash.

handleStreamingError_ now resets the MediaSource before switching variants, and Player.onError_ skips its own reset if the error was already handled, avoiding a double reset.

Fixes #10331