### PR TITLE
chore: Stop using TypedArray at compile-time

### DIFF
--- a/build/conformance.textproto
+++ b/build/conformance.textproto
@@ -132,10 +132,19 @@ requirement: {
     "function template(a) { new Int32Array(a) }"
   value:
     "/** @param {BufferSource} a */"
+    "function template(a) { new Float16Array(a) }"
+  value:
+    "/** @param {BufferSource} a */"
     "function template(a) { new Float32Array(a) }"
   value:
     "/** @param {BufferSource} a */"
     "function template(a) { new Float64Array(a) }"
+  value:
+    "/** @param {BufferSource} a */"
+    "function template(a) { new BigInt64Array(a) }"
+  value:
+    "/** @param {BufferSource} a */"
+    "function template(a) { new BigUint64Array(a) }"
   error_message: "Use shaka.util.BufferUtils.view* instead."
   whitelist_regexp: "lib/util/buffer_utils.js"
   whitelist_regexp: "lib/util/data_view_reader.js"
@@ -175,6 +184,18 @@ requirement: {
   type: BANNED_PROPERTY
   value: "DataView.prototype.buffer"
   value: "TypedArray.prototype.buffer"
+  value: "Int8Array.prototype.buffer"
+  value: "Uint8Array.prototype.buffer"
+  value: "Uint8ClampedArray.prototype.buffer"
+  value: "Int16Array.prototype.buffer"
+  value: "Uint16Array.prototype.buffer"
+  value: "Int32Array.prototype.buffer"
+  value: "Uint32Array.prototype.buffer"
+  value: "Float16Array.prototype.buffer"
+  value: "Float32Array.prototype.buffer"
+  value: "Float64Array.prototype.buffer"
+  value: "BigInt64Array.prototype.buffer"
+  value: "BigUint64Array.prototype.buffer"
   error_message:
     "Using \"TypedArray.buffer\" is not safe since it doesn\'t "
     "handle sub-arrays"

--- a/lib/cast/cast_utils.js
+++ b/lib/cast/cast_utils.js
@@ -73,8 +73,12 @@ shaka.cast.CastUtils = class {
         return shaka.cast.CastUtils.unpackTimeRanges_(value);
       }
 
+      // TypeScript has no TypedArray alias, so to prepare for TypeScript, we
+      // stop using TypedArray and arbitrarily pick the specific TypedArray of
+      // Uint8Array for the purposes of this cast.  If BYTES_PER_ELEMENT is not
+      // 1, it's not a Uint8Array.
       if (ArrayBuffer.isView(value) &&
-      /** @type {TypedArray} */(value).BYTES_PER_ELEMENT === 1) {
+      /** @type {Uint8Array} */(value).BYTES_PER_ELEMENT === 1) {
         // Some of our code cares about Uint8Arrays actually being Uint8Arrays,
         // so this gives them special treatment.
         return shaka.cast.CastUtils.unpackUint8Array_(

--- a/lib/util/string_utils.js
+++ b/lib/util/string_utils.js
@@ -13,7 +13,6 @@ goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.Lazy');
 
-
 /**
  * @namespace shaka.util.StringUtils
  * @summary A set of string utility functions.
@@ -263,7 +262,7 @@ shaka.util.StringUtils = class {
    * errors on very large arrays.  This breaks up the array into several pieces
    * to avoid this.
    *
-   * @param {!TypedArray} array
+   * @param {!shaka.util.StringUtils.IntegerTypedArray} array
    * @return {string}
    */
   static fromCharCode(array) {
@@ -334,7 +333,19 @@ shaka.util.StringUtils = class {
 };
 
 
-/** @private {!shaka.util.Lazy.<function(!TypedArray):string>} */
+/**
+ * The typed arrays we convert to strings.  TypeScript has no TypedArray alias,
+ * so name the specific ones rather than the general type.
+ *
+ * @typedef {!Uint8Array|!Uint16Array|!Uint32Array}
+ */
+shaka.util.StringUtils.IntegerTypedArray;
+
+
+/**
+ * @private {!shaka.util.Lazy.<
+ *     function(!shaka.util.StringUtils.IntegerTypedArray):string>}
+ */
 shaka.util.StringUtils.fromCharCodeImpl_ = new shaka.util.Lazy(() => {
   /**
    * @param {number} size

--- a/lib/util/uint8array_utils.js
+++ b/lib/util/uint8array_utils.js
@@ -153,8 +153,12 @@ shaka.util.Uint8ArrayUtils = class {
 
     for (let i = start; i < end; ++i) {
       const value = array[i];
+      // TypeScript has no TypedArray alias, so to prepare for TypeScript, we
+      // stop using TypedArray and arbitrarily pick the specific TypedArray of
+      // Uint8Array for the purposes of this cast.  If BYTES_PER_ELEMENT is not
+      // 1, it's not a Uint8Array.
       if (ArrayBuffer.isView(value) &&
-      /** @type {TypedArray} */ (value).BYTES_PER_ELEMENT === 1) {
+      /** @type {!Uint8Array} */ (value).BYTES_PER_ELEMENT === 1) {
         result.set(/** @type {!Uint8Array} */(value), offset);
       } else {
         result.set(BufferUtils.toUint8(value), offset);


### PR DESCRIPTION
TypeScript doesn't have .d.ts definitions for TypedArray, so we replace it with either a specific TypedArray (like Uint8Array) or a typedef that includes several.