### PR TITLE
fix(Ads): Restrict click-through URIs to http(s) schemes

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -1073,6 +1073,13 @@ shaka.ads.InterstitialAdManager = class {
           return;
         }
         this.sendEvent_(shaka.ads.Utils.AD_CLICKED);
+        if (!shaka.ads.InterstitialAdManager.isSafeClickThroughUri_(
+            interstitial.clickThroughUrl)) {
+          shaka.log.warning(
+              'Ignoring click-through with unsupported URI scheme:',
+              interstitial.clickThroughUrl);
+          return;
+        }
         window.open(interstitial.clickThroughUrl, '_blank');
       });
     }
@@ -1344,6 +1351,13 @@ shaka.ads.InterstitialAdManager = class {
         }
         if (!ad.isPaused()) {
           ad.pause();
+        }
+        if (!shaka.ads.InterstitialAdManager.isSafeClickThroughUri_(
+            interstitial.clickThroughUrl)) {
+          shaka.log.warning(
+              'Ignoring click-through with unsupported URI scheme:',
+              interstitial.clickThroughUrl);
+          return;
         }
         window.open(interstitial.clickThroughUrl, '_blank');
       });
@@ -2539,6 +2553,30 @@ shaka.ads.InterstitialAdManager = class {
       }
     }
     return false;
+  }
+
+  /**
+   * Returns true if a click-through URI is safe to hand to window.open().
+   *
+   * Click-through URIs come from manifests and ad decision responses, which
+   * are not trusted input. window.open() with a javascript: URI executes in
+   * the opener's origin, so restrict click-throughs to http(s). Control
+   * characters and whitespace are stripped before the scheme is read, because
+   * browsers ignore them when resolving the scheme of a URL. A URI with no
+   * scheme is relative and resolves against the page, so it is allowed.
+   *
+   * @param {string} uri
+   * @return {boolean}
+   * @private
+   */
+  static isSafeClickThroughUri_(uri) {
+    const normalizedUri = uri.replace(/[\u0000-\u0020]+/g, '');
+    const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.\-]*):/.exec(normalizedUri);
+    if (!schemeMatch) {
+      return true;
+    }
+    const scheme = schemeMatch[1].toLowerCase();
+    return scheme == 'http' || scheme == 'https';
   }
 };
 

--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -2570,8 +2570,9 @@ shaka.ads.InterstitialAdManager = class {
    * @private
    */
   static isSafeClickThroughUri_(uri) {
+    // eslint-disable-next-line no-control-regex
     const normalizedUri = uri.replace(/[\u0000-\u0020]+/g, '');
-    const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.\-]*):/.exec(normalizedUri);
+    const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(normalizedUri);
     if (!schemeMatch) {
       return true;
     }

--- a/test/ads/interstitial_ad_manager_unit.js
+++ b/test/ads/interstitial_ad_manager_unit.js
@@ -3157,4 +3157,38 @@ describe('Interstitial Ad manager', () => {
     const interstitials = interstitialAdManager.getInterstitials();
     expect(interstitials.length).toBe(1);
   });
+
+  describe('click-through URI scheme', () => {
+    const isSafe = (uri) =>
+      shaka.ads.InterstitialAdManager.isSafeClickThroughUri_(uri);
+
+    it('allows http(s) and relative URIs', () => {
+      expect(isSafe('https://example.com/offer')).toBe(true);
+      expect(isSafe('http://example.com/offer')).toBe(true);
+      expect(isSafe('HTTPS://example.com/offer')).toBe(true);
+      expect(isSafe('/offer')).toBe(true);
+      expect(isSafe('offer.html')).toBe(true);
+    });
+
+    it('rejects javascript: URIs', () => {
+      expect(isSafe('javascript:alert(1)')).toBe(false);
+      expect(isSafe('JavaScript:alert(1)')).toBe(false);
+    });
+
+    it('rejects javascript: URIs hidden by control characters', () => {
+      // Browsers ignore leading control characters and whitespace when
+      // resolving a URL's scheme, so they must be stripped before the check.
+      expect(isSafe('\u0000javascript:alert(1)')).toBe(false);
+      expect(isSafe('  javascript:alert(1)')).toBe(false);
+      expect(isSafe('java\nscript:alert(1)')).toBe(false);
+      expect(isSafe('java\tscript:alert(1)')).toBe(false);
+    });
+
+    it('rejects other non-http schemes', () => {
+      expect(isSafe('data:text/html,<script>alert(1)</script>')).toBe(false);
+      expect(isSafe('blob:https://example.com/abc')).toBe(false);
+      expect(isSafe('vbscript:msgbox(1)')).toBe(false);
+      expect(isSafe('file:///etc/passwd')).toBe(false);
+    });
+  });
 });

--- a/test/ads/interstitial_ad_manager_unit.js
+++ b/test/ads/interstitial_ad_manager_unit.js
@@ -3159,6 +3159,7 @@ describe('Interstitial Ad manager', () => {
   });
 
   describe('click-through URI scheme', () => {
+    /** @suppress {visibility} */
     const isSafe = (uri) =>
       shaka.ads.InterstitialAdManager.isSafeClickThroughUri_(uri);
 
@@ -3171,7 +3172,9 @@ describe('Interstitial Ad manager', () => {
     });
 
     it('rejects javascript: URIs', () => {
+      // eslint-disable-next-line no-script-url
       expect(isSafe('javascript:alert(1)')).toBe(false);
+      // eslint-disable-next-line no-script-url
       expect(isSafe('JavaScript:alert(1)')).toBe(false);
     });
 
@@ -3187,6 +3190,7 @@ describe('Interstitial Ad manager', () => {
     it('rejects other non-http schemes', () => {
       expect(isSafe('data:text/html,<script>alert(1)</script>')).toBe(false);
       expect(isSafe('blob:https://example.com/abc')).toBe(false);
+      // cspell: disable-next-line
       expect(isSafe('vbscript:msgbox(1)')).toBe(false);
       expect(isSafe('file:///etc/passwd')).toBe(false);
     });

--- a/test/ads/interstitial_ad_manager_unit.js
+++ b/test/ads/interstitial_ad_manager_unit.js
@@ -3195,4 +3195,112 @@ describe('Interstitial Ad manager', () => {
       expect(isSafe('file:///etc/passwd')).toBe(false);
     });
   });
+
+  describe('click-through', () => {
+    /** @type {!jasmine.Spy} */
+    let openSpy;
+
+    beforeEach(() => {
+      openSpy = spyOn(window, 'open');
+    });
+
+    /**
+     * @param {string} clickThroughUrl
+     * @return {!shaka.extern.AdInterstitial}
+     */
+    function overlayInterstitial(clickThroughUrl) {
+      return {
+        id: null,
+        groupId: null,
+        startTime: 0,
+        endTime: null,
+        uri: 'test.html',
+        mimeType: 'text/html',
+        isSkippable: false,
+        skipOffset: null,
+        skipFor: null,
+        canJump: false,
+        resumeOffset: null,
+        playoutLimit: null,
+        once: true,
+        pre: true,
+        post: false,
+        timelineRange: false,
+        loop: false,
+        overlay: {
+          viewport: {
+            x: 1920,
+            y: 1080,
+          },
+          topLeft: {
+            x: 0,
+            y: 0,
+          },
+          size: {
+            x: 1920,
+            y: 1080,
+          },
+        },
+        displayOnBackground: false,
+        currentVideo: null,
+        background: null,
+        clickThroughUrl: clickThroughUrl,
+        tracking: null,
+      };
+    }
+
+    /**
+     * Starts an overlay interstitial with the given click-through URI and
+     * clicks on it.
+     *
+     * @param {string} clickThroughUrl
+     */
+    async function startAdAndClick(clickThroughUrl) {
+      await interstitialAdManager.addInterstitials(
+          [overlayInterstitial(clickThroughUrl)]);
+
+      video.play();
+      video.dispatchEvent(new Event('timeupdate'));
+
+      await shaka.test.Util.shortDelay();
+
+      // An overlay interstitial with a text/html mimeType is rendered into an
+      // iframe inside the ad container, and that element carries the click
+      // listener.
+      const element = adContainer.querySelector('iframe');
+      expect(element).not.toBeNull();
+      element.dispatchEvent(new Event('click'));
+    }
+
+    it('opens http(s) click-through URIs', async () => {
+      await startAdAndClick('https://example.com/offer');
+
+      expect(openSpy).toHaveBeenCalledWith(
+          'https://example.com/offer', '_blank');
+    });
+
+    it('does not open javascript: click-through URIs', async () => {
+      // eslint-disable-next-line no-script-url
+      await startAdAndClick('javascript:alert(1)');
+
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not open data: click-through URIs', async () => {
+      await startAdAndClick('data:text/html,<script>alert(1)</script>');
+
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+
+    it('still reports the click when the URI is rejected', async () => {
+      // eslint-disable-next-line no-script-url
+      await startAdAndClick('javascript:alert(1)');
+
+      const eventValue = {
+        type: 'ad-clicked',
+      };
+      expect(onEventSpy).toHaveBeenCalledWith(
+          jasmine.objectContaining(eventValue));
+    });
+  });
 });

--- a/test/ads/interstitial_ad_manager_unit.js
+++ b/test/ads/interstitial_ad_manager_unit.js
@@ -3158,8 +3158,8 @@ describe('Interstitial Ad manager', () => {
     expect(interstitials.length).toBe(1);
   });
 
+  /** @suppress {visibility} */
   describe('click-through URI scheme', () => {
-    /** @suppress {visibility} */
     const isSafe = (uri) =>
       shaka.ads.InterstitialAdManager.isSafeClickThroughUri_(uri);
 


### PR DESCRIPTION
## Problem

Interstitial click-through URIs are taken from manifests and ad decision responses and passed
straight to `window.open()` with no scheme check:

```js
// lib/ads/interstitial_ad_manager.js:1076 and :1348
window.open(interstitial.clickThroughUrl, '_blank');
```

`clickThroughUrl` is populated from untrusted content by every interstitial source:

* HLS `X-ASSET-LIST` / `X-AD-CREATIVE-SIGNALING` — `interstitial_ad_manager.js:1852`
  (`interstitial.clickThroughUrl = payloadSlot.clickThrough;`)
* VAST `<ClickThrough>` — `vast_interstitial_parser.js:92-99`, `:204-210`
* DASH interstitials — `dash_interstitial_parser.js`

`window.open()` with a `javascript:` URI executes in the **opener's** origin, so a manifest can run
script in the embedding page once the viewer clicks the ad.

I verified this on current `main` (`f9c6fcd`) with a local harness that serves the repository's own
`test/test/assets/hls-interstitial` fixture and the real built `dist/shaka-player.ui.debug.js`,
changing only the ad-decision JSON to add a `clickThrough` value. Shaka fetched the asset list
itself (the request log shows `/media/ads.json?_HLS_primary_id=<uuid>`, a parameter Shaka appends),
started a real media interstitial, and after one ordinary click the click-through read
`document.cookie` and page state from the embedding document and wrote to its DOM. With an ordinary
`https:` click-through instead, the same harness gets a `SecurityError`, as expected.

Worth noting for reviewers: it was previously suggested in #10166 that browsers block
`window.open('javascript:...')`. They do not — I re-checked in Chromium 145 headless and headful;
the script runs in the opener's context (no popup is even created). That is probably why this sink
has been overlooked.

## Change

Adds `isSafeClickThroughUri_()` and applies it at both `window.open()` call sites, which is the
single choke point covering all three parsers. Non-http(s) click-throughs are ignored with a
warning instead of being opened.

The scheme parsing mirrors the approach proposed in #10166 for `interstitial.uri`: control
characters and whitespace are stripped before the scheme is read, because browsers ignore them when
resolving a URL's scheme (so a leading NUL or an embedded newline inside `javascript:` is still
caught). A URI with no scheme is relative and resolves against the page, so it is still allowed.

Note this is a different sink from #10166 — that change guarded `interstitial.uri` at the top of
the ad-start path and never referenced `clickThroughUrl`, so an interstitial with a benign `https`
`uri` plus a `javascript:` `clickThrough` is unaffected by it.

## Testing

Adds unit tests in `test/ads/interstitial_ad_manager_unit.js` covering http(s) and relative URIs,
`javascript:` in mixed case, `javascript:` smuggled behind control characters and whitespace, and
`data:` / `blob:` / `vbscript:` / `file:`.
