### PR TITLE
fix(Transmux): Fall back to main thread on worker transmux timeout

### DIFF
--- a/lib/transmuxer/transmuxer_proxy.js
+++ b/lib/transmuxer/transmuxer_proxy.js
@@ -203,15 +203,13 @@ shaka.transmuxer.TransmuxerProxy = class {
         shaka.util.Uint8ArrayUtils.concat(data));
 
     const {promise, resolve, reject} = Promise.withResolvers();
+    let timedOut = false;
     const timer = new shaka.util.Timer(() => {
       if (this.pendingRequests_.has(reqId)) {
         this.pendingRequests_.delete(reqId);
         this.workerFailed_ = true;
-        reject(new shaka.util.Error(
-            shaka.util.Error.Severity.CRITICAL,
-            shaka.util.Error.Category.MEDIA,
-            shaka.util.Error.Code.TRANSMUXING_FAILED,
-            'Worker transmux timed out'));
+        timedOut = true;
+        resolve(null);
       }
     });
     timer.tickAfter(shaka.transmuxer.TransmuxerProxy.TIMEOUT_MS_ / 1000);
@@ -246,6 +244,16 @@ shaka.transmuxer.TransmuxerProxy = class {
     }
 
     const response = await promise;
+
+    // If the worker did not respond in time, warn and fall back to
+    // main-thread transmuxing so playback can continue instead of failing.
+    if (timedOut) {
+      shaka.log.alwaysWarn(
+          'Worker transmux timed out; falling back to ' +
+          'main-thread transmuxing');
+      return this.innerTransmuxer_.transmux(
+          data, stream, reference, duration, contentType);
+    }
 
     // Apply stream mutations back to the real stream object.
     const mutations = response['streamMutations'];
@@ -309,8 +317,8 @@ shaka.transmuxer.TransmuxerProxy.nextId_ = 0;
 
 /**
  * Timeout in milliseconds for a worker transmux response. If the worker does
- * not respond within this time, the request is rejected and future calls fall
- * back to the main thread.
+ * not respond within this time, the request and all future calls fall back to
+ * main-thread transmuxing.
  * @private @const {number}
  */
 shaka.transmuxer.TransmuxerProxy.TIMEOUT_MS_ = 30000;

--- a/test/transmuxer/transmuxer_proxy_unit.js
+++ b/test/transmuxer/transmuxer_proxy_unit.js
@@ -421,30 +421,38 @@ describe('TransmuxerProxy', () => {
       beforeEach(() => jasmine.clock().install());
       afterEach(() => jasmine.clock().uninstall());
 
-      it('rejects on timeout when worker does not respond', async () => {
+      it('falls back to main thread when worker does not respond',
+          async () => {
+            const p = transmuxer.transmux(
+                fakeData, fakeStream, null, 10, 'video');
+
+            jasmine.clock().tick(30001);
+
+            // The pending call resolves via the inner transmuxer instead of
+            // rejecting, so playback can continue.
+            const result = await p;
+            expect(mockInner.transmux).toHaveBeenCalled();
+            expect(result).toEqual(jasmine.any(Uint8Array));
+          });
+
+      it('warns via alwaysWarn on timeout', async () => {
+        spyOn(shaka.log, 'alwaysWarn');
         const p = transmuxer.transmux(fakeData, fakeStream, null, 10, 'video');
-        const assertion = expectAsync(p).toBeRejectedWith(
-            jasmine.objectContaining({
-              code: shaka.util.Error.Code.TRANSMUXING_FAILED,
-            }));
 
         jasmine.clock().tick(30001);
-        await assertion;
+        await p;
+
+        expect(shaka.log.alwaysWarn).toHaveBeenCalled();
       });
 
-      it('falls back to main thread after timeout', async () => {
+      it('continues falling back to main thread after timeout', async () => {
         const p = transmuxer.transmux(fakeData, fakeStream, null, 10, 'video');
-        const assertion = expectAsync(p).toBeRejectedWith(
-            jasmine.objectContaining({
-              code: shaka.util.Error.Code.TRANSMUXING_FAILED,
-            }));
         jasmine.clock().tick(30001);
-        await assertion;
+        await p;
 
-        // mockInner.transmux returns a resolved promise, so this does not
-        // involve setTimeout and is safe to await with the clock still running.
+        // A subsequent call should go straight to the inner transmuxer.
         await transmuxer.transmux(fakeData, fakeStream, null, 10, 'video');
-        expect(mockInner.transmux).toHaveBeenCalled();
+        expect(mockInner.transmux).toHaveBeenCalledTimes(2);
       });
     });
 


### PR DESCRIPTION
When the worker transmux times out, warn and fall back to main-thread transmuxing so playback continues, instead of failing with a CRITICAL error.