### PR TITLE
fix: Resync sequence-mode append when a segment lands at the wrong position

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1576,6 +1576,20 @@ shaka.media.MediaSourceEngine = class {
       }
     }
 
+    // The segment may have collapsed onto the previous one (e.g. a spliced-in
+    // ad-break segment); resync so later segments don't inherit the offset.
+    if (reference && !reference.isPreload() && !isChunkedData &&
+        this.manifestType_ !== shaka.media.ManifestParser.MSF) {
+      const bufferEndAfter = this.bufferEnd(contentType);
+      if (bufferEndAfter != null) {
+        const segmentDuration = reference.endTime - reference.startTime;
+        const offset = Math.abs(bufferEndAfter - reference.endTime);
+        if (segmentDuration > 0.100 && offset > segmentDuration / 2) {
+          await this.resync(contentType, reference.endTime);
+        }
+      }
+    }
+
     return {
       mediaTimestamp: mediaTimestamp,
     };

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -1073,6 +1073,89 @@ describe('MediaSourceEngine', () => {
 
       expect(videoSourceBuffer.timestampOffset).toBe(0.50);
     });
+
+    it('resyncs when a segment lands at the wrong buffered position',
+        async () => {
+          const initObject = new Map();
+          initObject.set(ContentType.VIDEO, fakeVideoStream);
+          videoSourceBuffer.mode = 'sequence';
+
+          await mediaSourceEngine.init(initObject, /* sequenceMode= */ true);
+          spyOn(mediaSourceEngine, 'resync').and.callThrough();
+
+          // Simulates a segment that collapses onto the previous one.
+          videoSourceBuffer.buffered =
+              createFakeBuffered([{start: 0, end: 10}]);
+          videoSourceBuffer.appendBuffer.and.callFake(() => {
+            videoSourceBuffer.buffered =
+                createFakeBuffered([{start: 0, end: 10.05}]);
+          });
+
+          const reference = dummyReference(10, 20);
+          const p = mediaSourceEngine.appendBuffer(
+              ContentType.VIDEO, buffer, reference, fakeStream,
+              /* hasClosedCaptions= */ false);
+          videoSourceBuffer.updateend();
+          await p;
+
+          expect(mediaSourceEngine.resync)
+              .toHaveBeenCalledWith(ContentType.VIDEO, 20);
+          expect(videoSourceBuffer.timestampOffset).toBe(20);
+        });
+
+    it('does not resync when the segment lands at the expected position',
+        async () => {
+          const initObject = new Map();
+          initObject.set(ContentType.VIDEO, fakeVideoStream);
+          videoSourceBuffer.mode = 'sequence';
+
+          await mediaSourceEngine.init(initObject, /* sequenceMode= */ true);
+          spyOn(mediaSourceEngine, 'resync').and.callThrough();
+
+          videoSourceBuffer.buffered =
+              createFakeBuffered([{start: 0, end: 10}]);
+          videoSourceBuffer.appendBuffer.and.callFake(() => {
+            videoSourceBuffer.buffered =
+                createFakeBuffered([{start: 0, end: 20}]);
+          });
+
+          const reference = dummyReference(10, 20);
+          const p = mediaSourceEngine.appendBuffer(
+              ContentType.VIDEO, buffer, reference, fakeStream,
+              /* hasClosedCaptions= */ false);
+          videoSourceBuffer.updateend();
+          await p;
+
+          expect(mediaSourceEngine.resync).not.toHaveBeenCalled();
+        });
+
+    it('resyncs even when nothing was buffered before this append',
+        async () => {
+          const initObject = new Map();
+          initObject.set(ContentType.VIDEO, fakeVideoStream);
+          videoSourceBuffer.mode = 'sequence';
+
+          await mediaSourceEngine.init(initObject, /* sequenceMode= */ true);
+          spyOn(mediaSourceEngine, 'resync').and.callThrough();
+
+          // No previously buffered range for this track (e.g. right after a
+          // discontinuity reset) - the check must not depend on one.
+          videoSourceBuffer.buffered = createFakeBuffered([]);
+          videoSourceBuffer.appendBuffer.and.callFake(() => {
+            videoSourceBuffer.buffered =
+                createFakeBuffered([{start: 0, end: 10.05}]);
+          });
+
+          const reference = dummyReference(10, 20);
+          const p = mediaSourceEngine.appendBuffer(
+              ContentType.VIDEO, buffer, reference, fakeStream,
+              /* hasClosedCaptions= */ false);
+          videoSourceBuffer.updateend();
+          await p;
+
+          expect(mediaSourceEngine.resync)
+              .toHaveBeenCalledWith(ContentType.VIDEO, 20);
+        });
   });
 
   describe('remove', () => {


### PR DESCRIPTION
Fixes #10462 

Within a discontinuity group, only the first segment gets a fresh timestampOffset; later segments are positioned by rebasing on that one reference point. If a segment's embedded timestamps aren't actually continuous (e.g. a spliced-in ad-break slate/filler segment), it lands on top of the previous segment's position, and every later segment in the group inherits the same error.

Adds a check after append: if the buffered end for this track doesn't land near the segment's expected end time, resync so only the next segment needs correcting, not the rest of the group.

Added unit tests covering both the resync trigger and the no-false-positive case, and confirmed the fix resolves a real audio/video desync after a slate segment, tested live via CAF on a Chromecast device.

Need this fix cherry-picked into 4.x to use on Chromecast.
