### PR TITLE
feat(cea): complete CEA-608/708 control codes and display modes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,6 +70,7 @@ Justin Swaney <justin.mark.swaney@gmail.com>
 JW Player <*@jwplayer.com>
 KimKyuHoi <k546kh@gmail.com>
 Konstantin Grushetsky <github@grushetsky.net>
+Kyson Li <kisenlee@gmail.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Martin Stark <martin.stark@eyevinn.se>
 Mariano Facundo Scigliano <mfacundo94@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -99,6 +99,7 @@ Jürgen Kartnaller <kartnaller@lovelysystems.com>
 Justin Swaney <justin.mark.swaney@gmail.com>
 KimKyuHoi <k546kh@gmail.com>
 Konstantin Grushetsky <github@grushetsky.net>
+Kyson Li <kisenlee@gmail.com>
 Leandro Ribeiro Moreira <leandro.ribeiro.moreira@gmail.com>
 Leo Antunes <leo@costela.net>
 Loïc Raux <loicraux@gmail.com>

--- a/lib/cea/cea608_data_channel.js
+++ b/lib/cea/cea608_data_channel.js
@@ -8,7 +8,6 @@ goog.provide('shaka.cea.Cea608DataChannel');
 
 goog.require('shaka.cea.Cea608Memory');
 goog.require('shaka.cea.CeaUtils');
-goog.require('shaka.log');
 
 
 /**
@@ -27,13 +26,14 @@ shaka.cea.Cea608DataChannel = class {
     this.type_ = shaka.cea.Cea608DataChannel.CaptionType.NONE;
 
     /**
-     * Text buffer for CEA-608 "text mode". Although, we don't emit text mode.
-     * So, this buffer serves as a no-op placeholder, just in case we receive
-     * captions that toggle text mode.
+     * Text buffer for CEA-608 "text mode". Characters written while text mode
+     * is active accumulate here and are emitted (and scrolled) on Carriage
+     * Return, just like roll-up captions.
      * @private @const {!shaka.cea.Cea608Memory}
      */
     this.text_ =
         new shaka.cea.Cea608Memory(fieldNum, channelNum);
+    this.text_.setTextMode(true);
 
     /**
      * Displayed memory.
@@ -177,13 +177,14 @@ shaka.cea.Cea608DataChannel = class {
     buf.setTextColor(textColor);
     buf.setIndent(indent);
 
-    // A PAC starts a new row, so any tab offset from the previous row no longer
-    // applies. Clear it so horizontal positioning doesn't leak into this row or
-    // a later caption that reuses this buffer.
+    // Clear any previous tab offset so it does not leak into this row.
     buf.setOffset(null);
 
     // Clear the background color, since new row (PAC) should reset ALL styles.
     buf.setBackgroundColor(shaka.cea.CeaUtils.DEFAULT_BG_COLOR);
+
+    // PAC resets styles, including any active Flash-On (FON) run.
+    buf.setFlash(false);
   }
 
   /**
@@ -259,7 +260,8 @@ shaka.cea.Cea608DataChannel = class {
       case MiscCmd.AON:
         break;
       case MiscCmd.DER:
-        // Delete to End of Row. Not implemented since position not supported.
+        // Delete to End of Row.
+        this.controlDer_();
         break;
       case MiscCmd.RU2:
         parsedClosedCaption = this.controlRu_(2, pts);
@@ -308,9 +310,12 @@ shaka.cea.Cea608DataChannel = class {
    * @private
    */
   controlCr_(pts) {
+    const CaptionType = shaka.cea.Cea608DataChannel.CaptionType;
     const buf = this.curBuf_;
-    // Only rollup and text mode is affected, but we don't emit text mode.
-    if (this.type_ !== shaka.cea.Cea608DataChannel.CaptionType.ROLLUP) {
+    // Only rollup and text mode are scroll windows affected by CR.
+    const isScrollMode =
+        this.type_ === CaptionType.ROLLUP || this.type_ === CaptionType.TEXT;
+    if (!isScrollMode) {
       return null;
     }
     // Force out the scroll window since the top row will cleared. Roll-up is
@@ -376,6 +381,9 @@ shaka.cea.Cea608DataChannel = class {
    * @private
    */
   controlFon_(time) {
+    // Flash-On marks following characters as flashing (mapped to bold) and,
+    // like other mid-row codes, advances the cursor with a space.
+    this.curBuf_.setFlash(true);
     this.curBuf_.addChar(
         shaka.cea.Cea608Memory.CharSet.BASIC_NORTH_AMERICAN,
         ' '.charCodeAt(0), time);
@@ -490,6 +498,14 @@ shaka.cea.Cea608DataChannel = class {
   }
 
   /**
+   * Handles DER - Delete to End of Row.
+   * @private
+   */
+  controlDer_() {
+    this.curBuf_.eraseToEndOfRow();
+  }
+
+  /**
    * Handles TR - Text Restart.
    * Clears text buffer and resumes Text Mode.
    * @private
@@ -502,12 +518,11 @@ shaka.cea.Cea608DataChannel = class {
   /**
    * Handles RTD - Resume Text Display.
    * Resumes text mode. No need to force anything out, because Text Mode doesn't
-   * affect current display. Also, this decoder does not emit Text Mode anyway.
+   * affect the displayed/non-displayed memory; characters now accumulate in the
+   * text buffer and are emitted on Carriage Return (see controlCr_).
    * @private
    */
   controlRtd_() {
-    shaka.log.warnOnce('Cea608DataChannel',
-        'CEA-608 text mode entered, but is unsupported');
     this.curBuf_ = this.text_;
     this.type_ = shaka.cea.Cea608DataChannel.CaptionType.TEXT;
   }
@@ -658,7 +673,7 @@ shaka.cea.Cea608DataChannel = class {
   isBackgroundAttribute_(b1, b2) {
     // For Background Attribute Codes, the bytes take the following form:
     // Bg provided: b1 -> |0|0|0|1|C|0|0|0| b2 -> |0|0|1|0|COLOR|T|
-    // No Bg:       b1 -> |0|0|0|1|C|1|1|1| b2 -> |0|0|1|0|1|1|0|1|
+    // No Bg: b1 -> |0|0|0|1|C|1|1|1| b2 -> |0|0|1|0|1|1|0|1|
     return (((b1 & 0xf7) === 0x10) && ((b2 & 0xf0) === 0x20)) ||
              (((b1 & 0xf7) === 0x17) && ((b2 & 0xff) === 0x2D));
   }
@@ -673,7 +688,7 @@ shaka.cea.Cea608DataChannel = class {
   isSpecialNorthAmericanChar_(b1, b2) {
     // The bytes take the following form:
     // b1 -> |0|0|0|1|C|0|0|1|
-    // b2 -> |0|0|1|1|  CHAR |
+    // b2 -> |0|0|1|1| CHAR |
     return ((b1 & 0xf7) === 0x11) && ((b2 & 0xf0) === 0x30);
   }
 
@@ -721,7 +736,7 @@ shaka.cea.Cea608DataChannel.MiscCmd_ = {
   // "RCL - Resume Caption Loading"
   RCL: 0x20,
 
-  // "BS  - BackSpace"
+  // "BS - BackSpace"
   BS: 0x21,
 
   // "AOD - Unused (alarm off)"
@@ -757,7 +772,7 @@ shaka.cea.Cea608DataChannel.MiscCmd_ = {
   // "EDM - Erase Displayed Mem"
   EDM: 0x2c,
 
-  // "CR  - Carriage return"
+  // "CR - Carriage return"
   CR: 0x2d,
 
   // "ENM - Erase Nondisplayed Mem"

--- a/lib/cea/cea608_memory.js
+++ b/lib/cea/cea608_memory.js
@@ -50,6 +50,12 @@ shaka.cea.Cea608Memory = class {
     this.channelNum_ = channelNum;
 
     /**
+     * Whether this buffer holds CEA-608 text-mode content (T1–T4 streams).
+     * @private {boolean}
+     */
+    this.isTextMode_ = false;
+
+    /**
      * @private {boolean}
      */
     this.underline_ = false;
@@ -58,6 +64,12 @@ shaka.cea.Cea608Memory = class {
      * @private {boolean}
      */
     this.italics_ = false;
+
+    /**
+     * Whether subsequently added characters are part of a Flash-On (FON) run.
+     * @private {boolean}
+     */
+    this.flash_ = false;
 
     /**
      * @private {string}
@@ -93,7 +105,7 @@ shaka.cea.Cea608Memory = class {
   forceEmit(startTime, endTime, progressive = false) {
     const Cea608Memory = shaka.cea.Cea608Memory;
     const stream = shaka.cea.CeaUtils.getCea608StreamName(
-        this.fieldNum_, this.channelNum_);
+        this.fieldNum_, this.channelNum_, this.isTextMode_);
     const topLevelCue = new shaka.text.Cue(
         startTime, endTime, /* payload= */ '');
     topLevelCue.lineInterpretation =
@@ -109,9 +121,12 @@ shaka.cea.Cea608Memory = class {
     if (line) {
       topLevelCue.line = line;
     }
-    if (this.indent_ != null && this.offset_ != null) {
-      topLevelCue.position = 10 + Math.min(70, this.indent_ * 10) +
-          this.offset_ * 2.5;
+    // Position from PAC indent and/or tab offset when either is set.
+    if (this.indent_ != null || this.offset_ != null) {
+      const indentPosition =
+          this.indent_ != null ? Math.min(70, this.indent_ * 10) : 0;
+      const offsetPosition = this.offset_ != null ? this.offset_ * 2.5 : 0;
+      topLevelCue.position = 10 + indentPosition + offsetPosition;
     }
     return shaka.cea.CeaUtils.getParsedCaption(
         topLevelCue, stream, this.rows_, startTime, endTime, progressive);
@@ -200,7 +215,7 @@ shaka.cea.Cea608Memory = class {
     if (char) {
       const styledChar = new shaka.cea.CeaUtils.StyledChar(
           char, this.underline_, this.italics_,
-          this.backgroundColor_, this.textColor_, time);
+          this.backgroundColor_, this.textColor_, time, this.flash_);
       this.rows_[this.row_].push(styledChar);
     }
   }
@@ -210,6 +225,13 @@ shaka.cea.Cea608Memory = class {
    */
   eraseChar() {
     this.rows_[this.row_].pop();
+  }
+
+  /**
+   * Handles DER - Delete to End of Row. Clears the active row contents.
+   */
+  eraseToEndOfRow() {
+    this.rows_[this.row_] = [];
   }
 
   /**
@@ -276,6 +298,14 @@ shaka.cea.Cea608Memory = class {
   }
 
   /**
+   * Sets whether subsequently added characters belong to a Flash-On (FON) run.
+   * @param {boolean} flash
+   */
+  setFlash(flash) {
+    this.flash_ = flash;
+  }
+
+  /**
    * @param {string} color
    */
   setTextColor(color) {
@@ -290,6 +320,8 @@ shaka.cea.Cea608Memory = class {
   }
 
   /**
+   * Sets the tab offset applied to the caption start position, or clears it
+   * when {@code null}.
    * @param {?number} offset
    */
   setOffset(offset) {
@@ -301,6 +333,14 @@ shaka.cea.Cea608Memory = class {
    */
   setIndent(indent) {
     this.indent_ = indent;
+  }
+
+  /**
+   * Marks this buffer as a CEA-608 text-mode buffer (T1–T4 streams).
+   * @param {boolean} isTextMode
+   */
+  setTextMode(isTextMode) {
+    this.isTextMode_ = isTextMode;
   }
 };
 

--- a/lib/cea/cea708_service.js
+++ b/lib/cea/cea708_service.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// cspell:ignore PNSTY
-
 goog.provide('shaka.cea.Cea708Service');
 
 goog.require('shaka.cea.Cea708Window');
@@ -233,9 +231,8 @@ shaka.cea.Cea708Service = class {
    * @private
    */
   handleC1_(dtvccPacket, captionCommand, pts) {
-    // Note: This decoder ignores delay and delayCancel control codes in the C1.
-    // group. These control codes delay processing of data for a set amount of
-    // time, however this decoder processes that data immediately.
+    // Delay/DelayCancel do not affect timing here, but Delay's operand byte
+    // must still be consumed for block alignment.
 
     if (captionCommand >= 0x80 && captionCommand <= 0x87) {
       const windowNum = captionCommand & 0x07;
@@ -255,6 +252,12 @@ shaka.cea.Cea708Service = class {
     } else if (captionCommand === 0x8c) {
       const bitmap = dtvccPacket.readByte().value;
       return this.deleteWindows_(bitmap, pts);
+    } else if (captionCommand === 0x8d) {
+      // DLY (Delay): consume exactly one operand byte to keep block alignment.
+      this.delay_(dtvccPacket);
+    } else if (captionCommand === 0x8e) {
+      // DLC (DelayCancel): no operand byte.
+      this.delayCancel_();
     } else if (captionCommand === 0x8f) {
       return this.reset_(pts);
     } else if (captionCommand === 0x90) {
@@ -270,6 +273,24 @@ shaka.cea.Cea708Service = class {
       this.defineWindow_(dtvccPacket, windowNum, pts);
     }
     return [];
+  }
+
+  /**
+   * Handles Delay (DLY, 0x8d). Consumes the operand byte for block alignment;
+   * this decoder applies no delay.
+   * @param {!shaka.cea.DtvccPacket} dtvccPacket
+   * @throws {!shaka.util.Error}
+   * @private
+   */
+  delay_(dtvccPacket) {
+    dtvccPacket.readByte();
+  }
+
+  /**
+   * Handles DelayCancel (DLC, 0x8e). No-op; this decoder applies no delays.
+   * @private
+   */
+  delayCancel_() {
   }
 
   /**
@@ -385,18 +406,22 @@ shaka.cea.Cea708Service = class {
    * @private
    */
   hideWindows_(windowsBitmap, pts) {
-    let parsedClosedCaption = null;
+    const parsedClosedCaptions = [];
 
     // Hides windows from the 8 bit bitmap.
     for (const windowId of this.getSpecifiedWindowIds_(windowsBitmap)) {
       const window = this.windows_[windowId];
       if (window.isVisible()) {
         // We are turning off the visibility, emit!
-        parsedClosedCaption = window.forceEmit(pts, this.serviceNumber_);
+        const newParsedClosedCaption =
+            window.forceEmit(pts, this.serviceNumber_);
+        if (newParsedClosedCaption) {
+          parsedClosedCaptions.push(newParsedClosedCaption);
+        }
       }
       window.hide();
     }
-    return parsedClosedCaption ? [parsedClosedCaption] : [];
+    return parsedClosedCaptions;
   }
 
   /**
@@ -406,14 +431,18 @@ shaka.cea.Cea708Service = class {
    * @private
    */
   toggleWindows_(windowsBitmap, pts) {
-    let parsedClosedCaption = null;
+    const parsedClosedCaptions = [];
 
     // Toggles windows from the 8 bit bitmap.
     for (const windowId of this.getSpecifiedWindowIds_(windowsBitmap)) {
       const window = this.windows_[windowId];
       if (window.isVisible()) {
         // We are turning off the visibility, emit!
-        parsedClosedCaption = window.forceEmit(pts, this.serviceNumber_);
+        const newParsedClosedCaption =
+            window.forceEmit(pts, this.serviceNumber_);
+        if (newParsedClosedCaption) {
+          parsedClosedCaptions.push(newParsedClosedCaption);
+        }
       } else {
         // We are turning on visibility, set the start time.
         window.setStartTime(pts);
@@ -421,7 +450,7 @@ shaka.cea.Cea708Service = class {
 
       window.toggle();
     }
-    return parsedClosedCaption ? [parsedClosedCaption] : [];
+    return parsedClosedCaptions;
   }
 
   /**
@@ -477,27 +506,36 @@ shaka.cea.Cea708Service = class {
    * @private
    */
   setPenAttributes_(dtvccPacket) {
-    // Two bytes follow. For the purpose of this decoder, we are only concerned
-    // with byte 2, which is of the form |I|U|EDTYP|FNTAG|.
-
+    // Two bytes follow.
+    // Byte 1 is of the form |PENSIZE|OFFSET|TEXTTAG|.
+    // PENSIZE (2 bits): Pen size (0 = small, 1 = standard, 2 = large).
+    // OFFSET (2 bits): Subscript/normal/superscript (unused in this decoder).
+    // TEXTTAG (4 bits): Text tag (unused in this decoder).
+    // Byte 2 is of the form |I|U|EDTYP|FNTAG|.
     // I (1 bit): Italics toggle.
     // U (1 bit): Underline toggle.
-    // EDTYP (3 bits): Edge type (unused in this decoder).
-    // FNTAG (3 bits): Font tag (unused in this decoder).
+    // EDTYP (3 bits): Edge type.
+    // FNTAG (3 bits): Font tag.
     // More info at https://en.wikipedia.org/wiki/CEA-708#SetPenAttributes_(0x90_+_2_bytes)
 
-    dtvccPacket.skip(1); // Skip first byte
+    const attrByte1 = dtvccPacket.readByte().value;
     const attrByte2 = dtvccPacket.readByte().value;
 
     if (!this.currentWindow_) {
       return;
     }
 
+    const penSize = (attrByte1 & 0xc0) >> 6;
     const italics = (attrByte2 & 0x80) > 0;
     const underline = (attrByte2 & 0x40) > 0;
+    const edgeType = (attrByte2 & 0x38) >> 3;
+    const fontStyle = attrByte2 & 0x07;
 
     this.currentWindow_.setPenItalics(italics);
     this.currentWindow_.setPenUnderline(underline);
+    this.currentWindow_.setPenSize(penSize);
+    this.currentWindow_.setPenFontStyle(fontStyle);
+    this.currentWindow_.setPenEdgeType(edgeType);
   }
 
   /**
@@ -565,13 +603,13 @@ shaka.cea.Cea708Service = class {
    */
   setWindowAttributes_(dtvccPacket) {
     // 4 bytes follow, with the following form:
-    // Byte 1 contains fill-color information. Unused in this decoder.
-    // Byte 2 contains border color information. Unused in this decoder.
-    // Byte 3 contains justification information. In this decoder, we only use
-    // the last 2 bits, which specifies text justification on the screen.
+    // Byte 1 = |FILL_OPACITY|FILL_R|FILL_G|FILL_B| : window fill color/opacity.
+    // Byte 2 contains border color/type information. Unused in this decoder.
+    // Byte 3 = |BORDER_TYPE2|WORD_WRAP|PRINT_DIR|SCROLL_DIR|JUSTIFY| : the last
+    // 2 bits are text justification, and bit 0x40 is the word-wrap flag.
     // Byte 4 is special effects. Unused in this decoder.
     // More info at https://en.wikipedia.org/wiki/CEA-708#SetWindowAttributes_(0x97_+_4_bytes)
-    dtvccPacket.skip(1); // Fill color not supported, skip.
+    const b1 = dtvccPacket.readByte().value;
     dtvccPacket.skip(1); // Border colors not supported, skip.
     const b3 = dtvccPacket.readByte().value;
     dtvccPacket.skip(1); // Effects not supported, skip.
@@ -580,7 +618,22 @@ shaka.cea.Cea708Service = class {
       return;
     }
 
-    // Word wrap is outdated as of CEA-708-E, so we ignore those bits.
+    // Fill color properties: |FILL_OPACITY|FILL_R|FILL_G|FILL_B|, with the same
+    // 2-bits-per-channel encoding as SetPenColor.
+    const fillOpacity = (b1 & 0xc0) >> 6;
+    const fillBlue = b1 & 0x03;
+    const fillGreen = (b1 & 0x0c) >> 2;
+    const fillRed = (b1 & 0x30) >> 4;
+
+    // Transparent fill clears the window background; otherwise map the color.
+    const fillColor =
+        fillOpacity === shaka.cea.Cea708Service.FILL_OPACITY_TRANSPARENT ?
+        '' : this.rgbColorToCssColor_(fillRed, fillGreen, fillBlue);
+    this.currentWindow_.setWindowFillColor(fillColor);
+
+    const wordWrap = (b3 & 0x40) > 0;
+    this.currentWindow_.setWordWrap(wordWrap);
+
     // Extract the text justification and set it on the window.
     const justification =
       /** @type {!shaka.cea.Cea708Window.TextJustification} */ (b3 & 0x03);
@@ -624,20 +677,63 @@ shaka.cea.Cea708Service = class {
     const rowCount = (b4 & 0x0f) + 1; // Spec says to add 1.
     const anchorId = (b4 & 0xf0) >> 4;
     const colCount = (b5 & 0x3f) + 1; // Spec says to add 1.
+    const windowStyle = (b6 & 0x38) >> 3; // WNSTY: predefined window style id.
+    const penStyle = b6 & 0x07; // PNSTY: predefined pen style id.
 
-    // If pen style = 0 AND window previously existed, keep its pen style.
-    // Otherwise, change the pen style (For now, just reset to the default pen).
-    // TODO add support for predefined pen styles and fonts.
-    const penStyle = b6 & 0x07;
-    if (!windowAlreadyExists || penStyle !== 0) {
-      this.windows_[windowNum].resetPen();
-    }
+    const window = /** @type {!shaka.cea.Cea708Window} */ (
+      this.windows_[windowNum]);
 
-    this.windows_[windowNum].defineWindow(visible, verticalAnchor,
+    window.defineWindow(visible, verticalAnchor,
         horAnchor, anchorId, relativeToggle, rowCount, colCount);
 
-    // Set the current window to the newly defined window.
-    this.currentWindow_ = this.windows_[windowNum];
+    // WNSTY 0 keeps the prior style on an existing window; new windows default
+    // to style 1.
+    this.applyWindowStylePreset_(window,
+        windowAlreadyExists ? windowStyle : (windowStyle || 1));
+
+    // PNSTY 0 keeps the current pen on an existing window.
+    if (!windowAlreadyExists || penStyle !== 0) {
+      this.applyPenStylePreset_(window, penStyle || 1);
+    }
+
+    this.currentWindow_ = window;
+  }
+
+  /**
+   * Applies a predefined window style (WNSTY). Preset 0 leaves the current
+   * style unchanged.
+   * @param {!shaka.cea.Cea708Window} window
+   * @param {number} presetId 0-7. 0 keeps the existing style.
+   * @private
+   */
+  applyWindowStylePreset_(window, presetId) {
+    if (presetId === 0) {
+      return;
+    }
+    const preset = shaka.cea.Cea708Service.WindowStylePresets[presetId];
+    if (!preset) {
+      return;
+    }
+    window.setPrintDirection(preset.printDirection);
+    window.setScrollDirection(preset.scrollDirection);
+    window.setWordWrap(preset.wordWrap);
+  }
+
+  /**
+   * Applies a predefined pen style (PNSTY). Unknown ids fall back to preset 1.
+   * @param {!shaka.cea.Cea708Window} window
+   * @param {number} presetId 1-7.
+   * @private
+   */
+  applyPenStylePreset_(window, presetId) {
+    const preset = shaka.cea.Cea708Service.PenStylePresets[presetId] ||
+        shaka.cea.Cea708Service.PenStylePresets[1];
+
+    window.resetPen();
+
+    window.setPenSize(preset.penSize);
+    window.setPenFontStyle(preset.fontStyle);
+    window.setPenEdgeType(preset.edgeType);
   }
 
   /**
@@ -689,6 +785,13 @@ shaka.cea.Cea708Service.ASCII_HOR_CARRIAGE_RETURN = 0x0e;
 shaka.cea.Cea708Service.EXT_CEA708_CTRL_CODE_BYTE1 = 0x10;
 
 /**
+ * SetWindowAttributes fill-opacity id for a fully transparent window fill
+ * (CTA-708-E §8.4.2). A transparent fill means no background is drawn.
+ * @private @const {number}
+ */
+shaka.cea.Cea708Service.FILL_OPACITY_TRANSPARENT = 3;
+
+/**
  * Holds characters mapping for bytes that are G2 control codes.
  * @private @const {!Map<number, string>}
  */
@@ -707,6 +810,89 @@ shaka.cea.Cea708Service.G2Charset = new Map([
 shaka.cea.Cea708Service.Colors = [
   'black', 'blue', 'green', 'cyan',
   'red', 'magenta', 'yellow', 'white',
+];
+
+/**
+ * A predefined window style (WNSTY) as defined by CTA-708-E §8.6.2.
+ * Print/scroll directions use the CTA-708 direction encoding:
+ * 0 = left-to-right, 1 = right-to-left, 2 = top-to-bottom, 3 = bottom-to-top.
+ * @typedef {{
+ *   justification: number,
+ *   printDirection: number,
+ *   scrollDirection: number,
+ *   wordWrap: boolean,
+ * }}
+ *
+ * @property {number} justification
+ *   Text justification (CTA-708-E §8.4.3): 0 = left, 1 = right, 2 = center,
+ *   3 = full.
+ * @property {number} printDirection Direction text is printed.
+ * @property {number} scrollDirection Direction the window scrolls/effects.
+ * @property {boolean} wordWrap Whether the window wraps words.
+ */
+shaka.cea.Cea708Service.WindowStylePreset;
+
+/**
+ * The 7 predefined window styles (presetId 1-7) from CTA-708-E §8.6.2, indexed
+ * by preset id (index 0 is unused). Styles 1, 2, 4 and 5 are left-justified,
+ * styles 3 and 6 are centered, and style 7 is the "ticker tape" style that
+ * prints top-to-bottom and scrolls right-to-left.
+ * @const {!Array<?shaka.cea.Cea708Service.WindowStylePreset>}
+ */
+shaka.cea.Cea708Service.WindowStylePresets = [
+  null, // Index 0 is unused; style ids start at 1.
+  // 1: NTSC-style pop-up captions.
+  {justification: 0, printDirection: 0, scrollDirection: 3, wordWrap: false},
+  // 2: Pop-up captions without a black background.
+  {justification: 0, printDirection: 0, scrollDirection: 3, wordWrap: false},
+  // 3: NTSC-style centered pop-up captions.
+  {justification: 2, printDirection: 0, scrollDirection: 3, wordWrap: false},
+  // 4: NTSC-style roll-up captions.
+  {justification: 0, printDirection: 0, scrollDirection: 3, wordWrap: true},
+  // 5: Roll-up captions without a black background.
+  {justification: 0, printDirection: 0, scrollDirection: 3, wordWrap: true},
+  // 6: NTSC-style centered roll-up captions.
+  {justification: 2, printDirection: 0, scrollDirection: 3, wordWrap: true},
+  // 7: Ticker-tape captions.
+  {justification: 0, printDirection: 2, scrollDirection: 1, wordWrap: false},
+];
+
+/**
+ * A predefined pen style (PNSTY) as defined by CTA-708-E §8.6.3.
+ * @typedef {{
+ *   penSize: number,
+ *   fontStyle: number,
+ *   edgeType: number,
+ * }}
+ *
+ * @property {number} penSize Pen size: 0 = small, 1 = standard, 2 = large.
+ * @property {number} fontStyle Font style/tag (0 = default/undefined font).
+ * @property {number} edgeType Pen edge type (0 = none, 3 = uniform, etc.).
+ */
+shaka.cea.Cea708Service.PenStylePreset;
+
+/**
+ * The 7 predefined pen styles (presetId 1-7) from CTA-708-E §8.6.3, indexed by
+ * preset id (index 0 is unused). All predefined pen styles use the standard
+ * pen size; they differ by font style and, for styles 6 and 7, a uniform edge.
+ * @const {!Array<?shaka.cea.Cea708Service.PenStylePreset>}
+ */
+shaka.cea.Cea708Service.PenStylePresets = [
+  null, // Index 0 is unused; style ids start at 1.
+  // 1: Default (undefined) font, no edge.
+  {penSize: 1, fontStyle: 0, edgeType: 0},
+  // 2: Monospaced font with serifs.
+  {penSize: 1, fontStyle: 1, edgeType: 0},
+  // 3: Proportionally spaced font with serifs.
+  {penSize: 1, fontStyle: 2, edgeType: 0},
+  // 4: Monospaced font without serifs.
+  {penSize: 1, fontStyle: 3, edgeType: 0},
+  // 5: Proportionally spaced font without serifs.
+  {penSize: 1, fontStyle: 4, edgeType: 0},
+  // 6: Monospaced font without serifs, uniform edge.
+  {penSize: 1, fontStyle: 3, edgeType: 3},
+  // 7: Proportionally spaced font without serifs, uniform edge.
+  {penSize: 1, fontStyle: 4, edgeType: 3},
 ];
 
 /**

--- a/lib/cea/cea708_window.js
+++ b/lib/cea/cea708_window.js
@@ -91,6 +91,63 @@ shaka.cea.Cea708Window = class {
     this.justification_ = shaka.cea.Cea708Window.TextJustification.CENTER;
 
     /**
+     * Print direction of the window, as defined by a predefined window style
+     * (CTA-708-E §8.6.2). 0 = left-to-right, 1 = right-to-left,
+     * 2 = top-to-bottom, 3 = bottom-to-top. Stored for region handling; this
+     * decoder currently renders left-to-right only.
+     * @private {number}
+     */
+    this.printDirection_ = 0;
+
+    /**
+     * Scroll (effect) direction of the window, as defined by a predefined
+     * window style (CTA-708-E §8.6.2). Same value space as printDirection.
+     * Defaults to bottom-to-top, matching roll-up scrolling.
+     * @private {number}
+     */
+    this.scrollDirection_ = 3;
+
+    /**
+     * Whether the window wraps words, as defined by a predefined window style
+     * (CTA-708-E §8.6.2). Stored for region handling; not yet rendered.
+     * @private {boolean}
+     */
+    this.wordWrap_ = false;
+
+    /**
+     * Pen size of the window, as defined by a predefined pen style
+     * (CTA-708-E §8.6.3). 0 = small, 1 = standard, 2 = large.
+     * @private {number}
+     */
+    this.penSize_ = shaka.cea.Cea708Window.PenSize.STANDARD;
+
+    /**
+     * Font style (tag) of the window, as defined by a predefined pen style
+     * (CTA-708-E §8.6.3). 0 = default/undefined font.
+     * @private {number}
+     */
+    this.penFontStyle_ = 0;
+
+    /**
+     * Pen edge type of the window, as defined by a predefined pen style
+     * (CTA-708-E §8.6.3). 0 = none. Stored for cue styling; not yet rendered.
+     * @private {number}
+     */
+    this.penEdgeType_ = 0;
+
+    /**
+     * Fill (background) color of the window, as set by SetWindowAttributes
+     * (CTA-708-E §8.4.2). One of the 8 named CSS colors the decoder quantizes
+     * to, or the empty string when no fill color has been applied (e.g. a
+     * transparent fill). Stored here because the text renderer's
+     * {@link shaka.text.CueRegion} has no background-color field; the fill
+     * color is applied to the emitted top-level cue's background in
+     * {@link forceEmit}.
+     * @private {string}
+     */
+    this.fillColor_ = '';
+
+    /**
      * An array of rows of styled characters, representing the
      * current text and styling of text in this window.
      * @private {!Array<!Array<?shaka.cea.CeaUtils.StyledChar>>}
@@ -311,6 +368,15 @@ shaka.cea.Cea708Window = class {
 
     this.adjustRegion_(topLevelCue.region);
 
+    // Apply the window's fill (background) color, if one was set via
+    // SetWindowAttributes. The text renderer's CueRegion has no background
+    // color field, so the fill color is applied to the top-level cue's
+    // background instead (CTA-708-E §8.4.2). An empty fill color leaves the
+    // cue's default background untouched.
+    if (this.fillColor_) {
+      topLevelCue.backgroundColor = this.fillColor_;
+    }
+
     const caption = shaka.cea.CeaUtils.getParsedCaption(
         topLevelCue, stream, this.memory_, this.startTime_, endTime);
     if (caption) {
@@ -373,6 +439,112 @@ shaka.cea.Cea708Window = class {
    */
   setJustification(justification) {
     this.justification_ = justification;
+  }
+
+  /**
+   * Sets the window's print direction (CTA-708-E §8.6.2).
+   * @param {number} printDirection
+   */
+  setPrintDirection(printDirection) {
+    this.printDirection_ = printDirection;
+  }
+
+  /**
+   * @return {number}
+   */
+  getPrintDirection() {
+    return this.printDirection_;
+  }
+
+  /**
+   * Sets the window's scroll (effect) direction (CTA-708-E §8.6.2).
+   * @param {number} scrollDirection
+   */
+  setScrollDirection(scrollDirection) {
+    this.scrollDirection_ = scrollDirection;
+  }
+
+  /**
+   * @return {number}
+   */
+  getScrollDirection() {
+    return this.scrollDirection_;
+  }
+
+  /**
+   * Sets whether the window wraps words (CTA-708-E §8.6.2).
+   * @param {boolean} wordWrap
+   */
+  setWordWrap(wordWrap) {
+    this.wordWrap_ = wordWrap;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  getWordWrap() {
+    return this.wordWrap_;
+  }
+
+  /**
+   * Sets the window's pen size (CTA-708-E §8.6.3).
+   * @param {number} penSize
+   */
+  setPenSize(penSize) {
+    this.penSize_ = penSize;
+  }
+
+  /**
+   * @return {number}
+   */
+  getPenSize() {
+    return this.penSize_;
+  }
+
+  /**
+   * Sets the window's pen font style/tag (CTA-708-E §8.6.3).
+   * @param {number} penFontStyle
+   */
+  setPenFontStyle(penFontStyle) {
+    this.penFontStyle_ = penFontStyle;
+  }
+
+  /**
+   * @return {number}
+   */
+  getPenFontStyle() {
+    return this.penFontStyle_;
+  }
+
+  /**
+   * Sets the window's pen edge type (CTA-708-E §8.6.3).
+   * @param {number} penEdgeType
+   */
+  setPenEdgeType(penEdgeType) {
+    this.penEdgeType_ = penEdgeType;
+  }
+
+  /**
+   * @return {number}
+   */
+  getPenEdgeType() {
+    return this.penEdgeType_;
+  }
+
+  /**
+   * Sets the window's fill (background) color (CTA-708-E §8.4.2). The empty
+   * string clears any previously applied fill color.
+   * @param {string} fillColor
+   */
+  setWindowFillColor(fillColor) {
+    this.fillColor_ = fillColor;
+  }
+
+  /**
+   * @return {string}
+   */
+  getWindowFillColor() {
+    return this.fillColor_;
   }
 
   /**
@@ -484,6 +656,16 @@ shaka.cea.Cea708Window.TextJustification = {
   RIGHT: 1,
   CENTER: 2,
   FULL: 3,
+};
+
+/**
+ * Predefined pen sizes (CTA-708-E §8.6.3).
+ * @const @enum {number}
+ */
+shaka.cea.Cea708Window.PenSize = {
+  SMALL: 0,
+  STANDARD: 1,
+  LARGE: 2,
 };
 
 /**

--- a/lib/cea/cea_decoder.js
+++ b/lib/cea/cea_decoder.js
@@ -346,6 +346,13 @@ shaka.cea.CeaDecoder = class {
           ccPacket.ccData1, ccPacket.ccData2, ccPacket.pts);
     }
 
+    // A caption emitted from text mode is surfaced on a text-channel stream
+    // (T1–T4) that differs from the captioning stream (CC1–CC4) tracked above,
+    // so make sure its stream name is discoverable via getStreams().
+    if (parsedClosedCaption) {
+      this.streams_.add(parsedClosedCaption.stream);
+    }
+
     return parsedClosedCaption;
   }
 

--- a/lib/cea/cea_utils.js
+++ b/lib/cea/cea_utils.js
@@ -52,6 +52,7 @@ shaka.cea.CeaUtils = class {
     // Keeps track of the current styles for a cue being emitted.
     let currentUnderline = false;
     let currentItalics = false;
+    let currentFlash = false;
     let currentTextColor = shaka.cea.CeaUtils.DEFAULT_TXT_COLOR;
     let currentBackgroundColor = shaka.cea.CeaUtils.DEFAULT_BG_COLOR;
 
@@ -63,7 +64,7 @@ shaka.cea.CeaUtils = class {
     // Create first cue that will be nested in top level cue. Default styles.
     let currentCue = shaka.cea.CeaUtils.createStyledCue(
         startTime, endTime, currentUnderline, currentItalics,
-        currentTextColor, currentBackgroundColor);
+        currentTextColor, currentBackgroundColor, currentFlash);
 
     // Logic: Reduce rows into a single top level cue containing nested cues.
     // Each nested cue corresponds either a style change or a line break.
@@ -103,6 +104,7 @@ shaka.cea.CeaUtils = class {
         }
         const underline = styledChar.isUnderlined();
         const italics = styledChar.isItalicized();
+        const flash = styledChar.isFlashing();
         const textColor = styledChar.getTextColor();
         const backgroundColor = styledChar.getBackgroundColor();
 
@@ -115,6 +117,7 @@ shaka.cea.CeaUtils = class {
 
         // If any style property or the reveal time has changed, open a new cue.
         if (underline != currentUnderline || italics != currentItalics ||
+            flash != currentFlash ||
             textColor != currentTextColor ||
             backgroundColor != currentBackgroundColor ||
             time != currentTime) {
@@ -124,10 +127,11 @@ shaka.cea.CeaUtils = class {
           }
           currentCue = shaka.cea.CeaUtils.createStyledCue(
               time, endTime, underline,
-              italics, textColor, backgroundColor);
+              italics, textColor, backgroundColor, flash);
 
           currentUnderline = underline;
           currentItalics = italics;
+          currentFlash = flash;
           currentTextColor = textColor;
           currentBackgroundColor = backgroundColor;
           currentTime = time;
@@ -150,7 +154,7 @@ shaka.cea.CeaUtils = class {
       currentTime = startTime;
       currentCue = shaka.cea.CeaUtils.createStyledCue(
           startTime, endTime, currentUnderline, currentItalics,
-          currentTextColor, currentBackgroundColor);
+          currentTextColor, currentBackgroundColor, currentFlash);
     }
 
     if (topLevelCue.nestedCues.length) {
@@ -170,16 +174,22 @@ shaka.cea.CeaUtils = class {
    * @param {boolean} italics
    * @param {string} txtColor
    * @param {string} bgColor
+   * @param {boolean=} flash Whether the run is CEA-608 Flash-On (FON), mapped
+   *   to a static bold style.
    * @return {!shaka.text.Cue}
    */
   static createStyledCue(startTime, endTime, underline,
-      italics, txtColor, bgColor) {
+      italics, txtColor, bgColor, flash = false) {
     const cue = new shaka.text.Cue(startTime, endTime, /* payload= */ '');
     if (underline) {
       cue.textDecoration.push(shaka.text.Cue.textDecoration.UNDERLINE);
     }
     if (italics) {
       cue.fontStyle = shaka.text.Cue.fontStyle.ITALIC;
+    }
+    if (flash) {
+      // Flash-On has no blink in the cue model; surface it as bold.
+      cue.fontWeight = shaka.text.Cue.fontWeight.BOLD;
     }
     cue.color = txtColor;
     cue.backgroundColor = bgColor;
@@ -199,14 +209,18 @@ shaka.cea.CeaUtils = class {
   }
 
   /**
-   * Returns the CEA-608 stream/mode name (e.g. "CC1") for a given field and
-   * channel pair.
+   * Returns the CEA-608 stream/mode name (e.g. "CC1" or "T1") for a given field
+   * and channel pair.
    * @param {number} fieldNum Field number (0 or 1).
    * @param {number} channelNum Channel number (0 or 1).
+   * @param {boolean=} isTextMode If true, return a text-channel name (T1–T4)
+   *   instead of a captioning channel name (CC1–CC4).
    * @return {string}
    */
-  static getCea608StreamName(fieldNum, channelNum) {
-    return `CC${((fieldNum << 1) | channelNum) + 1}`;
+  static getCea608StreamName(fieldNum, channelNum, isTextMode = false) {
+    // Text-mode buffers map to the text channels (T1–T4); captioning buffers
+    // map to the caption channels (CC1–CC4).
+    return `${isTextMode ? 'T' : 'CC'}${((fieldNum << 1) | channelNum) + 1}`;
   }
 
   /**
@@ -254,9 +268,11 @@ shaka.cea.CeaUtils.StyledChar = class {
    *   character was decoded. Used by paint-on and roll-up modes to reveal text
    *   character by character. May be null when timing is irrelevant (e.g.
    *   pop-on, or CEA-708).
+   * @param {boolean=} flash Whether the character is part of a CEA-608
+   *   Flash-On (FON) run.
    */
   constructor(character, underline, italics, backgroundColor, textColor,
-      time = null) {
+      time = null, flash = false) {
     /**
      * @private {string}
      */
@@ -286,6 +302,11 @@ shaka.cea.CeaUtils.StyledChar = class {
      * @private {?number}
      */
     this.time_ = time;
+
+    /**
+     * @private {boolean}
+     */
+    this.flash_ = flash;
   }
 
   /**
@@ -328,6 +349,13 @@ shaka.cea.CeaUtils.StyledChar = class {
    */
   getTextColor() {
     return this.textColor_;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  isFlashing() {
+    return this.flash_;
   }
 };
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -378,6 +378,7 @@ pasp
 payl
 piff
 playout
+pnsty
 pocs
 podduration
 postroll
@@ -435,6 +436,7 @@ tenc
 tcmp
 tcom
 tcop
+texttag
 tfdt
 tfhd
 tfrf

--- a/test/cea/cea608_memory_unit.js
+++ b/test/cea/cea608_memory_unit.js
@@ -48,6 +48,22 @@ describe('Cea608Memory', () => {
     expect(caption).toEqual(expectedCaption);
   });
 
+  it('emits on the text stream (T1) when marked as a text buffer', () => {
+    const text = 'test word';
+    const startTime = 1;
+    const endTime = 2;
+    // A text-mode buffer surfaces captions on the text channel (T1) rather
+    // than the captioning channel (CC1).
+    memory.setTextMode(true);
+    for (const c of text) {
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, c.charCodeAt(0));
+    }
+    const caption = memory.forceEmit(startTime, endTime);
+
+    expect(caption).not.toBe(null);
+    expect(caption.stream).toBe('T1');
+  });
+
   it('adds and emits a series of special characters from the buffer', () => {
     const startTime = 1;
     const endTime = 2;
@@ -146,6 +162,52 @@ describe('Cea608Memory', () => {
     expect(caption).toEqual(expectedCaption);
   });
 
+  it('marks flash-on (FON) runs with a static bold style', () => {
+    const startTime = 1;
+    const endTime = 2;
+    const expectedText = 'test';
+
+    // Flash-On marks subsequently added characters as flashing, which maps to
+    // a static bold cue style (no animated blinking).
+    memory.setFlash(true);
+    for (const c of expectedText) {
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, c.charCodeAt(0));
+    }
+
+    // Turning flash off returns subsequent characters to the default style,
+    // splitting them into their own nested cue.
+    memory.setFlash(false);
+    for (const c of expectedText) {
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, c.charCodeAt(0));
+    }
+
+    const topLevelCue = new shaka.text.Cue(startTime, endTime, '');
+    topLevelCue.line = 10;
+    topLevelCue.lineInterpretation =
+        shaka.text.Cue.lineInterpretation.PERCENTAGE;
+    topLevelCue.nestedCues = [
+      CeaUtils.createStyledCue(startTime, endTime,
+          expectedText, /* underline= */ false, /* italics= */ false,
+          /* textColor= */ shaka.cea.CeaUtils.DEFAULT_TXT_COLOR,
+          /* backgroundColor= */ shaka.cea.CeaUtils.DEFAULT_BG_COLOR,
+          /* flash= */ true),
+
+      CeaUtils.createStyledCue(startTime, endTime,
+          expectedText, /* underline= */ false, /* italics= */ false,
+          /* textColor= */ shaka.cea.CeaUtils.DEFAULT_TXT_COLOR,
+          /* backgroundColor= */ shaka.cea.CeaUtils.DEFAULT_BG_COLOR,
+          /* flash= */ false),
+    ];
+
+    const expectedCaption = {
+      stream,
+      cue: topLevelCue,
+    };
+
+    const caption = memory.forceEmit(startTime, endTime);
+    expect(caption).toEqual(expectedCaption);
+  });
+
   it('trims leading and trailing newlines', () => {
     const startTime = 1;
     const endTime = 2;
@@ -173,7 +235,6 @@ describe('Cea608Memory', () => {
     // [2]: test
     // [3]:
     // [4]: test
-    // ...
     // So we expect that test\n\ntest is emitted
     const topLevelCue = new shaka.text.Cue(startTime, endTime, '');
     // Anchored to the first non-empty row (row 2), not the cursor row (6).
@@ -237,48 +298,67 @@ describe('Cea608Memory', () => {
     expect(caption).toEqual(expectedCaption);
   });
 
-  it('emits a horizontal position from the indent and tab offset', () => {
+  describe('tab-offset and indent positioning', () => {
+    // A tab offset shifts the horizontal start position independent of the PAC
+    // indent, and the position derives from whichever of indent/offset is set.
     const startTime = 1;
     const endTime = 2;
-    const text = 'test';
-    memory.setIndent(2);
-    memory.setOffset(3);
-    for (const c of text) {
-      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, c.charCodeAt(0));
-    }
 
-    const caption = memory.forceEmit(startTime, endTime);
-    // position = 10 + min(70, indent * 10) + offset * 2.5 = 10 + 20 + 7.5
-    expect(caption.cue.position).toBe(37.5);
-  });
+    beforeEach(() => {
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, 'a'.charCodeAt(0));
+    });
 
-  it('does not emit a position without both indent and tab offset', () => {
-    const startTime = 1;
-    const endTime = 2;
-    const text = 'test';
-    memory.setIndent(2); // No tab offset set.
-    for (const c of text) {
-      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, c.charCodeAt(0));
-    }
+    it('leaves position unset when neither indent nor offset set', () => {
+      const caption = memory.forceEmit(startTime, endTime);
+      expect(caption.cue.position).toBe(null);
+    });
 
-    const caption = memory.forceEmit(startTime, endTime);
-    expect(caption.cue.position).toBe(null);
-  });
+    it('derives position from the offset alone', () => {
+      // Offset 2 with no indent: 10 + (2 * 2.5) = 15.
+      memory.setOffset(2);
+      const caption = memory.forceEmit(startTime, endTime);
+      expect(caption.cue.position).toBe(15);
+    });
 
-  it('clears the indent and tab offset on reset', () => {
-    const startTime = 1;
-    const endTime = 2;
-    const text = 'test';
-    memory.setIndent(2);
-    memory.setOffset(3);
-    memory.reset();
-    for (const c of text) {
-      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, c.charCodeAt(0));
-    }
+    it('derives position from the indent alone', () => {
+      // Indent 3 with no offset: 10 + min(70, 3 * 10) = 40.
+      memory.setIndent(3);
+      const caption = memory.forceEmit(startTime, endTime);
+      expect(caption.cue.position).toBe(40);
+    });
 
-    const caption = memory.forceEmit(startTime, endTime);
-    // The positioning state was cleared, so no position should be emitted.
-    expect(caption.cue.position).toBe(null);
+    it('combines indent and offset when both are present', () => {
+      // Indent 3 and offset 2: 10 + min(70, 30) + (2 * 2.5) = 45.
+      memory.setIndent(3);
+      memory.setOffset(2);
+      const caption = memory.forceEmit(startTime, endTime);
+      expect(caption.cue.position).toBe(45);
+    });
+
+    it('clamps the indent contribution to 70', () => {
+      // Indent 8 clamps to 70: 10 + min(70, 80) + (1 * 2.5) = 82.5.
+      memory.setIndent(8);
+      memory.setOffset(1);
+      const caption = memory.forceEmit(startTime, endTime);
+      expect(caption.cue.position).toBe(82.5);
+    });
+
+    it('treats a cleared offset as not present', () => {
+      memory.setOffset(2);
+      memory.setOffset(null);
+      const caption = memory.forceEmit(startTime, endTime);
+      expect(caption.cue.position).toBe(null);
+    });
+
+    it('clears the indent and tab offset on reset', () => {
+      memory.setIndent(2);
+      memory.setOffset(3);
+      memory.reset();
+      memory.addChar(CharSet.BASIC_NORTH_AMERICAN, 'b'.charCodeAt(0));
+      const caption = memory.forceEmit(startTime, endTime);
+      // The positioning state was cleared, so no position should be emitted.
+      expect(caption.cue.position).toBe(null);
+    });
   });
 
   describe('eraseBuffer', () => {
@@ -458,6 +538,112 @@ describe('Cea608Memory', () => {
       const caption = memory.forceEmit(startTime, endTime);
       expect(caption).toEqual(expectedCaption);
     });
+  });
+
+  describe('eraseToEndOfRow (DER locality)', () => {
+    // After DER, the active row is cleared; other rows and the cursor row are
+    // unchanged.
+
+    // Deterministic inline PRNG (mulberry32).
+    const mulberry32 = (seed) => {
+      let a = seed >>> 0;
+      return () => {
+        a |= 0;
+        a = (a + 0x6D2B79F5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    };
+
+    const CC_ROWS = shaka.cea.Cea608Memory.CC_ROWS;
+
+    // Printable ASCII letters/digits that map to themselves in the basic
+    // North American char set, keeping generated content easy to reason about.
+    const ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789 ';
+
+    /**
+     * Builds a fresh memory and writes the given per-row content into it,
+     * leaving the cursor on `activeRow`.
+     * @param {!Map<number, string>} rowContent Map of row index -> text.
+     * @param {number} activeRow
+     * @return {!shaka.cea.Cea608Memory}
+     */
+    const buildMemory = (rowContent, activeRow) => {
+      const mem =
+          new shaka.cea.Cea608Memory(/* fieldNum= */ 0, /* channelNum= */ 0);
+      // Iterate keys (rather than destructuring entries) because Closure types
+      // a destructured Map entry tuple as Array<KEY|VALUE>, widening row/text.
+      for (const row of rowContent.keys()) {
+        mem.setRow(row);
+        const text = rowContent.get(row) || '';
+        for (const c of text) {
+          mem.addChar(CharSet.BASIC_NORTH_AMERICAN, c.charCodeAt(0));
+        }
+      }
+      mem.setRow(activeRow);
+      return mem;
+    };
+
+    // A spread of fixed seeds so the suite is deterministic but covers a wide
+    // range of generated buffer states.
+    const seeds = [1, 7, 42, 99, 1337, 2024, 0xc0ffee, 123456];
+    const iterationsPerSeed = 25;
+
+    for (const seed of seeds) {
+      it(`preserves locality for randomized states (seed ${seed})`, () => {
+        const startTime = 1;
+        const endTime = 2;
+        const rand = mulberry32(seed);
+        const randInt = (min, maxInclusive) =>
+          min + Math.floor(rand() * (maxInclusive - min + 1));
+
+        for (let iter = 0; iter < iterationsPerSeed; iter++) {
+          // Randomly populate a subset of rows with random-length content.
+          /** @type {!Map<number, string>} */
+          const rowContent = new Map();
+          for (let row = 1; row <= CC_ROWS; row++) {
+            // ~60% chance a given row holds content.
+            if (rand() < 0.6) {
+              const len = randInt(1, 10);
+              let text = '';
+              for (let i = 0; i < len; i++) {
+                text += ALPHABET[randInt(0, ALPHABET.length - 1)];
+              }
+              rowContent.set(row, text);
+            }
+          }
+
+          // Pick a random active row (the DER cursor row).
+          const activeRow = randInt(1, CC_ROWS);
+
+          // Actual: build the state, then apply DER on the active row.
+          const actual = buildMemory(rowContent, activeRow);
+          const rowBefore = actual.getRow();
+          actual.eraseToEndOfRow();
+
+          // Cursor row must be unchanged by DER.
+          expect(actual.getRow()).toBe(rowBefore);
+
+          // Expected post-condition: identical buffer with the active row's
+          // content removed; every other row untouched.
+          /** @type {!Map<number, string>} */
+          const expectedContent = new Map();
+          for (const row of rowContent.keys()) {
+            if (row !== activeRow) {
+              expectedContent.set(row, rowContent.get(row) || '');
+            }
+          }
+          const expected = buildMemory(expectedContent, activeRow);
+
+          // The decoder-visible state is what forceEmit produces; equal output
+          // means other rows are unchanged and the active row was cleared.
+          const actualCaption = actual.forceEmit(startTime, endTime);
+          const expectedCaption = expected.forceEmit(startTime, endTime);
+          expect(actualCaption).toEqual(expectedCaption);
+        }
+      });
+    }
   });
 
   describe('progressive reveal', () => {

--- a/test/cea/cea708_service_unit.js
+++ b/test/cea/cea708_service_unit.js
@@ -276,6 +276,52 @@ describe('Cea708Service', () => {
     expect(captions).toEqual(expectedCaptions);
   });
 
+  it('setPenAttributes reads pen size, font tag, and edge type', () => {
+    const Cea708Window = shaka.cea.Cea708Window;
+    const controlCodes = [
+      ...defineWindow,
+      // SetPenAttributes (0x90 + 2 bytes).
+      // Byte 1 |PENSIZE|OFFSET|TEXTTAG|: top 2 bits = 0b10 -> large pen size.
+      // Byte 2 |I|U|EDTYP|FNTAG|: I=1, U=0, EDTYP=0b101 (5), FNTAG=0b011 (3).
+      0x90, 0x80, 0xab,
+    ];
+
+    const packet = createCea708PacketFromBytes(controlCodes, startTime);
+    getCaptionsFromPackets(service, packet);
+
+    const window = (/** @type {?} */ (service))['windows_'][windowId];
+    expect(window).not.toBeNull();
+    // Pen size from byte 1 (large = 2).
+    expect(window.getPenSize()).toBe(Cea708Window.PenSize.LARGE);
+    // Edge type and font tag from byte 2.
+    expect(window.getPenEdgeType()).toBe(5);
+    expect(window.getPenFontStyle()).toBe(3);
+    // Italics/underline behavior must be unchanged.
+    expect(window['italics_']).toBe(true);
+    expect(window['underline_']).toBe(false);
+  });
+
+  it('setPenAttributes leaves pen size small when byte 1 is zero', () => {
+    const Cea708Window = shaka.cea.Cea708Window;
+    const controlCodes = [
+      ...defineWindow,
+      // Byte 1 = 0x00 -> pen size small (0). Byte 2 = 0xc0 -> italics +
+      // underline.
+      0x90, 0x00, 0xc0,
+    ];
+
+    const packet = createCea708PacketFromBytes(controlCodes, startTime);
+    getCaptionsFromPackets(service, packet);
+
+    const window = (/** @type {?} */ (service))['windows_'][windowId];
+    expect(window).not.toBeNull();
+    expect(window.getPenSize()).toBe(Cea708Window.PenSize.SMALL);
+    expect(window.getPenEdgeType()).toBe(0);
+    expect(window.getPenFontStyle()).toBe(0);
+    expect(window['italics_']).toBe(true);
+    expect(window['underline_']).toBe(true);
+  });
+
   it('setPenColor sets foreground and background color correctly', () => {
     const controlCodes = [
       ...defineWindow,
@@ -451,10 +497,11 @@ describe('Cea708Service', () => {
       // Series of G0 control codes that add text.
       0x74, 0x65, 0x73, 0x74, // t, e, s, t
 
-      // Currently, setWindowAttributes is only used to justify text,
-      // as specified by the last 2 bits of the fourth byte. The
-      // other bytes after the first byte are "don't care".
-      0x97, 0x00, 0x00, 0x01, 0x00, // Justify right
+      // setWindowAttributes justifies text via the last 2 bits of byte 3.
+      // Byte 1 is the fill color/opacity; use 0xc0 (transparent fill) so this
+      // test stays focused on justification and applies no background. Byte 2
+      // (border) and byte 4 (effects) are "don't care".
+      0x97, 0xc0, 0x00, 0x01, 0x00, // Transparent fill, justify right
     ];
 
     const packet1 = createCea708PacketFromBytes(controlCodes, startTime);
@@ -478,6 +525,100 @@ describe('Cea708Service', () => {
 
     const captions = getCaptionsFromPackets(service, packet1, packet2);
     expect(captions).toEqual(expectedCaptions);
+  });
+
+  it('applies a setWindowAttributes fill color to the cue background', () => {
+    const controlCodes = [
+      ...defineWindow,
+      // Series of G0 control codes that add text.
+      0x74, 0x65, 0x73, 0x74, // t, e, s, t
+
+      // setWindowAttributes (4 bytes). Byte 1 is the fill color/opacity:
+      // |FILL_OPACITY(2)|FILL_R(2)|FILL_G(2)|FILL_B(2)|. 0x33 = solid opacity
+      // (0b00), red 0b00, green 0b11, blue 0b11 -> magenta. Byte 3 (0x02) keeps
+      // the default (center) justification and word wrap off.
+      0x97, 0x33, 0x00, 0x02, 0x00,
+    ];
+
+    const packet1 = createCea708PacketFromBytes(controlCodes, startTime);
+    const packet2 = createCea708PacketFromBytes(hideWindow, endTime);
+
+    const text = 'test';
+    const topLevelCue = CeaUtils.createWindowedCue(startTime, endTime, '',
+        serviceNumber, windowId, rowCount, colCount, anchorId);
+    // The fill color is applied to the top-level cue's background.
+    topLevelCue.backgroundColor = 'magenta';
+    topLevelCue.nestedCues = [
+      CeaUtils.createDefaultCue(startTime, endTime, /* payload= */ text),
+    ];
+
+    const expectedCaptions = [
+      {
+        stream,
+        cue: topLevelCue,
+      },
+    ];
+
+    const captions = getCaptionsFromPackets(service, packet1, packet2);
+    expect(captions).toEqual(expectedCaptions);
+  });
+
+  it('does not apply a transparent setWindowAttributes fill', () => {
+    const controlCodes = [
+      ...defineWindow,
+      // Series of G0 control codes that add text.
+      0x74, 0x65, 0x73, 0x74, // t, e, s, t
+
+      // setWindowAttributes with a transparent fill (opacity id 3, 0b11 in the
+      // top two bits of byte 1). No background should be applied even though
+      // the color bits would otherwise map to a color. Byte 3 (0x02) keeps the
+      // default (center) justification.
+      0x97, 0xff, 0x00, 0x02, 0x00,
+    ];
+
+    const packet1 = createCea708PacketFromBytes(controlCodes, startTime);
+    const packet2 = createCea708PacketFromBytes(hideWindow, endTime);
+
+    const text = 'test';
+    const topLevelCue = CeaUtils.createWindowedCue(startTime, endTime, '',
+        serviceNumber, windowId, rowCount, colCount, anchorId);
+    // No backgroundColor is set on the top-level cue (default empty).
+    topLevelCue.nestedCues = [
+      CeaUtils.createDefaultCue(startTime, endTime, /* payload= */ text),
+    ];
+
+    const expectedCaptions = [
+      {
+        stream,
+        cue: topLevelCue,
+      },
+    ];
+
+    const captions = getCaptionsFromPackets(service, packet1, packet2);
+    expect(captions).toEqual(expectedCaptions);
+  });
+
+  it('reads the setWindowAttributes word-wrap flag', () => {
+    const controlCodes = [
+      ...defineWindow,
+      // Series of G0 control codes that add text.
+      0x74, 0x65, 0x73, 0x74, // t, e, s, t
+
+      // setWindowAttributes with a transparent fill (byte 1 = 0xc0) and byte 3
+      // = 0x40, which sets the word-wrap bit (0x40) and keeps default
+      // justification.
+      0x97, 0xc0, 0x00, 0x40, 0x00,
+    ];
+
+    const packet1 = createCea708PacketFromBytes(controlCodes, startTime);
+
+    // Decode the packet so setWindowAttributes is processed.
+    getCaptionsFromPackets(service, packet1);
+
+    // The current window should have word wrap enabled.
+    const window = (/** @type {?} */ (service))['windows_'][windowId];
+    expect(window).not.toBeNull();
+    expect(window.getWordWrap()).toBe(true);
   });
 
   it('handles the carriage return command correctly', () => {
@@ -880,6 +1021,798 @@ describe('Cea708Service', () => {
       const captions = getCaptionsFromPackets(service, packet1, packet2,
           packet3, packet4, packet5, packet6);
       expect(captions).toEqual(expectedCaptions);
+    });
+  });
+
+  describe('handles predefined window and pen styles (WNSTY/PNSTY)', () => {
+    const Cea708Window = shaka.cea.Cea708Window;
+
+    /**
+     * Builds a DefineWindow command (for window #0) whose b6 byte encodes the
+     * given predefined window style (WNSTY) and pen style (PNSTY).
+     * @param {number} windowStyle 0-7
+     * @param {number} penStyle 0-7
+     * @return {!Array<number>}
+     */
+    const defineWindowWithStyles = (windowStyle, penStyle) => {
+      const b6 = ((windowStyle & 0x07) << 3) | (penStyle & 0x07);
+      return [0x98, 0x38, 0x00, 0x00, 0x1f, 0x1f, b6];
+    };
+
+    /**
+     * Defines window #0 in the service with the given style bytes and returns
+     * the resulting window.
+     * @param {number} windowStyle
+     * @param {number} penStyle
+     * @return {!shaka.cea.Cea708Window}
+     */
+    const defineStyledWindow = (windowStyle, penStyle) => {
+      const packet = createCea708PacketFromBytes(
+          defineWindowWithStyles(windowStyle, penStyle), startTime);
+      getCaptionsFromPackets(service, packet);
+      const window = (/** @type {?} */ (service))['windows_'][windowId];
+      expect(window).not.toBeNull();
+      return /** @type {!shaka.cea.Cea708Window} */ (window);
+    };
+
+    it('applies each predefined window style deterministically', () => {
+      // Expected (printDirection, scrollDirection, wordWrap) per style id.
+      const expected = {
+        1: {printDirection: 0, scrollDirection: 3, wordWrap: false},
+        2: {printDirection: 0, scrollDirection: 3, wordWrap: false},
+        3: {printDirection: 0, scrollDirection: 3, wordWrap: false},
+        4: {printDirection: 0, scrollDirection: 3, wordWrap: true},
+        5: {printDirection: 0, scrollDirection: 3, wordWrap: true},
+        6: {printDirection: 0, scrollDirection: 3, wordWrap: true},
+        7: {printDirection: 2, scrollDirection: 1, wordWrap: false},
+      };
+      const svc = /** @type {?} */ (service);
+
+      for (let id = 1; id <= 7; id++) {
+        const window1 = new Cea708Window(windowId, serviceNumber);
+        const window2 = new Cea708Window(windowId, serviceNumber);
+        svc['applyWindowStylePreset_'](window1, id);
+        svc['applyWindowStylePreset_'](window2, id);
+
+        // Pure function of the preset id: two windows get identical state.
+        expect(window1.getPrintDirection()).toBe(expected[id].printDirection);
+        expect(window1.getScrollDirection()).toBe(expected[id].scrollDirection);
+        expect(window1.getWordWrap()).toBe(expected[id].wordWrap);
+
+        expect(window2.getPrintDirection()).toBe(window1.getPrintDirection());
+        expect(window2.getScrollDirection()).toBe(window1.getScrollDirection());
+        expect(window2.getWordWrap()).toBe(window1.getWordWrap());
+      }
+    });
+
+    it('applies each predefined pen style deterministically', () => {
+      // Expected (penSize, fontStyle, edgeType) per style id.
+      const expected = {
+        1: {penSize: 1, fontStyle: 0, edgeType: 0},
+        2: {penSize: 1, fontStyle: 1, edgeType: 0},
+        3: {penSize: 1, fontStyle: 2, edgeType: 0},
+        4: {penSize: 1, fontStyle: 3, edgeType: 0},
+        5: {penSize: 1, fontStyle: 4, edgeType: 0},
+        6: {penSize: 1, fontStyle: 3, edgeType: 3},
+        7: {penSize: 1, fontStyle: 4, edgeType: 3},
+      };
+      const svc = /** @type {?} */ (service);
+
+      for (let id = 1; id <= 7; id++) {
+        const window1 = new Cea708Window(windowId, serviceNumber);
+        const window2 = new Cea708Window(windowId, serviceNumber);
+        svc['applyPenStylePreset_'](window1, id);
+        svc['applyPenStylePreset_'](window2, id);
+
+        expect(window1.getPenSize()).toBe(expected[id].penSize);
+        expect(window1.getPenFontStyle()).toBe(expected[id].fontStyle);
+        expect(window1.getPenEdgeType()).toBe(expected[id].edgeType);
+
+        expect(window2.getPenSize()).toBe(window1.getPenSize());
+        expect(window2.getPenFontStyle()).toBe(window1.getPenFontStyle());
+        expect(window2.getPenEdgeType()).toBe(window1.getPenEdgeType());
+      }
+    });
+
+    it('leaves an existing window style unchanged for preset id 0', () => {
+      const window = new Cea708Window(windowId, serviceNumber);
+      const svc = /** @type {?} */ (service);
+      // Seed a non-default style (style 7: ticker tape).
+      svc['applyWindowStylePreset_'](window, 7);
+      const printDirection = window.getPrintDirection();
+      const scrollDirection = window.getScrollDirection();
+      const wordWrap = window.getWordWrap();
+
+      // Preset id 0 must keep the existing style.
+      svc['applyWindowStylePreset_'](window, 0);
+      expect(window.getPrintDirection()).toBe(printDirection);
+      expect(window.getScrollDirection()).toBe(scrollDirection);
+      expect(window.getWordWrap()).toBe(wordWrap);
+    });
+
+    it('defines a new window with style 0 using preset 1 defaults', () => {
+      // A brand new window with WNSTY=0 should resolve to predefined style 1.
+      const window = defineStyledWindow(
+          /* windowStyle= */ 0, /* penStyle= */ 0);
+      expect(window.getPrintDirection()).toBe(0);
+      expect(window.getScrollDirection()).toBe(3);
+      expect(window.getWordWrap()).toBe(false);
+
+      // Preset 1 / default pen: standard size, default font, no edge.
+      expect(window.getPenSize()).toBe(Cea708Window.PenSize.STANDARD);
+      expect(window.getPenFontStyle()).toBe(0);
+      expect(window.getPenEdgeType()).toBe(0);
+    });
+
+    it('reads WNSTY and PNSTY from the DefineWindow b6 byte', () => {
+      // Window style 7 (ticker), pen style 6 (mono no-serif, uniform edge).
+      const window = defineStyledWindow(
+          /* windowStyle= */ 7, /* penStyle= */ 6);
+      expect(window.getPrintDirection()).toBe(2);
+      expect(window.getScrollDirection()).toBe(1);
+      expect(window.getWordWrap()).toBe(false);
+
+      expect(window.getPenSize()).toBe(1);
+      expect(window.getPenFontStyle()).toBe(3);
+      expect(window.getPenEdgeType()).toBe(3);
+    });
+
+    it('keeps default center justification for a styled window', () => {
+      // Defining a window with a predefined style must not change the decoder's
+      // default (center) justification, which is governed by
+      // SetWindowAttributes. This guards the existing default rendering.
+      const controlCodes = [
+        ...defineWindowWithStyles(/* windowStyle= */ 0, /* penStyle= */ 0),
+        0x74, 0x65, 0x73, 0x74, // t, e, s, t
+      ];
+      const packet1 = createCea708PacketFromBytes(controlCodes, startTime);
+      const packet2 = createCea708PacketFromBytes(hideWindow, endTime);
+
+      const topLevelCue = CeaUtils.createWindowedCue(startTime, endTime, '',
+          serviceNumber, windowId, rowCount, colCount, anchorId);
+      topLevelCue.nestedCues = [
+        CeaUtils.createDefaultCue(startTime, endTime, /* payload= */ 'test'),
+      ];
+
+      const captions = getCaptionsFromPackets(service, packet1, packet2);
+      expect(captions).toEqual([{stream, cue: topLevelCue}]);
+      // Default textAlign is CENTER and must be preserved.
+      expect(captions[0].cue.textAlign).toBe(shaka.text.Cue.textAlign.CENTER);
+    });
+
+    // For a given (WNSTY, PNSTY) pair, the resulting style is a pure function
+    // of those preset ids (prior style is used only when an id is 0).
+
+    /**
+     * A small, deterministic PRNG (mulberry32). Given the same seed it always
+     * produces the same sequence, which keeps this property test reproducible.
+     * @param {number} seed
+     * @return {function(): number} Returns floats in [0, 1).
+     */
+    const mulberry32 = (seed) => {
+      let a = seed >>> 0;
+      return () => {
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    };
+
+    /**
+     * Draws a random integer in [0, maxInclusive] from the given PRNG.
+     * @param {function(): number} rng
+     * @param {number} maxInclusive
+     * @return {number}
+     */
+    const randInt = (rng, maxInclusive) =>
+      Math.floor(rng() * (maxInclusive + 1));
+
+    // The preset tables are the source of truth for the expected style state.
+    const WindowStylePresets =
+        shaka.cea.Cea708Service.WindowStylePresets;
+    const PenStylePresets = shaka.cea.Cea708Service.PenStylePresets;
+
+    /**
+     * Resolves a raw WNSTY id to the preset id actually applied to a freshly
+     * defined window: a window style of 0 on a new window defaults to style 1.
+     * @param {number} windowStyle 0-7
+     * @return {number}
+     */
+    const resolveNewWindowStyle = (windowStyle) => windowStyle || 1;
+
+    /**
+     * Resolves a raw PNSTY id to the preset id actually applied to a freshly
+     * defined window: a pen style of 0 on a new window defaults to style 1.
+     * @param {number} penStyle 0-7
+     * @return {number}
+     */
+    const resolveNewPenStyle = (penStyle) => penStyle || 1;
+
+    /**
+     * Defines window #0 on a brand-new service with the given style bytes and
+     * returns the resulting window. Each call uses a fresh service/window so
+     * the "new window" semantics (style 0 -> default style 1) apply.
+     * @param {number} windowStyle 0-7
+     * @param {number} penStyle 0-7
+     * @return {!shaka.cea.Cea708Window}
+     */
+    const defineFreshStyledWindow = (windowStyle, penStyle) => {
+      const freshService = new shaka.cea.Cea708Service(serviceNumber);
+      const packet = createCea708PacketFromBytes(
+          defineWindowWithStyles(windowStyle, penStyle), startTime);
+      getCaptionsFromPackets(freshService, packet);
+      const window =
+          (/** @type {?} */ (freshService))['windows_'][windowId];
+      expect(window).not.toBeNull();
+      return /** @type {!shaka.cea.Cea708Window} */ (window);
+    };
+
+    /**
+     * Snapshots the preset-derived state of a window into a plain object so two
+     * windows can be compared for equality.
+     * @param {!shaka.cea.Cea708Window} window
+     * @return {!Object}
+     */
+    const styleSnapshot = (window) => ({
+      printDirection: window.getPrintDirection(),
+      scrollDirection: window.getScrollDirection(),
+      wordWrap: window.getWordWrap(),
+      penSize: window.getPenSize(),
+      fontStyle: window.getPenFontStyle(),
+      edgeType: window.getPenEdgeType(),
+    });
+
+    it('predefined style is a pure function of (WNSTY, PNSTY)', () => {
+      // A spread of fixed seeds keeps the test deterministic while still
+      // exercising many randomly chosen (windowStyle, penStyle) pairs.
+      const seeds = [
+        0x00000001, 0x00c0ffee, 0x0badf00d, 0x00012345,
+        0x00abcdef, 0x9e3779b9, 0x2545f491, 0xdeadbeef,
+      ];
+      const iterationsPerSeed = 40;
+
+      for (const seed of seeds) {
+        const rng = mulberry32(seed);
+        for (let i = 0; i < iterationsPerSeed; i++) {
+          const windowStyle = randInt(rng, 7); // WNSTY in [0, 7].
+          const penStyle = randInt(rng, 7); // PNSTY in [0, 7].
+
+          // Expected state comes straight from the preset tables, with the
+          // "new window" resolution of id 0 -> default style 1.
+          const expectedWindowPreset =
+              WindowStylePresets[resolveNewWindowStyle(windowStyle)];
+          const expectedPenPreset =
+              PenStylePresets[resolveNewPenStyle(penStyle)];
+
+          const window = defineFreshStyledWindow(windowStyle, penStyle);
+
+          // The resulting window-style state matches the preset table exactly.
+          expect(window.getPrintDirection())
+              .toBe(expectedWindowPreset.printDirection);
+          expect(window.getScrollDirection())
+              .toBe(expectedWindowPreset.scrollDirection);
+          expect(window.getWordWrap()).toBe(expectedWindowPreset.wordWrap);
+
+          // The resulting pen-style state matches the preset table exactly.
+          expect(window.getPenSize()).toBe(expectedPenPreset.penSize);
+          expect(window.getPenFontStyle()).toBe(expectedPenPreset.fontStyle);
+          expect(window.getPenEdgeType()).toBe(expectedPenPreset.edgeType);
+
+          // Determinism: decoding the same (WNSTY, PNSTY) again on a fresh
+          // service yields byte-for-byte identical preset-derived state.
+          const window2 = defineFreshStyledWindow(windowStyle, penStyle);
+          expect(styleSnapshot(window2)).toEqual(styleSnapshot(window));
+        }
+      }
+    });
+
+    it('uses prior style only for id 0 on an existing window', () => {
+      // a preset id of 0 keeps the existing
+      // style, but only when the window already existed. Re-defining the same
+      // window with (WNSTY=0, PNSTY=0) must leave the previously applied preset
+      // state untouched.
+      const seeds = [0x13572468, 0x0f0f0f0f, 0x77777777, 0xa5a5a5a5];
+      const iterationsPerSeed = 20;
+
+      for (const seed of seeds) {
+        const rng = mulberry32(seed);
+        for (let i = 0; i < iterationsPerSeed; i++) {
+          // Pick non-zero ids so there is a concrete prior style to preserve.
+          const windowStyle = 1 + randInt(rng, 6); // [1, 7]
+          const penStyle = 1 + randInt(rng, 6); // [1, 7]
+
+          const freshService = new shaka.cea.Cea708Service(serviceNumber);
+
+          // First define establishes the window's preset-derived style.
+          getCaptionsFromPackets(freshService, createCea708PacketFromBytes(
+              defineWindowWithStyles(windowStyle, penStyle), startTime));
+          const window =
+              (/** @type {?} */ (freshService))['windows_'][windowId];
+          expect(window).not.toBeNull();
+          const priorState = styleSnapshot(
+              /** @type {!shaka.cea.Cea708Window} */ (window));
+
+          // Re-defining the existing window with id 0 keeps the prior style.
+          getCaptionsFromPackets(freshService, createCea708PacketFromBytes(
+              defineWindowWithStyles(/* windowStyle= */ 0, /* penStyle= */ 0),
+              endTime));
+          expect(styleSnapshot(
+              /** @type {!shaka.cea.Cea708Window} */ (window)))
+              .toEqual(priorState);
+        }
+      }
+    });
+  });
+
+  describe('reserved C2/C3 codes and unmapped G2/G3 chars', () => {
+    // a C2 or C3 reserved control code skips the spec-mandated number
+    // of operand bytes without altering window state. Per CTA-708-E, the C2
+    // set skips 0/1/2/3 operand bytes for code ranges 0x00-0x07 / 0x08-0x0f /
+    // 0x10-0x17 / 0x18-0x1f, and the C3 set skips 4/5 operand bytes for ranges
+    // 0x80-0x87 / 0x88-0x8f.
+    // a G2 or G3 character with no mapping renders the spec-mandated
+    // underline ('_') placeholder; mapped characters render their glyph.
+
+    /**
+     * Decodes a fresh service with: defineWindow, a reserved control code
+     * followed by its operand bytes, then the text "test", then a hide-window.
+     * The operand bytes are printable G0 characters, so an incorrect skip count
+     * would either leak an operand into the output or consume part of "test" --
+     * "test" survives intact only when exactly the right number of operand
+     * bytes is skipped (). The window geometry in the emitted cue also
+     * confirms the window state was not altered by the reserved code.
+     * @param {number} reservedCode The synthetic extended control-code value
+     *   (e.g. 0x1008 for a C2 0x08, 0x1080 for a C3 0x80).
+     * @param {!Array<number>} operandBytes Operand bytes that follow the code.
+     * @return {!Array<shaka.extern.ICaptionDecoder.ClosedCaption>}
+     */
+    const decodeReservedThenText = (reservedCode, operandBytes) => {
+      const svc = new shaka.cea.Cea708Service(serviceNumber);
+      const controlCodes = [
+        ...defineWindow,
+        reservedCode, ...operandBytes,
+        0x74, 0x65, 0x73, 0x74, // t, e, s, t
+      ];
+      const packet1 = createCea708PacketFromBytes(controlCodes, startTime);
+      const packet2 = createCea708PacketFromBytes(hideWindow, endTime);
+      return getCaptionsFromPackets(svc, packet1, packet2);
+    };
+
+    /**
+     * The expected caption when a reserved code is fully skipped and only the
+     * text "test" renders in window #0 with its original geometry.
+     * @return {!Array<shaka.extern.ICaptionDecoder.ClosedCaption>}
+     */
+    const expectedTestCaption = () => {
+      const topLevelCue = CeaUtils.createWindowedCue(startTime, endTime, '',
+          serviceNumber, windowId, rowCount, colCount, anchorId);
+      topLevelCue.nestedCues = [
+        CeaUtils.createDefaultCue(startTime, endTime, /* payload= */ 'test'),
+      ];
+      return [{stream, cue: topLevelCue}];
+    };
+
+    /**
+     * Decodes a fresh service with: defineWindow, a single G2/G3 character
+     * control code, then a hide-window, and returns the emitted captions.
+     * @param {number} charCode The synthetic extended control-code value
+     *   (e.g. 0x1025 for a G2 char, 0x10a0 for a G3 char).
+     * @return {!Array<shaka.extern.ICaptionDecoder.ClosedCaption>}
+     */
+    const decodeSingleChar = (charCode) => {
+      const svc = new shaka.cea.Cea708Service(serviceNumber);
+      const packet1 = createCea708PacketFromBytes(
+          [...defineWindow, charCode], startTime);
+      const packet2 = createCea708PacketFromBytes(hideWindow, endTime);
+      return getCaptionsFromPackets(svc, packet1, packet2);
+    };
+
+    /**
+     * The expected caption when a single character renders in window #0.
+     * @param {string} text The rendered glyph or placeholder.
+     * @return {!Array<shaka.extern.ICaptionDecoder.ClosedCaption>}
+     */
+    const expectedCharCaption = (text) => {
+      const topLevelCue = CeaUtils.createWindowedCue(startTime, endTime, '',
+          serviceNumber, windowId, rowCount, colCount, anchorId);
+      topLevelCue.nestedCues = [
+        CeaUtils.createDefaultCue(startTime, endTime, /* payload= */ text),
+      ];
+      return [{stream, cue: topLevelCue}];
+    };
+
+    // Operand bytes 'V'..'Z' (0x56-0x5a) are printable G0 characters.
+
+    it('C2 0x00-0x07 reserved codes skip 0 operand bytes', () => {
+      // No operand bytes follow; text decodes immediately after the code.
+      expect(decodeReservedThenText(0x1000, []))
+          .toEqual(expectedTestCaption());
+      expect(decodeReservedThenText(0x1007, []))
+          .toEqual(expectedTestCaption());
+    });
+
+    it('C2 0x08-0x0f reserved codes skip 1 operand byte', () => {
+      expect(decodeReservedThenText(0x1008, [0x56]))
+          .toEqual(expectedTestCaption());
+      expect(decodeReservedThenText(0x100f, [0x56]))
+          .toEqual(expectedTestCaption());
+    });
+
+    it('C2 0x10-0x17 reserved codes skip 2 operand bytes', () => {
+      expect(decodeReservedThenText(0x1010, [0x56, 0x57]))
+          .toEqual(expectedTestCaption());
+      expect(decodeReservedThenText(0x1017, [0x56, 0x57]))
+          .toEqual(expectedTestCaption());
+    });
+
+    it('C2 0x18-0x1f reserved codes skip 3 operand bytes', () => {
+      expect(decodeReservedThenText(0x1018, [0x56, 0x57, 0x58]))
+          .toEqual(expectedTestCaption());
+      expect(decodeReservedThenText(0x101f, [0x56, 0x57, 0x58]))
+          .toEqual(expectedTestCaption());
+    });
+
+    it('C3 0x80-0x87 reserved codes skip 4 operand bytes', () => {
+      expect(decodeReservedThenText(0x1080, [0x56, 0x57, 0x58, 0x59]))
+          .toEqual(expectedTestCaption());
+      expect(decodeReservedThenText(0x1087, [0x56, 0x57, 0x58, 0x59]))
+          .toEqual(expectedTestCaption());
+    });
+
+    it('C3 0x88-0x8f reserved codes skip 5 operand bytes', () => {
+      expect(decodeReservedThenText(0x1088, [0x56, 0x57, 0x58, 0x59, 0x5a]))
+          .toEqual(expectedTestCaption());
+      expect(decodeReservedThenText(0x108f, [0x56, 0x57, 0x58, 0x59, 0x5a]))
+          .toEqual(expectedTestCaption());
+    });
+
+    it('renders a mapped G2 character as its glyph', () => {
+      // 0x25 maps to the horizontal ellipsis in the G2 charset.
+      expect(decodeSingleChar(0x1025)).toEqual(expectedCharCaption('…'));
+    });
+
+    it('renders an unmapped G2 character as the underline placeholder', () => {
+      // 0x36 has no mapping in the G2 charset, so the spec mandates '_'.
+      expect(decodeSingleChar(0x1036)).toEqual(expectedCharCaption('_'));
+    });
+
+    it('renders the only mapped G3 character (0xa0) as [CC]', () => {
+      expect(decodeSingleChar(0x10a0)).toEqual(expectedCharCaption('[CC]'));
+    });
+
+    it('renders unmapped G3 characters as the underline placeholder', () => {
+      // As of CEA-708-E, G3 maps only 0xa0; every other code renders '_'.
+      expect(decodeSingleChar(0x10a1)).toEqual(expectedCharCaption('_'));
+      expect(decodeSingleChar(0x10db)).toEqual(expectedCharCaption('_'));
+    });
+  });
+
+  describe('window-command bitmap selection and current-window safety', () => {
+    // a window command (clear/display/hide/toggle/delete) carrying an
+    // 8-bit window bitmap affects exactly the set of EXISTING windows whose bit
+    // is set, and no others. Windows whose bit is set but that were never
+    // defined are silently ignored (getSpecifiedWindowIds_ filters them out).
+    // a command that targets a non-existent window, or a pen/character
+    // command issued with no current window, is ignored and emits no cue.
+
+    // Text codes that spell 'test'.
+    const textControlCodes = [0x74, 0x65, 0x73, 0x74];
+
+    /**
+     * Builds a DefineWindow command for the given window number (0-7). The
+     * window geometry matches `defineWindow` (16 rows, 32 cols, upper-center
+     * anchor); only the visibility bit of b1 varies.
+     * @param {number} windowNum 0-7.
+     * @param {boolean} visible Whether the window's visible bit is set.
+     * @return {!Array<number>}
+     */
+    const defineWindowCmd = (windowNum, visible) => {
+      // b1: 0x18 keeps the row/col-lock bits; 0x20 is the visibility bit.
+      const b1 = visible ? 0x38 : 0x18;
+      return [0x98 + windowNum, b1, 0x00, 0x00, 0x1f, 0x1f, 0x00];
+    };
+
+    /**
+     * The shared 708 service array of windows, exposed for state assertions.
+     * @param {!shaka.cea.Cea708Service} svc
+     * @return {!Array<?shaka.cea.Cea708Window>}
+     */
+    const windowsOf = (svc) => (/** @type {?} */ (svc))['windows_'];
+
+    /**
+     * Builds the expected caption for window `id` containing the text 'test'.
+     * @param {number} id Window number.
+     * @param {number} cueStart
+     * @param {number} cueEnd
+     * @return {shaka.extern.ICaptionDecoder.ClosedCaption}
+     */
+    const expectedTestCue = (id, cueStart, cueEnd) => {
+      const topLevelCue = CeaUtils.createWindowedCue(cueStart, cueEnd, '',
+          serviceNumber, id, rowCount, colCount, anchorId);
+      topLevelCue.nestedCues = [
+        CeaUtils.createDefaultCue(cueStart, cueEnd, /* payload= */ 'test'),
+      ];
+      return {stream, cue: topLevelCue};
+    };
+
+    /**
+     * Defines windows 0, 2, and 5 (each with the text 'test') on the service.
+     * Windows 1 and 3 are intentionally left undefined so a bitmap can target
+     * them without effect. Window 5's bit is left out of the test bitmap so it
+     * can serve as the "untouched" control.
+     * @param {boolean} visible Whether the windows are defined visible.
+     */
+    const defineWindows025 = (visible) => {
+      const controlCodes = [];
+      for (const id of [0, 2, 5]) {
+        controlCodes.push(...defineWindowCmd(id, visible), ...textControlCodes);
+      }
+      const packet = createCea708PacketFromBytes(controlCodes, startTime);
+      getCaptionsFromPackets(service, packet);
+    };
+
+    // Bitmap selecting windows {0, 1, 2, 3}. Only 0 and 2 exist; 1 and 3 do
+    // not, and 5 is deliberately excluded.
+    const bitmap0123 = 0x0f;
+
+    it('delete affects only existing windows whose bit is set', () => {
+      defineWindows025(/* visible= */ true);
+
+      const deletePacket =
+          createCea708PacketFromBytes([0x8c, bitmap0123], endTime);
+      const captions = getCaptionsFromPackets(service, deletePacket);
+
+      // Only the existing, selected windows (0 and 2) emit and are deleted.
+      expect(captions).toEqual([
+        expectedTestCue(windowId, startTime, endTime),
+        expectedTestCue(2, startTime, endTime),
+      ]);
+
+      const windows = windowsOf(service);
+      expect(windows[0]).toBeNull();
+      expect(windows[2]).toBeNull();
+      // Window 5 was not selected, so it must be untouched.
+      expect(windows[5]).not.toBeNull();
+      expect(windows[5].isVisible()).toBe(true);
+    });
+
+    it('clear affects only existing windows whose bit is set', () => {
+      defineWindows025(/* visible= */ true);
+
+      const clearPacket =
+          createCea708PacketFromBytes([0x88, bitmap0123], endTime);
+      const captions = getCaptionsFromPackets(service, clearPacket);
+
+      expect(captions).toEqual([
+        expectedTestCue(windowId, startTime, endTime),
+        expectedTestCue(2, startTime, endTime),
+      ]);
+
+      const windows = windowsOf(service);
+      // Clear keeps the window but empties its memory: a later emit is null.
+      expect(windows[0]).not.toBeNull();
+      expect(windows[0].forceEmit(endTime + 1, serviceNumber)).toBeNull();
+      expect(windows[2]).not.toBeNull();
+      expect(windows[2].forceEmit(endTime + 1, serviceNumber)).toBeNull();
+      // Window 5 was not selected: its memory is intact and still emits.
+      expect(windows[5]).not.toBeNull();
+      expect(windows[5].forceEmit(endTime + 1, serviceNumber)).not.toBeNull();
+    });
+
+    it('hide affects only existing windows whose bit is set', () => {
+      defineWindows025(/* visible= */ true);
+
+      const hidePacket =
+          createCea708PacketFromBytes([0x8a, bitmap0123], endTime);
+      const captions = getCaptionsFromPackets(service, hidePacket);
+
+      // Both hidden, visible windows emit their contents.
+      expect(captions).toEqual([
+        expectedTestCue(windowId, startTime, endTime),
+        expectedTestCue(2, startTime, endTime),
+      ]);
+
+      const windows = windowsOf(service);
+      expect(windows[0].isVisible()).toBe(false);
+      expect(windows[2].isVisible()).toBe(false);
+      // Window 5 was not selected, so its visibility is unchanged.
+      expect(windows[5].isVisible()).toBe(true);
+    });
+
+    it('toggle affects only existing windows whose bit is set', () => {
+      defineWindows025(/* visible= */ true);
+
+      const togglePacket =
+          createCea708PacketFromBytes([0x8b, bitmap0123], endTime);
+      const captions = getCaptionsFromPackets(service, togglePacket);
+
+      // Visible windows being toggled off emit their contents.
+      expect(captions).toEqual([
+        expectedTestCue(windowId, startTime, endTime),
+        expectedTestCue(2, startTime, endTime),
+      ]);
+
+      const windows = windowsOf(service);
+      expect(windows[0].isVisible()).toBe(false);
+      expect(windows[2].isVisible()).toBe(false);
+      // Window 5 was not selected, so its visibility is unchanged.
+      expect(windows[5].isVisible()).toBe(true);
+    });
+
+    it('display affects only existing windows whose bit is set', () => {
+      // Define the windows hidden so display has an observable effect.
+      defineWindows025(/* visible= */ false);
+
+      const displayPacket =
+          createCea708PacketFromBytes([0x89, bitmap0123], endTime);
+      const captions = getCaptionsFromPackets(service, displayPacket);
+
+      // Display emits no cue; it only changes visibility.
+      expect(captions).toEqual([]);
+
+      const windows = windowsOf(service);
+      expect(windows[0].isVisible()).toBe(true);
+      expect(windows[2].isVisible()).toBe(true);
+      // Window 5 was not selected, so it remains hidden.
+      expect(windows[5].isVisible()).toBe(false);
+    });
+
+    it('ignores a window command targeting only non-existent windows', () => {
+      // Only window 5 exists; the bitmap selects windows {0, 1} which do not.
+      const controlCodes = [
+        ...defineWindowCmd(5, /* visible= */ true), ...textControlCodes,
+      ];
+      getCaptionsFromPackets(
+          service, createCea708PacketFromBytes(controlCodes, startTime));
+
+      const deletePacket =
+          createCea708PacketFromBytes([0x8c, 0x03], endTime);
+      const captions = getCaptionsFromPackets(service, deletePacket);
+
+      // No existing window matches the bitmap, so nothing is emitted...
+      expect(captions).toEqual([]);
+      // ...and the one defined window is untouched.
+      const windows = windowsOf(service);
+      expect(windows[5]).not.toBeNull();
+      expect(windows[5].isVisible()).toBe(true);
+    });
+
+    it('keeps the current window when SetCurrentWindow targets an ' +
+        'undefined window', () => {
+      // Define window 0, type 'te', then SetCurrentWindow to window 2 (0x82),
+      // which was never defined. The command must be ignored so the current
+      // window stays window 0, and the remaining text 'st' lands in window 0.
+      const controlCodes = [
+        ...defineWindowCmd(windowId, /* visible= */ true),
+        0x74, 0x65, // t, e
+        0x82, // SetCurrentWindow -> window 2 (undefined): ignored.
+        0x73, 0x74, // s, t
+      ];
+      const packet1 = createCea708PacketFromBytes(controlCodes, startTime);
+      const packet2 = createCea708PacketFromBytes(hideWindow, endTime);
+      const captions = getCaptionsFromPackets(service, packet1, packet2);
+
+      // All four characters landed in window 0.
+      expect(captions).toEqual([
+        expectedTestCue(windowId, startTime, endTime),
+      ]);
+      // Window 2 was never created by the ignored SetCurrentWindow command.
+      expect(windowsOf(service)[2]).toBeNull();
+    });
+
+    it('ignores pen and character commands when there is no current ' +
+        'window', () => {
+      // With no DefineWindow first, there is no current window. Each command
+      // still reads its operand bytes (keeping the block aligned) but must be
+      // a no-op that creates no window and emits no cue.
+      const controlCodes = [
+        0x74, 0x65, 0x73, 0x74, // G0 text 'test' with no current window.
+        0x92, 0x02, 0x00, // SetPenLocation (reads 2 operand bytes).
+        0x90, 0x00, 0xc0, // SetPenAttributes (reads 2 operand bytes).
+        0x91, 0x30, 0x33, 0x00, // SetPenColor (reads 3 operand bytes).
+      ];
+      const packet = createCea708PacketFromBytes(controlCodes, startTime);
+
+      // No exception (operands consumed) and no cue emitted.
+      const captions = getCaptionsFromPackets(service, packet);
+      expect(captions).toEqual([]);
+
+      // No window was created by any of the commands.
+      for (const window of windowsOf(service)) {
+        expect(window).toBeNull();
+      }
+    });
+
+    // A window command affects exactly the existing windows whose bitmap bit
+    // is set. delete (0x8c) is used as the representative command.
+
+    /**
+     * A small, deterministic PRNG (mulberry32). Given the same seed it always
+     * produces the same sequence, which keeps this property test reproducible.
+     * @param {number} seed
+     * @return {function(): number} Returns floats in [0, 1).
+     */
+    const mulberry32 = (seed) => {
+      let a = seed >>> 0;
+      return () => {
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    };
+
+    /**
+     * Draws a random integer in [0, maxInclusive] from the given PRNG.
+     * @param {function(): number} rng
+     * @param {number} maxInclusive
+     * @return {number}
+     */
+    const randInt = (rng, maxInclusive) =>
+      Math.floor(rng() * (maxInclusive + 1));
+
+    it('delete affects exactly the existing windows whose bit is set', () => {
+      // A spread of fixed seeds keeps the test deterministic while exercising
+      // many randomly chosen (defined-window set, bitmap) pairs.
+      const seeds = [
+        0x00000001, 0x00c0ffee, 0x0badf00d, 0x00012345,
+        0x00abcdef, 0x9e3779b9, 0x2545f491, 0xdeadbeef,
+      ];
+      const iterationsPerSeed = 30;
+
+      for (const seed of seeds) {
+        const rng = mulberry32(seed);
+        for (let i = 0; i < iterationsPerSeed; i++) {
+          // Randomly define a subset of windows 0-7 (each with ~1/2 chance),
+          // and pick a random 8-bit window bitmap for the delete command.
+          const definedIds = [];
+          for (let id = 0; id < 8; id++) {
+            if (rng() < 0.5) {
+              definedIds.push(id);
+            }
+          }
+          const bitmap = randInt(rng, 0xff);
+
+          // Each defined window is visible and holds the text 'test'.
+          const svc = new shaka.cea.Cea708Service(serviceNumber);
+          const controlCodes = [];
+          for (const id of definedIds) {
+            controlCodes.push(
+                ...defineWindowCmd(id, /* visible= */ true),
+                ...textControlCodes);
+          }
+          if (controlCodes.length) {
+            getCaptionsFromPackets(
+                svc, createCea708PacketFromBytes(controlCodes, startTime));
+          }
+
+          // The command should affect exactly the existing, selected windows.
+          const affected = new Set(
+              definedIds.filter((id) => (bitmap & (1 << id)) !== 0));
+
+          getCaptionsFromPackets(
+              svc, createCea708PacketFromBytes([0x8c, bitmap], endTime));
+
+          const windows = windowsOf(svc);
+          for (let id = 0; id < 8; id++) {
+            if (affected.has(id)) {
+              // Selected, existing windows are deleted.
+              expect(windows[id]).toBeNull();
+            } else if (definedIds.includes(id)) {
+              // Existing but unselected windows are untouched: still present,
+              // still visible, and still holding their 'test' content.
+              expect(windows[id]).not.toBeNull();
+              expect(windows[id].isVisible()).toBe(true);
+              expect(windows[id].forceEmit(endTime + 1, serviceNumber))
+                  .not.toBeNull();
+            } else {
+              // Never-defined windows remain null regardless of the bitmap.
+              expect(windows[id]).toBeNull();
+            }
+          }
+        }
+      }
     });
   });
 });

--- a/test/cea/cea708_window_unit.js
+++ b/test/cea/cea708_window_unit.js
@@ -59,6 +59,52 @@ describe('Cea708Window', () => {
     expect(caption).toEqual(expectedCaption);
   });
 
+  it('applies the window fill color to the emitted cue background', () => {
+    const text = 'test word';
+    window.setWindowFillColor('magenta');
+    for (const c of text) {
+      window.setCharacter(c);
+    }
+
+    const topLevelCue = CeaUtils.createWindowedCue(startTime, endTime, '',
+        serviceNumber, 0, rowCount, colCount);
+    // The fill color is applied to the top-level cue's background.
+    topLevelCue.backgroundColor = 'magenta';
+    topLevelCue.nestedCues = [
+      CeaUtils.createDefaultCue(startTime, endTime, text),
+    ];
+
+    const caption = window.forceEmit(endTime, serviceNumber);
+    const expectedCaption = {
+      stream,
+      cue: topLevelCue,
+    };
+
+    expect(caption).toEqual(expectedCaption);
+  });
+
+  it('does not set a cue background when no fill color is applied', () => {
+    const text = 'test word';
+    for (const c of text) {
+      window.setCharacter(c);
+    }
+
+    const topLevelCue = CeaUtils.createWindowedCue(startTime, endTime, '',
+        serviceNumber, 0, rowCount, colCount);
+    // No backgroundColor is set on the top-level cue (default empty).
+    topLevelCue.nestedCues = [
+      CeaUtils.createDefaultCue(startTime, endTime, text),
+    ];
+
+    const caption = window.forceEmit(endTime, serviceNumber);
+    const expectedCaption = {
+      stream,
+      cue: topLevelCue,
+    };
+
+    expect(caption).toEqual(expectedCaption);
+  });
+
   describe('handles carriage returns', () => {
     it('handles a regular carriage return', () => {
       const text1 = 'test';
@@ -370,6 +416,192 @@ describe('Cea708Window', () => {
     expect(caption).toEqual(expectedCaption);
   });
 
+
+  describe('pen-bounds safety', () => {
+    // setCharacter writes a character only when the pen is within the
+    // window's row and column counts; otherwise the window memory remains
+    // unchanged (and nothing is emitted). The window is defined with rowCount
+    // rows and colCount columns in beforeEach, so valid pen indices are
+    // [0, rowCount) x [0, colCount).
+
+    it('does not write a character when the pen row is out of bounds', () => {
+      // Row == rowCount is one past the last valid row.
+      window.setPenLocation(/* row= */ rowCount, /* col= */ 0);
+      window.setCharacter('x');
+
+      // Memory is unchanged, so nothing is emitted.
+      expect(window.forceEmit(endTime, serviceNumber)).toBeNull();
+    });
+
+    it('does not write a character when the pen column is out of bounds',
+        () => {
+          // Col == colCount is one past the last valid column.
+          window.setPenLocation(/* row= */ 0, /* col= */ colCount);
+          window.setCharacter('x');
+
+          expect(window.forceEmit(endTime, serviceNumber)).toBeNull();
+        });
+
+    it('does not write a character when the pen location is negative', () => {
+      window.setPenLocation(/* row= */ -1, /* col= */ 0);
+      window.setCharacter('x');
+      expect(window.forceEmit(endTime, serviceNumber)).toBeNull();
+
+      window.setPenLocation(/* row= */ 0, /* col= */ -1);
+      window.setCharacter('y');
+      expect(window.forceEmit(endTime, serviceNumber)).toBeNull();
+    });
+
+    it('leaves existing window memory unchanged for an out-of-bounds write',
+        () => {
+          const text = 'test';
+          for (const c of text) {
+            window.setCharacter(c);
+          }
+
+          // Move the pen out of bounds and attempt to write. This must not add
+          // to or corrupt the existing memory.
+          window.setPenLocation(/* row= */ rowCount, /* col= */ 0);
+          window.setCharacter('X');
+
+          const topLevelCue = CeaUtils.createWindowedCue(startTime, endTime, '',
+              serviceNumber, 0, rowCount, colCount);
+          topLevelCue.nestedCues = [
+            CeaUtils.createDefaultCue(startTime, endTime, text),
+          ];
+
+          const caption = window.forceEmit(endTime, serviceNumber);
+          expect(caption).toEqual({stream, cue: topLevelCue});
+        });
+
+    it('writes a character at the last in-bounds pen location', () => {
+      // The last valid row is rowCount - 1; leading empty rows are trimmed by
+      // the emitter, so the single character appears with no line breaks.
+      const text = 'hi';
+      window.setPenLocation(/* row= */ rowCount - 1, /* col= */ 0);
+      for (const c of text) {
+        window.setCharacter(c);
+      }
+
+      const topLevelCue = CeaUtils.createWindowedCue(startTime, endTime, '',
+          serviceNumber, 0, rowCount, colCount);
+      topLevelCue.nestedCues = [
+        CeaUtils.createDefaultCue(startTime, endTime, text),
+      ];
+
+      const caption = window.forceEmit(endTime, serviceNumber);
+      expect(caption).toEqual({stream, cue: topLevelCue});
+    });
+
+    // setCharacter writes only when the pen is within rowCount/colCount;
+    // an out-of-bounds write leaves the window memory unchanged.
+
+    /**
+     * A small, deterministic PRNG (mulberry32). Given the same seed it always
+     * produces the same sequence, which keeps this property test reproducible.
+     * @param {number} seed
+     * @return {function(): number} Returns floats in [0, 1).
+     */
+    const mulberry32 = (seed) => {
+      let a = seed >>> 0;
+      return () => {
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    };
+
+    /**
+     * Draws a random integer in [0, maxInclusive] from the given PRNG.
+     * @param {function(): number} rng
+     * @param {number} maxInclusive
+     * @return {number}
+     */
+    const randInt = (rng, maxInclusive) =>
+      Math.floor(rng() * (maxInclusive + 1));
+
+    /**
+     * Draws a random integer in [min, max] (both inclusive) from the PRNG.
+     * @param {function(): number} rng
+     * @param {number} min
+     * @param {number} max
+     * @return {number}
+     */
+    const randIntRange = (rng, min, max) =>
+      min + Math.floor(rng() * (max - min + 1));
+
+    // A small alphabet of printable characters used for the random writes.
+    const alphabet = 'abcXYZ0189';
+
+    /**
+     * Builds a fresh window matching the beforeEach geometry (rowCount rows,
+     * colCount columns) so the "new window" pen-bounds semantics apply.
+     * @return {!shaka.cea.Cea708Window}
+     */
+    const makeWindow = () => {
+      const w = new shaka.cea.Cea708Window(/* windowNum= */ 0, serviceNumber);
+      w.defineWindow(
+          /* visible= */ true, /* verticalAnchor= */ 0, /* horAnchor= */ 0,
+          /* anchorId= */ 0, /* relativeToggle= */ false, rowCount, colCount);
+      w.setStartTime(startTime);
+      return w;
+    };
+
+    it('out-of-bounds writes never change the emitted memory', () => {
+      // A spread of fixed seeds keeps the test deterministic while exercising
+      // many randomly chosen (row, col, char) operation sequences.
+      const seeds = [
+        0x00000001, 0x00c0ffee, 0x0badf00d, 0x00012345,
+        0x00abcdef, 0x9e3779b9, 0x2545f491, 0xdeadbeef,
+      ];
+      const iterationsPerSeed = 30;
+
+      for (const seed of seeds) {
+        const rng = mulberry32(seed);
+        for (let i = 0; i < iterationsPerSeed; i++) {
+          // Generate a sequence of writes. Each location ranges from one past
+          // the negative edge to one past the positive edge, so roughly the
+          // outer values are out of bounds and the rest are valid.
+          const opCount = randIntRange(rng, 1, 20);
+          const ops = [];
+          for (let k = 0; k < opCount; k++) {
+            ops.push({
+              row: randIntRange(rng, -2, rowCount + 1),
+              col: randIntRange(rng, -2, colCount + 1),
+              char: alphabet[randInt(rng, alphabet.length - 1)],
+            });
+          }
+
+          // The "full" window applies every op. Out-of-bounds ops must be
+          // no-ops, so its emitted memory must match the baseline below.
+          const full = makeWindow();
+          for (const op of ops) {
+            full.setPenLocation(op.row, op.col);
+            full.setCharacter(op.char);
+          }
+
+          // The baseline window applies only the in-bounds ops. Because every
+          // op explicitly sets the pen location before writing, dropping the
+          // out-of-bounds ops is equivalent to writing nothing for them.
+          const baseline = makeWindow();
+          for (const op of ops) {
+            const inBounds = op.row >= 0 && op.row < rowCount &&
+                op.col >= 0 && op.col < colCount;
+            if (inBounds) {
+              baseline.setPenLocation(op.row, op.col);
+              baseline.setCharacter(op.char);
+            }
+          }
+
+          // The out-of-bounds writes left the memory unchanged: the full
+          // sequence emits exactly what the in-bounds-only sequence emits.
+          expect(full.forceEmit(endTime, serviceNumber))
+              .toEqual(baseline.forceEmit(endTime, serviceNumber));
+        }
+      }
+    });
+  });
 
   it('correctly handles display(), hide(), and toggle() commands', () => {
     window.display(); // The window should be visible.

--- a/test/cea/cea_baseline_unit.js
+++ b/test/cea/cea_baseline_unit.js
@@ -1,0 +1,193 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression baseline for the CEA decoder.
+ *
+ * Task 1 of the cea-608-708-captions spec asks us to (a) record the current
+ * behavior of the known conformance-gap areas before any fixes land, and
+ * (b) provide deterministic raw-byte test helpers (a CEA-608 byte-pair builder
+ * and a CEA-708 DTVCC service-block builder) for later tasks.
+ *
+ * These tests intentionally assert the CURRENT (pre-fix) behavior so that the
+ * later tasks can flip them as the gaps are closed:
+ *   - CEA-608 Text Mode emits nothing (gap 608-1).
+ *   - CEA-608 Delete-to-End-of-Row (DER) is a no-op (gap 608-2).
+ *   - CEA-708 Delay (0x8d) now consumes its operand byte so the service-block
+ *     byte counter stays aligned (gap 708-3, fixed).
+ * They also exercise the new builders to prove they frame bytes the decoder
+ * accepts.
+ */
+describe('CeaDecoder regression baseline', () => {
+  const CeaUtils = shaka.test.CeaUtils;
+
+  /** @type {!shaka.cea.CeaDecoder} */
+  let decoder;
+
+  beforeEach(() => {
+    decoder = new shaka.cea.CeaDecoder();
+  });
+
+  describe('raw-byte test helpers', () => {
+    it('withOddParity produces odd parity bytes', () => {
+      // 0x00 has zero ones -> parity bit set.
+      expect(CeaUtils.withOddParity(0x00)).toBe(0x80);
+      // 0x01 has one (odd) bit -> parity bit stays clear.
+      expect(CeaUtils.withOddParity(0x01)).toBe(0x01);
+      // 't' = 0x74 has four ones (even) -> parity bit set -> 0xf4.
+      expect(CeaUtils.withOddParity(0x74)).toBe(0xf4);
+      // 'e' = 0x65 has four ones (even) -> parity bit set -> 0xe5.
+      expect(CeaUtils.withOddParity(0x65)).toBe(0xe5);
+    });
+
+    it('cea608Pair frames a field-1 byte pair like the decoder expects', () => {
+      // Field 1 -> cc_type 0 -> cc-info byte 0xfc.
+      const triple = CeaUtils.cea608Pair(1, 0x94, 0x20);
+      expect(triple).toEqual([0xfc, 0x94, 0x20]);
+
+      // Field 2 -> cc_type 1 -> cc-info byte 0xfd.
+      const triple2 = CeaUtils.cea608Pair(2, 0x15, 0x20);
+      expect(triple2).toEqual([0xfd, 0x15, 0x20]);
+    });
+
+    it('buildCea608Sei produces a decodable pop-on caption', () => {
+      // Pop-on "te" on CC1 via the builder, then flush with EOC + EDM.
+      // applyParity lets us pass logical 7-bit codes; the builder applies the
+      // odd-parity bit the decoder requires (e.g. 0x14 -> 0x94).
+      const popon = CeaUtils.buildCea608Sei([
+        {field: 1, b1: 0x14, b2: 0x20, applyParity: true}, // RCL (pop-on).
+        {field: 1, b1: 0x74, b2: 0x65, applyParity: true}, // t, e.
+        {field: 1, b1: 0x14, b2: 0x2f, applyParity: true}, // EOC (flip).
+      ]);
+      const edm = CeaUtils.buildCea608Sei([
+        {field: 1, b1: 0x14, b2: 0x2c, applyParity: true}, // EDM.
+      ]);
+
+      decoder.extract(popon, 1);
+      decoder.extract(edm, 2);
+      const captions = decoder.decode();
+
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('CC1');
+    });
+
+    it('dtvccServiceBlock frames the service header correctly', () => {
+      // Service 1, 3 data bytes -> header (1 << 5) | 3 = 0x23.
+      const block = CeaUtils.dtvccServiceBlock(1, [0x41, 0x42, 0x43]);
+      expect(block).toEqual([0x23, 0x41, 0x42, 0x43]);
+
+      // Service >= 7 uses the extended-header form.
+      const extended = CeaUtils.dtvccServiceBlock(10, [0x41]);
+      expect(extended[0]).toBe((0x07 << 5) | 0x01); // standard header.
+      expect(extended[1]).toBe(0x0a); // extended service number.
+      expect(extended.slice(2)).toEqual([0x41]);
+    });
+
+    it('buildDtvccSei produces a decodable DTVCC caption', () => {
+      // Define a visible window #0 (10x10) and write "test" into service #1.
+      const data = [
+        0x98, 0x38, // DefineWindow #0, visible.
+        0x00, 0x00,
+        0x0a, 0x0a,
+        0x00,
+        0x74, 0x65, 0x73, 0x74, // t, e, s, t (G0 text).
+      ];
+      const packet = CeaUtils.buildDtvccSei([
+        CeaUtils.dtvccServiceBlock(1, data),
+      ]);
+
+      // Hide windows to flush the caption out.
+      const hide = CeaUtils.buildDtvccSei([
+        CeaUtils.dtvccServiceBlock(1, [0x8a, 0xff]),
+      ]);
+
+      decoder.extract(packet, 1);
+      decoder.extract(hide, 2);
+      const captions = decoder.decode();
+
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('svc1');
+    });
+  });
+
+  describe('current gap-area behavior (to be fixed by later tasks)', () => {
+    it('CEA-608 Text Mode emits a cue on Carriage Return (gap 608-1)', () => {
+      // Enter text mode (TR = Text Restart, 0x14 0x2a) and type "te".
+      const textMode = CeaUtils.buildCea608Sei([
+        {field: 1, b1: 0x14, b2: 0x2a, applyParity: true}, // TR -> text mode.
+        {field: 1, b1: 0x74, b2: 0x65, applyParity: true}, // t, e.
+      ]);
+      // A later Carriage Return flushes the buffered text line.
+      const carriageReturn = CeaUtils.buildCea608Sei([
+        {field: 1, b1: 0x14, b2: 0x2d, applyParity: true}, // CR.
+      ]);
+
+      decoder.extract(textMode, 1);
+      decoder.extract(carriageReturn, 2);
+      const captions = decoder.decode();
+
+      // Text mode now emits a cue when a CR follows non-empty text.
+      expect(captions.length).toBe(1);
+    });
+
+    it('CEA-608 DER erases from the cursor to the end of the row (gap 608-2)',
+        () => {
+          // Pop-on "test", then issue DER (0x14 0x24). DER now erases from the
+          // cursor to the end of the active row, clearing the buffered word
+          // before the EOC flip, so no caption is emitted on flush.
+          const popon = CeaUtils.buildCea608Sei([
+            {field: 1, b1: 0x14, b2: 0x20, applyParity: true}, // RCL (pop-on).
+            {field: 1, b1: 0x74, b2: 0x65, applyParity: true}, // t, e.
+            {field: 1, b1: 0x73, b2: 0x74, applyParity: true}, // s, t.
+            {field: 1, b1: 0x14, b2: 0x24, applyParity: true}, // DER.
+            {field: 1, b1: 0x14, b2: 0x2f, applyParity: true}, // EOC (flip).
+          ]);
+          const edm = CeaUtils.buildCea608Sei([
+            {field: 1, b1: 0x14, b2: 0x2c, applyParity: true}, // EDM.
+          ]);
+
+          decoder.extract(popon, 1);
+          decoder.extract(edm, 2);
+          const captions = decoder.decode();
+
+          // DER cleared the row, so the flipped buffer is empty: no caption.
+          expect(captions.length).toBe(0);
+        });
+
+    it('CEA-708 Delay (0x8d) consumes its operand byte (gap 708-3 fixed)',
+        () => {
+          // Define a window, then a Delay (0x8d) whose 1-byte operand is the
+          // printable char 'A' (0x41), then "est". Now that the decoder
+          // consumes the Delay operand, the 'A' is correctly read as the delay
+          // operand (and discarded), so the rendered text is just "est".
+          const data = [
+            0x98, 0x38, // DefineWindow #0, visible -> becomes current window.
+            0x00, 0x00,
+            0x0a, 0x0a,
+            0x00,
+            0x8d, 0x41, // Delay + operand 'A' (operand now consumed).
+            0x65, 0x73, 0x74, // e, s, t.
+          ];
+          const packet = CeaUtils.buildDtvccSei([
+            CeaUtils.dtvccServiceBlock(1, data),
+          ]);
+          const hide = CeaUtils.buildDtvccSei([
+            CeaUtils.dtvccServiceBlock(1, [0x8a, 0xff]),
+          ]);
+
+          decoder.extract(packet, 1);
+          decoder.extract(hide, 2);
+          const captions = decoder.decode();
+
+          expect(captions.length).toBe(1);
+          expect(captions[0].stream).toBe('svc1');
+          const text = captions[0].cue.nestedCues
+              .map((c) => c.payload).join('');
+          // Corrected behavior: the operand is consumed, so it no longer leaks.
+          expect(text).toBe('est');
+        });
+  });
+});

--- a/test/cea/cea_decoder_unit.js
+++ b/test/cea/cea_decoder_unit.js
@@ -28,8 +28,10 @@ describe('CeaDecoder', () => {
   describe('decodes CEA-608', () => {
     const edmCodeByte2 = 0x2c; // Erase displayed memory byte 2.
 
-    // Blank padding control code between two control codes that are the same.
-    const blankPaddingControlCode = new Uint8Array([0x97, 0x23]);
+    // A harmless no-op control pair (AON, "alarm on") used as padding between
+    // two control codes that are the same, to break duplicate-suppression
+    // without affecting caption content or position.
+    const blankPaddingControlCode = new Uint8Array([0x94, 0x23]);
 
     // Erases displayed memory on every captioning mode.
     const eraseDisplayedMemory = new Uint8Array([
@@ -218,6 +220,110 @@ describe('CeaDecoder', () => {
       }];
 
       decoder.extract(midrowStyleChangeCC2Packet, startTimeCaption1);
+      decoder.extract(eraseDisplayedMemory, startTimeCaption2);
+      const captions = decoder.decode();
+
+      expect(captions).toEqual(expectedCaptions);
+    });
+
+    // Locks the PAC styling semantics: a PAC sets the row
+    // and the base style (color/italics/underline) AND resets the background
+    // color to default. A yellow background is set first, then a PAC arrives;
+    // the subsequently written characters must render with the PAC's base style
+    // (green, underlined) on the default (reset) background, not yellow.
+    it('PAC resets background and sets base style on CC3', () => {
+      const controlCount = 0x06;
+      const captionData = 0xc0 | controlCount;
+      const pacResetsBgCC3Packet = new Uint8Array([
+        ...atscCaptionInitBytes, captionData, /* padding= */ 0xff,
+        0xfd, 0x15, 0x20, // Pop-on mode (RCL control code).
+        0xfd, 0x90, 0x2a, // Background attribute yellow (set before the PAC).
+        0xfd, 0x13, 0xe3, // PAC: underline + green on last row.
+        0xfd, 0xf4, 0xe5, // t, e
+        0xfd, 0x73, 0xf4, // s, t
+        0xfd, 0x15, 0x2f, // EOC
+      ]);
+
+      const startTimeCaption1 = 1;
+      const startTimeCaption2 = 2;
+      const expectedText = 'test';
+
+      // A single nested cue: green + underlined text on the DEFAULT background,
+      // proving the PAC reset the previously-set yellow background.
+      const topLevelCue = new shaka.text.Cue(
+          startTimeCaption1, startTimeCaption2, '');
+      topLevelCue.line = 74;
+      topLevelCue.lineInterpretation =
+          shaka.text.Cue.lineInterpretation.PERCENTAGE;
+      topLevelCue.nestedCues = [
+        CeaUtils.createStyledCue(
+            startTimeCaption1, startTimeCaption2, expectedText,
+            /* underline= */ true, /* italics= */ false,
+            /* textColor= */ 'green', /* backgroundColor= */ DEFAULT_BG_COLOR),
+      ];
+
+      const expectedCaptions = [{
+        stream: 'CC3',
+        cue: topLevelCue,
+      }];
+
+      decoder.extract(pacResetsBgCC3Packet, startTimeCaption1);
+      decoder.extract(eraseDisplayedMemory, startTimeCaption2);
+      const captions = decoder.decode();
+
+      expect(captions).toEqual(expectedCaptions);
+    });
+
+    // Locks the mid-row styling semantics: a mid-row code
+    // inserts a single spacing character and changes foreground color, italics,
+    // and underline from that point onward, WITHOUT resetting the background.
+    // Here a yellow background is set, "ab" is written, then a red + underline
+    // mid-row code is received followed by "cd". The mid-row space joins the
+    // leading default-color run, "cd" picks up red + underline, and the yellow
+    // background carries across the mid-row change unchanged.
+    it('mid-row inserts space and changes fg/style, keeping bg on CC2', () => {
+      const controlCount = 0x06;
+      const captionData = 0xc0 | controlCount;
+      const midrowKeepsBgCC2Packet = new Uint8Array([
+        ...atscCaptionInitBytes, captionData, /* padding= */ 0xff,
+        0xfc, 0x1c, 0x20, // Pop-on mode (RCL control code).
+        0xfc, 0x98, 0x2a, // Background attribute yellow.
+        0xfc, 0x61, 0x62, // a, b
+        0xfc, 0x19, 0x29, // Red + underline mid-row style control code.
+        0xfc, 0xe3, 0x64, // c, d
+        0xfc, 0x1c, 0x2f, // EOC
+      ]);
+
+      const startTimeCaption1 = 1;
+      const startTimeCaption2 = 2;
+
+      // "ab" plus the mid-row spacing character keep the default foreground on
+      // the yellow background; "cd" turns red + underlined on the same yellow
+      // background (mid-row does not reset the background).
+      const topLevelCue = new shaka.text.Cue(
+          startTimeCaption1, startTimeCaption2, '');
+      topLevelCue.line = 10;
+      topLevelCue.lineInterpretation =
+          shaka.text.Cue.lineInterpretation.PERCENTAGE;
+      topLevelCue.nestedCues = [
+        CeaUtils.createStyledCue(
+            startTimeCaption1, startTimeCaption2, 'ab ',
+            /* underline= */ false, /* italics= */ false,
+            /* textColor= */ shaka.cea.CeaUtils.DEFAULT_TXT_COLOR,
+            /* backgroundColor= */ 'yellow'),
+
+        CeaUtils.createStyledCue(
+            startTimeCaption1, startTimeCaption2, 'cd',
+            /* underline= */ true, /* italics= */ false,
+            /* textColor= */ 'red', /* backgroundColor= */ 'yellow'),
+      ];
+
+      const expectedCaptions = [{
+        stream: 'CC2',
+        cue: topLevelCue,
+      }];
+
+      decoder.extract(midrowKeepsBgCC2Packet, startTimeCaption1);
       decoder.extract(eraseDisplayedMemory, startTimeCaption2);
       const captions = decoder.decode();
 
@@ -455,13 +561,13 @@ describe('CeaDecoder', () => {
           ...atscCaptionInitBytes, 0xc0 | controlCount1, /* padding= */ 0xff,
           0xfc, 0x94, 0x25, // Roll-up 2 rows control code.
           0xfc, ...carriageReturnControlCode,
-          0xfc, 0x97, 0x23, // Blank padding control code
+          0xfc, 0x94, 0x23, // No-op padding control code (AON).
         ]),
         new Uint8Array([
           ...atscCaptionInitBytes, 0xc0 | controlCount1, /* padding= */ 0xff,
           0xfc, 0x31, 0xae, // 1, .
           0xfc, ...carriageReturnControlCode,
-          0xfc, 0x97, 0x23, // Blank padding control code
+          0xfc, 0x94, 0x23, // No-op padding control code (AON).
         ]),
         new Uint8Array([
           ...atscCaptionInitBytes, 0xc0 | controlCount2, /* padding= */ 0xff,
@@ -525,7 +631,7 @@ describe('CeaDecoder', () => {
       expect(captions).toEqual(expectedCaptions);
     });
 
-    it('does not emit text sent while in CEA-608 Text Mode', () => {
+    it('emits text sent while in CEA-608 Text Mode', () => {
       const controlCount = 0x03;
       const captionData = 0xc0 | controlCount;
       const textModePacket = new Uint8Array([
@@ -535,14 +641,57 @@ describe('CeaDecoder', () => {
         0xfc, 0x73, 0xf4, // s, t
       ]);
 
+      // A later packet issues a Carriage Return to flush the text line.
+      const carriageReturnPacket = new Uint8Array([
+        ...atscCaptionInitBytes, 0xc1, /* padding= */ 0xff,
+        0xfc, 0x94, 0xad, // Carriage return on CC1.
+      ]);
+
       const startTimeCaption1 = 1;
       const startTimeCaption2 = 2;
 
       decoder.extract(textModePacket, startTimeCaption1);
-      decoder.extract(eraseDisplayedMemory, startTimeCaption2);
+      decoder.extract(carriageReturnPacket, startTimeCaption2);
 
       const captions = decoder.decode();
-      expect(captions).toEqual([]);
+      // Text mode now emits a cue when a CR follows non-empty text.
+      expect(captions.length).toBe(1);
+      // The text-mode caption is surfaced on the text channel (T1), not the
+      // captioning channel (CC1).
+      expect(captions[0].stream).toBe('T1');
+      // getStreams() reports the text-mode stream once text-mode cues are
+      // produced.
+      expect(decoder.getStreams()).toContain('T1');
+    });
+
+    it('surfaces text-mode cues on the matching text channel (T2)', () => {
+      const controlCount = 0x03;
+      const captionData = 0xc0 | controlCount;
+      // CC2 is field 1, channel 1 (control byte 1 = 0x1c), so its text mode
+      // emits on T2.
+      const textModePacket = new Uint8Array([
+        ...atscCaptionInitBytes, captionData, /* padding= */ 0xff,
+        0xfc, 0x1c, 0x2a, // Text mode (Text restart control code) on CC2.
+        0xfc, 0xf4, 0xe5, // t, e
+        0xfc, 0x73, 0xf4, // s, t
+      ]);
+
+      // A later packet issues a Carriage Return to flush the text line.
+      const carriageReturnPacket = new Uint8Array([
+        ...atscCaptionInitBytes, 0xc1, /* padding= */ 0xff,
+        0xfc, 0x1c, 0xad, // Carriage return on CC2.
+      ]);
+
+      decoder.extract(textModePacket, /* pts= */ 1);
+      decoder.extract(carriageReturnPacket, /* pts= */ 2);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      // The text-channel number tracks the field/channel (CC2 -> T2).
+      expect(captions[0].stream).toBe('T2');
+      expect(decoder.getStreams()).toContain('T2');
+      // The captioning stream (CC2) is never emitted as a text cue.
+      expect(captions[0].stream).not.toBe('CC2');
     });
 
     it('resets the decoder on >=45 consecutive bad frames', () => {
@@ -578,6 +727,1101 @@ describe('CeaDecoder', () => {
       const captions = decoder.decode();
       expect(captions.length).toBe(0);
     });
+  });
+
+  describe('CEA-608 stream robustness', () => {
+    // Raw CEA-608 control bytes (parity is applied by the test helper).
+    const RCL = {b1: 0x14, b2: 0x20}; // Resume Caption Loading (pop-on).
+    const EOC = {b1: 0x14, b2: 0x2f}; // End Of Caption (flip memories).
+    const EDM = {b1: 0x14, b2: 0x2c}; // Erase Displayed Memory.
+
+    beforeEach(() => {
+      decoder.clear();
+    });
+
+    /**
+     * Builds a field-1 CEA-608 pair descriptor for buildCea608Sei, applying
+     * odd parity unless told otherwise.
+     * @param {number} b1
+     * @param {number} b2
+     * @param {boolean=} applyParity
+     * @return {{field: number, b1: number, b2: number, applyParity: boolean}}
+     */
+    function pair(b1, b2, applyParity = true) {
+      return {field: 1, b1, b2, applyParity};
+    }
+
+    /**
+     * Decodes a CC1 pop-on caption that renders "test", optionally inserting
+     * extra byte pairs between the "te" and "st" character pairs. The inserted
+     * pairs let us prove that ignored data (XDS, even-parity frames) does not
+     * alter the resulting caption.
+     * @param {!Array<{field: number, b1: number, b2: number,
+     *   applyParity: boolean}>} insertedPairs
+     * @return {!Array<!shaka.extern.ICaptionDecoder.ClosedCaption>}
+     */
+    function decodePopon(insertedPairs) {
+      decoder.clear();
+      const pairs = [
+        pair(RCL.b1, RCL.b2), // Pop-on mode.
+        pair(0x74, 0x65), // t, e
+        ...insertedPairs,
+        pair(0x73, 0x74), // s, t
+        pair(EOC.b1, EOC.b2), // EOC flips "test" into displayed memory.
+      ];
+      decoder.extract(CeaUtils.buildCea608Sei(pairs), /* pts= */ 1);
+      // A later EDM forces the displayed memory out as a cue.
+      decoder.extract(
+          CeaUtils.buildCea608Sei([pair(EDM.b1, EDM.b2)]), /* pts= */ 2);
+      return decoder.decode();
+    }
+
+    /**
+     * Extracts `count` consecutive bad (even-parity) frames on field 1,
+     * chunked across SEI messages since cc_count is only 5 bits wide.
+     * @param {number} count
+     * @param {number} startPts
+     */
+    function extractBadFrames(count, startPts) {
+      let remaining = count;
+      let pts = startPts;
+      while (remaining > 0) {
+        const chunk = Math.min(remaining, 31);
+        const pairs = [];
+        for (let i = 0; i < chunk; i++) {
+          // 0x03 has even parity, so the pair is rejected as a bad frame.
+          pairs.push({field: 1, b1: 0x03, b2: 0x03, applyParity: false});
+        }
+        decoder.extract(CeaUtils.buildCea608Sei(pairs), pts++);
+        remaining -= chunk;
+      }
+    }
+
+    // the decoder must strip the odd-parity bit before interpreting
+    // bytes. The helper sets parity bits on every byte; correct text proves
+    // the bit is removed (otherwise 0xf4 etc. would map to other glyphs).
+    it('strips the parity bit before interpreting byte pairs', () => {
+      const captions = decodePopon([]);
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('CC1');
+      const text = captions[0].cue.nestedCues.map((c) => c.payload).join('');
+      expect(text).toBe('test');
+    });
+
+    // a pair where either byte has even parity yields no cue.
+    const evenParityCases = [
+      {name: 'both bytes have even parity', b1: 0x00, b2: 0x00},
+      {name: 'only the first byte has even parity',
+        b1: 0x03, b2: CeaUtils.withOddParity(0x41)},
+      {name: 'only the second byte has even parity',
+        b1: CeaUtils.withOddParity(0x41), b2: 0x03},
+      {name: 'both bytes are 0xff', b1: 0xff, b2: 0xff},
+    ];
+    for (const testCase of evenParityCases) {
+      it(`produces no cue when ${testCase.name}`, () => {
+        const sei = CeaUtils.buildCea608Sei(
+            [{field: 1, b1: testCase.b1, b2: testCase.b2, applyParity: false}]);
+        decoder.extract(sei, /* pts= */ 1);
+        const captions = decoder.decode();
+        expect(captions).toEqual([]);
+      });
+    }
+
+    // an even-parity pair injected mid-caption is ignored entirely
+    // (it neither emits a cue nor corrupts the surrounding buffer).
+    it('ignores an even-parity pair inserted mid-caption', () => {
+      const baseline = decodePopon([]);
+      const withBadFrame = decodePopon(
+          [{field: 1, b1: 0x03, b2: 0x03, applyParity: false}]);
+      expect(baseline.length).toBe(1);
+      expect(withBadFrame).toEqual(baseline);
+    });
+
+    // the reset boundary is exactly 45 consecutive bad frames.
+    it('does not reset before 45 consecutive bad frames', () => {
+      extractBadFrames(/* count= */ 44, /* startPts= */ 1);
+      spyOn(decoder, 'reset').and.callThrough();
+      decoder.decode();
+      expect(decoder.reset).not.toHaveBeenCalled();
+    });
+
+    it('resets exactly at the 45th consecutive bad frame', () => {
+      extractBadFrames(/* count= */ 45, /* startPts= */ 1);
+      spyOn(decoder, 'reset').and.callThrough();
+      decoder.decode();
+      expect(decoder.reset).toHaveBeenCalledTimes(1);
+    });
+
+    // a valid frame clears the bad-frame counter, so bad frames
+    // on either side of it never sum past the reset threshold.
+    it('clears the bad-frame counter after a valid frame', () => {
+      extractBadFrames(/* count= */ 44, /* startPts= */ 1);
+      // A valid RCL control pair resets the counter to zero.
+      decoder.extract(
+          CeaUtils.buildCea608Sei([pair(RCL.b1, RCL.b2)]), /* pts= */ 45);
+      extractBadFrames(/* count= */ 44, /* startPts= */ 46);
+      spyOn(decoder, 'reset').and.callThrough();
+      decoder.decode();
+      expect(decoder.reset).not.toHaveBeenCalled();
+    });
+
+    // XDS control codes (b1 in [0x01, 0x0F]) are ignored and leave
+    // the displayed/non-displayed buffers unchanged.
+    it('ignores XDS control codes without altering caption buffers', () => {
+      const baseline = decodePopon([]);
+      const withXds = decodePopon([
+        pair(0x01, 0x01), // XDS control code (lowest range).
+        pair(0x0f, 0x0f), // XDS control code (highest range).
+      ]);
+      expect(baseline.length).toBe(1);
+      expect(withXds).toEqual(baseline);
+    });
+
+    // a stream made up solely of XDS pairs emits nothing.
+    it('emits no cue for a stream of only XDS control codes', () => {
+      const sei = CeaUtils.buildCea608Sei([
+        pair(0x01, 0x20),
+        pair(0x05, 0x40),
+        pair(0x0f, 0x0f),
+      ]);
+      decoder.extract(sei, /* pts= */ 1);
+      const captions = decoder.decode();
+      expect(captions).toEqual([]);
+    });
+  });
+
+  describe('CEA-608 stream robustness (seeded-random properties)', () => {
+    // Raw CEA-608 control bytes (parity applied by the test helper).
+    const RCL = {b1: 0x14, b2: 0x20}; // Resume Caption Loading (pop-on).
+    const EOC = {b1: 0x14, b2: 0x2f}; // End Of Caption (flip memories).
+    const EDM = {b1: 0x14, b2: 0x2c}; // Erase Displayed Memory.
+
+    /** A spread of fixed seeds so the suite covers many random inputs. */
+    const SEEDS = [1, 2, 3, 7, 13, 42, 101, 1337, 65535, 0xc0ffee];
+
+    /**
+     * Deterministic 32-bit PRNG (mulberry32). Returns a function producing
+     * floats in [0, 1). Seeding makes every generated case reproducible.
+     * @param {number} seed
+     * @return {function(): number}
+     */
+    function makeRng(seed) {
+      let a = seed >>> 0;
+      return () => {
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    /**
+     * @param {function(): number} rng
+     * @param {number} min
+     * @param {number} max Inclusive.
+     * @return {number}
+     */
+    function randInt(rng, min, max) {
+      return min + Math.floor(rng() * (max - min + 1));
+    }
+
+    /**
+     * Forces even parity on a 7-bit payload: sets the parity bit (bit 7) only
+     * when the payload already has an odd number of ones, so the resulting
+     * 8-bit byte always has an even number of ones. The decoder requires odd
+     * parity, so such a byte is always rejected as a bad frame. This is the
+     * inverse of shaka.test.CeaUtils.withOddParity.
+     * @param {number} byte
+     * @return {number}
+     */
+    function withEvenParity(byte) {
+      let b = byte & 0x7f;
+      let ones = 0;
+      for (let i = 0; i < 7; i++) {
+        ones += (b >> i) & 0x01;
+      }
+      if ((ones & 0x01) === 0x01) {
+        b |= 0x80;
+      }
+      return b;
+    }
+
+    /**
+     * Builds a field-1 pair descriptor whose first byte has even parity, so the
+     * pair is guaranteed to be rejected as a bad frame (). Bytes are
+     * pre-parity, so applyParity is false.
+     * @param {function(): number} rng
+     * @return {{field: number, b1: number, b2: number, applyParity: boolean}}
+     */
+    function randomBadPair(rng) {
+      return {
+        field: 1,
+        b1: withEvenParity(randInt(rng, 0x00, 0x7f)),
+        b2: randInt(rng, 0x00, 0xff),
+        applyParity: false,
+      };
+    }
+
+    /**
+     * Extracts a list of pairs as bad frames, chunked across SEI messages
+     * because cc_count is only 5 bits wide (max 31 triples per message).
+     * @param {!shaka.cea.CeaDecoder} dec
+     * @param {!Array<{field: number, b1: number, b2: number,
+     *   applyParity: boolean}>} pairs
+     * @param {number} startPts
+     */
+    function extractChunked(dec, pairs, startPts) {
+      let pts = startPts;
+      for (let i = 0; i < pairs.length; i += 31) {
+        const chunk = pairs.slice(i, i + 31);
+        dec.extract(CeaUtils.buildCea608Sei(chunk), pts++);
+      }
+    }
+
+    /**
+     * Field-1 pair with odd parity applied by the builder.
+     * @param {number} b1
+     * @param {number} b2
+     * @return {{field: number, b1: number, b2: number, applyParity: boolean}}
+     */
+    function oddPair(b1, b2) {
+      return {field: 1, b1, b2, applyParity: true};
+    }
+
+    // any byte pair where a byte has even parity yields no cue and
+    // increments the bad-frame counter. We prove the increment behaviorally:
+    // K bad frames followed by (45 - K) more bad frames must trigger exactly
+    // one reset, which only happens once the counter reaches 45.
+    for (const seed of SEEDS) {
+      it(`rejects even-parity pairs and counts them (seed ${seed})`, () => {
+        const rng = makeRng(seed);
+        const dec = new shaka.cea.CeaDecoder();
+        const k = randInt(rng, 1, 44);
+
+        const firstBatch = [];
+        for (let i = 0; i < k; i++) {
+          firstBatch.push(randomBadPair(rng));
+        }
+        const secondBatch = [];
+        for (let i = 0; i < 45 - k; i++) {
+          secondBatch.push(randomBadPair(rng));
+        }
+
+        spyOn(dec, 'reset').and.callThrough();
+
+        // First K (< 45) bad frames: no cue, and not yet enough to reset.
+        extractChunked(dec, firstBatch, /* startPts= */ 1);
+        expect(dec.decode()).toEqual([]);
+        expect(dec.reset).not.toHaveBeenCalled();
+
+        // The remaining frames bring the running total to exactly 45, which
+        // can only happen if every bad frame incremented the counter by one.
+        extractChunked(dec, secondBatch, /* startPts= */ 100);
+        expect(dec.decode()).toEqual([]);
+        expect(dec.reset).toHaveBeenCalledTimes(1);
+      });
+    }
+
+    // injecting XDS control codes (b1 in [0x01, 0x0F]) into a
+    // caption stream leaves the decoded output identical to the same stream
+    // with the XDS pairs removed.
+    for (const seed of SEEDS) {
+      it(`isolates injected XDS pairs from caption output (seed ${seed})`,
+          () => {
+            const rng = makeRng(seed);
+
+            // Build a random run of basic North American characters (A-Z) so
+            // the caption renders deterministically. Each pair carries two
+            // letters.
+            const charCount = randInt(rng, 1, 8);
+            const charPairs = [];
+            for (let i = 0; i < charCount; i++) {
+              const c1 = randInt(rng, 0x41, 0x5a); // 'A'..'Z'
+              const c2 = randInt(rng, 0x41, 0x5a); // 'A'..'Z'
+              charPairs.push(oddPair(c1, c2));
+            }
+
+            // Random XDS pairs to inject. b1 in [0x01, 0x0F] is the XDS range;
+            // both bytes get odd parity so the pair reaches the XDS branch
+            // (rather than being dropped earlier as a bad frame).
+            const xdsCount = randInt(rng, 1, 6);
+            const xdsPairs = [];
+            for (let i = 0; i < xdsCount; i++) {
+              const b1 = randInt(rng, 0x01, 0x0f);
+              const b2 = randInt(rng, 0x20, 0x7f);
+              xdsPairs.push(oddPair(b1, b2));
+            }
+
+            // Interleave the XDS pairs into the character run at random spots.
+            const mixed = charPairs.slice();
+            for (const xds of xdsPairs) {
+              const pos = randInt(rng, 0, mixed.length);
+              mixed.splice(pos, 0, xds);
+            }
+
+            const rcl = oddPair(RCL.b1, RCL.b2);
+            const eoc = oddPair(EOC.b1, EOC.b2);
+            const baselinePairs = [rcl, ...charPairs, eoc];
+            const xdsInjectedPairs = [rcl, ...mixed, eoc];
+
+            const baseline = decodeCaption(baselinePairs);
+            const withXds = decodeCaption(xdsInjectedPairs);
+
+            // The caption must actually be emitted, and XDS must not alter it.
+            expect(baseline.length).toBe(1);
+            expect(baseline[0].stream).toBe('CC1');
+            expect(withXds).toEqual(baseline);
+          });
+    }
+
+    /**
+     * Decodes a pop-on caption on a fresh decoder: extracts the supplied pairs
+     * at pts 1, then an EDM at pts 2 to flush displayed memory into a cue.
+     * @param {!Array<{field: number, b1: number, b2: number,
+     *   applyParity: boolean}>} pairs
+     * @return {!Array<!shaka.extern.ICaptionDecoder.ClosedCaption>}
+     */
+    function decodeCaption(pairs) {
+      const dec = new shaka.cea.CeaDecoder();
+      dec.extract(CeaUtils.buildCea608Sei(pairs), /* pts= */ 1);
+      dec.extract(
+          CeaUtils.buildCea608Sei([oddPair(EDM.b1, EDM.b2)]), /* pts= */ 2);
+      return dec.decode();
+    }
+  });
+
+  describe('CEA-608 duplicate control-code suppression', () => {
+    // FCC practice transmits control codes twice; an identical control pair in
+    // the immediately following frame must be applied exactly once.
+    // BackSpace (BS) is used as the probe because its effect -- erasing one
+    // displayed character -- is directly observable in the emitted cue text.
+
+    // Raw CEA-608 control bytes (parity applied by the test helper).
+    const RCL = {b1: 0x14, b2: 0x20}; // Resume Caption Loading (pop-on).
+    const EOC = {b1: 0x14, b2: 0x2f}; // End Of Caption (flip memories).
+    const EDM = {b1: 0x14, b2: 0x2c}; // Erase Displayed Memory.
+    const BS = {b1: 0x14, b2: 0x21}; // BackSpace (erases the last character).
+    const PAD = {b1: 0x14, b2: 0x23}; // Harmless filler control pair (AON).
+
+    beforeEach(() => {
+      decoder.clear();
+    });
+
+    /**
+     * Field-1 pair descriptor for buildCea608Sei with odd parity applied.
+     * @param {number} b1
+     * @param {number} b2
+     * @return {{field: number, b1: number, b2: number, applyParity: boolean}}
+     */
+    function pair(b1, b2) {
+      return {field: 1, b1, b2, applyParity: true};
+    }
+
+    /**
+     * Pops on the word "test", runs the supplied control/character pairs,
+     * flips the caption out with EOC, and flushes it to a cue with EDM. The
+     * returned text is the concatenation of the emitted nested-cue payloads.
+     * @param {!Array<{field: number, b1: number, b2: number,
+     *   applyParity: boolean}>} insertedPairs
+     * @return {string}
+     */
+    function decodePoponText(insertedPairs) {
+      const pairs = [
+        pair(RCL.b1, RCL.b2), // Pop-on mode.
+        pair(0x74, 0x65), // t, e
+        pair(0x73, 0x74), // s, t
+        ...insertedPairs,
+        pair(EOC.b1, EOC.b2), // Flip "test" (minus any erases) into display.
+      ];
+      decoder.extract(CeaUtils.buildCea608Sei(pairs), /* pts= */ 1);
+      decoder.extract(
+          CeaUtils.buildCea608Sei([pair(EDM.b1, EDM.b2)]), /* pts= */ 2);
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('CC1');
+      return captions[0].cue.nestedCues.map((c) => c.payload).join('');
+    }
+
+    // Baseline: a single BS erases exactly one character ("test" -> "tes").
+    // This anchors what "applied once" looks like for the duplicate cases.
+    it('applies a single control pair once', () => {
+      expect(decodePoponText([pair(BS.b1, BS.b2)])).toBe('tes');
+    });
+
+    // an identical control pair in two immediately consecutive frames
+    // is applied exactly once, so only one character is erased ("test" ->
+    // "tes"), matching the single-BS baseline rather than erasing two.
+    it('applies a duplicated control pair in consecutive frames once', () => {
+      expect(decodePoponText([
+        pair(BS.b1, BS.b2), // BS.
+        pair(BS.b1, BS.b2), // Duplicate BS in the very next frame -> ignored.
+      ])).toBe('tes');
+    });
+
+    // Suppression is limited to the immediately following frame and a single
+    // match: once an intervening (non-duplicate) control pair is seen, a
+    // repeated BS counts again, erasing a second character ("test" -> "te").
+    it('does not suppress a repeat separated by another control pair', () => {
+      expect(decodePoponText([
+        pair(BS.b1, BS.b2), // First BS erases "t".
+        pair(PAD.b1, PAD.b2), // Intervening control pair clears the match.
+        pair(BS.b1, BS.b2), // Second BS now applies, erasing "s".
+      ])).toBe('te');
+    });
+
+    // Only one duplicate is swallowed: a control pair sent three times in a
+    // row applies twice (first + third), since suppression resets after the
+    // single ignored frame ("test" -> "te").
+    it('suppresses only one duplicate in a run of three', () => {
+      expect(decodePoponText([
+        pair(BS.b1, BS.b2), // Applies (erases "t").
+        pair(BS.b1, BS.b2), // Duplicate -> ignored.
+        pair(BS.b1, BS.b2), // Match cleared, applies again (erases "s").
+      ])).toBe('te');
+    });
+  });
+
+  describe('CEA-608 text mode', () => {
+    // 2.7). Text mode is entered via RTD or TR; typed characters accumulate in
+    // a dedicated text buffer and are emitted (like roll-up) on Carriage
+    // Return, surfaced on the text-channel streams (T1-T4). Raw control bytes
+    // are listed here; the test helper applies odd parity.
+    const RTD = {b1: 0x14, b2: 0x2b}; // Resume Text Display (enter text mode).
+    const TR = {b1: 0x14, b2: 0x2a}; // Text Restart (clear buffer + enter).
+    const CR = {b1: 0x14, b2: 0x2d}; // Carriage Return (emit + scroll).
+    const EDM = {b1: 0x14, b2: 0x2c}; // Erase Displayed Memory.
+    const RCL = {b1: 0x14, b2: 0x20}; // Resume Caption Loading (pop-on).
+    const EOC = {b1: 0x14, b2: 0x2f}; // End Of Caption (flip memories).
+    const RU2 = {b1: 0x14, b2: 0x25}; // Roll-Up, 2 rows.
+
+    beforeEach(() => {
+      decoder.clear();
+    });
+
+    /**
+     * Builds a CEA-608 pair descriptor for buildCea608Sei with odd parity
+     * applied. The channel bit lives in b1, so callers pass the raw control
+     * bytes (e.g. 0x1c selects channel 2). Field defaults to 1 (CC1/CC2).
+     * @param {number} b1
+     * @param {number} b2
+     * @param {number=} field
+     * @return {{field: number, b1: number, b2: number, applyParity: boolean}}
+     */
+    function pair(b1, b2, field = 1) {
+      return {field, b1, b2, applyParity: true};
+    }
+
+    /**
+     * Concatenates the nested-cue payloads of an emitted caption into a string.
+     * @param {!shaka.extern.ICaptionDecoder.ClosedCaption} caption
+     * @return {string}
+     */
+    function textOf(caption) {
+      return caption.cue.nestedCues.map((c) => c.payload).join('');
+    }
+
+    // entering text mode via RTD, typing, then a CR emits a
+    // single cue on the matching text-mode stream (CC1 -> T1), and the stream
+    // is discoverable via getStreams().
+    it('enters text mode via RTD and emits a cue on T1 at CR', () => {
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(RTD.b1, RTD.b2), // Enter text mode.
+        pair(0x74, 0x65), // t, e
+        pair(0x73, 0x74), // s, t
+      ]), /* pts= */ 1);
+      // CR must arrive at a later pts so that startTime < endTime.
+      decoder.extract(
+          CeaUtils.buildCea608Sei([pair(CR.b1, CR.b2)]), /* pts= */ 2);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('T1');
+      expect(textOf(captions[0])).toBe('test');
+      expect(captions[0].cue.startTime).toBe(1);
+      expect(captions[0].cue.endTime).toBe(2);
+      expect(decoder.getStreams()).toContain('T1');
+    });
+
+    // entering text mode via TR behaves the same as RTD for a
+    // fresh buffer -- typing then CR emits the text on T1.
+    it('enters text mode via TR and emits a cue on T1 at CR', () => {
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(TR.b1, TR.b2), // Text Restart -> clears (already empty) + enter.
+        pair(0x74, 0x65), // t, e
+        pair(0x73, 0x74), // s, t
+      ]), /* pts= */ 1);
+      decoder.extract(
+          CeaUtils.buildCea608Sei([pair(CR.b1, CR.b2)]), /* pts= */ 2);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('T1');
+      expect(textOf(captions[0])).toBe('test');
+      expect(decoder.getStreams()).toContain('T1');
+    });
+
+    // the text-channel number tracks the field/channel of the control
+    // code. b1 = 0x1c selects channel 2 (CC2), so its text mode emits on T2.
+    it('surfaces a channel-2 text-mode caption on T2', () => {
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(0x1c, RTD.b2), // Enter text mode on channel 2.
+        pair(0x74, 0x65), // t, e
+        pair(0x73, 0x74), // s, t
+      ]), /* pts= */ 1);
+      decoder.extract(
+          CeaUtils.buildCea608Sei([pair(0x1c, CR.b2)]), /* pts= */ 2);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('T2');
+      expect(textOf(captions[0])).toBe('test');
+      expect(decoder.getStreams()).toContain('T2');
+    });
+
+    // field 2 (cc_type 1) with b1 = 0x15 selects CC3, so its text mode
+    // emits on T3.
+    it('surfaces a field-2 text-mode caption on T3', () => {
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(0x15, RTD.b2, /* field= */ 2), // Enter text mode on CC3.
+        pair(0x74, 0x65, /* field= */ 2), // t, e
+        pair(0x73, 0x74, /* field= */ 2), // s, t
+      ]), /* pts= */ 1);
+      decoder.extract(CeaUtils.buildCea608Sei(
+          [pair(0x15, CR.b2, /* field= */ 2)]), /* pts= */ 2);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('T3');
+      expect(textOf(captions[0])).toBe('test');
+      expect(decoder.getStreams()).toContain('T3');
+    });
+
+    // a Text Restart clears the text buffer. Text typed before the TR
+    // ("AB") must not appear in the cue emitted after it; only the text typed
+    // afterward ("CD") survives.
+    it('clears the text buffer on TR', () => {
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(RTD.b1, RTD.b2), // Enter text mode.
+        pair(0x41, 0x42), // A, B (typed before the restart).
+      ]), /* pts= */ 1);
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(TR.b1, TR.b2), // Text Restart clears the buffer ("AB" is dropped).
+        pair(0x43, 0x44), // C, D (typed after the restart).
+      ]), /* pts= */ 2);
+      decoder.extract(
+          CeaUtils.buildCea608Sei([pair(CR.b1, CR.b2)]), /* pts= */ 3);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('T1');
+      // Only the post-restart text survives; "AB" was cleared by TR.
+      expect(textOf(captions[0])).toBe('CD');
+    });
+
+    // Erase Displayed Memory does NOT clear the text buffer while text
+    // mode is active. The text typed before EDM survives and is emitted by the
+    // subsequent CR.
+    it('does not clear the text buffer on EDM while in text mode', () => {
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(RTD.b1, RTD.b2), // Enter text mode.
+        pair(0x74, 0x65), // t, e
+        pair(0x73, 0x74), // s, t
+        pair(EDM.b1, EDM.b2), // EDM must not touch the text buffer.
+      ]), /* pts= */ 1);
+      decoder.extract(
+          CeaUtils.buildCea608Sei([pair(CR.b1, CR.b2)]), /* pts= */ 2);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('T1');
+      // The text survived the EDM.
+      expect(textOf(captions[0])).toBe('test');
+    });
+
+    // pop-on captioning is unaffected by the text-mode changes -- it
+    // still emits on the captioning stream (CC1), never a text stream.
+    it('leaves pop-on captioning emitting on CC1', () => {
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(RCL.b1, RCL.b2), // Pop-on mode.
+        pair(0x74, 0x65), // t, e
+        pair(0x73, 0x74), // s, t
+        pair(EOC.b1, EOC.b2), // Flip "test" into displayed memory.
+      ]), /* pts= */ 1);
+      decoder.extract(
+          CeaUtils.buildCea608Sei([pair(EDM.b1, EDM.b2)]), /* pts= */ 2);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('CC1');
+      expect(textOf(captions[0])).toBe('test');
+    });
+
+    // roll-up captioning is unaffected by the text-mode changes -- it
+    // still emits on the captioning stream (CC1), never a text stream.
+    it('leaves roll-up captioning emitting on CC1', () => {
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(RU2.b1, RU2.b2), // Roll-up, 2 rows.
+        pair(0x74, 0x65), // t, e
+        pair(0x73, 0x74), // s, t
+      ]), /* pts= */ 1);
+      decoder.extract(
+          CeaUtils.buildCea608Sei([pair(CR.b1, CR.b2)]), /* pts= */ 2);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('CC1');
+      expect(textOf(captions[0])).toBe('test');
+    });
+  });
+
+  describe('CEA-608 text mode (seeded-random properties)', () => {
+    // After entering text mode and issuing CR with non-empty text, decode()
+    // emits at least one cue on a text-mode stream (T1-T4).
+
+    // Raw CEA-608 control bytes (parity applied by the test helper).
+    const RTD = {b1: 0x14, b2: 0x2b}; // Resume Text Display (enter text mode).
+    const TR = {b1: 0x14, b2: 0x2a}; // Text Restart (clear buffer + enter).
+    const CR = {b1: 0x14, b2: 0x2d}; // Carriage Return (emit + scroll).
+
+    /** A spread of fixed seeds so the suite covers many random inputs. */
+    const SEEDS = [1, 2, 3, 7, 13, 42, 101, 1337, 65535, 0xc0ffee];
+
+    /**
+     * Deterministic 32-bit PRNG (mulberry32). Returns a function producing
+     * floats in [0, 1). Seeding makes every generated case reproducible.
+     * @param {number} seed
+     * @return {function(): number}
+     */
+    function makeRng(seed) {
+      let a = seed >>> 0;
+      return () => {
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    /**
+     * @param {function(): number} rng
+     * @param {number} min
+     * @param {number} max Inclusive.
+     * @return {number}
+     */
+    function randInt(rng, min, max) {
+      return min + Math.floor(rng() * (max - min + 1));
+    }
+
+    /**
+     * Field-1 pair descriptor for buildCea608Sei with odd parity applied.
+     * @param {number} b1
+     * @param {number} b2
+     * @return {{field: number, b1: number, b2: number, applyParity: boolean}}
+     */
+    function pair(b1, b2) {
+      return {field: 1, b1, b2, applyParity: true};
+    }
+
+    // For every seed, enter text mode (randomly via RTD or TR), type a random
+    // run of non-empty printable text, then issue a CR at a strictly later pts
+    // (the decoder seeds prevEndTime_ via firstPts(), so startTime < endTime is
+    // required for emission). At least one cue must be emitted on a T{n}
+    // stream.
+    for (const seed of SEEDS) {
+      it(`emits a text-mode cue for random text + CR (seed ${seed})`, () => {
+        const rng = makeRng(seed);
+        decoder.clear();
+
+        // Randomly choose the text-mode entry control code.
+        const entry = rng() < 0.5 ? RTD : TR;
+
+        // Build a non-empty run of printable basic North American characters,
+        // each pair carrying two characters. Bytes are drawn from [0x21, 0x7e]
+        // (printable, excluding space and DEL) so the typed text is always
+        // visibly non-empty. The pair count stays small so the entry, text,
+        // and CR comfortably fit within a single SEI message's triple budget.
+        const pairCount = randInt(rng, 1, 12);
+        const entered = [pair(entry.b1, entry.b2)];
+        for (let i = 0; i < pairCount; i++) {
+          const c1 = randInt(rng, 0x21, 0x7e);
+          const c2 = randInt(rng, 0x21, 0x7e);
+          entered.push(pair(c1, c2));
+        }
+
+        decoder.extract(CeaUtils.buildCea608Sei(entered), /* pts= */ 1);
+        // The CR arrives at a strictly later pts so that startTime < endTime.
+        decoder.extract(
+            CeaUtils.buildCea608Sei([pair(CR.b1, CR.b2)]), /* pts= */ 2);
+
+        const captions = decoder.decode();
+
+        // Text mode must be live: at least one cue is emitted, and every
+        // emitted cue lands on a text-mode stream (T1-T4).
+        expect(captions.length).toBeGreaterThanOrEqual(1);
+        for (const caption of captions) {
+          expect(caption.stream[0]).toBe('T');
+        }
+      });
+    }
+  });
+
+  describe('CEA-608 mode exclusivity (seeded-random properties)', () => {
+    // After a random walk through mode-switch controls, typed characters emerge
+    // on exactly the stream that mode mandates (CC{n} or T{n}).
+
+    // Mode-switch control codes (field 1, channel 1). Each selects one of the
+    // four CEA-608 display modes and points curBuf_ at that mode's buffer.
+    const RCL = {b1: 0x14, b2: 0x20}; // Pop-on: curBuf -> non-displayed.
+    const RDC = {b1: 0x14, b2: 0x29}; // Paint-on: curBuf -> displayed.
+    const RU2 = {b1: 0x14, b2: 0x25}; // Roll-up 2: curBuf -> displayed.
+    const RU3 = {b1: 0x14, b2: 0x26}; // Roll-up 3: curBuf -> displayed.
+    const RU4 = {b1: 0x14, b2: 0x27}; // Roll-up 4: curBuf -> displayed.
+    const RTD = {b1: 0x14, b2: 0x2b}; // Resume Text Display: curBuf -> text.
+    const TR = {b1: 0x14, b2: 0x2a}; // Text Restart: curBuf -> text.
+
+    // Flush control codes used to force the active buffer out as a cue.
+    const EOC = {b1: 0x14, b2: 0x2f}; // End Of Caption (flip pop-on memory).
+    const EDM = {b1: 0x14, b2: 0x2c}; // Erase Displayed Memory (emit display).
+    const CR = {b1: 0x14, b2: 0x2d}; // Carriage Return (emit scroll window).
+    const AON = {b1: 0x14, b2: 0x23}; // Alarm-On no-op; breaks dup-suppression.
+
+    /** Stable identifiers for the four CEA-608 display modes. */
+    const Mode = {
+      POPON: 'POPON',
+      PAINTON: 'PAINTON',
+      ROLLUP: 'ROLLUP',
+      TEXT: 'TEXT',
+    };
+
+    /** Every mode-switch code paired with the mode it selects. */
+    const MODE_SWITCHES = [
+      {mode: Mode.POPON, code: RCL},
+      {mode: Mode.PAINTON, code: RDC},
+      {mode: Mode.ROLLUP, code: RU2},
+      {mode: Mode.ROLLUP, code: RU3},
+      {mode: Mode.ROLLUP, code: RU4},
+      {mode: Mode.TEXT, code: RTD},
+      {mode: Mode.TEXT, code: TR},
+    ];
+
+    /** A spread of fixed seeds so the suite covers many random inputs. */
+    const SEEDS = [1, 2, 3, 7, 13, 42, 101, 1337, 65535, 0xc0ffee];
+
+    /**
+     * Deterministic 32-bit PRNG (mulberry32). Returns a function producing
+     * floats in [0, 1). Seeding makes every generated case reproducible.
+     * @param {number} seed
+     * @return {function(): number}
+     */
+    function makeRng(seed) {
+      let a = seed >>> 0;
+      return () => {
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    /**
+     * @param {function(): number} rng
+     * @param {number} min
+     * @param {number} max Inclusive.
+     * @return {number}
+     */
+    function randInt(rng, min, max) {
+      return min + Math.floor(rng() * (max - min + 1));
+    }
+
+    /**
+     * Field-1 pair descriptor for buildCea608Sei with odd parity applied.
+     * @param {number} b1
+     * @param {number} b2
+     * @return {{field: number, b1: number, b2: number, applyParity: boolean}}
+     */
+    function pair(b1, b2) {
+      return {field: 1, b1, b2, applyParity: true};
+    }
+
+    // For every seed, walk a random-length sequence of mode switches, then
+    // type a non-empty run of letters and flush. The flush is chosen to force
+    // out whichever buffer the final mode made active, and is sent at strictly
+    // increasing pts so that startTime < endTime (the decoder seeds
+    // prevEndTime_ from the first packet's pts, which is 1 here).
+    for (const seed of SEEDS) {
+      it(`routes typed text to the active mode's stream (seed ${seed})`, () => {
+        const rng = makeRng(seed);
+        decoder.clear();
+
+        // Build a random-length sequence of mode switches, separated by an AON
+        // no-op so duplicate-control-code suppression never drops a switch and
+        // the final switch always takes effect. No characters are typed during
+        // the sequence, so every intermediate buffer stays empty and the
+        // intermediate switches produce no cue (RU* force-emits only an empty
+        // displayed memory, the others emit nothing).
+        const switchCount = randInt(rng, 1, 8);
+        const sequence = [];
+        let finalMode = null;
+        for (let i = 0; i < switchCount; i++) {
+          const choice =
+              MODE_SWITCHES[randInt(rng, 0, MODE_SWITCHES.length - 1)];
+          if (i > 0) {
+            sequence.push(pair(AON.b1, AON.b2)); // Break dup-suppression.
+          }
+          sequence.push(pair(choice.code.b1, choice.code.b2));
+          finalMode = choice.mode;
+        }
+
+        // After the final switch, type a short non-empty run of letters
+        // (A-Z) into whatever buffer the final mode made active.
+        const charPairs = randInt(rng, 1, 4);
+        for (let i = 0; i < charPairs; i++) {
+          const c1 = randInt(rng, 0x41, 0x5a); // 'A'..'Z'
+          const c2 = randInt(rng, 0x41, 0x5a); // 'A'..'Z'
+          sequence.push(pair(c1, c2));
+        }
+
+        decoder.extract(CeaUtils.buildCea608Sei(sequence), /* pts= */ 1);
+
+        // Flush the active buffer per the final mode, at strictly later pts.
+        let expectedStream;
+        if (finalMode === Mode.POPON) {
+          // Pop-on writes to non-displayed memory: EOC flips it into the
+          // display (emitting the previously displayed, empty memory), then
+          // EDM emits the now-displayed text.
+          decoder.extract(
+              CeaUtils.buildCea608Sei([pair(EOC.b1, EOC.b2)]), /* pts= */ 2);
+          decoder.extract(
+              CeaUtils.buildCea608Sei([pair(EDM.b1, EDM.b2)]), /* pts= */ 3);
+          expectedStream = 'CC1';
+        } else if (finalMode === Mode.PAINTON) {
+          // Paint-on writes to displayed memory: EDM emits it directly.
+          decoder.extract(
+              CeaUtils.buildCea608Sei([pair(EDM.b1, EDM.b2)]), /* pts= */ 2);
+          expectedStream = 'CC1';
+        } else if (finalMode === Mode.ROLLUP) {
+          // Roll-up writes to displayed memory: CR emits + scrolls it.
+          decoder.extract(
+              CeaUtils.buildCea608Sei([pair(CR.b1, CR.b2)]), /* pts= */ 2);
+          expectedStream = 'CC1';
+        } else { // Mode.TEXT
+          // Text mode writes to the text buffer: CR emits + scrolls it on the
+          // text stream.
+          decoder.extract(
+              CeaUtils.buildCea608Sei([pair(CR.b1, CR.b2)]), /* pts= */ 2);
+          expectedStream = 'T1';
+        }
+
+        const captions = decoder.decode();
+
+        // Exactly one cue is produced -- a single active buffer received the
+        // characters -- and it lands on exactly the stream the final mode
+        // mandates: a text stream (T1) for text mode, a caption stream (CC1)
+        // for the three caption modes. This is the observable witness that
+        // curBuf_ matched type_ at the point the characters were written.
+        expect(captions.length).toBe(1);
+        expect(captions[0].stream).toBe(expectedStream);
+      });
+    }
+  });
+
+  describe('CEA-608 display modes', () => {
+    // Example tests locking the CEA-608 display-mode semantics.
+    // 2.6): the pop-on End Of Caption (EOC) memory flip, roll-up window sizing
+    // (RU2/RU3/RU4) plus the pre-emit of any displayed non-roll-up content
+    // before switching modes, and paint-on (RDC) mode exclusivity. Raw control
+    // bytes are listed here; the test helper applies odd parity.
+
+    // Miscellaneous control codes (field 1). The channel bit lives in b1.
+    const RCL = {b1: 0x14, b2: 0x20}; // Resume Caption Loading (pop-on).
+    const EOC = {b1: 0x14, b2: 0x2f}; // End Of Caption (flip memories).
+    const EDM = {b1: 0x14, b2: 0x2c}; // Erase Displayed Memory.
+    const CR = {b1: 0x14, b2: 0x2d}; // Carriage Return (emit + scroll).
+    const AON = {b1: 0x14, b2: 0x23}; // Alarm-On no-op; breaks dup-suppression.
+    const RDC = {b1: 0x14, b2: 0x29}; // Resume Direct Captions (paint-on).
+    /** Roll-Up control codes keyed by their window size (rows). */
+    const RU = {
+      2: {b1: 0x14, b2: 0x25}, // Roll-Up, 2 rows.
+      3: {b1: 0x14, b2: 0x26}, // Roll-Up, 3 rows.
+      4: {b1: 0x14, b2: 0x27}, // Roll-Up, 4 rows.
+    };
+
+    beforeEach(() => {
+      decoder.clear();
+    });
+
+    /**
+     * Builds a field-1 CEA-608 pair descriptor for buildCea608Sei with odd
+     * parity applied. The channel bit lives in b1, so callers pass the raw
+     * control bytes verbatim.
+     * @param {number} b1
+     * @param {number} b2
+     * @return {{field: number, b1: number, b2: number, applyParity: boolean}}
+     */
+    function pair(b1, b2) {
+      return {field: 1, b1, b2, applyParity: true};
+    }
+
+    /**
+     * Concatenates the nested-cue payloads of an emitted caption into a string.
+     * @param {!shaka.extern.ICaptionDecoder.ClosedCaption} caption
+     * @return {string}
+     */
+    function textOf(caption) {
+      return caption.cue.nestedCues.map((c) => c.payload).join('');
+    }
+
+    /**
+     * Counts the line-break cues in an emitted caption. A roll-up window of N
+     * rows produces N - 1 line breaks between its rows.
+     * @param {!shaka.extern.ICaptionDecoder.ClosedCaption} caption
+     * @return {number}
+     */
+    function lineBreakCount(caption) {
+      return caption.cue.nestedCues.filter((c) => c.lineBreak).length;
+    }
+
+    // End Of Caption emits the currently displayed memory AND swaps
+    // displayed/non-displayed memory. Two successive pop-on captions prove the
+    // flip: the first EOC loads "AB" into the display (emitting nothing yet),
+    // the second EOC emits that displayed "AB" and swaps in the freshly loaded
+    // "CD", which a trailing EDM then emits.
+    it('flips loaded memory into the display and emits the prior caption ' +
+        'on EOC', () => {
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(RCL.b1, RCL.b2), // Pop-on: load the non-displayed buffer.
+        pair(0x41, 0x42), // A, B
+        pair(EOC.b1, EOC.b2), // EOC flips "AB" into the display.
+      ]), /* pts= */ 1);
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(RCL.b1, RCL.b2), // Pop-on: load the (now empty) non-displayed buf.
+        pair(0x43, 0x44), // C, D
+        pair(EOC.b1, EOC.b2), // EOC emits "AB" and flips "CD" into the display.
+      ]), /* pts= */ 2);
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(EDM.b1, EDM.b2), // EDM emits the now-displayed "CD".
+      ]), /* pts= */ 3);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(2);
+      // The first emit is the previously displayed "AB": EOC emits the
+      // currently displayed memory BEFORE swapping the loaded buffer in.
+      expect(captions[0].stream).toBe('CC1');
+      expect(textOf(captions[0])).toBe('AB');
+      expect(captions[0].cue.startTime).toBe(1);
+      expect(captions[0].cue.endTime).toBe(2);
+      // The second emit is "CD": the second EOC swapped the freshly loaded
+      // non-displayed buffer into the display.
+      expect(captions[1].stream).toBe('CC1');
+      expect(textOf(captions[1])).toBe('CD');
+      expect(captions[1].cue.startTime).toBe(2);
+      expect(captions[1].cue.endTime).toBe(3);
+    });
+
+    // pop-on writes go to the non-displayed buffer, which is not
+    // shown until an EOC flips it in. Without an EOC, an EDM finds the
+    // displayed memory empty and emits nothing.
+    it('does not display loaded pop-on memory until an EOC flips it in', () => {
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(RCL.b1, RCL.b2), // Pop-on mode.
+        pair(0x41, 0x42), // A, B loaded into non-displayed memory.
+      ]), /* pts= */ 1);
+      decoder.extract(CeaUtils.buildCea608Sei([
+        pair(EDM.b1, EDM.b2), // EDM erases/emits the (empty) displayed memory.
+      ]), /* pts= */ 2);
+
+      const captions = decoder.decode();
+      // No EOC arrived, so the loaded "AB" never flipped into the display.
+      expect(captions).toEqual([]);
+    });
+
+    /**
+     * Rolls up `lineCount` single-pair lines in a window of `size` rows. The
+     * Roll-Up command is prepended to the first packet; every line is sent in
+     * its own SEI at a strictly increasing pts (so each Carriage Return emits
+     * with startTime < endTime), and an Alarm-On no-op trails each CR to defeat
+     * the duplicate-control-code suppression between consecutive CRs.
+     * @param {number} size Roll-up window size (2, 3, or 4).
+     * @param {number} lineCount Number of lines to roll up.
+     * @return {!Array<!shaka.extern.ICaptionDecoder.ClosedCaption>}
+     */
+    function rollup(size, lineCount) {
+      for (let i = 0; i < lineCount; i++) {
+        const pairs = [];
+        if (i === 0) {
+          pairs.push(pair(RU[size].b1, RU[size].b2)); // Enter roll-up.
+        }
+        // Two distinct letters per line keep each rolled row visibly non-empty.
+        pairs.push(pair(0x41 + i, 0x61 + i));
+        pairs.push(pair(CR.b1, CR.b2)); // Emit + scroll.
+        pairs.push(pair(AON.b1, AON.b2)); // No-op; resets dup-suppression.
+        decoder.extract(CeaUtils.buildCea608Sei(pairs), /* pts= */ i + 1);
+      }
+      return decoder.decode();
+    }
+
+    // a Roll-Up command sets the scroll window to the requested size.
+    // Rolling up more lines than the window holds saturates it, so the final
+    // emitted caption shows exactly `size` rows (size - 1 line breaks). Testing
+    // all three sizes proves RU2/RU3/RU4 are honored distinctly.
+    for (const size of [2, 3, 4]) {
+      it(`sets the roll-up window to exactly ${size} rows (RU${size})`, () => {
+        // Six lines saturates every window size in [2, 4].
+        const captions = rollup(size, /* lineCount= */ 6);
+        expect(captions.length).toBeGreaterThan(0);
+        const last = captions[captions.length - 1];
+        expect(last.stream).toBe('CC1');
+        // A saturated N-row window emits N rows, i.e. N - 1 line breaks.
+        expect(lineBreakCount(last)).toBe(size - 1);
+      });
+    }
+
+    // a Roll-Up command must emit any displayed non-roll-up content
+    // before switching modes. A pop-on "test" is flipped into the display, then
+    // an RU2 arrives: the displayed "test" is emitted as the mode switches.
+    it('emits displayed non-roll-up content before switching to roll-up',
+        () => {
+          decoder.extract(CeaUtils.buildCea608Sei([
+            pair(RCL.b1, RCL.b2), // Pop-on mode.
+            pair(0x74, 0x65), // t, e
+            pair(0x73, 0x74), // s, t
+            pair(EOC.b1, EOC.b2), // Flip "test" into the display.
+          ]), /* pts= */ 1);
+          decoder.extract(CeaUtils.buildCea608Sei([
+            pair(RU[2].b1, RU[2].b2), // RU2 forces out "test" before switching.
+          ]), /* pts= */ 2);
+
+          const captions = decoder.decode();
+          expect(captions.length).toBe(1);
+          expect(captions[0].stream).toBe('CC1');
+          expect(textOf(captions[0])).toBe('test');
+          expect(captions[0].cue.startTime).toBe(1);
+          expect(captions[0].cue.endTime).toBe(2);
+        });
+
+    // paint-on (RDC) directs character writes to the displayed buffer,
+    // and only one mode is active at a time. Pop-on first loads "AB" into the
+    // non-displayed buffer; RDC then makes the displayed buffer active, so "CD"
+    // is written there. A trailing EDM emits only the paint-on "CD" -- the
+    // pop-on "AB" sits in the non-displayed buffer and was never flipped in.
+    it('paint-on (RDC) writes to displayed memory, keeping modes exclusive',
+        () => {
+          decoder.extract(CeaUtils.buildCea608Sei([
+            pair(RCL.b1, RCL.b2), // Pop-on: active buffer is non-displayed.
+            pair(0x41, 0x42), // A, B -> non-displayed memory.
+            pair(RDC.b1, RDC.b2), // Paint-on: active buffer becomes displayed.
+            pair(0x43, 0x44), // C, D -> displayed memory.
+          ]), /* pts= */ 1);
+          decoder.extract(CeaUtils.buildCea608Sei([
+            pair(EDM.b1, EDM.b2), // Emit the displayed memory.
+          ]), /* pts= */ 2);
+
+          const captions = decoder.decode();
+          expect(captions.length).toBe(1);
+          expect(captions[0].stream).toBe('CC1');
+          // Only the paint-on text in displayed memory is emitted.
+          expect(textOf(captions[0])).toBe('CD');
+        });
   });
 
   describe('decodes CEA-708', () => {
@@ -664,5 +1908,674 @@ describe('CeaDecoder', () => {
       expect(shaka.log.warnOnce).toHaveBeenCalledTimes(1);
       expect(captions).toEqual([]);
     });
+
+    it('recovers from a malformed block without corrupting built windows',
+        () => {
+          // over-read): a malformed service block that declares more bytes than
+          // are present makes DtvccPacket.readByte run off the end of the
+          // packet, raising a typed shaka.util.Error with Code
+          // BUFFER_READ_OUT_OF_BOUNDS. decodeCea708_ must catch it, log exactly
+          // once via warnOnce('CEA708_INVALID_DATA', ...), and continue
+          // decoding subsequent packets without corrupting window state that
+          // was built by an EARLIER packet.
+          const serviceNumber = 1;
+          const startTime = 1;
+          const midTime = 2;
+          const endTime = 3;
+
+          // SEI 1 (valid): define a visible window #0 (11 rows x 11 cols) and
+          // render "test" into it. This builds window state that lives on the
+          // persistent Cea708Service for service #1.
+          const defineWindow = [0x98, 0x38, 0x00, 0x00, 0x0a, 0x0a, 0x00];
+          const text = [0x74, 0x65, 0x73, 0x74]; // t, e, s, t
+          const validSei = CeaUtils.buildDtvccSei([
+            CeaUtils.dtvccServiceBlock(
+                serviceNumber, [...defineWindow, ...text]),
+          ]);
+
+          // SEI 2 (malformed): a service block for the SAME service whose
+          // header claims 31 (0x1f) bytes follow, but only two benign null
+          // bytes are actually present. Reading the declared block length runs
+          // past the end of the DTVCC packet and throws
+          // BUFFER_READ_OUT_OF_BOUNDS. The header is built by hand because the
+          // dtvccServiceBlock() helper would otherwise compute an honest
+          // (matching) block size.
+          const malformedHeader = ((serviceNumber & 0x07) << 5) | 0x1f;
+          const malformedSei = CeaUtils.buildDtvccSei([
+            [malformedHeader, 0x00, 0x00],
+          ]);
+
+          // SEI 3 (valid): hide all windows, which flushes the earlier window
+          // #0 out as a cue. If the malformed block had corrupted the window,
+          // this would emit nothing or the wrong text.
+          const hideSei = CeaUtils.buildDtvccSei([
+            CeaUtils.dtvccServiceBlock(serviceNumber, [0x8a, 0xff]),
+          ]);
+
+          spyOn(shaka.log, 'warnOnce').and.callThrough();
+
+          decoder.clear();
+          decoder.extract(validSei, startTime);
+          decoder.extract(malformedSei, midTime);
+          decoder.extract(hideSei, endTime);
+
+          // decode() must not let the typed error propagate out.
+          /** @type {!Array<!shaka.extern.ICaptionDecoder.ClosedCaption>} */
+          let captions = [];
+          expect(() => {
+            captions = decoder.decode();
+          }).not.toThrow();
+
+          // The malformed block was caught and logged exactly once.
+          expect(shaka.log.warnOnce).toHaveBeenCalledWith('CEA708_INVALID_DATA',
+              'Buffer read out of bounds / invalid CEA-708 Data.');
+          expect(shaka.log.warnOnce).toHaveBeenCalledTimes(1);
+
+          // The previously-built window survived intact: hiding it still emits
+          // the earlier "test" content on the right stream.
+          expect(captions.length).toBe(1);
+          expect(captions[0].stream).toBe('svc' + serviceNumber);
+          expect(captions[0].cue.nestedCues.map((c) => c.payload).join(''))
+              .toBe('test');
+        });
+  });
+
+  describe('CEA-708 DTVCC block alignment (seeded-random properties)', () => {
+    // Delay (0x8d) consumes one operand byte; DelayCancel (0x8e) has none.
+    // Interleaving them among G0 text must not change the rendered output.
+
+    const serviceNumber = 1;
+
+    /** A spread of fixed seeds so the suite covers many random inputs. */
+    const SEEDS = [1, 2, 3, 7, 13, 42, 101, 1337, 65535, 0xc0ffee];
+
+    // DefineWindow #0 (DF0, 0x98) + 6 bytes: a visible window with 11 rows and
+    // 11 columns and window/pen style 0. Matches the existing CEA-708 fixtures.
+    const defineWindow = [0x98, 0x38, 0x00, 0x00, 0x0a, 0x0a, 0x00];
+
+    // HideWindows (HDW, 0x8a) with an all-ones bitmap, in its own SEI; hiding a
+    // visible window forces its buffer out as a cue.
+    const hideSei = CeaUtils.buildDtvccSei(
+        [CeaUtils.dtvccServiceBlock(serviceNumber, [0x8a, 0xff])]);
+
+    beforeEach(() => {
+      decoder.clear();
+    });
+
+    /**
+     * Deterministic 32-bit PRNG (mulberry32). Returns a function producing
+     * floats in [0, 1). Seeding makes every generated case reproducible.
+     * @param {number} seed
+     * @return {function(): number}
+     */
+    function makeRng(seed) {
+      let a = seed >>> 0;
+      return () => {
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    /**
+     * @param {function(): number} rng
+     * @param {number} min
+     * @param {number} max Inclusive.
+     * @return {number}
+     */
+    function randInt(rng, min, max) {
+      return min + Math.floor(rng() * (max - min + 1));
+    }
+
+    /**
+     * Wraps a service-block body (DefineWindow followed by the supplied bytes)
+     * as a DTVCC SEI for the test service.
+     * @param {!Array<number>} bodyBytes
+     * @return {!Uint8Array}
+     */
+    function buildServiceSei(bodyBytes) {
+      const data = [...defineWindow, ...bodyBytes];
+      const block = CeaUtils.dtvccServiceBlock(serviceNumber, data);
+      return CeaUtils.buildDtvccSei([block]);
+    }
+
+    /**
+     * Decodes a single service block (DefineWindow + body), then hides the
+     * window to flush it, and returns the concatenated rendered text. Asserts
+     * exactly one caption was emitted on the expected service stream.
+     * @param {!Array<number>} bodyBytes
+     * @return {string}
+     */
+    function decodeText(bodyBytes) {
+      decoder.clear();
+      decoder.extract(buildServiceSei(bodyBytes), /* pts= */ 1);
+      decoder.extract(hideSei, /* pts= */ 2);
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      expect(captions[0].stream).toBe('svc' + serviceNumber);
+      return captions[0].cue.nestedCues.map((c) => c.payload).join('');
+    }
+
+    // A delay operand drawn from values that include printable G0 codes, so a
+    // mis-counted operand would visibly leak into the rendered text.
+    /**
+     * @param {function(): number} rng
+     * @return {number}
+     */
+    function randomDelayOperand(rng) {
+      // Half the time use a printable letter ('A'..'Z'); otherwise any byte.
+      return rng() < 0.5 ?
+          randInt(rng, 0x41, 0x5a) : randInt(rng, 0x00, 0xff);
+    }
+
+    // interleaving Delay / DelayCancel commands among G0 text never
+    // changes the rendered text, because each command consumes exactly its
+    // spec-defined length and leaves the block aligned.
+    for (const seed of SEEDS) {
+      it(`keeps the block aligned across random delays (seed ${seed})`, () => {
+        const rng = makeRng(seed);
+
+        // Build a token stream of text characters ('A'..'Z'), Delay commands
+        // (0x8d + operand), and DelayCancel commands (0x8e). At least one text
+        // character (so something is rendered) and at least one Delay (so the
+        // operand-consumption path is exercised).
+        const textCount = randInt(rng, 1, 8);
+        const delayCount = randInt(rng, 1, 4);
+        const cancelCount = randInt(rng, 0, 2);
+
+        const tokens = [];
+        for (let i = 0; i < textCount; i++) {
+          tokens.push({type: 'text', byte: randInt(rng, 0x41, 0x5a)});
+        }
+        for (let i = 0; i < delayCount; i++) {
+          tokens.push({type: 'delay', operand: randomDelayOperand(rng)});
+        }
+        for (let i = 0; i < cancelCount; i++) {
+          tokens.push({type: 'delayCancel'});
+        }
+
+        // Deterministic Fisher-Yates shuffle so commands and text interleave.
+        for (let i = tokens.length - 1; i > 0; i--) {
+          const j = randInt(rng, 0, i);
+          const tmp = tokens[i];
+          tokens[i] = tokens[j];
+          tokens[j] = tmp;
+        }
+
+        // Flatten the tokens into service-block body bytes.
+        const withDelays = [];
+        for (const token of tokens) {
+          if (token.type === 'text') {
+            withDelays.push(token.byte);
+          } else if (token.type === 'delay') {
+            withDelays.push(0x8d, token.operand);
+          } else {
+            withDelays.push(0x8e);
+          }
+        }
+
+        // The expected text is just the text tokens, in their shuffled order;
+        // delay operands and command bytes must contribute nothing.
+        const textBytes =
+            tokens.filter((t) => t.type === 'text').map((t) => t.byte);
+        const expectedText =
+            textBytes.map((b) => String.fromCharCode(b)).join('');
+
+        // Decode the delay-laden block and the delay-free baseline.
+        const withDelaysText = decodeText(withDelays);
+        const baselineText = decodeText(textBytes);
+
+        // Alignment proof: the delays neither shift nor leak any bytes.
+        expect(withDelaysText).toBe(expectedText);
+        expect(withDelaysText).toBe(baselineText);
+      });
+    }
+
+    // A focused, non-random case: a Delay whose operand byte (0x41 = 'A') is a
+    // printable G0 code sits between 'H' and 'I'. If the operand were not
+    // consumed it would render as 'A' (giving "HAI"); correct alignment yields
+    // "HI".
+    it('consumes a printable delay operand instead of rendering it', () => {
+      const body = [
+        0x48, // 'H'
+        0x8d, 0x41, // Delay, operand 0x41 ('A') -- must be consumed.
+        0x49, // 'I'
+      ];
+      expect(decodeText(body)).toBe('HI');
+    });
+
+    // DelayCancel (0x8e) carries no operand; placing it between 'O' and 'K'
+    // must not consume the following text byte.
+    it('treats DelayCancel as a single byte with no operand', () => {
+      const body = [
+        0x4f, // 'O'
+        0x8e, // DelayCancel, no operand.
+        0x4b, // 'K'
+      ];
+      expect(decodeText(body)).toBe('OK');
+    });
+  });
+
+  describe('cue output correctness (timing and structure)', () => {
+    // Emitted cues must have startTime < endTime, be well-ordered per stream,
+    // and form a Cue tree of styled runs and line breaks.
+    const RU2 = {b1: 0x14, b2: 0x25}; // Roll-Up, 2 rows.
+    const CR = {b1: 0x14, b2: 0x2d}; // Carriage Return (emit + scroll).
+    const AON = {b1: 0x14, b2: 0x23}; // Alarm-On no-op; breaks dup-suppression.
+
+    const serviceNumber = 1;
+
+    beforeEach(() => {
+      decoder.clear();
+    });
+
+    /**
+     * Builds a field-1 CEA-608 pair descriptor for buildCea608Sei with odd
+     * parity applied. The channel bit lives in b1, so callers pass the raw
+     * control bytes verbatim.
+     * @param {number} b1
+     * @param {number} b2
+     * @return {{field: number, b1: number, b2: number, applyParity: boolean}}
+     */
+    function pair(b1, b2) {
+      return {field: 1, b1, b2, applyParity: true};
+    }
+
+    /**
+     * Concatenates the nested-cue payloads of an emitted caption into a string.
+     * @param {!shaka.extern.ICaptionDecoder.ClosedCaption} caption
+     * @return {string}
+     */
+    function textOf(caption) {
+      return caption.cue.nestedCues.map((c) => c.payload).join('');
+    }
+
+    /**
+     * Asserts timing invariants over an emitted caption list that all belong
+     * to a single stream: each cue has startTime < endTime, and consecutive
+     * cues are non-overlapping and ordered (next.startTime >= prev.endTime).
+     * @param {!Array<!shaka.extern.ICaptionDecoder.ClosedCaption>} captions
+     */
+    function assertWellOrderedTiming(captions) {
+      for (let i = 0; i < captions.length; i++) {
+        const cue = captions[i].cue;
+        expect(cue.startTime).toBeLessThan(cue.endTime);
+        if (i > 0) {
+          expect(cue.startTime)
+              .toBeGreaterThanOrEqual(captions[i - 1].cue.endTime);
+        }
+      }
+    }
+
+    // A CEA-608 roll-up stream emits a cue per Carriage Return.
+    it('emits well-ordered CEA-608 roll-up cues on a single stream', () => {
+      const lineCount = 4;
+      for (let i = 0; i < lineCount; i++) {
+        const pairs = [];
+        if (i === 0) {
+          pairs.push(pair(RU2.b1, RU2.b2)); // Enter roll-up (2 rows).
+        }
+        // Two distinct letters per line keep each rolled row non-empty.
+        pairs.push(pair(0x41 + i, 0x61 + i));
+        pairs.push(pair(CR.b1, CR.b2)); // Emit + scroll.
+        pairs.push(pair(AON.b1, AON.b2)); // No-op; resets dup-suppression.
+        decoder.extract(CeaUtils.buildCea608Sei(pairs), /* pts= */ i + 1);
+      }
+
+      const captions = decoder.decode();
+      // Several consecutive cues are produced (one per Carriage Return).
+      expect(captions.length).toBeGreaterThan(1);
+      // They all belong to the same captioning stream.
+      for (const caption of captions) {
+        expect(caption.stream).toBe('CC1');
+      }
+      assertWellOrderedTiming(captions);
+    });
+
+    // A saturated 2-row roll-up window emits two text rows with one line break.
+    it('emits a CEA-608 roll-up caption as a nested Cue tree with a line ' +
+        'break', () => {
+      const lineCount = 4;
+      for (let i = 0; i < lineCount; i++) {
+        const pairs = [];
+        if (i === 0) {
+          pairs.push(pair(RU2.b1, RU2.b2)); // Enter roll-up (2 rows).
+        }
+        pairs.push(pair(0x41 + i, 0x61 + i)); // Two distinct letters per line.
+        pairs.push(pair(CR.b1, CR.b2)); // Emit + scroll.
+        pairs.push(pair(AON.b1, AON.b2)); // No-op; resets dup-suppression.
+        decoder.extract(CeaUtils.buildCea608Sei(pairs), /* pts= */ i + 1);
+      }
+
+      const captions = decoder.decode();
+      expect(captions.length).toBeGreaterThan(1);
+
+      // Inspect the last caption: a 2-row roll-up window shows both rows.
+      const caption = captions[captions.length - 1];
+      const topLevelCue = caption.cue;
+      // The emitted caption is a Cue tree.
+      expect(topLevelCue).toEqual(jasmine.any(shaka.text.Cue));
+      expect(topLevelCue.nestedCues.length).toBeGreaterThan(0);
+      // Every child is itself a Cue (styled run or line break).
+      for (const nested of topLevelCue.nestedCues) {
+        expect(nested).toEqual(jasmine.any(shaka.text.Cue));
+      }
+
+      // The two rows are separated by exactly one line-break cue, with a
+      // non-empty text run on either side of it.
+      const lineBreakIndexes = [];
+      topLevelCue.nestedCues.forEach((nested, index) => {
+        if (nested.lineBreak) {
+          lineBreakIndexes.push(index);
+        }
+      });
+      expect(lineBreakIndexes.length).toBe(1);
+      const breakIndex = lineBreakIndexes[0];
+      // A text run precedes and follows the line break.
+      expect(breakIndex).toBeGreaterThan(0);
+      expect(breakIndex).toBeLessThan(topLevelCue.nestedCues.length - 1);
+      expect(topLevelCue.nestedCues[breakIndex - 1].payload).not.toBe('');
+      expect(topLevelCue.nestedCues[breakIndex + 1].payload).not.toBe('');
+      // The line-break cue itself carries no text.
+      expect(topLevelCue.nestedCues[breakIndex].payload).toBe('');
+    });
+
+    // A styled CEA-608 run is surfaced as a nested cue that carries
+    // the run's style fields (here: green, underlined text). This proves the
+    // nested-cue structure expresses styled runs, not just plain text.
+    it('expresses a styled CEA-608 run as a styled nested cue', () => {
+      const controlCount = 0x08;
+      const captionData = 0xc0 | controlCount;
+      // Pop-on "green" on CC3 with an underline + green PAC (matches the
+      // existing styling fixtures).
+      const greenTextCC3Packet = new Uint8Array([
+        ...atscCaptionInitBytes, captionData, /* padding= */ 0xff,
+        0xfd, 0x15, 0x20, // Pop-on mode (RCL control code) on CC3.
+        0xfd, 0x13, 0xe3, // PAC: underline + green on the last row.
+        0xfd, 0x67, 0xf2, // g, r
+        0xfd, 0xe5, 0xe5, // e, e
+        0xfd, 0x6e, 0x20, // n, space
+        0xfd, 0xf4, 0xe5, // t, e
+        0xfd, 0xf8, 0xf4, // x, t
+        0xfd, 0x15, 0x2f, // EOC
+      ]);
+      // EDM (on every mode/channel) forces the displayed memory out as a cue.
+      const eraseDisplayedMemory = new Uint8Array([
+        ...atscCaptionInitBytes, 0xc4, /* padding= */ 0xff,
+        0xfc, 0x94, 0x2c, // EDM on CC1.
+        0xfc, 0x1c, 0x2c, // EDM on CC2.
+        0xfd, 0x15, 0x2c, // EDM on CC3.
+        0xfd, 0x9d, 0x2c, // EDM on CC4.
+      ]);
+
+      decoder.extract(greenTextCC3Packet, /* pts= */ 1);
+      decoder.extract(eraseDisplayedMemory, /* pts= */ 2);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      const topLevelCue = captions[0].cue;
+      expect(topLevelCue).toEqual(jasmine.any(shaka.text.Cue));
+      expect(topLevelCue.nestedCues.length).toBe(1);
+
+      const styledRun = topLevelCue.nestedCues[0];
+      expect(styledRun).toEqual(jasmine.any(shaka.text.Cue));
+      expect(styledRun.payload).toBe('green text');
+      // The run carries the styling expressed by the PAC.
+      expect(styledRun.color).toBe('green');
+      expect(styledRun.textDecoration)
+          .toContain(shaka.text.Cue.textDecoration.UNDERLINE);
+      // The timing invariant still holds for a single emitted cue.
+      assertWellOrderedTiming(captions);
+    });
+
+    // A CEA-708 service emits a cue per Form Feed (which
+    // flushes the visible window and clears it). Three Form Feeds followed by a
+    // window hide produce a run of cues on one service stream that must all
+    // satisfy the timing invariants.
+    it('emits well-ordered CEA-708 cues on a single stream', () => {
+      // DefineWindow #0 (DF0, 0x98) + 6 bytes: a visible 11x11 window. Matches
+      // the existing CEA-708 fixtures.
+      const defineWindow = [0x98, 0x38, 0x00, 0x00, 0x0a, 0x0a, 0x00];
+      const formFeed = 0x0c; // C0 Form Feed: emit (if visible) then clear.
+
+      // pts 1: define the window and load "AB".
+      decoder.extract(CeaUtils.buildDtvccSei([CeaUtils.dtvccServiceBlock(
+          serviceNumber, [...defineWindow, 0x41, 0x42])]), /* pts= */ 1);
+      // pts 2: Form Feed flushes "AB", clears, then loads "CD".
+      decoder.extract(CeaUtils.buildDtvccSei([CeaUtils.dtvccServiceBlock(
+          serviceNumber, [formFeed, 0x43, 0x44])]), /* pts= */ 2);
+      // pts 3: Form Feed flushes "CD", clears, then loads "EF".
+      decoder.extract(CeaUtils.buildDtvccSei([CeaUtils.dtvccServiceBlock(
+          serviceNumber, [formFeed, 0x45, 0x46])]), /* pts= */ 3);
+      // pts 4: hide the window to flush "EF".
+      decoder.extract(CeaUtils.buildDtvccSei([CeaUtils.dtvccServiceBlock(
+          serviceNumber, [0x8a, 0xff])]), /* pts= */ 4);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(3);
+      for (const caption of captions) {
+        expect(caption.stream).toBe('svc' + serviceNumber);
+      }
+      expect(captions.map((c) => textOf(c))).toEqual(['AB', 'CD', 'EF']);
+      assertWellOrderedTiming(captions);
+    });
+
+    // A CEA-708 caption spanning two rows is a shaka.text.Cue tree
+    // whose nested cues are the per-row text runs separated by a line-break
+    // cue. Text is written on row 0, the pen is moved to row 1 via
+    // SetPenLocation, more text is written, and a window hide flushes the
+    // single multi-row caption.
+    it('emits a CEA-708 caption as a nested Cue tree with a line break', () => {
+      const defineWindow = [0x98, 0x38, 0x00, 0x00, 0x0a, 0x0a, 0x00];
+      // SetPenLocation (SPL, 0x92): row in b1's low nibble, col in b2.
+      const setPenRow1 = [0x92, 0x01, 0x00];
+
+      // Define a visible window, load "AB" on row 0, move the pen to row 1,
+      // load "CD", all in one service block.
+      decoder.extract(CeaUtils.buildDtvccSei([CeaUtils.dtvccServiceBlock(
+          serviceNumber,
+          [...defineWindow, 0x41, 0x42, ...setPenRow1, 0x43, 0x44])]),
+      /* pts= */ 1);
+      // Hide the window to flush the two-row caption.
+      decoder.extract(CeaUtils.buildDtvccSei([CeaUtils.dtvccServiceBlock(
+          serviceNumber, [0x8a, 0xff])]), /* pts= */ 2);
+
+      const captions = decoder.decode();
+      expect(captions.length).toBe(1);
+      const topLevelCue = captions[0].cue;
+      expect(topLevelCue).toEqual(jasmine.any(shaka.text.Cue));
+      // Every child is a Cue (text run or line break).
+      for (const nested of topLevelCue.nestedCues) {
+        expect(nested).toEqual(jasmine.any(shaka.text.Cue));
+      }
+
+      // Exactly one line break separates the two rows, with a text run on
+      // either side.
+      const lineBreakIndexes = [];
+      topLevelCue.nestedCues.forEach((nested, index) => {
+        if (nested.lineBreak) {
+          lineBreakIndexes.push(index);
+        }
+      });
+      expect(lineBreakIndexes.length).toBe(1);
+      const breakIndex = lineBreakIndexes[0];
+      expect(breakIndex).toBeGreaterThan(0);
+      expect(breakIndex).toBeLessThan(topLevelCue.nestedCues.length - 1);
+      expect(topLevelCue.nestedCues[breakIndex - 1].payload).toBe('AB');
+      expect(topLevelCue.nestedCues[breakIndex + 1].payload).toBe('CD');
+      // The timing invariant holds for the emitted cue.
+      assertWellOrderedTiming(captions);
+    });
+  });
+
+  describe('monotonic cue timing (seeded-random properties)', () => {
+    // Per stream: startTime < endTime, and consecutive cues satisfy
+    // next.startTime >= prev.endTime.
+
+    const RU2 = {b1: 0x14, b2: 0x25}; // Roll-Up, 2 rows.
+    const CR = {b1: 0x14, b2: 0x2d}; // Carriage Return (emit + scroll).
+    const AON = {b1: 0x14, b2: 0x23}; // Alarm-On no-op; breaks dup-suppression.
+
+    const serviceNumber = 1;
+    // DefineWindow #0 (DF0, 0x98) + 6 bytes: a visible 11x11 window. Matches
+    // the existing CEA-708 fixtures.
+    const defineWindow = [0x98, 0x38, 0x00, 0x00, 0x0a, 0x0a, 0x00];
+    const formFeed = 0x0c; // C0 Form Feed: emit (if visible) then clear.
+    const hideWindows = [0x8a, 0xff]; // HideWindows (HDW) with all-ones bitmap.
+
+    /** A spread of fixed seeds so the suite covers many random inputs. */
+    const SEEDS = [1, 2, 3, 7, 13, 42, 101, 1337, 65535, 0xc0ffee];
+
+    beforeEach(() => {
+      decoder.clear();
+    });
+
+    /**
+     * Deterministic 32-bit PRNG (mulberry32). Returns a function producing
+     * floats in [0, 1). Seeding makes every generated case reproducible.
+     * @param {number} seed
+     * @return {function(): number}
+     */
+    function makeRng(seed) {
+      let a = seed >>> 0;
+      return () => {
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    /**
+     * @param {function(): number} rng
+     * @param {number} min
+     * @param {number} max Inclusive.
+     * @return {number}
+     */
+    function randInt(rng, min, max) {
+      return min + Math.floor(rng() * (max - min + 1));
+    }
+
+    /**
+     * Builds a field-1 CEA-608 pair descriptor for buildCea608Sei with odd
+     * parity applied.
+     * @param {number} b1
+     * @param {number} b2
+     * @return {{field: number, b1: number, b2: number, applyParity: boolean}}
+     */
+    function pair(b1, b2) {
+      return {field: 1, b1, b2, applyParity: true};
+    }
+
+    /**
+     * Wraps a CEA-708 service-block body for the test service as a DTVCC SEI.
+     * @param {!Array<number>} bodyBytes
+     * @return {!Uint8Array}
+     */
+    function dtvccSei(bodyBytes) {
+      return CeaUtils.buildDtvccSei(
+          [CeaUtils.dtvccServiceBlock(serviceNumber, bodyBytes)]);
+    }
+
+    /**
+     * Groups an emitted caption list by its stream name.
+     * @param {!Array<!shaka.extern.ICaptionDecoder.ClosedCaption>} captions
+     * @return {!Map<string,
+     *   !Array<!shaka.extern.ICaptionDecoder.ClosedCaption>>}
+     */
+    function groupByStream(captions) {
+      const byStream = new Map();
+      for (const caption of captions) {
+        if (!byStream.has(caption.stream)) {
+          byStream.set(caption.stream, []);
+        }
+        byStream.get(caption.stream).push(caption);
+      }
+      return byStream;
+    }
+
+    /**
+     * Asserts over a list of cues that all belong to a
+     * single stream: each cue has startTime < endTime, and consecutive cues
+     * satisfy next.startTime >= prev.endTime.
+     * @param {!Array<!shaka.extern.ICaptionDecoder.ClosedCaption>} captions
+     */
+    function assertWellOrderedTiming(captions) {
+      for (let i = 0; i < captions.length; i++) {
+        const cue = captions[i].cue;
+        expect(cue.startTime).toBeLessThan(cue.endTime);
+        if (i > 0) {
+          expect(cue.startTime)
+              .toBeGreaterThanOrEqual(captions[i - 1].cue.endTime);
+        }
+      }
+    }
+    // Across a randomized multi-stream decode, every stream's cues are
+    // well-ordered in time.
+    for (const seed of SEEDS) {
+      it(`emits per-stream well-ordered cues (seed ${seed})`, () => {
+        const rng = makeRng(seed);
+
+        // Build a CEA-608 roll-up sub-sequence on CC1: one SEI per line, each
+        // emitting a cue on its Carriage Return. The first line enters roll-up;
+        // every line trails an Alarm-On no-op so duplicate-control-code
+        // suppression never drops a consecutive Carriage Return.
+        const lineCount = randInt(rng, 2, 5);
+        const seq608 = [];
+        for (let i = 0; i < lineCount; i++) {
+          const pairs = [];
+          if (i === 0) {
+            pairs.push(pair(RU2.b1, RU2.b2));
+          }
+          // Two distinct letters per line keep each rolled row non-empty.
+          const c1 = randInt(rng, 0x41, 0x5a); // 'A'..'Z'
+          const c2 = randInt(rng, 0x41, 0x5a); // 'A'..'Z'
+          pairs.push(pair(c1, c2));
+          pairs.push(pair(CR.b1, CR.b2));
+          pairs.push(pair(AON.b1, AON.b2));
+          seq608.push(() => CeaUtils.buildCea608Sei(pairs));
+        }
+
+        // Build a CEA-708 sub-sequence on svc1: define a visible window with an
+        // initial text run, then a number of Form Feeds (each flushes the
+        // previous run and loads a new one), and finally a window hide to flush
+        // the last run. This emits ffCount + 1 cues on svc1.
+        const ffCount = randInt(rng, 1, 4);
+        const seq708 = [];
+        const firstChars = [randInt(rng, 0x41, 0x5a), randInt(rng, 0x41, 0x5a)];
+        seq708.push(() => dtvccSei([...defineWindow, ...firstChars]));
+        for (let i = 0; i < ffCount; i++) {
+          const chars = [randInt(rng, 0x41, 0x5a), randInt(rng, 0x41, 0x5a)];
+          seq708.push(() => dtvccSei([formFeed, ...chars]));
+        }
+        seq708.push(() => dtvccSei(hideWindows));
+
+        // Interleave the two sub-sequences, preserving each one's relative
+        // order, then deliver every SEI at a strictly increasing pts.
+        let i608 = 0;
+        let i708 = 0;
+        let pts = 1;
+        while (i608 < seq608.length || i708 < seq708.length) {
+          const take608 = i708 >= seq708.length ||
+              (i608 < seq608.length && rng() < 0.5);
+          const build = take608 ? seq608[i608++] : seq708[i708++];
+          decoder.extract(build(), /* pts= */ pts++);
+        }
+
+        const captions = decoder.decode();
+        const byStream = groupByStream(captions);
+        // More than one stream emitted cues, so the per-stream grouping is
+        // exercised (CC1 from roll-up, svc1 from the CEA-708 service).
+        expect(byStream.size).toBeGreaterThan(1);
+        expect(byStream.has('CC1')).toBe(true);
+        expect(byStream.has('svc' + serviceNumber)).toBe(true);
+        // the timing invariant holds independently per stream.
+        for (const streamCaptions of byStream.values()) {
+          expect(streamCaptions.length).toBeGreaterThan(0);
+          assertWellOrderedTiming(streamCaptions);
+        }
+      });
+    }
   });
 });

--- a/test/media/closed_caption_parser_unit.js
+++ b/test/media/closed_caption_parser_unit.js
@@ -9,15 +9,41 @@
  */
 describe('ClosedCaptionParser', () => {
   const ceaInitSegmentUri = '/base/test/test/assets/cea-init.mp4';
+  // MP4 H.264 stream carrying CEA-608 captions inside ITU-T T.35 SEI messages.
+  const ceaSegmentUri = '/base/test/test/assets/cea-segment.mp4';
+  // MP4 stream with a dedicated CEA-608 caption track (raw `c608` byte pairs).
+  const cea608TrackInitSegmentUri =
+      '/base/test/test/assets/cea608-track-init.mp4';
+  const cea608TrackSegmentUri =
+      '/base/test/test/assets/cea608-track-segment.mp4';
+  // MPEG-TS stream carrying both CEA-608 and CEA-708 captions in video SEI.
+  const tsCaptionsUri = '/base/test/test/assets/captions-test.ts';
+
   /** @type {!ArrayBuffer} */
   let ceaInitSegment;
+  /** @type {!ArrayBuffer} */
+  let ceaSegment;
+  /** @type {!ArrayBuffer} */
+  let cea608TrackInitSegment;
+  /** @type {!ArrayBuffer} */
+  let cea608TrackSegment;
+  /** @type {!ArrayBuffer} */
+  let tsCaptions;
 
 
   beforeAll(async () => {
     [
       ceaInitSegment,
+      ceaSegment,
+      cea608TrackInitSegment,
+      cea608TrackSegment,
+      tsCaptions,
     ] = await Promise.all([
       shaka.test.Util.fetch(ceaInitSegmentUri),
+      shaka.test.Util.fetch(ceaSegmentUri),
+      shaka.test.Util.fetch(cea608TrackInitSegmentUri),
+      shaka.test.Util.fetch(cea608TrackSegmentUri),
+      shaka.test.Util.fetch(tsCaptionsUri),
     ]);
   });
 
@@ -176,6 +202,111 @@ describe('ClosedCaptionParser', () => {
       expect(getDecoder(parser)).not.toBe(ceaDecoderBefore);
       expect(getDecoder(parser)).toEqual(customDecoder);
       expect(getDecoderCache(parser).size).toBe(2);
+    });
+  });
+
+  describe('integration', () => {
+    /**
+     * Asserts the cue-timing invariant from every emitted cue
+     * satisfies startTime < endTime, and (per stream) consecutive cues never
+     * overlap. This is the end-to-end guard for captions produced by the full
+     * parse -> extract -> decode pipeline.
+     * @param {!Array<!shaka.extern.ICaptionDecoder.ClosedCaption>} captions
+     */
+    function expectValidCueTiming(captions) {
+      /** @type {!Map<string, number>} */
+      const lastEndByStream = new Map();
+      for (const caption of captions) {
+        const cue = caption.cue;
+        // 6.1: a cue must have positive, ordered duration.
+        expect(cue.startTime).toBeLessThan(cue.endTime);
+        // 6.1: consecutive cues on a single stream must not overlap.
+        if (lastEndByStream.has(caption.stream)) {
+          expect(cue.startTime)
+              .toBeGreaterThanOrEqual(lastEndByStream.get(caption.stream));
+        }
+        lastEndByStream.set(caption.stream, cue.endTime);
+      }
+    }
+
+    // MP4 H.264 elementary stream must decode end-to-end and surface their
+    // captioning streams via getStreams().
+    it('decodes CEA-608 SEI captions from an MP4 H.264 stream', () => {
+      const parser = new shaka.media.ClosedCaptionParser('video/mp4');
+      parser.init(ceaInitSegment);
+
+      const captions = parser.parseFrom(ceaSegment);
+
+      expectValidCueTiming(captions);
+      // This asset carries field-1 (CC1) and field-2 (CC3) caption data.
+      const streams = parser.getStreams();
+      expect(streams).toContain('CC1');
+      expect(streams).toContain('CC3');
+    });
+
+    // `c608` byte pairs (the RAW608 packet format) rather than SEI. Exercise
+    // the extractRaw608 path through the parser end-to-end.
+    it('decodes CEA-608 captions from a raw c608 MP4 track', () => {
+      const parser = new shaka.media.ClosedCaptionParser('video/mp4');
+      parser.init(cea608TrackInitSegment);
+
+      const captions = parser.parseFrom(cea608TrackSegment);
+
+      expectValidCueTiming(captions);
+      // The raw 608 track decodes on field 1 -> CC1.
+      expect(parser.getStreams()).toContain('CC1');
+    });
+
+    // CEA-708 captions inside video SEI. The TS parser needs no init segment.
+    // This drives the CEA-708 service/window decode path (Delay alignment and
+    // window selection) end-to-end alongside CEA-608.
+    it('decodes CEA-608 and CEA-708 captions from an MPEG-TS stream', () => {
+      const parser = new shaka.media.ClosedCaptionParser('video/mp2t');
+
+      const captions = parser.parseFrom(tsCaptions);
+
+      expectValidCueTiming(captions);
+      const streams = parser.getStreams();
+      // This asset carries CEA-608 (CC1) and one CEA-708 service (svc1).
+      expect(streams).toContain('CC1');
+      expect(streams).toContain('svc1');
+    });
+
+    // timeline. Each decoder keeps its own discovered-stream state, and the
+    // cached decoder is restored (not recreated) when we return to a previously
+    // seen timeline across a discontinuity.
+    it('caches and restores a decoder per continuity timeline', () => {
+      const parser = new shaka.media.ClosedCaptionParser('video/mp4');
+
+      // Timeline 0: decode the SEI segment so the decoder discovers CC1/CC3.
+      parser.init(ceaInitSegment, /* adaptation= */ false,
+          /* continuityTimeline= */ 0);
+      parser.parseFrom(ceaSegment);
+      const timeline0Decoder = getDecoder(parser);
+      expect(parser.getStreams()).toContain('CC1');
+      expect(getDecoderCache(parser).size).toBe(1);
+
+      // Discontinuity to timeline 1: a fresh decoder is created and cached, so
+      // it has not discovered any streams yet.
+      parser.init(ceaInitSegment, /* adaptation= */ false,
+          /* continuityTimeline= */ 1);
+      const timeline1Decoder = getDecoder(parser);
+      expect(timeline1Decoder).not.toBe(timeline0Decoder);
+      expect(getDecoderCache(parser).size).toBe(2);
+      expect(parser.getStreams()).toEqual([]);
+
+      // Decode on timeline 1 so its decoder independently discovers streams.
+      parser.parseFrom(ceaSegment);
+      expect(parser.getStreams()).toContain('CC1');
+
+      // Return to timeline 0 across another discontinuity: the original decoder
+      // is restored from the cache (not recreated) with its state intact.
+      parser.init(ceaInitSegment, /* adaptation= */ false,
+          /* continuityTimeline= */ 0);
+      expect(getDecoder(parser)).toBe(timeline0Decoder);
+      expect(getDecoderCache(parser).size).toBe(2);
+      expect(parser.getStreams()).toContain('CC1');
+      expect(parser.getStreams()).toContain('CC3');
     });
   });
 

--- a/test/test/util/cea_utils.js
+++ b/test/test/util/cea_utils.js
@@ -31,16 +31,21 @@ shaka.test.CeaUtils = class {
    * @param {boolean} italics
    * @param {string} textColor
    * @param {string} backgroundColor
+   * @param {boolean=} flash Whether the run is CEA-608 Flash-On (FON), mapped
+   *   to a static bold style. Optional; defaults to false.
    * @return {!shaka.text.Cue}
    */
   static createStyledCue(startTime, endTime, payload, underline,
-      italics, textColor, backgroundColor) {
+      italics, textColor, backgroundColor, flash = false) {
     const cue = new shaka.text.Cue(startTime, endTime, payload);
     if (italics) {
       cue.fontStyle = shaka.text.Cue.fontStyle.ITALIC;
     }
     if (underline) {
       cue.textDecoration.push(shaka.text.Cue.textDecoration.UNDERLINE);
+    }
+    if (flash) {
+      cue.fontWeight = shaka.text.Cue.fontWeight.BOLD;
     }
     cue.color = textColor;
     cue.backgroundColor = backgroundColor;
@@ -126,5 +131,165 @@ shaka.test.CeaUtils = class {
     }
 
     return cue;
+  }
+
+  /**
+   * Computes odd parity for a 7-bit CEA-608 data byte, returning the byte with
+   * the parity bit (bit 7) set so that the total number of set bits is odd.
+   * CEA-608-E requires every transmitted byte to carry odd parity; the decoder
+   * verifies and then strips this bit. Using this helper keeps raw-byte test
+   * fixtures deterministic and spec-correct.
+   * @param {number} byte A value whose low 7 bits are the payload.
+   * @return {number} The 8-bit value with an odd-parity bit applied.
+   */
+  static withOddParity(byte) {
+    let b = byte & 0x7f;
+    let ones = 0;
+    for (let i = 0; i < 7; i++) {
+      ones += (b >> i) & 0x01;
+    }
+    // If the payload already has an odd number of ones, parity bit stays 0.
+    if ((ones & 0x01) === 0) {
+      b |= 0x80;
+    }
+    return b;
+  }
+
+  /**
+   * Builds a single 3-byte NTSC "cc triple" as it appears inside a cc_data()
+   * SEI payload: a cc-info byte (cc_valid + cc_type) followed by two data
+   * bytes. The cc-info byte is 0xfc | ccType with cc_valid set, matching the
+   * decoder's framing (CEA-608 field 1/2 -> 0xfc/0xfd, DTVCC data/start ->
+   * 0xfe/0xff).
+   * @param {number} ccType 0=608 field1, 1=608 field2, 2=DTVCC data,
+   *   3=DTVCC start.
+   * @param {number} b1 First data byte.
+   * @param {number} b2 Second data byte.
+   * @param {boolean=} valid Whether cc_valid is set (default true).
+   * @return {!Array<number>} The 3-byte triple.
+   */
+  static ccTriple(ccType, b1, b2, valid = true) {
+    // Reserved high bits are conventionally 1 (0xf8); cc_valid is bit 2 (0x04).
+    const ccInfo = 0xf8 | (valid ? 0x04 : 0x00) | (ccType & 0x03);
+    return [ccInfo, b1 & 0xff, b2 & 0xff];
+  }
+
+  /**
+   * Builds a deterministic CEA-608 byte-pair frame for the given NTSC field.
+   * Optionally applies odd parity to each data byte (off by default so callers
+   * can supply already parity-correct control codes verbatim, matching the
+   * existing fixtures).
+   * @param {number} field 1 for CC1/CC2 (cc_type 0), 2 for CC3/CC4 (cc_type 1).
+   * @param {number} b1 First data byte.
+   * @param {number} b2 Second data byte.
+   * @param {boolean=} applyParity When true, apply odd parity to b1 and b2.
+   * @return {!Array<number>} The 3-byte cc triple for this 608 pair.
+   */
+  static cea608Pair(field, b1, b2, applyParity = false) {
+    const ccType = field === 2 ? 1 : 0;
+    const d1 = applyParity ? shaka.test.CeaUtils.withOddParity(b1) : b1;
+    const d2 = applyParity ? shaka.test.CeaUtils.withOddParity(b2) : b2;
+    return shaka.test.CeaUtils.ccTriple(ccType, d1, d2);
+  }
+
+  /**
+   * Wraps a list of cc triples in a full user-data SEI message (T.35 / ATSC
+   * cc_data()) ready to hand to CeaDecoder.extract(). Prepends the ATSC
+   * identification bytes, a process_cc_data_flag header carrying the triple
+   * count, and the reserved padding byte.
+   * @param {!Array<!Array<number>>} triples Cc triples (see ccTriple).
+   * @return {!Uint8Array} A complete SEI user-data payload.
+   */
+  static wrapSei(triples) {
+    const initBytes = [
+      0xb5, // USA country code.
+      0x00, 0x31, // ATSC provider code.
+      0x47, 0x41, 0x39, 0x34, // ATSC user identifier ("GA94").
+      0x03, // user_data_type_code for cc_data().
+    ];
+    const count = triples.length & 0x1f;
+    // 0xc0 sets the reserved high bit and process_cc_data_flag (0x40).
+    const captionData = 0xc0 | count;
+    const bytes = [...initBytes, captionData, /* reserved padding= */ 0xff];
+    for (const triple of triples) {
+      bytes.push(...triple);
+    }
+    return new Uint8Array(bytes);
+  }
+
+  /**
+   * Convenience builder: turns a list of CEA-608 byte pairs into a complete
+   * SEI payload. Each pair is {field, b1, b2, applyParity?}.
+   * @param {!Array<{field: number, b1: number, b2: number,
+   *   applyParity: (boolean|undefined)}>} pairs
+   * @return {!Uint8Array} A complete SEI user-data payload.
+   */
+  static buildCea608Sei(pairs) {
+    const triples = pairs.map(
+        (p) => shaka.test.CeaUtils.cea608Pair(
+            p.field, p.b1, p.b2, p.applyParity || false));
+    return shaka.test.CeaUtils.wrapSei(triples);
+  }
+
+  /**
+   * Builds a single CEA-708 DTVCC service block: a service-block header
+   * (3-bit service number, 5-bit block size) followed by the service data.
+   * Uses the extended-service-block header form when serviceNumber >= 7.
+   * @param {number} serviceNumber The DTVCC service number (1-63).
+   * @param {!Array<number>} data The service block data bytes.
+   * @return {!Array<number>} The header byte(s) followed by data.
+   */
+  static dtvccServiceBlock(serviceNumber, data) {
+    const blockSize = data.length;
+    if (serviceNumber >= 7) {
+      // Standard header signals "extended" via service number 0b111, then an
+      // extended header byte carries the real 6-bit service number.
+      const standardHeader = (0x07 << 5) | (blockSize & 0x1f);
+      const extendedHeader = serviceNumber & 0x3f;
+      return [standardHeader, extendedHeader, ...data];
+    }
+    const header = ((serviceNumber & 0x07) << 5) | (blockSize & 0x1f);
+    return [header, ...data];
+  }
+
+  /**
+   * Assembles one or more DTVCC service blocks into a DTVCC packet and wraps it
+   * in a SEI payload. The packet is prefixed with a packet header whose low 6
+   * bits encode packet_size_code per CEA-708-E (so that 2 * size - 1 bytes
+   * follow), then the packet bytes are chunked into cc triples: the first
+   * triple is flagged as DTVCC_PACKET_START (cc_type 3) and the remainder as
+   * DTVCC_PACKET_DATA (cc_type 2).
+   * @param {!Array<!Array<number>>} serviceBlocks Blocks from
+   *   dtvccServiceBlock().
+   * @return {!Uint8Array} A complete SEI user-data payload.
+   */
+  static buildDtvccSei(serviceBlocks) {
+    // Concatenate all service block bytes into the packet body.
+    const body = [];
+    for (const block of serviceBlocks) {
+      body.push(...block);
+    }
+
+    // packet_size_code: number of byte pairs in the packet, including the
+    // header byte itself. total bytes = 1 (header) + body.length, rounded up
+    // to an even count of two-byte words.
+    const totalBytes = 1 + body.length;
+    const packetSizeCode = Math.ceil(totalBytes / 2) & 0x3f;
+    const packetBytes = [packetSizeCode, ...body];
+    // Pad to an even length so it chunks cleanly into 2-byte data pairs.
+    if (packetBytes.length % 2 !== 0) {
+      packetBytes.push(0x00);
+    }
+
+    const triples = [];
+    for (let i = 0; i < packetBytes.length; i += 2) {
+      const isStart = i === 0;
+      const ccType = isStart ?
+          shaka.cea.DtvccPacketBuilder.DTVCC_PACKET_START :
+          shaka.cea.DtvccPacketBuilder.DTVCC_PACKET_DATA;
+      triples.push(shaka.test.CeaUtils.ccTriple(
+          ccType, packetBytes[i], packetBytes[i + 1]));
+    }
+    return shaka.test.CeaUtils.wrapSei(triples);
   }
 };


### PR DESCRIPTION
Bring the inband closed-caption decoder closer to ANSI/CEA-608-E and ANSI/CTA-708-E by filling remaining control-code and display-mode gaps.

CEA-608:
- Text Mode emits on T1–T4; TR clears the text buffer; EDM ignores it
- Delete-to-End-of-Row (DER)
- Flash-On (FON) as a static bold style
- Cue position from indent and/or tab offset independently

CEA-708:
- Delay (0x8d) consumes its operand; DelayCancel (0x8e) handled
- Predefined window (WNSTY) and pen (PNSTY) style presets
- SetWindowAttributes fill color / word-wrap; SetPenAttributes size, font tag, and edge type
- Accumulate cues across windows for hide/toggle

Adds unit and integration coverage through ClosedCaptionParser.