### PR TITLE
fix(UI): Prevent playback rate menu jitter when dragging the slider

### DIFF
--- a/ui/less/playback_rate.less
+++ b/ui/less/playback_rate.less
@@ -130,7 +130,6 @@
   &.shaka-chosen-item {
     background: var(--shaka-rate-preset-active) !important;
     border-color: var(--shaka-rate-preset-border) !important;
-    font-weight: 600;
     color: var(--shaka-font-color);
     margin-left: 0;
   }


### PR DESCRIPTION
The chosen preset pill was rendered bold, and bold text is wider, so the pill and the menu resized every time the highlight moved. Mark the chosen pill with the border and background only.

Fixes https://github.com/shaka-project/shaka-player/issues/10455