### PR TITLE
fix(UI): Center the seek bar time on the pointer when there are no thumbnails

### DIFF
--- a/ui/less/thumbnails.less
+++ b/ui/less/thumbnails.less
@@ -19,6 +19,15 @@
     width: 7.5%;
   }
 
+  // When there is no thumbnail to show, the box must hug the time, instead of
+  // reserving the width of an image that is not being displayed. Otherwise the
+  // time would stop following the pointer well before the edges of the bar.
+  &.time-only {
+    min-width: 0;
+    width: auto;
+    max-width: 100%;
+  }
+
   .shaka-player-ui-thumbnail-image-container {
     background-color: var(--shaka-bg-solid);
     border: 1px solid var(--shaka-bg-solid);

--- a/ui/seek_bar.js
+++ b/ui/seek_bar.js
@@ -789,20 +789,31 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
       this.thumbnailTime_.textContent = time;
     }
 
+    const hasImageTracks = this.player.getImageTracks().length > 0;
+    const hasChapterThumbnails = chapter && chapter.images.length > 0;
+    const showImage = !isAdValue && (hasImageTracks || hasChapterThumbnails);
+
+    // The container reserves the width of a thumbnail, but when there is no
+    // image to show, only the time is visible, centered inside that much wider
+    // box.  Make the box hug the time in that case, so that the time itself,
+    // and not the empty space around it, is what gets centered on the pointer
+    // and clamped to the edges of the bar.
+    this.thumbnailImageContainer_.style.display = showImage ? '' : 'none';
+    this.thumbnailContainer_.classList.toggle('time-only', !showImage);
+
+    // Measure at a known offset: the width of the box hugging the time
+    // depends on the space left to the right of it, and the container is
+    // still positioned for the previous value at this point.
+    this.thumbnailContainer_.style.left = '0';
     const width = this.thumbnailContainer_.clientWidth;
     const leftPosition = Math.min(this.bar.offsetWidth - width,
         Math.max(0, pixelPosition - (width / 2)));
     this.thumbnailContainer_.style.left = leftPosition + 'px';
     this.thumbnailContainer_.style.visibility = 'visible';
 
-    const hasImageTracks = this.player.getImageTracks().length > 0;
-    const hasChapterThumbnails = chapter && chapter.images.length > 0;
-
-    if (isAdValue || !(hasImageTracks || hasChapterThumbnails)) {
-      this.thumbnailImageContainer_.style.display = 'none';
+    if (!showImage) {
       return;
     }
-    this.thumbnailImageContainer_.style.display = '';
 
     // Set the thumbnail height before getting the thumbnail because the
     // operation may take some time.


### PR DESCRIPTION
The thumbnail container always reserves the width of a thumbnail image, so on content without thumbnails the time label, which is centered inside that much wider box, stopped following the pointer well before the edges of the seek bar.

Hide the image container before positioning and let the box hug the time label when there is no image to show, so the label itself is what gets centered on the pointer and clamped to the edges of the bar.

Closes #10452