### PR TITLE
fix: Avoid re-downloading init segments on unbuffered seek

### DIFF
--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -278,11 +278,14 @@ shaka.media.SegmentPrefetch = class {
 
   /**
    * Clear all segment data.
+   * @param {boolean=} clearInitSegments
    * @public
    */
-  clearAll() {
+  clearAll(clearInitSegments = true) {
     this.clearMap_(this.segmentPrefetchMap_);
-    this.clearMap_(this.initSegmentPrefetchMap_);
+    if (clearInitSegments) {
+      this.clearMap_(this.initSegmentPrefetchMap_);
+    }
     this.resetPosition();
     const logPrefix = shaka.media.SegmentPrefetch.logPrefix_(this.stream_);
     shaka.log.debug(logPrefix, 'cleared all');

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3123,7 +3123,12 @@ shaka.media.StreamingEngine = class {
     shaka.log.debug(logPrefix, 'clearing buffer');
     if (mediaState.segmentPrefetch &&
         !this.audioPrefetchMap_.has(mediaState.stream)) {
-      mediaState.segmentPrefetch.clearAll();
+      // Keep prefetched init segments: clearing the buffer (e.g. on an
+      // unbuffered seek) does not invalidate them, since the stream and its
+      // init segment are unchanged and MSE remains initialized with it.
+      // Discarding them would cause the same init segment to be downloaded
+      // again unnecessarily.
+      mediaState.segmentPrefetch.clearAll(/* clearInitSegments= */ false);
     }
 
     if (safeMargin) {

--- a/test/media/segment_prefetch_unit.js
+++ b/test/media/segment_prefetch_unit.js
@@ -180,6 +180,48 @@ describe('SegmentPrefetch', () => {
       expect(fetchDispatcher).toHaveBeenCalledTimes(3);
     });
 
+    it('keeps init segments when clearInitSegments is false', async () => {
+      const references = [
+        makeReference(uri('0.10'), 0, 10),
+        makeReference(uri('10.20'), 10, 20),
+        makeReference(uri('20.30'), 20, 30),
+        makeReference(uri('30.40'), 30, 40),
+      ];
+      references[0].initSegmentReference =
+          new shaka.media.InitSegmentReference(() => ['init-0.mp4'], 0, 500);
+      references[1].initSegmentReference =
+          new shaka.media.InitSegmentReference(() => ['init-1.mp4'], 0, 500);
+      references[2].initSegmentReference =
+          new shaka.media.InitSegmentReference(() => ['init-2.mp4'], 0, 500);
+      references[3].initSegmentReference =
+          new shaka.media.InitSegmentReference(() => ['init-3.mp4'], 0, 500);
+
+      stream = createStream();
+      stream.segmentIndex = new shaka.media.SegmentIndex(references);
+      segmentPrefetch.switchStream(stream);
+
+      await segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
+      // 3 media segments + 3 init segments.
+      expect(fetchDispatcher).toHaveBeenCalledTimes(6);
+
+      segmentPrefetch.clearAll(/* clearInitSegments= */ false);
+
+      for (let i = 0; i < 3; i++) {
+        // Verify media segments are gone.
+        expect(segmentPrefetch.getPrefetchedSegment(references[i])).toBeNull();
+      }
+      // Verify init segments are kept.
+      for (let i = 0; i < 3; i++) {
+        const op = segmentPrefetch.getPrefetchedSegment(
+            references[i].initSegmentReference);
+        expect(op).not.toBeNull();
+      }
+
+      await segmentPrefetch.prefetchSegmentsByTime(references[0].startTime);
+
+      expect(fetchDispatcher).toHaveBeenCalledTimes(9);
+    });
+
     it('resets time pos so prefetch can happen again', () => {
       segmentPrefetch.prefetchSegmentsByTime(references[3].startTime);
       segmentPrefetch.clearAll();

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -2167,6 +2167,34 @@ describe('StreamingEngine', () => {
         text: [true, false, false, false],
       });
     });
+
+    it('does not re-fetch init segments when prefetch is enabled', async () => {
+      const config = shaka.util.PlayerConfiguration.createDefault().streaming;
+      config.segmentPrefetchLimit = 1;
+      streamingEngine.configure(config);
+
+      const segmentType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
+
+      streamingEngine.switchVariant(variant);
+      streamingEngine.switchTextStream(textStream);
+      await streamingEngine.start();
+      playing = true;
+
+      let seekComplete = false;
+      await runTest(() => {
+        if (presentationTimeInSeconds == 2 && !seekComplete) {
+          netEngine.expectRequest('0_audio_init', segmentType);
+          netEngine.expectRequest('0_video_init', segmentType);
+          netEngine.request.calls.reset();
+          presentationTimeInSeconds = 15;
+          streamingEngine.seeked();
+          seekComplete = true;
+        }
+      });
+
+      netEngine.expectNoRequest('0_audio_init', segmentType);
+      netEngine.expectNoRequest('0_video_init', segmentType);
+    });
   });
 
   describe('handles seeks (live)', () => {


### PR DESCRIPTION
An unbuffered seek force-clears the buffer, which discarded all prefetched init segments via `SegmentPrefetch.clearAll()`. The next prefetch pass then re-requested the same init segment URI, even though MSE remains initialized with it and the response is never consumed. The streaming engine's `lastInitSegmentReference` deliberately survives the seek, so the append path never uses the re-fetched data.

Since segmentPrefetchLimit defaults to 1, every default-config player makes this wasted request on every unbuffered seek.

Give clearAll() an opt-out for init segments and use it from the buffer-clearing path only. Stream switches still perform a full clear via `switchStream()`, and `clearInitSegments_()` still prunes entries no longer referenced after each prefetch pass.

Closes #10373