### PR TITLE
fix: Avoid quadratic copying of prefetched segment data

### DIFF
--- a/lib/media/segment_prefetch.js
+++ b/lib/media/segment_prefetch.js
@@ -476,19 +476,24 @@ shaka.media.SegmentPrefetchOperation = class {
    */
   dispatchFetch(reference, stream) {
     // We need to store the data, because streamDataCallback_ might not be
-    // available when you start getting the first data.
-    let buffered = new Uint8Array(0);
+    // available when you start getting the first data. Chunks are kept in a
+    // list and only concatenated once a callback consumes them, to avoid
+    // re-copying the accumulated buffer on every chunk.
+    /** @type {!Array<BufferSource>} */
+    let bufferedChunks = [];
     this.operation_ = this.fetchDispatcher_(
         reference, stream, async (data) => {
-          if (buffered.byteLength > 0) {
-            buffered = shaka.util.Uint8ArrayUtils.concat(buffered, data);
-          } else {
-            buffered = data;
+          if (!this.streamDataCallback_) {
+            bufferedChunks.push(data);
+            return;
           }
-          if (this.streamDataCallback_) {
-            await this.streamDataCallback_(buffered);
-            buffered = new Uint8Array(0);
+          let payload = data;
+          if (bufferedChunks.length > 0) {
+            bufferedChunks.push(data);
+            payload = shaka.util.Uint8ArrayUtils.concatRange(bufferedChunks);
+            bufferedChunks = [];
           }
+          await this.streamDataCallback_(payload);
         });
     return this.operation_.promise.catch((e) => {
       // Ignore OPERATION_ABORTED errors.


### PR DESCRIPTION
`SegmentPrefetchOperation.dispatchFetch` accumulates the response body by concatenating every network chunk onto a single `Uint8Array`, re-copying the entire accumulated buffer on each chunk. For a segment arriving in N chunks that is O(N²) byte copies, plus one discarded intermediate buffer per chunk for the GC.

The accumulated data has a single consumer: the `streamDataCallback_` attached via `getPrefetchedSegment` when playback catches up to an in-flight segment in low-latency mode. On regular content no callback is ever attached, and the buffer is built at quadratic cost and discarded. Since `segmentPrefetchLimit` defaults to 1, every default-config player pays this on every segment. On low-end smart TVs this blocks the main thread long enough to cause periodic playback freezes (1-2 seconds per segment on a 2018 LG TV).

This change stores the chunks in a list (no copying on arrival) and concatenates exactly once, when a callback consumes them. Delivered payloads are byte-identical in all cases: callback never attached, attached from the start, or attached mid-download.

Measured with DevTools 20x CPU throttling on a live DASH stream (Chromium 151, AMD Ryzen AI 9 HX PRO 370): per-segment main-thread tasks dropped from 220-340ms to 52-69ms, major GC time halved.

Closes #10446