### PR TITLE
ci(release): Suppress patch release PRs on main

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -21,9 +21,66 @@ jobs:
       pull-requests: write
 
     steps:
-      # Create/update release PR
+      # On main, we never want a *patch* release PR.  Patch releases are cut
+      # from the automatic release branches, not from main.  If release-please
+      # opened a patch-level PR on main, a maintainer could merge it by mistake.
+      #
+      # This step's ONLY job is to suppress release-please in that one case.
+      # It writes "run=false" when (and only when) it is confident the pending
+      # release on main is a patch.  The release-please step below treats
+      # anything other than "false" as "go", and this step continues on error,
+      # so any unexpected failure here leaves the output unset and lets
+      # release-please run by default.
+      - name: Decide whether to run release-please
+        id: gate
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          # Only main is ever suppressed; release branches always release.
+          if [[ "${{ github.ref_name }}" != "main" ]]; then
+            echo "On a release branch: running."
+            exit 0
+          fi
+
+          # Ask release-please itself what it *would* do, as a dry run.  Keep
+          # this version roughly in step with the release-please-action above.
+          if ! npx --yes release-please@17.10.3 release-pr \
+              --token="$GH_TOKEN" \
+              --repo-url="${{ github.repository }}" \
+              --target-branch=main \
+              --config-file=.release-please-config.json \
+              --manifest-file=.release-please-manifest.json \
+              --dry-run > dry-run.log 2>&1; then
+            echo "release-please dry-run failed: running."
+            cat dry-run.log || true
+            exit 0
+          fi
+          cat dry-run.log
+
+          # Extract the proposed version from the dry-run output.
+          NEXT=$(grep -oE '^title: .*release [0-9]+\.[0-9]+\.[0-9]+' dry-run.log \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
+          echo "Proposed version: ${NEXT:-<none>}"
+          if [[ -z "$NEXT" ]]; then
+            echo "Could not find a proposed version: running."
+            exit 0
+          fi
+
+          # The one case we suppress: the third part of the version is non-zero.
+          if [[ "$NEXT" =~ \.0$ ]]; then
+            echo "Proposed version is a feature release: running."
+          else
+            echo "Proposed version is a patch release: suppressing PR on main."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Create/update release PR.  Skipped only when the gate above is confident
+      # the pending release on main would be a patch (see that step).
       - uses: googleapis/release-please-action@v4
         id: release
+        # NOTE: The gate only sets run=false, or nothing at all.  Don't change.
+        if: steps.gate.outputs.run != 'false'
         with:
           # Make sure we create the PR against the correct branch.
           target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
release-please opens a release PR on main for any releasable change, including fix-only changesets.  After a minor release (e.g. v5.2.0), incoming bugfixes made it propose a patch PR (v5.2.1) on main, even though patch releases are cut from the automatic release branches.  A maintainer could merge that PR by mistake.

Add a gate step before the release-please step.  It writes 'run=false' only when it is confident the pending release is a patch, and the release-please step runs unless it sees that value (if: run != 'false').  The gate asks release-please itself, via a --dry-run, what version it would propose, then only allows a .0 version to be released from main.