### PR TITLE
fix(Transmux): Fall back to main thread when the transmux worker fails

### DIFF
--- a/lib/transmuxer/transmuxer_proxy.js
+++ b/lib/transmuxer/transmuxer_proxy.js
@@ -245,11 +245,13 @@ shaka.transmuxer.TransmuxerProxy = class {
 
     const response = await promise;
 
-    // If the worker did not respond in time, warn and fall back to
-    // main-thread transmuxing so playback can continue instead of failing.
-    if (timedOut) {
+    // A null response means the worker either did not respond in time
+    // (timedOut) or failed/was terminated (terminateWorker_ resolves pending
+    // requests with null). In both cases fall back to main-thread transmuxing
+    // so playback continues instead of failing.
+    if (timedOut || response === null) {
       shaka.log.alwaysWarn(
-          'Worker transmux timed out; falling back to ' +
+          'Worker transmux unavailable; falling back to ' +
           'main-thread transmuxing');
       return this.innerTransmuxer_.transmux(
           data, stream, reference, duration, contentType);
@@ -398,22 +400,23 @@ shaka.transmuxer.TransmuxerProxy.getOrCreateWorker_ = (workerUrlOverride) => {
 
 
 /**
- * Marks all active instances as failed, rejects their pending requests, and
- * shuts down the shared worker.
- * @param {string} message Error message for rejected promises.
+ * Marks all active instances as failed, resolves their pending requests so the
+ * callers fall back to main-thread transmuxing, and shuts down the shared
+ * worker.
+ * @param {string} message Reason the worker was terminated, for logging.
  * @private
  */
 shaka.transmuxer.TransmuxerProxy.terminateWorker_ = (message) => {
   const TransmuxerProxy = shaka.transmuxer.TransmuxerProxy;
+  shaka.log.warning(
+      'Transmuxer worker terminated, falling back to main thread:', message);
   for (const instance of TransmuxerProxy.activeInstances_.values()) {
     instance.workerFailed_ = true;
     for (const pending of instance.pendingRequests_.values()) {
       pending.timer.stop();
-      pending.reject(new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.MEDIA,
-          shaka.util.Error.Code.TRANSMUXING_FAILED,
-          message));
+      // Resolve (not reject) with null so the awaiting transmux() call falls
+      // back to the main thread instead of surfacing a fatal error.
+      pending.resolve(null);
     }
     instance.pendingRequests_.clear();
   }

--- a/test/transmuxer/transmuxer_proxy_unit.js
+++ b/test/transmuxer/transmuxer_proxy_unit.js
@@ -490,27 +490,31 @@ describe('TransmuxerProxy', () => {
     });
 
     describe('worker global error event', () => {
-      it('rejects the pending request', async () => {
+      it('falls back to main thread for the in-flight request', async () => {
         const p = transmuxer.transmux(fakeData, fakeStream, null, 10, 'video');
 
-        const assertion = expectAsync(p).toBeRejectedWith(
-            jasmine.objectContaining({
-              code: shaka.util.Error.Code.TRANSMUXING_FAILED,
-            }));
-
+        // The worker crashes / fails to load; its global error event fires
+        // while a transmux is in flight.
         capturedErrorHandler(new Event('error'));
-        await assertion;
-      });
 
-      it('falls back to main thread after worker error', async () => {
-        const p = transmuxer.transmux(fakeData, fakeStream, null, 10, 'video');
-        const rejection = expectAsync(p).toBeRejected();
-        capturedErrorHandler(new Event('error'));
-        await rejection;
-
-        await transmuxer.transmux(fakeData, fakeStream, null, 10, 'video');
+        // The pending call resolves via the inner transmuxer instead of
+        // rejecting, so playback can continue.
+        const result = await p;
         expect(mockInner.transmux).toHaveBeenCalled();
+        expect(result).toEqual(jasmine.any(Uint8Array));
       });
+
+      it('continues falling back to main thread after a worker error',
+          async () => {
+            const p = transmuxer.transmux(
+                fakeData, fakeStream, null, 10, 'video');
+            capturedErrorHandler(new Event('error'));
+            await p;
+
+            // A subsequent call goes straight to the inner transmuxer.
+            await transmuxer.transmux(fakeData, fakeStream, null, 10, 'video');
+            expect(mockInner.transmux).toHaveBeenCalledTimes(2);
+          });
     });
 
     it('surfaces init error with correct reqId on first transmux', async () => {


### PR DESCRIPTION
This PR makes a transmux worker crash or load failure fall back to main-thread transmuxing instead of failing playback with error 3018. Previously only the timeout path fell back - a worker error rejected the in-flight request.

relates to https://github.com/shaka-project/shaka-player/issues/10347