### PR TITLE
fix(net): isolate headers across retry attempts

### DIFF
--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -331,6 +331,7 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
     // request, it doesn't contaminate future requests.
     request.method = request.method || 'GET';
     request.headers = request.headers || {};
+    const originalHeaders = ObjectUtils.cloneObject(request.headers);
     request.retryParameters = request.retryParameters ?
         ObjectUtils.cloneObject(request.retryParameters) :
         shaka.net.NetworkingEngine.defaultRetryParameters();
@@ -338,7 +339,8 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
     request.attempt = 0;
 
     const requestOperation = /** @type {!shaka.util.AbortableOperation} */ (
-      this.makeRequestWithRetry_(type, request, context, numBytesRemainingObj));
+      this.makeRequestWithRetry_(
+          type, request, context, numBytesRemainingObj, originalHeaders));
     const responseFilterOperation = requestOperation.chain(
         (responseAndGotProgress) =>
           this.filterResponse_(type, responseAndGotProgress, context));
@@ -443,16 +445,18 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
    * @param {(shaka.extern.RequestContext|undefined)} context
    * @param {shaka.net.NetworkingEngine.NumBytesRemainingClass
    *        } numBytesRemainingObj
+   * @param {!Object<string, string>} originalHeaders
    * @return {!shaka.extern.IAbortableOperation.<
    *            shaka.net.NetworkingEngine.ResponseAndGotProgress>}
    * @private
    */
-  makeRequestWithRetry_(type, request, context, numBytesRemainingObj) {
+  makeRequestWithRetry_(
+      type, request, context, numBytesRemainingObj, originalHeaders) {
     const backoff = new shaka.net.Backoff(
         request.retryParameters, /* autoReset= */ false);
     return this.send_(
         type, request, context, backoff, /* lastError= */ null,
-        numBytesRemainingObj);
+        numBytesRemainingObj, originalHeaders);
   }
 
   /**
@@ -465,14 +469,19 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
    * @param {?shaka.util.Error} lastError
    * @param {shaka.net.NetworkingEngine.NumBytesRemainingClass
    *        } numBytesRemainingObj
+   * @param {!Object<string, string>} originalHeaders
    * @return {!shaka.extern.IAbortableOperation.<
    *               shaka.net.NetworkingEngine.ResponseAndGotProgress>}
    * @private
    */
-  send_(type, request, context, backoff, lastError, numBytesRemainingObj) {
+  send_(type, request, context, backoff, lastError, numBytesRemainingObj,
+      originalHeaders) {
     goog.asserts.assert(this.config_, 'Config must not be null!');
 
     const index = request.attempt % request.uris.length;
+    // Request filters can add origin-specific headers. Reset them before each
+    // retry so headers from one URI are not reused for another URI.
+    request.headers = shaka.util.ObjectUtils.cloneObject(originalHeaders);
     const filterRequestOperation = this.filterRequest_(type, request, context);
     const requestFilterStartTimeMs = Date.now();
     let requestFilterTimeMs = 0;
@@ -706,7 +715,8 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
           // Move to the next URI.
           ++request.attempt;
           return this.send_(
-              type, request, context, backoff, error, numBytesRemainingObj);
+              type, request, context, backoff, error, numBytesRemainingObj,
+              originalHeaders);
         }
       }
 
@@ -1075,4 +1085,3 @@ shaka.net.NetworkingEngine.OnRetry;
  * @export
  */
 shaka.net.NetworkingEngine.OnResponse;
-

--- a/test/net/networking_engine_unit.js
+++ b/test/net/networking_engine_unit.js
@@ -263,6 +263,89 @@ describe('NetworkingEngine', /** @suppress {accessControls} */ () => {
       expect(resolveScheme).toHaveBeenCalledTimes(1);
     });
 
+    it('does not leak CommonAccessToken to fallback hosts', async () => {
+      const tokenHeaderName = networkingEngine.config_
+          .commonAccessTokenHeaderName;
+
+      resolveScheme.and.callFake(() => {
+        const response = createResponse();
+        response.uri = 'resolve://trusted.example/segment1';
+        response.headers[tokenHeaderName] = 'token-abc';
+        return shaka.util.AbortableOperation.completed(response);
+      });
+      await networkingEngine
+          .request(
+              requestType, createRequest('resolve://trusted.example/segment1'))
+          .promise;
+
+      resolveScheme.calls.reset();
+      rejectScheme.and.callFake((uri, request) => {
+        expect(request.headers[tokenHeaderName]).toBe('token-abc');
+        return shaka.util.AbortableOperation.failed(error);
+      });
+      resolveScheme.and.callFake((uri, request) => {
+        expect(uri).toBe('resolve://attacker.example/segment2');
+        expect(request.headers[tokenHeaderName]).toBeUndefined();
+        return shaka.util.AbortableOperation.completed(createResponse());
+      });
+
+      const request = createRequest('', {
+        maxAttempts: 2,
+        baseDelay: 0,
+        backoffFactor: 0,
+        fuzzFactor: 0,
+        timeout: 0,
+        stallTimeout: 0,
+        connectionTimeout: 0,
+      });
+      request.uris = [
+        'reject://trusted.example/segment2',
+        'resolve://attacker.example/segment2',
+      ];
+      await networkingEngine.request(requestType, request).promise;
+
+      expect(rejectScheme).toHaveBeenCalledTimes(1);
+      expect(resolveScheme).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not leak request filter headers to fallback hosts', async () => {
+      networkingEngine.registerRequestFilter((type, request) => {
+        const index = request.attempt % request.uris.length;
+        const domain = shaka.util.URL.getDomain(request.uris[index]);
+        if (domain == 'trusted.example') {
+          request.headers['Authorization'] = 'Bearer token-abc';
+        }
+      });
+
+      rejectScheme.and.callFake((uri, request) => {
+        expect(request.headers['Authorization']).toBe('Bearer token-abc');
+        return shaka.util.AbortableOperation.failed(error);
+      });
+      resolveScheme.and.callFake((uri, request) => {
+        expect(uri).toBe('resolve://attacker.example/segment');
+        expect(request.headers['Authorization']).toBeUndefined();
+        return shaka.util.AbortableOperation.completed(createResponse());
+      });
+
+      const request = createRequest('', {
+        maxAttempts: 2,
+        baseDelay: 0,
+        backoffFactor: 0,
+        fuzzFactor: 0,
+        timeout: 0,
+        stallTimeout: 0,
+        connectionTimeout: 0,
+      });
+      request.uris = [
+        'reject://trusted.example/segment',
+        'resolve://attacker.example/segment',
+      ];
+      await networkingEngine.request(requestType, request).promise;
+
+      expect(rejectScheme).toHaveBeenCalledTimes(1);
+      expect(resolveScheme).toHaveBeenCalledTimes(1);
+    });
+
     it('won\'t retry for CRITICAL error', async () => {
       const request = createRequest('reject://foo', {
         maxAttempts: 5,


### PR DESCRIPTION
## Description

Reset request headers to their original baseline before each retry attempt.
This prevents headers added for one retry URI from being reused when
NetworkingEngine falls back to another URI.

## Changes

- Clone the original request headers before retry handling starts.
- Restore those headers before each request-filter pass.
- Add regression tests for Common Access Token and request-filter headers across fallback hosts.

## Testing

- `node --check lib/net/networking_engine.js`
- `node --check test/net/networking_engine_unit.js`
- Local PoC verification: Common Access Token fallback no longer leaks headers.
- Local PoC verification: request-filter Authorization fallback no longer leaks headers.

Note: the focused Karma test runner could not complete locally because `npm ci` failed in this environment. The failure was in dependency installation/tooling, before tests ran.
