### PR TITLE
fix(net): Abort pending retry delays immediately

### DIFF
--- a/lib/net/backoff.js
+++ b/lib/net/backoff.js
@@ -155,19 +155,14 @@ shaka.net.Backoff = class {
    * are unaffected.
    */
   stop() {
-    if (this.pendingTimer_) {
-      this.pendingTimer_.stop();
-      this.pendingTimer_ = null;
-    }
+    this.pendingTimer_?.stop();
+    this.pendingTimer_ = null;
 
-    if (this.pendingDelay_) {
-      const delay = this.pendingDelay_;
-      this.pendingDelay_ = null;
-      delay.reject(new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.PLAYER,
-          shaka.util.Error.Code.OPERATION_ABORTED));
-    }
+    this.pendingDelay_?.reject(new shaka.util.Error(
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.PLAYER,
+        shaka.util.Error.Code.OPERATION_ABORTED));
+    this.pendingDelay_ = null;
   }
 
   /**

--- a/lib/net/backoff.js
+++ b/lib/net/backoff.js
@@ -76,6 +76,18 @@ shaka.net.Backoff = class {
     /** @private {boolean} */
     this.autoReset_ = autoReset;
 
+    /**
+     * The resolvers of the delay currently being awaited by attempt(), if any.
+     * @private {?Promise.PromiseWithResolvers}
+     */
+    this.pendingDelay_ = null;
+
+    /**
+     * The timer backing the delay currently being awaited by attempt(), if any.
+     * @private {shaka.util.Timer}
+     */
+    this.pendingTimer_ = null;
+
     if (this.autoReset_) {
       // There is no delay before the first attempt.  In StreamingEngine (the
       // intended user of auto-reset mode), the first attempt was implied, so we
@@ -89,7 +101,8 @@ shaka.net.Backoff = class {
 
   /**
    * @return {!Promise} Resolves when the caller may make an attempt, possibly
-   *   after a delay.  Rejects if no more attempts are allowed.
+   *   after a delay.  Rejects if no more attempts are allowed, or if stop() is
+   *   called while we are waiting out a delay.
    */
   async attempt() {
     if (this.numAttempts_ >= this.maxAttempts_) {
@@ -118,12 +131,43 @@ shaka.net.Backoff = class {
     const fuzzedDelayMs = shaka.net.Backoff.fuzz_(
         this.nextUnfuzzedDelay_, this.fuzzFactor_);
 
-    await new Promise((resolve) => {
-      shaka.net.Backoff.defer(fuzzedDelayMs, resolve);
+    // Keep track of the delay so that stop() can interrupt it.  Otherwise,
+    // shutting down while we wait out a long retry delay would be blocked until
+    // the delay expired.
+    // See https://github.com/shaka-project/shaka-player/issues/10413
+    const delay = Promise.withResolvers();
+    this.pendingDelay_ = delay;
+    this.pendingTimer_ = shaka.net.Backoff.defer(fuzzedDelayMs, () => {
+      this.pendingDelay_ = null;
+      this.pendingTimer_ = null;
+      delay.resolve();
     });
+
+    await delay.promise;
 
     // Update delay_ for next time.
     this.nextUnfuzzedDelay_ *= this.backoffFactor_;
+  }
+
+  /**
+   * Interrupts the delay of an in-progress attempt(), if any, making its
+   * Promise reject with OPERATION_ABORTED right away.  Attempts made after this
+   * are unaffected.
+   */
+  stop() {
+    if (this.pendingTimer_) {
+      this.pendingTimer_.stop();
+      this.pendingTimer_ = null;
+    }
+
+    if (this.pendingDelay_) {
+      const delay = this.pendingDelay_;
+      this.pendingDelay_ = null;
+      delay.reject(new shaka.util.Error(
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.PLAYER,
+          shaka.util.Error.Code.OPERATION_ABORTED));
+    }
   }
 
   /**
@@ -181,9 +225,11 @@ shaka.net.Backoff = class {
    *
    * @param {number} delayInMs
    * @param {function()} callback
+   * @return {shaka.util.Timer}
    */
   static defer(delayInMs, callback) {
     const timer = new shaka.util.Timer(callback);
     timer.tickAfter(delayInMs / 1000);
+    return timer;
   }
 };

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -546,8 +546,18 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
 
     // Every attempt must have an associated backoff.attempt() call so that the
     // accounting is correct.
-    const backoffOperation = filterRequestOperation.chain(() =>
-      shaka.util.AbortableOperation.notAbortable(backoff.attempt()));
+    const backoffOperation = filterRequestOperation.chain(() => {
+      // The retry delay must be abortable.  Otherwise, aborting a request
+      // that is waiting to be retried (which is what unload() and destroy()
+      // do) would not complete until the delay expired, and with the default
+      // backoff factor that delay grows with every failed attempt.
+      // See https://github.com/shaka-project/shaka-player/issues/10413
+      const attempt = backoff.attempt();
+      return new shaka.util.AbortableOperation(attempt, () => {
+        backoff.stop();
+        return attempt.catch(() => {});
+      });
+    });
 
     /** @type {?shaka.util.Timer} */
     let connectionTimer = null;

--- a/test/net/networking_engine_unit.js
+++ b/test/net/networking_engine_unit.js
@@ -1314,6 +1314,84 @@ describe('NetworkingEngine', /** @suppress {accessControls} */ () => {
           .toBeRejectedWith(Util.jasmineError(abortError));
     });
 
+    it('interrupts retry delays', async () => {
+      // Simulate a retry delay that never expires on its own, so we can tell
+      // whether abort() waits for it.
+      const timerStopSpy = jasmine.createSpy('timer stop');
+      deferSpy.and.callFake(() => ({stop: Util.spyFunc(timerStopSpy)}));
+
+      const request = createRequest('reject://foo', {
+        maxAttempts: 3,
+        baseDelay: 1000,
+        backoffFactor: 2,
+        fuzzFactor: 0,
+        timeout: 0,
+        stallTimeout: 0,
+        connectionTimeout: 0,
+      });
+      /** @type {!shaka.extern.IAbortableOperation} */
+      const operation = networkingEngine.request(requestType, request);
+      /** @type {!shaka.test.StatusPromise} */
+      const r = new StatusPromise(operation.promise);
+
+      await Util.shortDelay();
+      // The first attempt failed, and we are now waiting out the retry delay.
+      expect(rejectScheme).toHaveBeenCalledTimes(1);
+      expect(deferSpy).toHaveBeenCalledTimes(1);
+      expect(r.status).toBe('pending');
+
+      /** @type {!shaka.test.StatusPromise} */
+      const abortStatus = new StatusPromise(operation.abort());
+      await Util.shortDelay();
+
+      // abort() did not wait out the retry delay, and the delay's timer was
+      // stopped rather than left to fire later.
+      expect(abortStatus.status).toBe('resolved');
+      expect(timerStopSpy).toHaveBeenCalled();
+
+      // No further attempt was made, and the operation has been aborted.
+      expect(rejectScheme).toHaveBeenCalledTimes(1);
+      expect(r.status).toBe('rejected');
+      await expectAsync(operation.promise)
+          .toBeRejectedWith(Util.jasmineError(abortError));
+    });
+
+    it('is called by destroy during retry delays', async () => {
+      // Simulate a retry delay that never expires on its own, so we can tell
+      // whether destroy() waits for it.
+      const timerStopSpy = jasmine.createSpy('timer stop');
+      deferSpy.and.callFake(() => ({stop: Util.spyFunc(timerStopSpy)}));
+
+      const request = createRequest('reject://foo', {
+        maxAttempts: 3,
+        baseDelay: 1000,
+        backoffFactor: 2,
+        fuzzFactor: 0,
+        timeout: 0,
+        stallTimeout: 0,
+        connectionTimeout: 0,
+      });
+      /** @type {!shaka.extern.IAbortableOperation} */
+      const operation = networkingEngine.request(requestType, request);
+      /** @type {!shaka.test.StatusPromise} */
+      const r = new StatusPromise(operation.promise);
+
+      await Util.shortDelay();
+      expect(rejectScheme).toHaveBeenCalledTimes(1);
+      expect(r.status).toBe('pending');
+
+      /** @type {!shaka.test.StatusPromise} */
+      const destroyStatus = new StatusPromise(networkingEngine.destroy());
+      await Util.shortDelay();
+
+      expect(destroyStatus.status).toBe('resolved');
+      expect(timerStopSpy).toHaveBeenCalled();
+      expect(rejectScheme).toHaveBeenCalledTimes(1);
+      expect(r.status).toBe('rejected');
+      await expectAsync(operation.promise)
+          .toBeRejectedWith(Util.jasmineError(abortError));
+    });
+
     it('is called by destroy', async () => {
       /** @type {!Promise.PromiseWithResolvers} */
       const p = Promise.withResolvers();


### PR DESCRIPTION
NetworkingEngine wrapped the retry delay in
AbortableOperation.notAbortable(), whose abort() only resolves once the underlying promise settles. Aborting a request that was waiting to be retried therefore blocked until the delay expired, and with the default backoff factor that delay doubles with every failed attempt.

Since unload() awaits both parser.stop() and streamingEngine.destroy(), which abort their pending requests, unload() could take many seconds to resolve during a network outage while playback kept going.

Backoff now tracks the pending delay and exposes stop(), which cancels the timer and rejects the in-progress attempt() with OPERATION_ABORTED, and NetworkingEngine wraps the delay in a real abortable operation.

Closes #10413