### PR TITLE
fix(UI): isolate keyboard shortcuts and fullscreen detection per player instance

### DIFF
--- a/test/ui/ui_unit.js
+++ b/test/ui/ui_unit.js
@@ -1732,6 +1732,32 @@ describe('UI', () => {
       /** @type {shaka.Player} */
       let player2;
 
+      /**
+       * Waits for seek completion by listening for 'timeandseekrangeupdated'
+       * events during the triggered action.
+       *
+       * @param {!shaka.ui.Controls} controls
+       * @param {!HTMLMediaElement} video
+       * @param {function()} triggerAction
+       * @return {!Promise<number>}
+       */
+      async function waitForSeek(controls, video, triggerAction) {
+        let recordedTime = video.currentTime;
+        let eventFired = false;
+        const onUpdate = () => {
+          recordedTime = video.currentTime;
+          eventFired = true;
+        };
+        controls.addEventListener('timeandseekrangeupdated', onUpdate);
+        try {
+          triggerAction();
+        } finally {
+          controls.removeEventListener('timeandseekrangeupdated', onUpdate);
+        }
+        expect(eventFired).toBe(true);
+        return recordedTime;
+      }
+
       beforeEach(async () => {
         container1 =
           /** @type {!HTMLElement} */ (document.createElement('div'));
@@ -1745,64 +1771,102 @@ describe('UI', () => {
         video2 = shaka.test.UiUtils.createVideoElement();
         container2.appendChild(video2);
 
+        Object.defineProperty(video1, 'duration', {
+          value: 100,
+          configurable: true,
+          writable: true,
+        });
+        Object.defineProperty(video2, 'duration', {
+          value: 100,
+          configurable: true,
+          writable: true,
+        });
+
+        let currentTime1 = 0;
+        Object.defineProperty(video1, 'currentTime', {
+          get: () => currentTime1,
+          set: (val) => {
+            currentTime1 = val;
+          },
+          configurable: true,
+        });
+
+        let currentTime2 = 0;
+        Object.defineProperty(video2, 'currentTime', {
+          get: () => currentTime2,
+          set: (val) => {
+            currentTime2 = val;
+          },
+          configurable: true,
+        });
+
         ui1 = await UiUtils.createUIThroughAPI(container1, video1);
         controls1 = ui1.getControls();
         player1 = controls1.getLocalPlayer();
         spyOn(player1, 'getAssetUri').and.returnValue('fake-uri-1');
         spyOn(player1, 'seekRange').and.returnValue({start: 0, end: 100});
-        spyOn(controls1, 'getDisplayTime').and.returnValue(50);
+        controls1.seekTo(50, false);
 
         ui2 = await UiUtils.createUIThroughAPI(container2, video2);
         controls2 = ui2.getControls();
         player2 = controls2.getLocalPlayer();
         spyOn(player2, 'getAssetUri').and.returnValue('fake-uri-2');
         spyOn(player2, 'seekRange').and.returnValue({start: 0, end: 100});
-        spyOn(controls2, 'getDisplayTime').and.returnValue(50);
+        controls2.seekTo(50, false);
       });
 
-      it('handles seekbar Space and Arrow keys with preventDefault', () => {
-        const playPauseSpy = spyOn(controls1, 'playPausePresentation');
-        const seekSpy = spyOn(controls1, 'seek_');
-        const seekBar = container1.querySelector('.shaka-seek-bar');
-        expect(seekBar).toBeTruthy();
+      it('handles seekbar Space and Arrow keys with preventDefault',
+          async () => {
+            const playSpy =
+                spyOn(video1, 'play').and.returnValue(Promise.resolve());
+            const seekBar = container1.querySelector('.shaka-seek-bar');
+            expect(seekBar).toBeTruthy();
 
-        /** @type {!HTMLElement} */ (seekBar).focus();
+            /** @type {!HTMLElement} */ (seekBar).focus();
 
-        const spaceEvent = new KeyboardEvent('keydown', {
-          key: ' ',
-          bubbles: true,
-          cancelable: true,
-        });
-        const spacePreventDefaultSpy =
-            spyOn(spaceEvent, 'preventDefault').and.callThrough();
-        seekBar.dispatchEvent(spaceEvent);
+            const spaceEvent = new KeyboardEvent('keydown', {
+              key: ' ',
+              bubbles: true,
+              cancelable: true,
+            });
+            const spacePreventDefaultSpy =
+                spyOn(spaceEvent, 'preventDefault').and.callThrough();
+            seekBar.dispatchEvent(spaceEvent);
 
-        expect(playPauseSpy).toHaveBeenCalledTimes(1);
-        expect(spacePreventDefaultSpy).toHaveBeenCalled();
+            expect(playSpy).toHaveBeenCalledTimes(1);
+            expect(spacePreventDefaultSpy).toHaveBeenCalled();
 
-        const arrowLeftEvent = new KeyboardEvent('keydown', {
-          key: 'ArrowLeft',
-          bubbles: true,
-          cancelable: true,
-        });
-        const arrowLeftPreventDefaultSpy =
-            spyOn(arrowLeftEvent, 'preventDefault').and.callThrough();
-        seekBar.dispatchEvent(arrowLeftEvent);
+            controls1.seekTo(50, false);
+            const arrowLeftEvent = new KeyboardEvent('keydown', {
+              key: 'ArrowLeft',
+              bubbles: true,
+              cancelable: true,
+            });
+            const arrowLeftPreventDefaultSpy =
+                spyOn(arrowLeftEvent, 'preventDefault').and.callThrough();
+            let updatedTime = await waitForSeek(controls1, video1, () => {
+              seekBar.dispatchEvent(arrowLeftEvent);
+            });
 
-        expect(seekSpy).toHaveBeenCalledWith(45);
-        expect(arrowLeftPreventDefaultSpy).toHaveBeenCalled();
+            expect(updatedTime).toBe(45);
+            expect(video1.currentTime).toBe(45);
+            expect(arrowLeftPreventDefaultSpy).toHaveBeenCalled();
 
-        const arrowRightEvent = new KeyboardEvent('keydown', {
-          key: 'ArrowRight',
-          bubbles: true,
-          cancelable: true,
-        });
-        seekBar.dispatchEvent(arrowRightEvent);
+            controls1.seekTo(50, false);
+            const arrowRightEvent = new KeyboardEvent('keydown', {
+              key: 'ArrowRight',
+              bubbles: true,
+              cancelable: true,
+            });
+            updatedTime = await waitForSeek(controls1, video1, () => {
+              seekBar.dispatchEvent(arrowRightEvent);
+            });
 
-        expect(seekSpy).toHaveBeenCalledWith(55);
-      });
+            expect(updatedTime).toBe(55);
+            expect(video1.currentTime).toBe(55);
+          });
 
-      it('isolates fullscreen status and keys between players', () => {
+      it('isolates fullscreen status and keys between players', async () => {
         const originalFullscreenElement =
             Object.getOwnPropertyDescriptor(document, 'fullscreenElement');
 
@@ -1815,20 +1879,32 @@ describe('UI', () => {
           expect(controls1.isFullScreenEnabled()).toBe(true);
           expect(controls2.isFullScreenEnabled()).toBe(false);
 
-          const playPause1Spy = spyOn(controls1, 'playPausePresentation');
-          const playPause2Spy = spyOn(controls2, 'playPausePresentation');
-          const seek1Spy = spyOn(controls1, 'seek_');
-          const seek2Spy = spyOn(controls2, 'seek_');
+          const play1Spy =
+              spyOn(video1, 'play').and.returnValue(Promise.resolve());
+          const play2Spy =
+              spyOn(video2, 'play').and.returnValue(Promise.resolve());
+          const pause1Spy = spyOn(video1, 'pause');
+          const pause2Spy = spyOn(video2, 'pause');
+
+          controls1.seekTo(50, false);
+          controls2.seekTo(50, false);
+
+          const initialTime1 = video1.currentTime;
+          const initialTime2 = video2.currentTime;
 
           const arrowLeftEvent = new KeyboardEvent('keydown', {
             key: 'ArrowLeft',
             bubbles: true,
             cancelable: true,
           });
-          window.dispatchEvent(arrowLeftEvent);
+          const updatedTime1 = await waitForSeek(controls1, video1, () => {
+            window.dispatchEvent(arrowLeftEvent);
+          });
 
-          expect(seek1Spy).toHaveBeenCalledWith(45);
-          expect(seek2Spy).not.toHaveBeenCalled();
+          expect(updatedTime1).toBe(45);
+          expect(video1.currentTime).toBe(45);
+          expect(video1.currentTime).not.toBe(initialTime1);
+          expect(video2.currentTime).toBe(initialTime2);
 
           const spaceEvent = new KeyboardEvent('keydown', {
             key: ' ',
@@ -1837,8 +1913,11 @@ describe('UI', () => {
           });
           window.dispatchEvent(spaceEvent);
 
-          expect(playPause1Spy).toHaveBeenCalledTimes(1);
-          expect(playPause2Spy).not.toHaveBeenCalled();
+          expect(play1Spy).toHaveBeenCalledTimes(1);
+          expect(play2Spy).not.toHaveBeenCalled();
+          expect(pause1Spy).not.toHaveBeenCalled();
+          expect(pause2Spy).not.toHaveBeenCalled();
+          expect(video2.currentTime).toBe(initialTime2);
         } finally {
           if (originalFullscreenElement) {
             Object.defineProperty(
@@ -1850,11 +1929,14 @@ describe('UI', () => {
         }
       });
 
-      it('does not leak seekbar focus events to other players', () => {
+      it('does not leak seekbar focus events to other players', async () => {
         ui2.configure({enableKeyboardPlaybackControlsInWindow: true});
 
-        const seek1Spy = spyOn(controls1, 'seek_');
-        const seek2Spy = spyOn(controls2, 'seek_');
+        controls1.seekTo(50, false);
+        controls2.seekTo(50, false);
+
+        const initialTime1 = video1.currentTime;
+        const initialTime2 = video2.currentTime;
 
         const seekBar1 = container1.querySelector('.shaka-seek-bar');
         expect(seekBar1).toBeTruthy();
@@ -1865,16 +1947,30 @@ describe('UI', () => {
           bubbles: true,
           cancelable: true,
         });
-        seekBar1.dispatchEvent(arrowRightEvent);
+        const updatedTime1 = await waitForSeek(controls1, video1, () => {
+          seekBar1.dispatchEvent(arrowRightEvent);
+        });
 
-        expect(seek1Spy).toHaveBeenCalledWith(55);
-        expect(seek2Spy).not.toHaveBeenCalled();
+        expect(updatedTime1).toBe(55);
+        expect(video1.currentTime).toBe(55);
+        expect(video1.currentTime).not.toBe(initialTime1);
+        expect(video2.currentTime).toBe(initialTime2);
       });
 
       it('does not trigger shortcuts when typing in a form input', () => {
         ui1.configure({enableKeyboardPlaybackControlsInWindow: true});
-        const playPauseSpy = spyOn(controls1, 'playPausePresentation');
-        const seekSpy = spyOn(controls1, 'seek_');
+
+        const playSpy =
+            spyOn(video1, 'play').and.returnValue(Promise.resolve());
+        const pauseSpy = spyOn(video1, 'pause');
+
+        controls1.seekTo(50, false);
+        const initialTime1 = video1.currentTime;
+
+        const timeUpdateSpy = jasmine.createSpy('timeUpdateSpy');
+        const timeUpdateListener = Util.spyFunc(timeUpdateSpy);
+        controls1.addEventListener(
+            'timeandseekrangeupdated', timeUpdateListener);
 
         const input =
         /** @type {!HTMLInputElement} */ (document.createElement('input'));
@@ -1896,9 +1992,13 @@ describe('UI', () => {
         });
         window.dispatchEvent(arrowLeftEvent);
 
-        expect(playPauseSpy).not.toHaveBeenCalled();
-        expect(seekSpy).not.toHaveBeenCalled();
+        expect(playSpy).not.toHaveBeenCalled();
+        expect(pauseSpy).not.toHaveBeenCalled();
+        expect(video1.currentTime).toBe(initialTime1);
+        expect(timeUpdateSpy).not.toHaveBeenCalled();
 
+        controls1.removeEventListener(
+            'timeandseekrangeupdated', timeUpdateListener);
         document.body.removeChild(input);
       });
     });

--- a/test/ui/ui_unit.js
+++ b/test/ui/ui_unit.js
@@ -1708,6 +1708,200 @@ describe('UI', () => {
         expect(bufferingTime).toBe(lastBufferingTime);
       });
     });
+
+    describe('keyboard shortcuts and multi-player isolation', () => {
+      /** @type {!HTMLElement} */
+      let container1;
+      /** @type {!HTMLVideoElement} */
+      let video1;
+      /** @type {shaka.ui.Overlay} */
+      let ui1;
+      /** @type {shaka.ui.Controls} */
+      let controls1;
+      /** @type {shaka.Player} */
+      let player1;
+
+      /** @type {!HTMLElement} */
+      let container2;
+      /** @type {!HTMLVideoElement} */
+      let video2;
+      /** @type {shaka.ui.Overlay} */
+      let ui2;
+      /** @type {shaka.ui.Controls} */
+      let controls2;
+      /** @type {shaka.Player} */
+      let player2;
+
+      beforeEach(async () => {
+        container1 =
+          /** @type {!HTMLElement} */ (document.createElement('div'));
+        document.body.appendChild(container1);
+        video1 = shaka.test.UiUtils.createVideoElement();
+        container1.appendChild(video1);
+
+        container2 =
+          /** @type {!HTMLElement} */ (document.createElement('div'));
+        document.body.appendChild(container2);
+        video2 = shaka.test.UiUtils.createVideoElement();
+        container2.appendChild(video2);
+
+        ui1 = await UiUtils.createUIThroughAPI(container1, video1);
+        controls1 = ui1.getControls();
+        player1 = controls1.getLocalPlayer();
+        spyOn(player1, 'getAssetUri').and.returnValue('fake-uri-1');
+        spyOn(player1, 'seekRange').and.returnValue({start: 0, end: 100});
+        spyOn(controls1, 'getDisplayTime').and.returnValue(50);
+
+        ui2 = await UiUtils.createUIThroughAPI(container2, video2);
+        controls2 = ui2.getControls();
+        player2 = controls2.getLocalPlayer();
+        spyOn(player2, 'getAssetUri').and.returnValue('fake-uri-2');
+        spyOn(player2, 'seekRange').and.returnValue({start: 0, end: 100});
+        spyOn(controls2, 'getDisplayTime').and.returnValue(50);
+      });
+
+      it('handles seekbar Space and Arrow keys with preventDefault', () => {
+        const playPauseSpy = spyOn(controls1, 'playPausePresentation');
+        const seekSpy = spyOn(controls1, 'seek_');
+        const seekBar = container1.querySelector('.shaka-seek-bar');
+        expect(seekBar).toBeTruthy();
+
+        /** @type {!HTMLElement} */ (seekBar).focus();
+
+        const spaceEvent = new KeyboardEvent('keydown', {
+          key: ' ',
+          bubbles: true,
+          cancelable: true,
+        });
+        const spacePreventDefaultSpy =
+            spyOn(spaceEvent, 'preventDefault').and.callThrough();
+        seekBar.dispatchEvent(spaceEvent);
+
+        expect(playPauseSpy).toHaveBeenCalledTimes(1);
+        expect(spacePreventDefaultSpy).toHaveBeenCalled();
+
+        const arrowLeftEvent = new KeyboardEvent('keydown', {
+          key: 'ArrowLeft',
+          bubbles: true,
+          cancelable: true,
+        });
+        const arrowLeftPreventDefaultSpy =
+            spyOn(arrowLeftEvent, 'preventDefault').and.callThrough();
+        seekBar.dispatchEvent(arrowLeftEvent);
+
+        expect(seekSpy).toHaveBeenCalledWith(45);
+        expect(arrowLeftPreventDefaultSpy).toHaveBeenCalled();
+
+        const arrowRightEvent = new KeyboardEvent('keydown', {
+          key: 'ArrowRight',
+          bubbles: true,
+          cancelable: true,
+        });
+        seekBar.dispatchEvent(arrowRightEvent);
+
+        expect(seekSpy).toHaveBeenCalledWith(55);
+      });
+
+      it('isolates fullscreen status and keys between players', () => {
+        const originalFullscreenElement =
+            Object.getOwnPropertyDescriptor(document, 'fullscreenElement');
+
+        try {
+          Object.defineProperty(document, 'fullscreenElement', {
+            get: () => container1,
+            configurable: true,
+          });
+
+          expect(controls1.isFullScreenEnabled()).toBe(true);
+          expect(controls2.isFullScreenEnabled()).toBe(false);
+
+          const playPause1Spy = spyOn(controls1, 'playPausePresentation');
+          const playPause2Spy = spyOn(controls2, 'playPausePresentation');
+          const seek1Spy = spyOn(controls1, 'seek_');
+          const seek2Spy = spyOn(controls2, 'seek_');
+
+          const arrowLeftEvent = new KeyboardEvent('keydown', {
+            key: 'ArrowLeft',
+            bubbles: true,
+            cancelable: true,
+          });
+          window.dispatchEvent(arrowLeftEvent);
+
+          expect(seek1Spy).toHaveBeenCalledWith(45);
+          expect(seek2Spy).not.toHaveBeenCalled();
+
+          const spaceEvent = new KeyboardEvent('keydown', {
+            key: ' ',
+            bubbles: true,
+            cancelable: true,
+          });
+          window.dispatchEvent(spaceEvent);
+
+          expect(playPause1Spy).toHaveBeenCalledTimes(1);
+          expect(playPause2Spy).not.toHaveBeenCalled();
+        } finally {
+          if (originalFullscreenElement) {
+            Object.defineProperty(
+                document, 'fullscreenElement', originalFullscreenElement);
+          } else {
+            // @ts-ignore
+            delete document['fullscreenElement'];
+          }
+        }
+      });
+
+      it('does not leak seekbar focus events to other players', () => {
+        ui2.configure({enableKeyboardPlaybackControlsInWindow: true});
+
+        const seek1Spy = spyOn(controls1, 'seek_');
+        const seek2Spy = spyOn(controls2, 'seek_');
+
+        const seekBar1 = container1.querySelector('.shaka-seek-bar');
+        expect(seekBar1).toBeTruthy();
+        /** @type {!HTMLElement} */ (seekBar1).focus();
+
+        const arrowRightEvent = new KeyboardEvent('keydown', {
+          key: 'ArrowRight',
+          bubbles: true,
+          cancelable: true,
+        });
+        seekBar1.dispatchEvent(arrowRightEvent);
+
+        expect(seek1Spy).toHaveBeenCalledWith(55);
+        expect(seek2Spy).not.toHaveBeenCalled();
+      });
+
+      it('does not trigger shortcuts when typing in a form input', () => {
+        ui1.configure({enableKeyboardPlaybackControlsInWindow: true});
+        const playPauseSpy = spyOn(controls1, 'playPausePresentation');
+        const seekSpy = spyOn(controls1, 'seek_');
+
+        const input =
+        /** @type {!HTMLInputElement} */ (document.createElement('input'));
+        input.type = 'text';
+        document.body.appendChild(input);
+        input.focus();
+
+        const spaceEvent = new KeyboardEvent('keydown', {
+          key: ' ',
+          bubbles: true,
+          cancelable: true,
+        });
+        window.dispatchEvent(spaceEvent);
+
+        const arrowLeftEvent = new KeyboardEvent('keydown', {
+          key: 'ArrowLeft',
+          bubbles: true,
+          cancelable: true,
+        });
+        window.dispatchEvent(arrowLeftEvent);
+
+        expect(playPauseSpy).not.toHaveBeenCalled();
+        expect(seekSpy).not.toHaveBeenCalled();
+
+        document.body.removeChild(input);
+      });
+    });
   });
 
 

--- a/test/ui/ui_unit.js
+++ b/test/ui/ui_unit.js
@@ -1732,32 +1732,6 @@ describe('UI', () => {
       /** @type {shaka.Player} */
       let player2;
 
-      /**
-       * Waits for seek completion by listening for 'timeandseekrangeupdated'
-       * events during the triggered action.
-       *
-       * @param {!shaka.ui.Controls} controls
-       * @param {!HTMLMediaElement} video
-       * @param {function()} triggerAction
-       * @return {!Promise<number>}
-       */
-      async function waitForSeek(controls, video, triggerAction) {
-        let recordedTime = video.currentTime;
-        let eventFired = false;
-        const onUpdate = () => {
-          recordedTime = video.currentTime;
-          eventFired = true;
-        };
-        controls.addEventListener('timeandseekrangeupdated', onUpdate);
-        try {
-          triggerAction();
-        } finally {
-          controls.removeEventListener('timeandseekrangeupdated', onUpdate);
-        }
-        expect(eventFired).toBe(true);
-        return recordedTime;
-      }
-
       beforeEach(async () => {
         container1 =
           /** @type {!HTMLElement} */ (document.createElement('div'));
@@ -1815,58 +1789,51 @@ describe('UI', () => {
         controls2.seekTo(50, false);
       });
 
-      it('handles seekbar Space and Arrow keys with preventDefault',
-          async () => {
-            const playSpy =
-                spyOn(video1, 'play').and.returnValue(Promise.resolve());
-            const seekBar = container1.querySelector('.shaka-seek-bar');
-            expect(seekBar).toBeTruthy();
+      it('handles seekbar Space and Arrow keys with preventDefault', () => {
+        const playSpy =
+            spyOn(video1, 'play').and.returnValue(Promise.resolve());
+        const seekBar = container1.querySelector('.shaka-seek-bar');
+        expect(seekBar).toBeTruthy();
 
-            /** @type {!HTMLElement} */ (seekBar).focus();
+        /** @type {!HTMLElement} */ (seekBar).focus();
 
-            const spaceEvent = new KeyboardEvent('keydown', {
-              key: ' ',
-              bubbles: true,
-              cancelable: true,
-            });
-            const spacePreventDefaultSpy =
-                spyOn(spaceEvent, 'preventDefault').and.callThrough();
-            seekBar.dispatchEvent(spaceEvent);
+        const spaceEvent = new KeyboardEvent('keydown', {
+          key: ' ',
+          bubbles: true,
+          cancelable: true,
+        });
+        const spacePreventDefaultSpy =
+            spyOn(spaceEvent, 'preventDefault').and.callThrough();
+        seekBar.dispatchEvent(spaceEvent);
 
-            expect(playSpy).toHaveBeenCalledTimes(1);
-            expect(spacePreventDefaultSpy).toHaveBeenCalled();
+        expect(playSpy).toHaveBeenCalledTimes(1);
+        expect(spacePreventDefaultSpy).toHaveBeenCalled();
 
-            controls1.seekTo(50, false);
-            const arrowLeftEvent = new KeyboardEvent('keydown', {
-              key: 'ArrowLeft',
-              bubbles: true,
-              cancelable: true,
-            });
-            const arrowLeftPreventDefaultSpy =
-                spyOn(arrowLeftEvent, 'preventDefault').and.callThrough();
-            let updatedTime = await waitForSeek(controls1, video1, () => {
-              seekBar.dispatchEvent(arrowLeftEvent);
-            });
+        controls1.seekTo(50, false);
+        const arrowLeftEvent = new KeyboardEvent('keydown', {
+          key: 'ArrowLeft',
+          bubbles: true,
+          cancelable: true,
+        });
+        const arrowLeftPreventDefaultSpy =
+            spyOn(arrowLeftEvent, 'preventDefault').and.callThrough();
+        seekBar.dispatchEvent(arrowLeftEvent);
 
-            expect(updatedTime).toBe(45);
-            expect(video1.currentTime).toBe(45);
-            expect(arrowLeftPreventDefaultSpy).toHaveBeenCalled();
+        expect(video1.currentTime).toBe(45);
+        expect(arrowLeftPreventDefaultSpy).toHaveBeenCalled();
 
-            controls1.seekTo(50, false);
-            const arrowRightEvent = new KeyboardEvent('keydown', {
-              key: 'ArrowRight',
-              bubbles: true,
-              cancelable: true,
-            });
-            updatedTime = await waitForSeek(controls1, video1, () => {
-              seekBar.dispatchEvent(arrowRightEvent);
-            });
+        controls1.seekTo(50, false);
+        const arrowRightEvent = new KeyboardEvent('keydown', {
+          key: 'ArrowRight',
+          bubbles: true,
+          cancelable: true,
+        });
+        seekBar.dispatchEvent(arrowRightEvent);
 
-            expect(updatedTime).toBe(55);
-            expect(video1.currentTime).toBe(55);
-          });
+        expect(video1.currentTime).toBe(55);
+      });
 
-      it('isolates fullscreen status and keys between players', async () => {
+      it('isolates fullscreen status and keys between players', () => {
         const originalFullscreenElement =
             Object.getOwnPropertyDescriptor(document, 'fullscreenElement');
 
@@ -1897,11 +1864,8 @@ describe('UI', () => {
             bubbles: true,
             cancelable: true,
           });
-          const updatedTime1 = await waitForSeek(controls1, video1, () => {
-            window.dispatchEvent(arrowLeftEvent);
-          });
+          window.dispatchEvent(arrowLeftEvent);
 
-          expect(updatedTime1).toBe(45);
           expect(video1.currentTime).toBe(45);
           expect(video1.currentTime).not.toBe(initialTime1);
           expect(video2.currentTime).toBe(initialTime2);
@@ -1929,7 +1893,7 @@ describe('UI', () => {
         }
       });
 
-      it('does not leak seekbar focus events to other players', async () => {
+      it('does not leak seekbar focus events to other players', () => {
         ui2.configure({enableKeyboardPlaybackControlsInWindow: true});
 
         controls1.seekTo(50, false);
@@ -1947,11 +1911,8 @@ describe('UI', () => {
           bubbles: true,
           cancelable: true,
         });
-        const updatedTime1 = await waitForSeek(controls1, video1, () => {
-          seekBar1.dispatchEvent(arrowRightEvent);
-        });
+        seekBar1.dispatchEvent(arrowRightEvent);
 
-        expect(updatedTime1).toBe(55);
         expect(video1.currentTime).toBe(55);
         expect(video1.currentTime).not.toBe(initialTime1);
         expect(video2.currentTime).toBe(initialTime2);
@@ -1966,11 +1927,6 @@ describe('UI', () => {
 
         controls1.seekTo(50, false);
         const initialTime1 = video1.currentTime;
-
-        const timeUpdateSpy = jasmine.createSpy('timeUpdateSpy');
-        const timeUpdateListener = Util.spyFunc(timeUpdateSpy);
-        controls1.addEventListener(
-            'timeandseekrangeupdated', timeUpdateListener);
 
         const input =
         /** @type {!HTMLInputElement} */ (document.createElement('input'));
@@ -1995,10 +1951,7 @@ describe('UI', () => {
         expect(playSpy).not.toHaveBeenCalled();
         expect(pauseSpy).not.toHaveBeenCalled();
         expect(video1.currentTime).toBe(initialTime1);
-        expect(timeUpdateSpy).not.toHaveBeenCalled();
 
-        controls1.removeEventListener(
-            'timeandseekrangeupdated', timeUpdateListener);
         document.body.removeChild(input);
       });
     });

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -1016,7 +1016,12 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
    */
   isFullScreenEnabled() {
     if (this.shouldUseDocumentFullscreen_()) {
-      return !!document.fullscreenElement;
+      if (!document.fullscreenElement) {
+        return false;
+      }
+      return document.fullscreenElement == this.config_.fullScreenElement ||
+          Boolean(this.config_.fullScreenElement &&
+          this.config_.fullScreenElement.contains(document.fullscreenElement));
     }
     const video = /** @type {HTMLVideoElement} */(this.localVideo_);
     if (video.webkitSupportsFullscreen) {
@@ -2153,12 +2158,35 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
     }
 
     const activeElement = document.activeElement;
-    const isVolumeBar = activeElement && activeElement.classList ?
-        activeElement.classList.contains('shaka-volume-bar') : false;
-    const isSeekBar = activeElement && activeElement.classList &&
-        activeElement.classList.contains('shaka-seek-bar');
+    if (activeElement) {
+      const tagName = activeElement.tagName.toLowerCase();
+      if (tagName == 'input' &&
+          !activeElement.classList.contains('shaka-range-element')) {
+        return;
+      }
+      const isEditable = tagName == 'textarea' || tagName == 'select' ||
+      /** @type {!HTMLElement} */ (activeElement).isContentEditable;
+      if (isEditable) {
+        return;
+      }
+    }
+
     const isFullscreen = this.isFullScreenEnabled();
-    const isControlsFocused = this.controlsContainer_.contains(activeElement);
+    const isControlsFocused = Boolean(activeElement &&
+        this.controlsContainer_.contains(activeElement));
+    const isContainerFocused = Boolean(activeElement &&
+        this.videoContainer_.contains(activeElement));
+
+    if (!isFullscreen && !isContainerFocused && activeElement &&
+        activeElement.closest &&
+        activeElement.closest('.shaka-video-container')) {
+      return;
+    }
+
+    const isVolumeBar = isControlsFocused && activeElement.classList ?
+        activeElement.classList.contains('shaka-volume-bar') : false;
+    const isSeekBar = isControlsFocused && activeElement.classList ?
+        activeElement.classList.contains('shaka-seek-bar') : false;
     const isFullscreenOrControlsInWindow = isFullscreen ||
         this.config_.enableKeyboardPlaybackControlsInWindow;
 
@@ -2221,13 +2249,15 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
         break;
       // Jump to the beginning of the video's seek range.
       case this.config_.shortcuts.home.toLowerCase():
-        if (this.seekBar_) {
+        if (this.seekBar_ && (isSeekBar || isFullscreenOrControlsInWindow)) {
+          event.preventDefault();
           this.seek_(this.player_.seekRange().start);
         }
         break;
       // Jump to the end of the video's seek range.
       case this.config_.shortcuts.end.toLowerCase():
-        if (this.seekBar_) {
+        if (this.seekBar_ && (isSeekBar || isFullscreenOrControlsInWindow)) {
+          event.preventDefault();
           this.seek_(this.player_.seekRange().end);
         }
         break;
@@ -2286,6 +2316,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
       case this.config_.shortcuts.play.toLowerCase():
         if (isSeekBar ||
             (isFullscreenOrControlsInWindow && !isControlsFocused)) {
+          event.preventDefault();
           this.playPausePresentation();
         }
         break;
@@ -2311,10 +2342,11 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
       case '8':
       case '9': {
         // Jump to percentage in the video
-        if (!this.ad_) {
+        if (!this.ad_ && (isSeekBar || isFullscreenOrControlsInWindow)) {
           const seekRange = this.player_.seekRange();
           const length = seekRange.end - seekRange.start;
           if (length > 0) {
+            event.preventDefault();
             const percentage = parseInt(event.key, 10) / 10;
             this.seek_(seekRange.start + (length * percentage));
           }


### PR DESCRIPTION
## Summary

Fixes #10429.

Keyboard shortcuts could behave inconsistently depending on focus and could affect multiple Shaka Player instances when one player was fullscreen.

## Changes

* Scope fullscreen detection to the appropriate Shaka Player instance instead of treating `document.fullscreenElement` as fullscreen for every player.
* Scope seek bar and volume bar focus handling to the player's own controls.
* Prevent keyboard shortcuts from leaking to other player instances.
* Ignore playback shortcuts when typing in editable form controls such as `<input>`, `<textarea>`, `<select>`, and `contenteditable`.
* Prevent browser scrolling when Space and relevant seek shortcuts are handled.
* Add regression tests covering fullscreen isolation, multi-player keyboard isolation, seek bar interaction, and form input handling.

## Testing

* `python build/check.py --force` — passed
* `python build/build.py` — passed
* `python build/test.py --browsers Chrome --quick --filter="keyboard shortcuts and multi-player isolation"` — 4/4 passed
* `git diff --check` — passed

The full quick test suite previously reported 3,330 passed, 3 skipped, and 1 pre-existing Chrome canvas SSIM failure unrelated to this change.

## Files Changed

* `ui/controls.js`
* `test/ui/ui_unit.js`

Fixes #10429.
#10429 