### PR TITLE
docs: clarify that shaka.util.Error does not extend native Error

### DIFF
--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -25,6 +25,21 @@ goog.provide('shaka.util.Error');
  *   <li><a href="https://hresult.info">Edge/PlayReady errors</a>
  * </ul>
  *
+ * The <code>@extends {Error}</code> annotation below is a type-only
+ * declaration for the Closure Compiler; this class does <b>not</b> actually
+ * extend the native <code>Error</code> at runtime (there is no <code>extends
+ * Error</code> clause and the constructor never calls <code>super()</code>).
+ * That annotation exists only so that our conformance checks (see
+ * build/conformance.textproto's <code>BanThrowOfNonErrorTypes</code> rule)
+ * accept <code>throw new shaka.util.Error(...)</code> throughout the
+ * codebase; it is not a promise about the runtime prototype chain.
+ * <br><br>
+ * In particular, <code>(new shaka.util.Error(...)) instanceof Error</code>
+ * is <code>false</code>.  This is intentional: it lets application code tell
+ * an unhandled native error apart from a Shaka-specific error by checking
+ * <code>instanceof Error</code> before checking
+ * <code>instanceof shaka.util.Error</code>.  See {@tutorial errors}.
+ *
  * @export
  * @implements {shaka.extern.Error}
  * @extends {Error}

--- a/test/util/error_unit.js
+++ b/test/util/error_unit.js
@@ -1,0 +1,25 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('Error', () => {
+  // Regression test for https://github.com/shaka-project/shaka-player/issues/10339
+  // shaka.util.Error intentionally does not extend the native Error type.
+  // This lets apps distinguish an unhandled native error from a
+  // Shaka-specific error via `instanceof Error`, as documented in
+  // docs/tutorials/errors.md.  If this ever starts failing, do not "fix" it
+  // by making shaka.util.Error extend Error — see the class-level JSDoc in
+  // lib/util/error.js for the tradeoffs (it would also break error
+  // reconstruction across the Cast bus in shaka.cast.CastUtils).
+  it('does not extend the native Error type', () => {
+    const error = new shaka.util.Error(
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.DRM,
+        shaka.util.Error.Code.LICENSE_REQUEST_FAILED);
+
+    expect(error instanceof Error).toBe(false);
+    expect(error instanceof shaka.util.Error).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #10339