### PR TITLE
fix: Fix stuck playback on multiplexed TS content

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -890,6 +890,14 @@ shaka.media.MediaSourceEngine = class {
 
   /**
    * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @return {boolean}
+   */
+  hasSourceBufferFor(contentType) {
+    return this.sourceBuffers_.has(contentType);
+  }
+
+  /**
+   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
    * @return {TimeRanges} The buffered ranges for the given content type, or
    *   null if the buffered ranges could not be obtained.
    * @private

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1582,11 +1582,24 @@ shaka.media.StreamingEngine = class {
     // is only used to determine if we have meet the buffering goal.  This
     // should be the same method that PlayheadObserver uses.  In reverse we
     // measure the content buffered behind the playhead instead.
-    const bufferedAhead = reverse ?
+    let bufferedAhead = reverse ?
         this.playerInterface_.mediaSourceEngine.bufferedBehindOf(
             mediaState.type, presentationTime) :
         this.playerInterface_.mediaSourceEngine.bufferedAheadOf(
             mediaState.type, presentationTime);
+
+    if (mediaState.type == ContentType.VIDEO &&
+        !this.mediaStates_.has(ContentType.AUDIO)) {
+      if (this.playerInterface_.mediaSourceEngine.hasSourceBufferFor(
+          ContentType.AUDIO)) {
+        let audioBufferedAhead = reverse ?
+            this.playerInterface_.mediaSourceEngine.bufferedBehindOf(
+                ContentType.AUDIO, presentationTime) :
+            this.playerInterface_.mediaSourceEngine.bufferedAheadOf(
+                ContentType.AUDIO, presentationTime);
+        bufferedAhead = Math.min(bufferedAhead, audioBufferedAhead);
+      }
+    }
 
     shaka.log.v2(logPrefix,
         'update_:',

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1588,6 +1588,12 @@ shaka.media.StreamingEngine = class {
         this.playerInterface_.mediaSourceEngine.bufferedAheadOf(
             mediaState.type, presentationTime);
 
+    // If the content if muxed audio+video, we will only have one media state,
+    // but MediaSource will have an additional SourceBuffer for audio.  In this
+    // case, we must also check how much audio is buffered, and take the
+    // minimum of the two.  This matches to the buffering management system,
+    // which sees only the intersection of audio & video.  Without this check,
+    // we can end up with playback hung in some edge cases.
     if (mediaState.type == ContentType.VIDEO &&
         !this.mediaStates_.has(ContentType.AUDIO)) {
       if (this.playerInterface_.mediaSourceEngine.hasSourceBufferFor(

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1592,7 +1592,7 @@ shaka.media.StreamingEngine = class {
         !this.mediaStates_.has(ContentType.AUDIO)) {
       if (this.playerInterface_.mediaSourceEngine.hasSourceBufferFor(
           ContentType.AUDIO)) {
-        let audioBufferedAhead = reverse ?
+        const audioBufferedAhead = reverse ?
             this.playerInterface_.mediaSourceEngine.bufferedBehindOf(
                 ContentType.AUDIO, presentationTime) :
             this.playerInterface_.mediaSourceEngine.bufferedAheadOf(

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -714,6 +714,53 @@ describe('StreamingEngine', () => {
         .toEqual([false, false, false, false]);
   });
 
+  /** @suppress {accessControls} */
+  it('fetches more if muxed audio is short', async () => {
+    // Setup a VOD manifest.
+    setupVod();
+
+    // Remove audio from the variant to simulate a video-only manifest that
+    // actually contains multiplexed audio (discovered later by
+    // MSE/transmuxer).
+    variant.audio = null;
+
+    // Configure a rebuffering goal of 10s and buffering goal of 10s.
+    const config = shaka.util.PlayerConfiguration.createDefault().streaming;
+    config.rebufferingGoal = 10;
+    config.bufferingGoal = 10;
+
+    mediaSourceEngine = new shaka.test.FakeMediaSourceEngine(segmentData);
+    // Simulate that MediaSourceEngine created video and audio SourceBuffers.
+    mediaSourceEngine.hasSourceBufferFor.and.callFake((type) => {
+      return type == ContentType.VIDEO || type == ContentType.AUDIO;
+    });
+
+    createStreamingEngine(config);
+
+    streamingEngine.switchVariant(variant);
+    await streamingEngine.start();
+    playing = true;
+
+    // Simulate a state where video is buffered to 11s (meets goal),
+    // but audio is only buffered to 9s (short of 10s goal).  To meet the
+    // overall goal, we would now need to fetch another segment.
+    mediaSourceEngine.bufferedAheadOf.withArgs(ContentType.VIDEO, 0)
+        .and.returnValue(11);
+    mediaSourceEngine.bufferedAheadOf.withArgs(ContentType.AUDIO, 0)
+        .and.returnValue(9);
+
+    // Call update_() manually for VIDEO.  If it only checked the video
+    // buffered range, it would think the goal were satisfied.  That is the bug
+    // this regression test is meant to cover.
+    await videoStream.createSegmentIndex();
+    const delay = await streamingEngine.update_(
+        streamingEngine.mediaStates_.get(ContentType.VIDEO));
+
+    // It should decide to fetch the next segment (returning null delay)
+    // because it checks the audio buffer and sees it's short of the goal.
+    expect(delay).toBeNull();
+  });
+
   it('marks muxed audio as endOfStream when video ends', async () => {
     setupVod();
 

--- a/test/test/externs/jasmine.js
+++ b/test/test/externs/jasmine.js
@@ -354,6 +354,13 @@ jasmine.Spy.prototype.and;
 
 
 /**
+ * @param {...*} varArgs
+ * @return {!jasmine.Spy}
+ */
+jasmine.Spy.prototype.withArgs = function(varArgs) {};
+
+
+/**
  * @param {string} name
  * @return {!jasmine.Spy}
  * @see https://github.com/shaka-project/closure-compiler/issues/1422

--- a/test/test/util/fake_media_source_engine.js
+++ b/test/test/util/fake_media_source_engine.js
@@ -163,6 +163,10 @@ shaka.test.FakeMediaSourceEngine = class {
     this.reset =
         jasmine.createSpy('reset').and.returnValue(Promise.resolve());
 
+    /** @type {!jasmine.Spy} */
+    this.hasSourceBufferFor =
+        jasmine.createSpy('hasSourceBufferFor').and.stub();
+
     this.textDisplayer = new shaka.test.FakeTextDisplayer();
   }
 


### PR DESCRIPTION
If the rebufferingGoal setting is roughly the same as the target segment size, the content is multiplexed, the video frames meet the target segment size, but the audio is a little short of that target... then playback got stuck on startup.

For example, 10-second segments, 10-second rebufferingGoal, and the first segment contains 9.98 seconds of audio and 10.01 seconds of video.  BufferingObserver would see the shorter of those two values (audio) and conclude that it shouldn't allow playback yet, while StreamingEngine would see the larger of those two (video) and decide it had fetched enough.  Deadlock.

This fixes the bug by making StreamingEngine check the minimum of the two buffered ranges for multiplexed content.  It detects this by checking for a video stream without a separate audio stream, but both audio and video at the MSE level.