### PR TITLE
fix: Only mark MSE append errors recoverable when the stream is disabled

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3253,6 +3253,7 @@ shaka.media.StreamingEngine = class {
         return;
       }
 
+      let mediaSourceReset = false;
       if (error.code == shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_THREW ||
           error.code == shaka.util.Error.Code.MEDIA_SOURCE_OPERATION_FAILED) {
         // A native append operation just failed on this SourceBuffer.  Reset
@@ -3262,7 +3263,7 @@ shaka.media.StreamingEngine = class {
         // asynchronously, if they receive another append on a SourceBuffer
         // that just failed.
         // See https://github.com/shaka-project/shaka-player/issues/10331
-        error.handled = await this.resetMediaSource(/* force= */ true);
+        mediaSourceReset = await this.resetMediaSource(/* force= */ true);
         for (const state of this.mediaStates_.values()) {
           this.cancelUpdate_(state);
         }
@@ -3273,11 +3274,12 @@ shaka.media.StreamingEngine = class {
       if (maxDisabledTime) {
         shaka.log.debug(logPrefix, 'Disabling stream due to error', error);
       }
-      error.handled = this.playerInterface_.disableStream(
-          mediaState.stream, maxDisabledTime) || error.handled;
+      const disabledStream = this.playerInterface_.disableStream(
+          mediaState.stream, maxDisabledTime);
+      error.handled = disabledStream || mediaSourceReset;
 
       // Decrease the error severity to recoverable
-      if (error.handled) {
+      if (disabledStream) {
         error.severity = shaka.util.Error.Severity.RECOVERABLE;
       }
     }


### PR DESCRIPTION
Track media-source reset and stream disable separately in handleStreamingError_. Keep error.handled true if either recovers playback, but lower severity to RECOVERABLE only when disableStream succeeds so a successful reset alone is not treated as a full recovery and is still treated as a CRITICAL error.

Related to #10380