### PR TITLE
fix: Don't re-encode existing query parameters when appending new ones

### DIFF
--- a/lib/util/url.js
+++ b/lib/util/url.js
@@ -43,6 +43,10 @@ shaka.util.URL = class {
 
         if (extraQueryParams) {
           // extraQueryParams expected format: "a=1&b=2"
+          // Append as raw text rather than through url.searchParams.
+          // Mutating url.searchParams would re-encode the query parameters
+          // already present in the URL, corrupting signed URLs whose tokens
+          // must survive byte-for-byte.  See setRawParams_ for details.
           const extra = extraQueryParams.replace(/^[?&]/, '');
           const search = url.search.replace(/^\?/, '');
           url.search = search ? (search + '&' + extra) : extra;

--- a/lib/util/url.js
+++ b/lib/util/url.js
@@ -43,10 +43,9 @@ shaka.util.URL = class {
 
         if (extraQueryParams) {
           // extraQueryParams expected format: "a=1&b=2"
-          const params = new URLSearchParams(extraQueryParams);
-          for (const [key, value] of params.entries()) {
-            url.searchParams.append(key, value);
-          }
+          const extra = extraQueryParams.replace(/^[?&]/, '');
+          const search = url.search.replace(/^\?/, '');
+          url.search = search ? (search + '&' + extra) : extra;
         }
 
         resolvedUris.push(url.toString());
@@ -159,9 +158,9 @@ shaka.util.URL = class {
       return uri;
     }
     const urlObj = new URL(uri);
-    for (const [key, value] of new URLSearchParams(params)) {
-      urlObj.searchParams.set(key, value);
-    }
+    const pairs = params.replace(/^[?&]/, '').split('&')
+        .filter((pair) => pair);
+    shaka.util.URL.setRawParams_(urlObj, pairs);
     return urlObj.toString();
   }
 
@@ -177,11 +176,34 @@ shaka.util.URL = class {
       return uri;
     }
     const url = new URL(uri);
-
+    const pairs = [];
     for (const [key, value] of params.entries()) {
-      url.searchParams.set(key, value);
+      pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
     }
-
+    shaka.util.URL.setRawParams_(url, pairs);
     return url.toString();
+  }
+
+  /**
+   * Replaces or appends raw "key=value" pairs in the query string of |url|,
+   * keeping the parameters that are already present byte-for-byte intact.
+   *
+   * Mutating |url.searchParams| instead would re-serialize the whole query
+   * string with application/x-www-form-urlencoded rules, percent-encoding
+   * characters that are legal in a query (e.g. "~", "=", "/") in parameters
+   * we never touched.  CDNs that sign URLs compare their tokens
+   * byte-for-byte, so a re-encoded token gets rejected.
+   *
+   * @param {!URL} url
+   * @param {!Array<string>} pairs Raw "key=value" strings, already
+   *   percent-encoded as they should appear in the URL.
+   * @private
+   */
+  static setRawParams_(url, pairs) {
+    const keyOf = (pair) => pair.split('=')[0];
+    const newKeys = new Set(pairs.map(keyOf));
+    const query = url.search.replace(/^\?/, '').split('&')
+        .filter((pair) => pair && !newKeys.has(keyOf(pair)));
+    url.search = query.concat(pairs).join('&');
   }
 };

--- a/test/util/url_unit.js
+++ b/test/util/url_unit.js
@@ -122,6 +122,17 @@ describe('URL', () => {
       expect(base).toEqual(['http://a.com/']);
       expect(relative).toEqual(['x']);
     });
+
+    it('does not re-encode existing query params', () => {
+      const base = ['http://example.com/'];
+      const relative = ['a?token=st=1~acl=/live/*~hmac=abc'];
+
+      const result = shaka.util.URL.resolveUris(base, relative, 'x=1');
+
+      expect(result)
+          .toEqual(['http://example.com/a?token=st=1~acl=/live/*~hmac=abc' +
+              '&x=1']);
+    });
   });
 
   describe('getDomain', () => {
@@ -226,6 +237,50 @@ describe('URL', () => {
 
       expect(result).toBe('http://example.com/?a=new');
     });
+
+    it('does not re-encode existing signed token params', () => {
+      // Signed URLs (e.g. Akamai or CloudFront tokens) are compared
+      // byte-for-byte by the CDN, so characters like "~", "=" and "/" in
+      // existing params must not be percent-encoded when we append our own
+      // params.  See https://github.com/video-dev/hls.js/pull/7969 for the
+      // same issue in hls.js.
+      const uri = 'https://example.com/media.m3u8' +
+          '?token=st=1600000000~exp=1600003600~acl=/live/*~hmac=abc123';
+
+      const params = new Map();
+      params.set('_HLS_msn', '5');
+      params.set('_HLS_skip', 'YES');
+
+      const result = shaka.util.URL.appendParams(uri, params);
+
+      expect(result).toBe('https://example.com/media.m3u8' +
+          '?token=st=1600000000~exp=1600003600~acl=/live/*~hmac=abc123' +
+          '&_HLS_msn=5&_HLS_skip=YES');
+    });
+
+    it('does not alter percent-encoding of existing params', () => {
+      const uri = 'https://example.com/media.m3u8?sig=a%2Fb%3Dc';
+
+      const params = new Map();
+      params.set('_HLS_skip', 'v2');
+
+      const result = shaka.util.URL.appendParams(uri, params);
+
+      expect(result)
+          .toBe('https://example.com/media.m3u8?sig=a%2Fb%3Dc&_HLS_skip=v2');
+    });
+
+    it('overwrites existing param without altering other params', () => {
+      const uri = 'https://example.com/media.m3u8?token=a=1~b=2&_HLS_msn=3';
+
+      const params = new Map();
+      params.set('_HLS_msn', '7');
+
+      const result = shaka.util.URL.appendParams(uri, params);
+
+      expect(result)
+          .toBe('https://example.com/media.m3u8?token=a=1~b=2&_HLS_msn=7');
+    });
   });
 
   describe('getScheme', () => {
@@ -303,6 +358,21 @@ describe('URL', () => {
       const uri = 'https://example.com/path?x=1';
       expect(shaka.util.URL.applyUrlParams(uri, () => 'tok=abc'))
           .toBe('https://example.com/path?x=1&tok=abc');
+    });
+
+    it('does not re-encode existing signed token params', () => {
+      const uri = 'https://example.com/manifest.mpd' +
+          '?token=st=1600000000~exp=1600003600~acl=/live/*~hmac=abc123';
+      expect(shaka.util.URL.applyUrlParams(uri, () => 'a=1'))
+          .toBe('https://example.com/manifest.mpd' +
+              '?token=st=1600000000~exp=1600003600~acl=/live/*~hmac=abc123' +
+              '&a=1');
+    });
+
+    it('preserves the encoding of the applied params', () => {
+      const uri = 'https://example.com/path';
+      expect(shaka.util.URL.applyUrlParams(uri, () => 'sig=a%2Fb%3Dc'))
+          .toBe('https://example.com/path?sig=a%2Fb%3Dc');
     });
   });
 


### PR DESCRIPTION
## Description

`shaka.util.URL.appendParams`, `applyUrlParams`, and `resolveUris` (with `extraQueryParams`) set new query parameters through `url.searchParams`. Reading the URL back afterwards re-serializes the whole query string using application/x-www-form-urlencoded rules, so characters that are perfectly legal in a query (`~`, `=`, `/`) come back percent-encoded in parameters Shaka never touched.

Given a live playlist URL carrying a signed token:

```
https://example.com/media.m3u8?token=st=1600000000~exp=1600003600~acl=/live/*~hmac=abc123
```

an LL-HLS delta update request currently becomes:

```
https://example.com/media.m3u8?token=st%3D1600000000%7Eexp%3D1600003600%7Eacl%3D%2Flive%2F*%7Ehmac%3Dabc123&_HLS_skip=YES
```

CDNs that sign URLs compare the token byte-for-byte, so the request is rejected with 403 and live playback stalls on the first reload. Akamai tokens are the common case; CloudFront is affected too, since its URL-safe base64 maps `/` to `~`, putting `~` in every `Policy` and `Signature` value.

Affected paths, all funneling through `lib/util/url.js`:

- LL-HLS blocking playlist reload / delta update directives (`_HLS_msn`, `_HLS_part`, `_HLS_skip`) in `HlsParser.updateStream_`
- Content steering pathway parameters (`_DASH_pathway` / `_HLS_pathway`)
- HLS interstitial asset list requests
- User-configured extra query parameters (DASH manifest/patch requests, `resolveUris`)

Native Apple HLS players do not rewrite the URL, so affected streams play fine in Safari, iOS, etc.

## Fix

Append or replace the new parameters as raw text on `url.search` instead of going through `url.searchParams`, keeping the pre-existing query string byte-for-byte intact. Parameters with the same key are still replaced rather than duplicated, matching the previous `searchParams.set()` semantics (a replaced parameter now moves to the end of the query instead of keeping its original slot). `resolveUris` keeps its previous append (not replace) semantics for `extraQueryParams`.

The fix relies on assignment to `url.search` not percent-encoding `~`, `=`, `/`, or `*`, as those are outside the URL spec's query percent-encode set (unlike the form-urlencoded serializer used by `searchParams`).

## Testing

- New unit tests in `test/util/url_unit.js` covering signed-token preservation, existing percent-encoding preservation, and same-key replacement for `appendParams`, `applyUrlParams`, and `resolveUris`.
- `python3 build/check.py` passes.
- `python3 build/test.py --quick --uncompiled` passes for the URL, HLS live, DashParser, content steering, and interstitial suites.

## AI assistance

This change was written with AI assistance (Claude Code, Claude Fable 5) and reviewed by the submitter; the commit carries the corresponding `Co-Authored-By` trailer per AGENT-ATTRIBUTION.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)