### PR TITLE
fix(UI): Fix context menu and rate slider touch behavior on mobile

### DIFF
--- a/test/ui/ui_unit.js
+++ b/test/ui/ui_unit.js
@@ -1481,6 +1481,71 @@ describe('UI', () => {
       });
     });
 
+    describe('custom context menu on touch devices', () => {
+      /** @type {!HTMLElement} */
+      let controlsContainer;
+      /** @type {!HTMLElement} */
+      let contextMenu;
+      /** @type {number} */
+      let originalMaxTouchPoints;
+
+      beforeEach(async () => {
+        originalMaxTouchPoints = navigator.maxTouchPoints;
+        // The touch listeners are only wired up on touch-capable devices, so
+        // pretend to be one before the UI is created.
+        Util.setMaxTouchPoints(1);
+
+        const config = {
+          customContextMenu: true,
+          contextMenuElements: [
+            'statistics',
+          ],
+        };
+        const ui = await UiUtils.createUIThroughAPI(
+            videoContainer, video, config);
+
+        const controls = ui.getControls();
+        controlsContainer = controls.getControlsContainer();
+        // onContainerTouch ignores touches until the media has a duration and
+        // only acts while the controls are showing (opaque).
+        Object.defineProperty(video, 'duration',
+            {value: 100, configurable: true});
+        controlsContainer.setAttribute('shown', 'true');
+
+        const contextMenus =
+            videoContainer.getElementsByClassName('shaka-context-menu');
+        expect(contextMenus.length).toBe(1);
+        contextMenu = /** @type {!HTMLElement} */ (contextMenus[0]);
+      });
+
+      afterEach(() => {
+        Util.setMaxTouchPoints(originalMaxTouchPoints);
+      });
+
+      it('stays open when the long-press is released', () => {
+        // A long-press fires 'contextmenu' while the finger is down, then
+        // 'touchend' when it is released.  The menu must survive the release.
+        UiUtils.simulateEvent(controlsContainer, 'touchstart');
+        UiUtils.simulateEvent(controlsContainer, 'contextmenu');
+        expect(contextMenu.classList.contains('shaka-hidden')).toBe(false);
+
+        UiUtils.simulateEvent(controlsContainer, 'touchend');
+        expect(contextMenu.classList.contains('shaka-hidden')).toBe(false);
+      });
+
+      it('closes on a subsequent tap', () => {
+        UiUtils.simulateEvent(controlsContainer, 'touchstart');
+        UiUtils.simulateEvent(controlsContainer, 'contextmenu');
+        UiUtils.simulateEvent(controlsContainer, 'touchend');
+        expect(contextMenu.classList.contains('shaka-hidden')).toBe(false);
+
+        // A separate tap (its own touchstart + touchend) closes the menu.
+        UiUtils.simulateEvent(controlsContainer, 'touchstart');
+        UiUtils.simulateEvent(controlsContainer, 'touchend');
+        expect(contextMenu.classList.contains('shaka-hidden')).toBe(true);
+      });
+    });
+
     describe('statistics context menu', () => {
       /** @type {!HTMLElement} */
       let statisticsButton;

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -328,6 +328,14 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
     /** @private {?number} */
     this.lastContainerTouchEventTime_ = null;
 
+    /**
+     * Set while a long-press is opening the custom context menu, so that the
+     * touchend which ends that same long-press does not immediately close the
+     * menu.  Reset on every touchstart and consumed by the next touchend.
+     * @private {boolean}
+     */
+    this.contextMenuOpenedByTouch_ = false;
+
     /** @private {!Array<!shaka.extern.IUIElement>} */
     this.elements_ = [];
 
@@ -1422,6 +1430,17 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
     this.videoContainer_.setAttribute('shaka-controls', 'true');
 
     if (navigator.maxTouchPoints > 0) {
+      this.eventManager_.listen(this.controlsContainer_, 'touchstart', () => {
+        // A fresh touch starts a new gesture; forget any previous long-press
+        // that opened the context menu.
+        this.contextMenuOpenedByTouch_ = false;
+      });
+      this.eventManager_.listen(this.controlsContainer_, 'contextmenu', () => {
+        // A long-press fires 'contextmenu' while the finger is still down.
+        // Remember it so the touchend that ends the press keeps the menu open
+        // (see onContainerTouch).
+        this.contextMenuOpenedByTouch_ = true;
+      });
       this.eventManager_.listen(this.controlsContainer_, 'touchend', (e) => {
         this.onContainerTouch(e);
       });
@@ -2000,6 +2019,17 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
   onContainerTouch(event) {
     if (!this.video_.duration) {
       // Can't play yet.  Ignore.
+      return;
+    }
+
+    if (this.contextMenuOpenedByTouch_ && this.anyContextMenusAreOpen()) {
+      // This touchend ends the long-press that just opened the context menu.
+      // Keep the menu open (matching desktop right-click behavior); a
+      // subsequent tap will close it through the normal path below.
+      this.contextMenuOpenedByTouch_ = false;
+      if (event.cancelable) {
+        event.preventDefault();
+      }
       return;
     }
 

--- a/ui/range_element.js
+++ b/ui/range_element.js
@@ -131,6 +131,11 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
           this.isChanging_ = true;
           this.setBarValueForTouch_(e);
           this.onChangeStart();
+          // Apply the new value right away, mirroring the mousedown handler.
+          // This makes a single tap seek to the touched position for controls
+          // that act on onChange (e.g. volume and playback-rate sliders),
+          // instead of requiring the user to drag the thumb.
+          this.onChange();
           e.stopPropagation();
         }
       });


### PR DESCRIPTION
- Keep the custom context menu open after a long-press ends: the touchend that releases the press no longer closes it (a later tap still does), matching desktop right-click behavior.
- Make a single tap on a range slider seek to the touched position by calling onChange() on touchstart, mirroring the mousedown handler. Fixes the playback-rate and volume sliders, which apply their value in onChange and previously required dragging.

Fixes #10363