### PR TITLE
fix: Fix duplicate error code 4058

### DIFF
--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -878,7 +878,8 @@ shaka.util.Error.Code = {
   /**
    * A catalog request timed out.
    *
-   * Formerly assigned to 4058, which was a duplicate of MSF_VOD_CONTENT_NOT_SUPPORTED.
+   * Formerly assigned to 4058, which was a duplicate of
+   * MSF_VOD_CONTENT_NOT_SUPPORTED.
    */
   'MSF_CATALOG_TIMEOUT': 4064,
 

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -844,11 +844,6 @@ shaka.util.Error.Code = {
   'MSF_VOD_CONTENT_NOT_SUPPORTED': 4058,
 
   /**
-   * A catalog request timed out.
-   */
-  'MSF_CATALOG_TIMEOUT': 4058,
-
-  /**
    * AES-256-GCM EXT-X-KEY must not include an IV attribute.
    */
   'HLS_INVALID_KEY_IV_FOR_GCM': 4059,
@@ -879,6 +874,13 @@ shaka.util.Error.Code = {
    * <br> error.data[0] is an array with the unsupported scheme URIs.
    */
   'DASH_UNSUPPORTED_ESSENTIAL_PROPERTY': 4063,
+
+  /**
+   * A catalog request timed out.
+   *
+   * Formerly assigned to 4058, which was a duplicate of MSF_VOD_CONTENT_NOT_SUPPORTED.
+   */
+  'MSF_CATALOG_TIMEOUT': 4064,
 
   // RETIRED: 'INCONSISTENT_BUFFER_STATE': 5000,
   // RETIRED: 'INVALID_SEGMENT_INDEX': 5001,
@@ -1123,7 +1125,7 @@ shaka.util.Error.Code = {
   'CAST_RECEIVER_APP_UNAVAILABLE': 8006,
 
 
-  // RETIRED: CAST_RECEIVER_APP_ID_MISSING': 8007,
+  // RETIRED: 'CAST_RECEIVER_APP_ID_MISSING': 8007,
 
 
   /**


### PR DESCRIPTION
The error code number 4058 was assigned to both MSF_VOD_CONTENT_NOT_SUPPORTED and MSF_CATALOG_TIMEOUT.  This moves MSF_CATALOG_TIMEOUT to the next available code in that group, 4064.

This was surfaced during an error code analysis on Shaka source as part of a Cast analytics effort.