### PR TITLE
ci: Bump GitHub Actions to their Node.js 24 runtime versions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
@@ -43,7 +43,7 @@ jobs:
         run: python3 build/all.py --only-es5
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: player-build
           path: dist/
@@ -114,7 +114,7 @@ jobs:
         run: sudo apt -y update && sudo apt -y install ffmpeg
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
@@ -161,7 +161,7 @@ jobs:
       # Some CI images (self-hosted or otherwise) don't have the minimum Java
       # version necessary for the compiler (Java 21).
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: player-build
           path: dist/
@@ -204,7 +204,7 @@ jobs:
           fi
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ always() && steps.coverage.outputs.coverage_found }}
         with:
           name: coverage
@@ -220,7 +220,7 @@ jobs:
 
       # Upload new screenshots and diffs on failure; ignore if missing
       - name: Upload screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
           name: screenshots-${{ matrix.browser }}-${{ matrix.os }}
@@ -235,7 +235,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false

--- a/.github/workflows/comment-bundle-size.yaml
+++ b/.github/workflows/comment-bundle-size.yaml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download report artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: bundle-report
           path: artifact

--- a/.github/workflows/github-pages-nightly-demo.yaml
+++ b/.github/workflows/github-pages-nightly-demo.yaml
@@ -16,17 +16,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21

--- a/.github/workflows/measure-bundle-size.yaml
+++ b/.github/workflows/measure-bundle-size.yaml
@@ -16,14 +16,14 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           path: head-source
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
@@ -42,7 +42,7 @@ jobs:
           cat ../head-sizes.json
 
       - name: Upload head sizes
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: head-sizes
           path: head-sizes.json
@@ -52,14 +52,14 @@ jobs:
 
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
           path: base-source
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
@@ -78,7 +78,7 @@ jobs:
           cat ../base-sizes.json
       
       - name: Upload base sizes
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: base-sizes
           path: base-sizes.json
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout repo (for script access)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # The script that generates the table should be run from `main`, not
           # the PR that triggered the workflow.
@@ -97,12 +97,12 @@ jobs:
           persist-credentials: false
 
       - name: Download head sizes
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: head-sizes
 
       - name: Download base sizes
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: base-sizes
 
@@ -118,7 +118,7 @@ jobs:
           cat report.md
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bundle-report
           path: report.md

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -44,7 +44,7 @@ jobs:
       is_latest: ${{ steps.compute.outputs.is_latest }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: refs/tags/${{ needs.release.outputs.tag_name }}
           persist-credentials: false
@@ -77,7 +77,7 @@ jobs:
     needs: release
     if: needs.release.outputs.release_created && needs.release.outputs.patch != '0'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Check out the origin repo, and do it at main, not the PR branch.
           ref: main
@@ -109,19 +109,19 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: refs/tags/${{ needs.release.outputs.tag_name }}
           persist-credentials: false
           # Needed to view all tags and correctly compute the latest tag.
           fetch-depth: 0
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           # NOTE: OIDC fails with node less than 24.
           node-version: 24
@@ -199,7 +199,7 @@ jobs:
     if: needs.compute-latest.outputs.is_latest == 'true'
     steps:
       - name: Check out source repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Check out the source repo at the release tag.
           ref: refs/tags/${{ needs.release.outputs.tag_name }}
@@ -208,12 +208,12 @@ jobs:
           # No credentials.
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
@@ -262,7 +262,7 @@ jobs:
     needs: release
     if: needs.release.outputs.release_created && needs.release.outputs.patch == '0'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: refs/tags/${{ needs.release.outputs.tag_name }}
           fetch-depth: 0

--- a/.github/workflows/report-incremental-coverage.yaml
+++ b/.github/workflows/report-incremental-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/selenium-lab-tests.yaml
+++ b/.github/workflows/selenium-lab-tests.yaml
@@ -81,7 +81,7 @@ jobs:
       INCLUDE: ${{ steps.configure.outputs.INCLUDE }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
           persist-credentials: false
@@ -152,7 +152,7 @@ jobs:
       statuses: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
           persist-credentials: false
@@ -166,7 +166,7 @@ jobs:
           state: pending
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
@@ -185,21 +185,21 @@ jobs:
               --filter ThisFilterMatchesNoTests || true
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: npm-cache
         with:
           path: node_modules/
           key: node-${{ hashFiles('package-lock.json') }}
 
       - name: Cache Babel output
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: babel-cache
         with:
           path: .babel-cache
           key: babel-${{ hashFiles('*.js', 'demo/**.js', 'lib/**.js', 'ui/**.js', 'test/**.js', 'third_party/**.js') }}
 
       - name: Store Player build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: shaka-player
           path: dist/
@@ -239,7 +239,7 @@ jobs:
     name: ${{ matrix.browser }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
           persist-credentials: false
@@ -253,19 +253,19 @@ jobs:
           state: pending
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       # The Docker image for this self-hosted runner doesn't contain java.
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: npm-cache
         with:
           path: node_modules/
@@ -274,7 +274,7 @@ jobs:
           enableCrossOsArchive: true  # Share archives from Linux to Windows
 
       - name: Cache Babel output
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: babel-cache
         with:
           path: .babel-cache
@@ -289,7 +289,7 @@ jobs:
       # Instead of building Shaka N times, build it once and fetch the build to
       # each Selenium runner in the matrix.
       - name: Fetch Player build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: shaka-player
           path: dist/
@@ -372,7 +372,7 @@ jobs:
           fi
 
       - name: Upload coverage report (Edge only)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         # If there's a coverage report, upload it, even if a previous step
         # failed.
         if: ${{ always() && steps.coverage.outputs.coverage_report }}
@@ -388,7 +388,7 @@ jobs:
 
       # Upload new screenshots and diffs on failure; ignore if missing
       - name: Upload screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ failure() || inputs.ignore_test_status }}
         with:
           # In this workflow, "browser" is the selenium node name, which can

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: shaka-project/shaka-github-tools
           persist-credentials: false

--- a/.github/workflows/talk-to-shaka-bot.yaml
+++ b/.github/workflows/talk-to-shaka-bot.yaml
@@ -23,7 +23,7 @@ jobs:
       COMMENT_BODY: ${{ github.event.comment.body }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/update-issues.yaml
+++ b/.github/workflows/update-issues.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: shaka-project/shaka-github-tools
           persist-credentials: false

--- a/.github/workflows/update-screenshots.yaml
+++ b/.github/workflows/update-screenshots.yaml
@@ -35,7 +35,7 @@ jobs:
       statuses: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
           persist-credentials: false
@@ -72,14 +72,14 @@ jobs:
     # the PR, and so must be untrusted!
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Get artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: test/test/assets/screenshots/
           pattern: screenshots-*
@@ -133,7 +133,7 @@ jobs:
     # by an actor with permission, and the default GitHub token doesn't work.
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
           fetch-depth: 0
@@ -232,7 +232,7 @@ jobs:
     # Will run on success or failure, but not if the workflow is cancelled.
     if: ${{ success() || failure() }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
           persist-credentials: false


### PR DESCRIPTION
GitHub Actions runners are deprecating Node.js 20, and actions still declaring `runs.using: node20` are now being force-run on Node 24 in compatibility mode, which GitHub flags as deprecated.

Bump actions/checkout, actions/cache, actions/setup-java, and actions/setup-node to v5, and actions/upload-artifact/download-artifact to v6/v7 respectively — the first major version of each that runs natively on Node 24 by default.