### PR TITLE
fix(MSF): Fix draft-16 negotiation and skip empty catalog objects

### DIFF
--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -375,6 +375,11 @@ shaka.msf.MSFParser = class {
 
       await this.msfTransport_.fetchTrack(
           namespace, 'catalog', (obj) => {
+            // Objects with no payload carry an object status (e.g. the
+            // draft-16 end-of-group marker), not catalog data; skip them.
+            if (!obj['data'].byteLength) {
+              return;
+            }
             try {
               const text = shaka.util.StringUtils.fromUTF8(obj['data']);
               const catalog = /** @type {msfCatalog.Catalog} */(
@@ -418,6 +423,11 @@ shaka.msf.MSFParser = class {
       // Subscribe to the "catalog" track in the given namespace
       const trackAlias = await this.msfTransport_.subscribeTrack(
           namespace, 'catalog', (obj) => {
+            // Objects with no payload carry an object status (e.g. the
+            // draft-16 end-of-group marker), not catalog data; skip them.
+            if (!obj['data'].byteLength) {
+              return;
+            }
             try {
               const text = shaka.util.StringUtils.fromUTF8(obj['data']);
               const catalog = /** @type {msfCatalog.Catalog} */(

--- a/lib/msf/msf_transport.js
+++ b/lib/msf/msf_transport.js
@@ -126,14 +126,31 @@ shaka.msf.MSFTransport = class {
     await this.webTransport_.ready;
     shaka.log.v1('WebTransport connection established');
 
-    // Determine negotiated version from WebTransport protocol
-    if (this.config_.version === shaka.config.MsfVersion.DRAFT_14) {
-      this.negotiatedVersion_ = shaka.msf.Utils.Version.DRAFT_14;
-    } else if (this.webTransport_.protocol === PROTOCOL_DRAFT_16) {
-      this.negotiatedVersion_ = shaka.msf.Utils.Version.DRAFT_16;
-    } else {
-      // Fall back to draft-14 in-band negotiation
-      this.negotiatedVersion_ = shaka.msf.Utils.Version.DRAFT_14;
+    // Determine the negotiated version. The WebTransport subprotocol echoed
+    // by the server (webTransport.protocol) is the authoritative signal when
+    // it is present, but many relays (e.g. moqtail) accept the offered
+    // subprotocol without echoing it back, leaving webTransport.protocol
+    // empty. Relying on an exact 'moqt-16' echo therefore wrongly downgrades
+    // draft-16 servers to draft-14, whose in-band CLIENT_SETUP a draft-16-only
+    // relay cannot parse (the connection is then dropped). So we only trust an
+    // explicit echo and otherwise honor the configured/offered version.
+    switch (this.config_.version) {
+      case shaka.config.MsfVersion.DRAFT_14:
+        this.negotiatedVersion_ = shaka.msf.Utils.Version.DRAFT_14;
+        break;
+      case shaka.config.MsfVersion.DRAFT_16:
+        this.negotiatedVersion_ = shaka.msf.Utils.Version.DRAFT_16;
+        break;
+      default:
+        // AUTO: we offer draft-16 and draft-14. Prefer draft-16 (our highest
+        // offered version) unless the server explicitly selected draft-14 via
+        // the subprotocol.
+        if (this.webTransport_.protocol === PROTOCOL_DRAFT_14) {
+          this.negotiatedVersion_ = shaka.msf.Utils.Version.DRAFT_14;
+        } else {
+          this.negotiatedVersion_ = shaka.msf.Utils.Version.DRAFT_16;
+        }
+        break;
     }
     goog.asserts.assert(this.negotiatedVersion_ != null,
         'this.negotiatedVersion_ must be non-null.');

--- a/project-words.txt
+++ b/project-words.txt
@@ -223,6 +223,7 @@ Jwplayer
 Kaltura
 Livesim
 moqlivemock
+moqtail
 muxjs
 Nagra
 Playready


### PR DESCRIPTION
Discovered while verifying the playback of moqtail assets