### PR TITLE
fix(offline): Don't leak an IndexedDB connection

### DIFF
--- a/lib/offline/indexeddb/storage_mechanism.js
+++ b/lib/offline/indexeddb/storage_mechanism.js
@@ -34,6 +34,14 @@ shaka.offline.indexeddb.StorageMechanism = class {
     /** @private {IDBDatabase} */
     this.db_ = null;
 
+    /**
+     * Set once destroy() has run, so that an open which is still in flight
+     * knows there is no longer anyone to hand the connection to.
+     *
+     * @private {boolean}
+     */
+    this.destroyed_ = false;
+
     /** @private {shaka.extern.StorageCell} */
     this.v1_ = null;
     /** @private {shaka.extern.StorageCell} */
@@ -72,12 +80,29 @@ shaka.offline.indexeddb.StorageMechanism = class {
 
     const open = window.indexedDB.open(name, version);
     open.onsuccess = (event) => {
-      if (timedOut) {
-        // Too late, we have already given up on opening the storage mechanism.
-        return;
-      }
       timeOutTimer.stop();
       const db = open.result;
+
+      // The open may finish after we have stopped waiting for it, either
+      // because it timed out above or because we were destroyed while it was
+      // still in flight.  Either way nothing will ever use this connection,
+      // and nothing else can close it, because the reference dies with this
+      // callback.  An abandoned connection is not harmless: while it stays
+      // open no one can delete or upgrade the database, and a request to do so
+      // blocks for the life of the page rather than failing.  Close it here,
+      // which is the only remaining chance to do so.
+      if (timedOut || this.destroyed_) {
+        shaka.log.debug('Closing', name, 'because the mechanism is gone.');
+        db.close();
+        // Settle the promise so that anything still awaiting init() unwinds.
+        // Resolve rather than reject: reaching here means we were torn down or
+        // gave up, both of which are quiet paths, and a rejection nobody is
+        // left to catch would surface as an unhandled error during teardown.
+        // If we timed out, the timer already rejected and this is a no-op.
+        p.resolve();
+        return;
+      }
+
       this.db_ = db;
       this.v1_ = shaka.offline.indexeddb.StorageMechanism.createV1_(db);
       this.v2_ = shaka.offline.indexeddb.StorageMechanism.createV2_(db);
@@ -117,6 +142,12 @@ shaka.offline.indexeddb.StorageMechanism = class {
    * @override
    */
   async destroy() {
+    // Set this before anything is awaited.  An open that is still in flight
+    // completes on this same thread later, and it needs to see that we are
+    // gone so that it closes the connection instead of handing it to a
+    // mechanism nobody holds any more.
+    this.destroyed_ = true;
+
     if (this.v1_) {
       await this.v1_.destroy();
     }

--- a/test/offline/storage_mechanism_unit.js
+++ b/test/offline/storage_mechanism_unit.js
@@ -1,0 +1,81 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+filterDescribe('StorageMechanism', offlineSupported, () => {
+  const dbName = 'shaka_offline_db';
+
+  /**
+   * Delete the offline database, reporting whether the delete completed or was
+   * left blocked by a connection that is still open.
+   *
+   * @param {number} timeoutSeconds
+   * @return {!Promise<string>}
+   */
+  function tryDeleteDatabase(timeoutSeconds) {
+    let blocked = false;
+
+    const deleted = new Promise((resolve, reject) => {
+      const request = window.indexedDB.deleteDatabase(dbName);
+      request.onblocked = () => {
+        blocked = true;
+      };
+      request.onsuccess = () => {
+        resolve('deleted');
+      };
+      request.onerror = () => {
+        reject(request.error);
+      };
+    });
+
+    // A blocked delete never settles on its own, so race it rather than let
+    // the spec sit until its timeout.
+    return Promise.race([
+      deleted,
+      shaka.test.Util.delay(timeoutSeconds).then(
+          () => blocked ? 'blocked by an open connection' : 'never finished'),
+    ]);
+  }
+
+  // The ordinary teardown, with the open allowed to finish first.  This runs
+  // before the regression test below on purpose: a leaked connection cannot be
+  // closed by anything, so once the case below has leaked one, every later
+  // delete in the same browser is blocked too.  Checking the ordinary path
+  // first keeps that collateral damage from hiding which case actually broke.
+  it('does not leak its connection when destroyed after init', async () => {
+    const muxer = new shaka.offline.StorageMuxer();
+
+    await muxer.init();
+    await muxer.destroy();
+
+    expect(await tryDeleteDatabase(10)).toBe('deleted');
+  });
+
+  // Regression test.  A storage mechanism opens its connection asynchronously,
+  // and the operation that wanted it can be torn down while that open is still
+  // in flight -- which is what happens when a player is destroyed during
+  // offline playback, since every segment read opens its own connection.
+  //
+  // The mechanism used to drop such a connection on the floor: destroy() saw
+  // no connection yet and closed nothing, then the open completed and handed
+  // the connection to a mechanism no one held any more.  Nothing could close
+  // it after that, and while it stayed open no one could delete or upgrade the
+  // database -- the request did not fail, it blocked for the life of the page,
+  // with every later IndexedDB operation queued behind it.
+  //
+  // The race only decides whether a connection leaks.  Once one has, the
+  // deadlock is certain, so this reproduces on every platform.
+  it('does not leak its connection when destroyed during init', async () => {
+    const muxer = new shaka.offline.StorageMuxer();
+
+    // Do not await init.  Destroying now lands inside the window between the
+    // open being issued and it completing, which is the case being tested.
+    const init = muxer.init();
+    await muxer.destroy();
+    await init;
+
+    expect(await tryDeleteDatabase(10)).toBe('deleted');
+  });
+});


### PR DESCRIPTION
When destroyed during init, a storage mechanism would leak an IndexedDB connection, permanently wedging the storage system.  This fixes failing IndexedDB tests on macOS, where the platform seems to have IDB timing more conducive to triggering the bug.

This is a long-standing bug that has plagued macOS test runs for ages. The earliest attempted workaround was in 2022 (see commit d4d37407c and issue #4566).

A storage mechanism opens its connection asynchronously, and whoever wanted it can be torn down while that open is still in flight.  That is not unusual: every offline segment read opens its own connection, so destroying a player during offline playback aborts reads at exactly that point.

When it happened, destroy() looked for a connection to close, found db_ still null because the open had not finished, and closed nothing. The open then completed and handed its connection to a mechanism nobody held a reference to any more.  Nothing could ever close it after that.

An abandoned connection is not harmless.  While one stays open, no other connection can delete or upgrade the database, and such a request does not fail, but rather blocks for the life of the page, with every later IndexedDB operation queued behind it.  A single leak wedges storage until the tab is closed.

Record that we have been destroyed, and close the connection when the open finishes with nobody left to receive it.  The same guard covers the case where the open outlives its timeout, which was abandoning connections the same way: onsuccess returned early, leaving the connection open and unreferenced.

Though the tests only failed commonly on macOS, the regression test reproduces on every platform: destroy a muxer without awaiting init, then delete the database and watch the request never complete.

We measured 20 runs of the offline suite x 3 macOS browsers (Edge, Opera, Chrome).  Those failed 10/20, 8/20, and 5/20 times respectively before this fix.  After the fix 0/20 across all three, so this is pretty conclusively fixed.