### PR TITLE
fix(offline): Close the database when another connection needs it

### DIFF
--- a/lib/offline/indexeddb/storage_mechanism.js
+++ b/lib/offline/indexeddb/storage_mechanism.js
@@ -79,6 +79,18 @@ shaka.offline.indexeddb.StorageMechanism = class {
       timeOutTimer.stop();
       const db = open.result;
       this.db_ = db;
+
+      // Even a connection we are still using should get out of the way when
+      // another one needs to delete or upgrade the database.  The browser asks
+      // by firing "versionchange", and holding on stalls that request for as
+      // long as we keep the connection, which for a read in flight during a
+      // delete means the delete waits on unrelated work.
+      db.onversionchange = () => {
+        shaka.log.debug('Closing', name, 'so another connection can delete',
+            'or upgrade it.');
+        db.close();
+      };
+
       this.v1_ = shaka.offline.indexeddb.StorageMechanism.createV1_(db);
       this.v2_ = shaka.offline.indexeddb.StorageMechanism.createV2_(db);
       this.v3_ = shaka.offline.indexeddb.StorageMechanism.createV3_(db);


### PR DESCRIPTION
While we hold a connection open, no other connection can delete or upgrade the database.  The browser asks us to step aside by firing a versionchange event on the connection, and until we close it, the other request waits.  We never listened for that event, so we never stepped aside.

The waiting request does not fail.  It blocks, and every later IndexedDB operation queues behind it, so a connection nobody closes can stall storage indefinitely.

PR #10434 is the real fix for the failures we were seeing.  It stops a connection from being abandoned in the first place, which is a question of object ownership and lifecycle hygiene.  This change is a safety net underneath it.  Honoring versionchange is what the API asks of every open connection, and it bounds the damage from any connection that outlives its owner, whether through a future bug or an operation that simply runs long.

The safety net is not hypothetical.  The handler is registered on the connection itself, so it fires even for a connection whose owner is gone.  The connections leaked by the bug in #10434 did receive versionchange events, so had this handler been in place, they would have closed themselves and storage would never have locked up.

Closing costs us nothing here, because nothing holds a mechanism for long.  Offline reads and writes each create their own muxer and destroy it when finished, so the next operation simply opens a new connection.