### PR TITLE
fix: Prevent screen.orientation methods from being garbage collected on Safari

### DIFF
--- a/lib/polyfill/orientation.js
+++ b/lib/polyfill/orientation.js
@@ -52,14 +52,21 @@ shaka.polyfill.Orientation = class {
    * @private
    */
   static installBasedOnScreenMethods_() {
+    // On Safari and iPadOS, methods assigned directly to the screen.orientation
+    // instance are vulnerable to garbage collection, which can leave the player
+    // unable to exit fullscreen.  Assigning the no-ops to the prototype instead
+    // keeps them alive.
+    // See: https://github.com/shaka-project/shaka-player/issues/10362
+    const orientationProto = /** @type {!ScreenOrientation} */ (
+      Object.getPrototypeOf(/** @type {!Object} */ (screen.orientation)));
     if (screen.orientation.lock === undefined) {
-      screen.orientation.lock = (orientation) => {
+      orientationProto.lock = (orientation) => {
         shaka.log.info('screen.orientation.lock is a no-op');
         return Promise.resolve();
       };
     }
     if (screen.orientation.unlock === undefined) {
-      screen.orientation.unlock = () => {
+      orientationProto.unlock = () => {
         shaka.log.info('screen.orientation.unlock is a no-op');
       };
     }


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/10362