### PR TITLE
fix(test): Skip Widevine tests on Edge with a revoked device certificate

### DIFF
--- a/lib/device/default_browser.js
+++ b/lib/device/default_browser.js
@@ -23,6 +23,17 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
 
     /** @private {!shaka.util.Lazy<?number>} */
     this.version_ = new shaka.util.Lazy(() => {
+      // Check Edge before Chrome.  Chromium-based Edge reports both, as in
+      // "Chrome/150.0.0.0 ... Edg/150.0.0.0", and Chrome's comes first, so
+      // matching Chrome would report the Chromium version rather than the
+      // browser's own.  They usually agree, but they are not the same number
+      // and callers asking an Edge device for its version mean Edge's.
+      // Matches legacy "Edge/18" and Chromium-based "Edg/150" alike.
+      const edge = navigator.userAgent.match(/Edge?\/(\d+)/);
+      if (edge) {
+        return parseInt(edge[1], /* base= */ 10);
+      }
+
       // Looking for something like "Chrome/106.0.0.0" or Firefox/135.0
       const match = navigator.userAgent.match(/(Chrome|Firefox)\/(\d+)/);
       if (match) {

--- a/test/media/content_workarounds_integration.js
+++ b/test/media/content_workarounds_integration.js
@@ -105,7 +105,7 @@ describe('ContentWorkarounds', () => {
       });
   for (const [keySystem, drmConfig] of keySystemsConfigs) {
     drmIt(`plays mixed clear encrypted content with ${keySystem}`, async () => {
-      if (!shakaSupport.drm[keySystem]) {
+      if (!checkDrmSupport(keySystem)) {
         pending('Needed DRM is not supported on this platform');
       }
       if (deviceDetected.getDeviceName() === 'Tizen' &&

--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -499,10 +499,49 @@ function checkPlayReadySupport() {
  * @return {boolean}
  */
 function checkWidevineSupport() {
+  // Edge cannot get a Widevine license where its content decryption module is
+  // the one it shipped with: the device certificate is revoked, and every
+  // license request comes back 400 with "status=ACCESS_DENIED,
+  // internal_status=DRM_DEVICE_CERTIFICATE_REVOKED".
+  //
+  // The browser version alone does not decide this, because the module updates
+  // on its own schedule.  Edge 151 works in our lab, where the machines persist
+  // and have taken a module update, and fails on GitHub's images, which are
+  // rebuilt from a base image each run and so keep the module Edge shipped
+  // with.  152 is the first version expected to ship a module that is accepted
+  // without an update.
+  if (deviceDetected.getDeviceName() === 'Edge') {
+    // The version is nullable, and an Edge we cannot identify is more likely
+    // to be an old one than a new one, so treat unknown as affected.
+    const version = deviceDetected.getVersion();
+    if (version === null || version < 152) {
+      return false;
+    }
+  }
   if (shakaSupport.drm['com.widevine.alpha']) {
     return true;
   }
   return false;
+}
+
+/**
+ * Check if a named key system is supported.
+ *
+ * Prefer this to reading shakaSupport.drm directly.  A key system can be
+ * present and still be unusable, as Widevine is on Edge with a revoked device
+ * certificate, and only the checks above know about those cases.
+ *
+ * @param {string} keySystem
+ * @return {boolean}
+ */
+function checkDrmSupport(keySystem) {
+  if (keySystem === 'com.widevine.alpha') {
+    return checkWidevineSupport();
+  }
+  if (keySystem === 'com.apple.fps') {
+    return checkFairPlaySupport();
+  }
+  return !!shakaSupport.drm[keySystem];
 }
 
 /**


### PR DESCRIPTION
Current stable versions of Edge cannot obtain a Widevine license on any operating system where its CDM is the one the browser shipped with.  CDM updates have gone out ahead of browser updates, but these are not hitting GitHub Actions VMs.  Every license request is answered with 400 and a body naming the reason: status=ACCESS_DENIED, internal_status=DRM_DEVICE_CERTIFICATE_REVOKED.  Chrome on the same machines, with the same content and the same license server, succeeds.

Nothing in the player can work around a revoked certificate.  Leaving these tests failing costs several failures on every Edge run and hides any other DRM problem that might appear there, so skip the ones that need a real license.  ClearKey tests keep running, since they need no certificate.

The browser version alone does not decide this, because the CDM updates on its own schedule.  Edge 151 works on machines that persist and have taken a CDM update, and fails on CI images that are rebuilt each run and so keep the CDM Edge shipped with.  152 is the first version expected to ship a CDM accepted without an update, so that is the cutoff.  When Edge 152 ships to GitHub Actions VMs, these tests will auto-enable and we expect them to work again.

Two supporting fixes are needed to make that cutoff mean what it says.  The device version was read from the user agent by matching Chrome, but Chromium-based Edge reports both its own version and Chromium's, with Chromium's first, so an Edge 151 built on Chromium 150 reported 150 and would have stayed suppressed on the very version expected to fix it.  Check for Edge first, which also reports legacy Edge correctly.  Only WebKit and Gecko callers read this value today, so nothing else changes.

And one test read shakaSupport.drm directly rather than going through the support checks, so it kept running on Edge and failing.  Add a helper that answers for a named key system while honoring platform suppressions: reading shakaSupport.drm tells you a key system is present, not that it is usable.

Fixes #10442