### PR TITLE
fix: Normalize Opus codec when multiplexed

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -613,7 +613,8 @@ shaka.media.MediaSourceEngine = class {
 
     if (contentType == ContentType.VIDEO && codecs &&
         stream.mimeType == 'video/mp4') {
-      codecs = shaka.util.MimeUtils.getCorrectVideoCodecs(codecs);
+      codecs = shaka.util.MimeUtils.getCorrectCodecs(
+          codecs, stream.mimeType);
     }
 
     let mimeType = shaka.util.MimeUtils.getFullType(
@@ -2674,6 +2675,9 @@ shaka.media.MediaSourceEngine = class {
   getRealInfo_(contentType, mimeType, codecs) {
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
     const MimeUtils = shaka.util.MimeUtils;
+    if (mimeType == 'video/mp4') {
+      codecs = MimeUtils.getCorrectCodecs(codecs, mimeType);
+    }
     /** @type {?shaka.extern.Transmuxer} */
     let transmuxer;
     let transmuxerMuxed = false;

--- a/lib/util/mime_utils.js
+++ b/lib/util/mime_utils.js
@@ -322,6 +322,27 @@ shaka.util.MimeUtils = class {
   }
 
   /**
+   * Corrects each codec in a potentially multiplexed codec string.
+   *
+   * @param {string} codecs
+   * @param {string} mimeType
+   * @return {string}
+   */
+  static getCorrectCodecs(codecs, mimeType) {
+    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    const MimeUtils = shaka.util.MimeUtils;
+    const allCodecs = codecs.split(',').map((codec) => codec.trim());
+    const audioCodec = shaka.util.ManifestParserUtils.guessCodecsSafe(
+        ContentType.AUDIO, allCodecs);
+    return allCodecs.map((codec) => {
+      if (codec == audioCodec) {
+        return MimeUtils.getCorrectAudioCodecs(codec, mimeType);
+      }
+      return MimeUtils.getCorrectVideoCodecs(codec);
+    }).join(',');
+  }
+
+  /**
    * Generates the correct video codec for MediaDecodingConfiguration and
    * for MediaSource.isTypeSupported.
    * @param {string} codec

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -401,6 +401,20 @@ describe('MediaSourceEngine', () => {
       expect(shaka.text.TextEngine).not.toHaveBeenCalled();
     });
 
+    it('corrects audio codecs in multiplexed MP4 video', async () => {
+      const stream = makeFakeStream('video/mp4');
+      stream.codecs = 'opus,av01.0.08M.08';
+
+      const initObject = new Map();
+      initObject.set(ContentType.VIDEO, stream);
+      await mediaSourceEngine.init(initObject, false);
+
+      const audioCodec = shaka.util.MimeUtils.getCorrectAudioCodecs(
+          'opus', stream.mimeType);
+      expect(mockMediaSource.addSourceBuffer).toHaveBeenCalledWith(
+          `video/mp4; codecs="${audioCodec},av01.0.08M.08"`);
+    });
+
     it('creates SourceBuffers with extra features', async () => {
       const config = shaka.util.PlayerConfiguration.createDefault().mediaSource;
       config.addExtraFeaturesToSourceBuffer = (mimeType) => {


### PR DESCRIPTION
## Description

Fixes #10328.

Safari requires the RFC-correct `Opus` codec casing when Opus is multiplexed with video in MP4. Shaka previously corrected audio-only codec strings but not audio codecs contained in multiplexed video codec lists.

Consequently, Safari rejected:

```text
video/mp4; codecs="opus,av01..."
```

Shaka then attempted to split the multiplexed stream across separate SourceBuffers, leaving playback stuck without emitting `canplay`.

This change:

- Normalizes each codec in a multiplexed codec list.
- Applies audio-specific corrections such as `opus` → `Opus` on WebKit.
- Uses the normalized codec string during SourceBuffer initialization and codec-switch checks.
- Adds regression coverage for multiplexed MP4 containing AV1 and Opus.

## Testing

- Reproduced the original failure in Safari 26.5.2.
- Confirmed the AV1+Opus fixture now plays to completion.
- MediaSourceEngine tests: 71 passing in Safari.
- MediaSourceEngine tests: 71 passing in Chrome.
- `python3 build/check.py` passes.