### PR TITLE
fix(Transmux): Support audio-only MPEG-TS renditions labeled 'labeled 'audio/mp2t'

### DIFF
--- a/lib/transmuxer/ts_transmuxer.js
+++ b/lib/transmuxer/ts_transmuxer.js
@@ -122,13 +122,15 @@ shaka.transmuxer.TsTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
 
 
   /**
-   * Check if the mimetype is 'video/mp2t'.
+   * Check if the mimetype is 'video/mp2t' or 'audio/mp2t'.
    * @param {string} mimeType
    * @return {boolean}
    * @private
    */
   isTsContainer_(mimeType) {
-    return mimeType.toLowerCase().split(';')[0] == 'video/mp2t';
+    const normalizedMimeType = mimeType.toLowerCase().split(';')[0];
+    return normalizedMimeType == 'video/mp2t' ||
+        normalizedMimeType == 'audio/mp2t';
   }
 
 
@@ -1000,4 +1002,10 @@ shaka.transmuxer.TsTransmuxer.SUPPORTED_VIDEO_CODECS_ = [
 shaka.transmuxer.TransmuxerEngine.registerTransmuxer(
     'video/mp2t',
     () => new shaka.transmuxer.TsTransmuxer('video/mp2t'),
+    shaka.transmuxer.TransmuxerEngine.PluginPriority.PREFERRED);
+
+// Alias of 'video/mp2t', for demuxed audio-only TS renditions.
+shaka.transmuxer.TransmuxerEngine.registerTransmuxer(
+    'audio/mp2t',
+    () => new shaka.transmuxer.TsTransmuxer('audio/mp2t'),
     shaka.transmuxer.TransmuxerEngine.PluginPriority.PREFERRED);

--- a/project-words.txt
+++ b/project-words.txt
@@ -123,6 +123,7 @@ datas
 Decryptor
 Decryptors
 degrad
+demuxed
 discardable
 displayer
 displayers

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -1695,6 +1695,53 @@ describe('HlsParser', () => {
     await testHlsParser(master, media, manifest);
   });
 
+  it('supports audio/mp2t mimetype for demuxed audio-only TS renditions',
+      async () => {
+        const master = [
+          '#EXTM3U\n',
+          '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aud1",LANGUAGE="eng",',
+          'URI="audio"\n',
+          '#EXT-X-STREAM-INF:BANDWIDTH=200,CODECS="avc1,mp4a",',
+          'RESOLUTION=960x540,FRAME-RATE=60,AUDIO="aud1"\n',
+          'video\n',
+        ].join('');
+
+        const videoMedia = [
+          '#EXTM3U\n',
+          '#EXT-X-PLAYLIST-TYPE:VOD\n',
+          '#EXT-X-MAP:URI="init.mp4"\n',
+          '#EXTINF:5,\n',
+          'main.mp4',
+        ].join('\n');
+
+        // No extension, so the mimetype comes from the Content-Type header.
+        const audioMedia = [
+          '#EXTM3U\n',
+          '#EXT-X-PLAYLIST-TYPE:VOD\n',
+          '#EXTINF:5,\n',
+          'main.test',
+        ].join('\n');
+
+        fakeNetEngine
+            .setResponseText('test:/master', master)
+            .setResponseText('test:/video', videoMedia)
+            .setResponseText('test:/audio', audioMedia)
+            .setResponseValue('test:/init.mp4', initSegmentData)
+            .setResponseValue('test:/main.mp4', segmentData)
+            .setResponseValue('test:/main.test', tsSegmentData);
+
+        fakeNetEngine.setHeaders('test:/main.test', {
+          'content-type': 'audio/mp2t',
+        });
+
+        const manifest = await parser.start('test:/master', playerInterface);
+        await loadAllStreamsFor(manifest);
+
+        const audioStream = manifest.variants[0].audio;
+        goog.asserts.assert(audioStream, 'Audio stream should exist!');
+        expect(audioStream.mimeType).toBe('audio/mp2t');
+      });
+
   it('parses manifest with HDR metadata', async () => {
     const master = [
       '#EXTM3U\n',

--- a/test/transmuxer/transmuxer_engine_integration.js
+++ b/test/transmuxer/transmuxer_engine_integration.js
@@ -28,6 +28,13 @@ describe('TransmuxerEngine', () => {
       expect(TransmuxerEngine.isSupported(
           mimeType, ContentType.VIDEO)).toBe(true);
     });
+
+    it('supports audio/mp2t as an alias of video/mp2t', () => {
+      const transportStreamAudioMp2tMimeType =
+          'audio/mp2t; codecs="mp4a.40.2"';
+      expect(TransmuxerEngine.isSupported(
+          transportStreamAudioMp2tMimeType, ContentType.AUDIO)).toBe(true);
+    });
   });
 
   describe('convertCodecs', () => {


### PR DESCRIPTION
Fixes #10463 

TransmuxerEngine only registered a transmuxer for 'video/mp2t', so demuxed audio-only HLS-TS renditions whose mimetype is 'audio/mp2t' had no matching transmuxer and failed to play.

Verified with the added unit/integration tests, and manually confirmed against a build of the pinned v4.15.55 tag with this fix applied, tested live via Cast Application Framework (CAF).

This fix needs to be applied to 4.x so it can be used in CAF.