### PR TITLE
fix(UI): Scope form element font inheritance to the player container

### DIFF
--- a/ui/less/containers.less
+++ b/ui/less/containers.less
@@ -25,6 +25,14 @@
   font-weight: normal;
   -webkit-font-smoothing: antialiased;
 
+  /* Form elements don't inherit font-family from their ancestors by default
+   * in most browsers; they fall back to the OS system font instead.  Force
+   * them to inherit so that the container's font-family applies
+   * consistently, without leaking this rule to the rest of the page. */
+  button, input, select, textarea {
+    font-family: inherit;
+  }
+
   /* prevent text caret from showing when 'Navigate pages with a text cursor'
    * setting is enabled on chromium-based browsers */
   user-select: none;

--- a/ui/less/general.less
+++ b/ui/less/general.less
@@ -172,13 +172,6 @@
   }
 }
 
-/* Form elements don't inherit font-family from their ancestors by default in
- * most browsers; they fall back to the OS system font instead.  Force them to
- * inherit so that Shaka UI containers' font-family applies consistently. */
-button, input, select, textarea {
-  font-family: inherit;
-}
-
 @media (forced-colors: active) {
   .shaka-overflow-menu,
   .shaka-settings-menu,


### PR DESCRIPTION
Move the button/input/select/textarea font-family:inherit rule out of general.less (where it applied globally to the whole page) into .shaka-video-container in containers.less, so it only affects Shaka's own UI and no longer leaks into the host page's form elements.

Related to https://github.com/shaka-project/shaka-player/pull/10138#discussion_r3576914884