### PR TITLE
fix(MSF): Correct LOC object property parsing

### DIFF
--- a/lib/msf/loc_parser.js
+++ b/lib/msf/loc_parser.js
@@ -17,18 +17,22 @@ goog.requireType('shaka.msf.Utils');
  *
  * ## Timing strategy
  *
- * The LOC spec (draft-ietf-moq-loc-02 §2.3.1) defines an optional Timestamp
- * property (ID 0x06) and an optional Timescale property (ID 0x08).
- * `parse()` resolves `startTime` through three sources in priority order:
+ * LOC defines an optional Timestamp property and an optional Timescale
+ * property (ID 0x08), carried as LOC Public Properties inside the MOQ Object
+ * Properties. `parse()` resolves `startTime` from two sources in priority
+ * order:
  *
- *   1. **Public properties** — `obj.extensions` (MOQ Object Header).
+ *   1. **Public properties** — `obj.extensions` (MOQ Object Properties).
  *      Readable by relays; preferred when present.
  *
- *   2. **Private properties** — the key-value prefix of `obj.data`
- *      (LOC §2.2).  May be end-to-end encrypted.
+ *   2. **Fallback** — `Number(obj.location.group) × frameDuration`.
+ *      Used when no Timestamp is carried.
  *
- *   3. **Fallback** — `Number(obj.location.group) × frameDuration`.
- *      Used when neither source carries a Timestamp.
+ * The Timestamp property was renumbered from 0x06 to 0x10 between
+ * draft-ietf-moq-loc-02 and -04, so both IDs are accepted: publishers of both
+ * vintages are deployed, and 0x06 additionally collides with MOQT's own
+ * SUBGROUP_DELIVERY_TIMEOUT (a Track property, so it does not appear here in
+ * practice). When both are present the current ID wins.
  *
  * When a Timestamp is found, `startTime` is computed as:
  *
@@ -45,17 +49,18 @@ goog.requireType('shaka.msf.Utils');
  *
  * ## Payload extraction
  *
- * Per LOC §2.2 the MOQ Object Payload layout is:
+ * The MOQ Object Payload is handed through unchanged as `result.payload`.
  *
- *   LOC Private Properties  (count vi64 + key-value pairs)  [optional]
- *   LOC Payload             (raw elementary bitstream)
+ * LOC-02 §2.2 also allowed a LOC Private Properties block (a count vi64
+ * followed by key-value pairs) to precede the bitstream, and this parser used
+ * to strip it. That block cannot be told apart from raw codec data — the
+ * first byte of a stereo AAC-LC `raw_data_block` reads as a count of 32 or 33
+ * — so the strip could silently truncate perfectly good media. LOC-04
+ * §3.1.3 drops the ad-hoc block entirely and delegates private metadata to
+ * the [SecureObjects] Private properties mechanism (type 0xA), so nothing is
+ * stripped here until that is implemented.
  *
- * `parse()` strips the Private Properties prefix if present and returns
- * only the bare bitstream in `result.payload`. If parsing the prefix fails
- * (e.g. the buffer starts with raw codec data that looks like count=0) the
- * full buffer is returned unchanged.
- *
- * @see https://www.ietf.org/archive/id/draft-ietf-moq-loc-02.html
+ * @see https://www.ietf.org/archive/id/draft-ietf-moq-loc-04.html
  * @final
  */
 shaka.msf.LOCParser = class {
@@ -71,51 +76,38 @@ shaka.msf.LOCParser = class {
    * Parses a single LOC MoQ object.
    *
    * Resolves `startTime` in priority order:
-   *   1. Timestamp property (ID 0x06) in public extensions (`obj.extensions`)
-   *   2. Timestamp property in private properties (LOC payload prefix)
-   *   3. Fallback: `groupId × frameDuration`
+   *   1. Timestamp property in public properties (`obj.extensions`)
+   *   2. Fallback: `groupId × frameDuration`
    *
    * @param {!shaka.msf.Utils.MOQObject} obj
    * @return {!{startTime: number, duration: number, payload: !Uint8Array}}
    */
   parse(obj) {
-    // ID of the LOC Timestamp property (§2.3.1.1, even → bigint value).
-    const TIMESTAMP_ID = BigInt(0x06);
-    // ID of the LOC Timescale property (§2.3.1.2, even → bigint value).
-    const TIMESCALE_ID = BigInt(0x08);
+    const LOCParser = shaka.msf.LOCParser;
 
-    // Always parse private properties first so that we have the payload offset
-    // (the Private Properties prefix must be stripped regardless of which
-    // timing source we use).
-    const {props: privateProps, payloadOffset} =
-        this.parsePrivateProperties_(obj.data);
-    const payload = shaka.util.BufferUtils.toUint8(obj.data, payloadOffset);
+    const payload = shaka.util.BufferUtils.toUint8(obj.data);
 
-    // 1. Public properties (MOQ Object Header Extensions)
-    // obj.extensions is a raw Uint8Array of length-bounded extension bytes
+    // Public properties (MOQ Object Properties).
+    // obj.extensions is a raw Uint8Array of length-bounded property bytes
     // (the total-length prefix was already consumed by the transport layer).
     // Parse it as a flat sequence of type+value pairs (no count prefix).
     if (obj.extensions && obj.extensions.byteLength > 0) {
       const pubProps = this.parseExtensions_(obj.extensions);
-      const pubTs = pubProps.get(TIMESTAMP_ID);
+      // draft-04 renumbered Timestamp from 0x06 to 0x10; accept both, current
+      // ID first, because publishers of both vintages are deployed.
+      let pubTs = pubProps.get(LOCParser.TIMESTAMP_ID_);
+      if (typeof pubTs !== 'bigint') {
+        pubTs = pubProps.get(LOCParser.TIMESTAMP_ID_LEGACY_);
+      }
       if (typeof pubTs === 'bigint') {
-        const pubScale = pubProps.get(TIMESCALE_ID);
+        const pubScale = pubProps.get(LOCParser.TIMESCALE_ID_);
         const startTime = this.timestampToSeconds_(pubTs,
             typeof pubScale === 'bigint' ? pubScale : undefined);
         return {startTime, duration: this.frameDuration_, payload};
       }
     }
 
-    // 2. Private properties (LOC payload prefix)
-    const privTs = privateProps.get(TIMESTAMP_ID);
-    if (typeof privTs === 'bigint') {
-      const privScale = privateProps.get(TIMESCALE_ID);
-      const startTime = this.timestampToSeconds_(privTs,
-          typeof privScale === 'bigint' ? privScale : undefined);
-      return {startTime, duration: this.frameDuration_, payload};
-    }
-
-    // 3. Fallback: GroupID × frameDuration
+    // Fallback: GroupID × frameDuration
     return {
       startTime: Number(obj.location.group) * this.frameDuration_,
       duration: this.frameDuration_,
@@ -143,18 +135,23 @@ shaka.msf.LOCParser = class {
   }
 
   /**
-   * Parses the raw MOQ Object Header Extensions buffer into a property map.
+   * Parses the raw MOQ Object Properties buffer into a property map.
    *
-   * Wire format — flat sequence of type+value pairs until buffer end
-   * (no leading count field; the total-length prefix was already consumed
-   * by the transport layer before storing the bytes in `obj.extensions`):
+   * Wire format — a flat sequence of MOQT Key-Value-Pairs
+   * (draft-ietf-moq-transport-18 §1.4.3) running to the end of the buffer;
+   * the total-length prefix was already consumed by the transport layer
+   * before storing the bytes in `obj.extensions`:
    *
-   *   type  (vi64)
-   *   value: vi64           when type is even
-   *          length (vi64) + bytes  when type is odd
+   *   delta type (vi64)
+   *   value: vi64           when the resolved type is even
+   *          length (vi64) + bytes  when the resolved type is odd
    *
-   * This differs from `parsePrivateProperties_()`, whose buffer begins with
-   * a count vi64.  Both share the same per-pair encoding.
+   * Types are DELTA encoded against the previous type in the block, starting
+   * from 0. Reading them as absolute is worse than dropping the trailing
+   * properties: a delta can collide with a real type and bind an unrelated
+   * property's value to it. With Timestamp and Timescale present the deltas
+   * are 6 and 2, so an absolute read loses Timescale entirely and
+   * timestampToSeconds_ silently falls back to its microsecond default.
    *
    * If parsing throws at any point the partial map built so far is returned,
    * so callers always receive a valid (possibly empty) map.
@@ -173,10 +170,13 @@ shaka.msf.LOCParser = class {
 
     try {
       let offset = 0;
+      /** @type {bigint} */
+      let previousType = BigInt(0);
       while (offset < data.byteLength) {
-        const typeResult = this.readVi64At_(data, offset);
-        offset += typeResult.bytesRead;
-        const type = typeResult.value;
+        const deltaResult = this.readVi64At_(data, offset);
+        offset += deltaResult.bytesRead;
+        const type = previousType + deltaResult.value;
+        previousType = type;
 
         if (type % BigInt(2) === BigInt(0)) {
           // Even type → single vi64 value
@@ -193,84 +193,11 @@ shaka.msf.LOCParser = class {
         }
       }
     } catch (e) {
-      shaka.log.v2('LOCParser: failed to parse extension headers, ' +
+      shaka.log.v2('LOCParser: failed to parse object properties, ' +
           'returning partial map', e);
     }
 
     return props;
-  }
-
-  /**
-   * Parses the optional LOC Private Properties block at the start of the raw
-   * MOQ Object Payload and returns the byte offset at which the actual media
-   * bitstream begins together with the parsed properties map.
-   *
-   * Wire format (mirrors msf_classes.js Reader.keyValuePairs()):
-   *   count  (vi64)
-   *   For each of `count` pairs:
-   *     type  (vi64)
-   *     value: vi64           when type is even
-   *            length (vi64) + bytes  when type is odd
-   *   <LOC Payload starts here>
-   *
-   * If parsing throws at any point `payloadOffset` is reset to 0 so the full
-   * buffer is returned as-is.
-   *
-   * @param {!Uint8Array} data  Raw MOQ Object Payload (obj.data).
-   * @return {{
-   *   props: !Map<bigint, bigint|!Uint8Array>,
-   *   payloadOffset: number,
-   * }}
-   * @private
-   */
-  parsePrivateProperties_(data) {
-    /** @type {!Map<bigint, bigint|!Uint8Array>} */
-    const props = new Map();
-
-    if (data.byteLength === 0) {
-      return {props, payloadOffset: 0};
-    }
-
-    try {
-      let offset = 0;
-
-      const countResult = this.readVi64At_(data, offset);
-      offset += countResult.bytesRead;
-      const count = Number(countResult.value);
-
-      // Sanity guard: an implausibly large count means the first byte is raw
-      // codec data (e.g. an H.264 start-code 0x00 0x00 0x00 0x01 reads as
-      // count=0 after masking).
-      if (count === 0 || count > 64) {
-        return {props, payloadOffset: 0};
-      }
-
-      for (let i = 0; i < count; i++) {
-        const typeResult = this.readVi64At_(data, offset);
-        offset += typeResult.bytesRead;
-        const type = typeResult.value;
-
-        if (type % BigInt(2) === BigInt(0)) {
-          // Even type → single vi64 value
-          const valResult = this.readVi64At_(data, offset);
-          offset += valResult.bytesRead;
-          props.set(type, valResult.value);
-        } else {
-          // Odd type → length-prefixed byte sequence
-          const lenResult = this.readVi64At_(data, offset);
-          offset += lenResult.bytesRead;
-          const len = Number(lenResult.value);
-          props.set(type, shaka.util.BufferUtils.toUint8(data, offset, len));
-          offset += len;
-        }
-      }
-
-      return {props, payloadOffset: offset};
-    } catch (e) {
-      shaka.log.v2('LOCParser: failed to parse private properties prefix, ' +
-          'using full buffer as payload', e);
-      return {props, payloadOffset: 0};
-    }
   }
 
   /**
@@ -378,3 +305,35 @@ shaka.msf.LOCParser = class {
     return null;
   }
 };
+
+
+/**
+ * ID of the LOC Timestamp property (draft-ietf-moq-loc-04 §2.3.1.1).
+ *
+ * Even, so the value is a bare vi64.
+ *
+ * @private @const {bigint}
+ */
+shaka.msf.LOCParser.TIMESTAMP_ID_ = BigInt(0x10);
+
+
+/**
+ * ID the LOC Timestamp property used up to draft-ietf-moq-loc-02.
+ *
+ * Accepted alongside the current ID because publishers of both vintages are
+ * deployed. It is read only when the current ID is absent, so a publisher
+ * that sends 0x10 is never affected by it.
+ *
+ * @private @const {bigint}
+ */
+shaka.msf.LOCParser.TIMESTAMP_ID_LEGACY_ = BigInt(0x06);
+
+
+/**
+ * ID of the LOC Timescale property (draft-ietf-moq-loc-04 §2.3.1.2).
+ *
+ * Unchanged across draft-02 and draft-04. Even, so the value is a bare vi64.
+ *
+ * @private @const {bigint}
+ */
+shaka.msf.LOCParser.TIMESCALE_ID_ = BigInt(0x08);

--- a/project-words.txt
+++ b/project-words.txt
@@ -180,6 +180,7 @@ unpadding
 unregisters
 unstore
 unviewed
+varint
 vint
 vints
 xywh

--- a/test/msf/loc_parser_unit.js
+++ b/test/msf/loc_parser_unit.js
@@ -1,0 +1,199 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('LOCParser', () => {
+  /** AAC at 48 kHz: 1024 samples per frame. */
+  const FRAME = 1024 / 48000;
+
+  /**
+   * Encodes a QUIC variable-length integer (RFC 9000 §16).
+   *
+   * @param {bigint} value
+   * @return {!Uint8Array}
+   */
+  function varint(value) {
+    if (value < BigInt(64)) {
+      return new Uint8Array([Number(value)]);
+    }
+    if (value < BigInt(16384)) {
+      const v = Number(value);
+      return new Uint8Array([0x40 | (v >> 8), v & 0xff]);
+    }
+    if (value < BigInt(1073741824)) {
+      const v = Number(value);
+      return new Uint8Array([
+        0x80 | (v >>> 24), (v >>> 16) & 0xff, (v >>> 8) & 0xff, v & 0xff,
+      ]);
+    }
+    const bytes = new Uint8Array(8);
+    let v = value;
+    for (let i = 7; i >= 0; i--) {
+      bytes[i] = Number(v & BigInt(0xff));
+      v >>= BigInt(8);
+    }
+    bytes[0] |= 0xc0;
+    return bytes;
+  }
+
+  /**
+   * Builds a MOQ Object Properties block from key-value pairs, delta encoding
+   * the types the way draft-ietf-moq-transport-18 §1.4.3 requires.
+   *
+   * @param {!Array<{type: number, value: (number|!Uint8Array)}>} pairs
+   *   Must be in ascending type order, as a real publisher writes them.
+   * @return {!Uint8Array}
+   */
+  function properties(pairs) {
+    /** @type {!Array<!Uint8Array>} */
+    const chunks = [];
+    let previousType = 0;
+    for (const pair of pairs) {
+      chunks.push(varint(BigInt(pair.type - previousType)));
+      previousType = pair.type;
+      const bytes = ArrayBuffer.isView(pair.value) ?
+          /** @type {!Uint8Array} */ (pair.value) :
+          null;
+      if (bytes) {
+        chunks.push(varint(BigInt(bytes.byteLength)));
+        chunks.push(bytes);
+      } else {
+        chunks.push(varint(BigInt(/** @type {number} */ (pair.value))));
+      }
+    }
+    return shaka.util.Uint8ArrayUtils.concat(...chunks);
+  }
+
+  /**
+   * @param {!Array<{type: number, value: (number|!Uint8Array)}>} pairs
+   * @param {!Uint8Array=} payload
+   * @param {number=} group
+   * @return {!shaka.msf.Utils.MOQObject}
+   */
+  function moqObject(pairs, payload, group) {
+    return /** @type {!shaka.msf.Utils.MOQObject} */ ({
+      trackAlias: BigInt(1),
+      location: {
+        group: BigInt(group || 0),
+        object: BigInt(0),
+        subgroup: BigInt(0),
+      },
+      data: payload || new Uint8Array([0x21, 0x11, 0x45]),
+      extensions: properties(pairs),
+      status: null,
+      payloadReadStartMs: 0,
+      receiveTimestampMs: 0,
+    });
+  }
+
+  describe('object property types', () => {
+    it('delta decodes the type of every property after the first', () => {
+      // Timestamp (0x10) then Timescale (0x08) cannot both be expressed by an
+      // absolute reader: written in ascending order the deltas are 8 and 8.
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const result = parser.parse(moqObject([
+        {type: 0x08, value: 1000},
+        {type: 0x10, value: 5000},
+      ]));
+
+      // 5000 / 1000, not 5000 / 1e6 and not the group fallback.
+      expect(result.startTime).toBeCloseTo(5, 6);
+    });
+
+    it('reads a lone property as an absolute type', () => {
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const result = parser.parse(moqObject([{type: 0x10, value: 2500000}]));
+      expect(result.startTime).toBeCloseTo(2.5, 6);
+    });
+
+    it('does not bind a delta to an unrelated property', () => {
+      // Read absolutely, the second pair's delta of 8 would be taken as
+      // Timescale (0x08) and the timeline would be out by a factor of 125000.
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const result = parser.parse(moqObject([
+        {type: 0x08, value: 90000},
+        {type: 0x10, value: 90000},
+      ]));
+      expect(result.startTime).toBeCloseTo(1, 6);
+    });
+  });
+
+  describe('timestamp property ID', () => {
+    it('reads the draft-04 ID (0x10)', () => {
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const result = parser.parse(moqObject([{type: 0x10, value: 1500000}]));
+      expect(result.startTime).toBeCloseTo(1.5, 6);
+    });
+
+    it('reads the legacy draft-02 ID (0x06)', () => {
+      // moqlivemock publishes this one.
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const result = parser.parse(moqObject([{type: 0x06, value: 1500000}]));
+      expect(result.startTime).toBeCloseTo(1.5, 6);
+    });
+
+    it('prefers the draft-04 ID when both are present', () => {
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const result = parser.parse(moqObject([
+        {type: 0x06, value: 1000000},
+        {type: 0x10, value: 3000000},
+      ]));
+      expect(result.startTime).toBeCloseTo(3, 6);
+    });
+
+    it('falls back to the group number when neither is present', () => {
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const result = parser.parse(
+          moqObject([{type: 0x0c, value: 42}], undefined, /* group= */ 7));
+      expect(result.startTime).toBeCloseTo(7 * FRAME, 9);
+    });
+  });
+
+  describe('payload', () => {
+    it('passes the object payload through untouched', () => {
+      // A stereo AAC-LC raw_data_block starts with 0x20/0x21, which the old
+      // private-properties strip read as a count of 32/33 and tried to parse
+      // as key-value pairs.
+      const aac = new Uint8Array([0x21, 0x11, 0x45, 0x00, 0x14, 0x50]);
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const result = parser.parse(
+          moqObject([{type: 0x10, value: 1000000}], aac));
+      expect(result.payload).toEqual(aac);
+    });
+
+    it('passes a length-prefixed NALU payload through untouched', () => {
+      const avc = new Uint8Array([0, 0, 0, 2, 0x65, 0x88]);
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const result = parser.parse(
+          moqObject([{type: 0x10, value: 1000000}], avc));
+      expect(result.payload).toEqual(avc);
+    });
+  });
+
+  describe('malformed properties', () => {
+    it('falls back to the group number when the block is truncated', () => {
+      const obj = moqObject([{type: 0x10, value: 1000000}],
+          undefined, /* group= */ 3);
+      // Cut the value short so readVi64At_ underflows.
+      obj.extensions = obj.extensions.subarray(0, 1);
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const result = parser.parse(obj);
+      expect(result.startTime).toBeCloseTo(3 * FRAME, 9);
+    });
+
+    it('keeps the properties parsed before a truncation', () => {
+      const full = properties([
+        {type: 0x10, value: 1000000},
+        {type: 0x11, value: new Uint8Array([1, 2, 3, 4])},
+      ]);
+      const obj = moqObject([]);
+      // Drop the trailing byte-string value, keeping the Timestamp intact.
+      obj.extensions = full.subarray(0, full.byteLength - 2);
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const result = parser.parse(obj);
+      expect(result.startTime).toBeCloseTo(1, 6);
+    });
+  });
+});


### PR DESCRIPTION
LOCParser read MOQ Object Properties in three non-conformant ways.

Property types are delta encoded against the previous type in the block (draft-ietf-moq-transport-18 §1.4.3; §11.2.1.2 makes Object Properties a sequence of Key-Value-Pairs). Reading them as absolute is worse than dropping the trailing properties: a delta can collide with a real type and bind an unrelated property's value to it. With Timestamp and Timescale present the deltas are 6 and 2, so Timescale went missing entirely and timestampToSeconds_ silently fell back to its microsecond default.

The Timestamp property ID moved from 0x06 to 0x10 between draft-ietf-moq-loc-02 and -04. Both are now accepted, the current one first, because publishers of both vintages are deployed.

The LOC Private Properties block is removed. It cannot be told apart from raw codec data — the first byte of a stereo AAC-LC raw_data_block reads as a count of 32 or 33 — so the strip could silently truncate perfectly good media. draft-ietf-moq-loc-04 §3.1.3 drops the block and delegates private metadata to the SecureObjects Private properties mechanism (type 0xA), so nothing is stripped until that is implemented.