### PR TITLE
feat(Ads): cooldown config for interstitial ad

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -102,6 +102,7 @@ Konstantin Grushetsky <github@grushetsky.net>
 Leandro Ribeiro Moreira <leandro.ribeiro.moreira@gmail.com>
 Leo Antunes <leo@costela.net>
 Loïc Raux <loicraux@gmail.com>
+Long Huang <hlislichking@gmail.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Martin Stark <martin.stark@eyevinn.se>
 Mariano Facundo Scigliano <mfacundo94@gmail.com>

--- a/demo/config.js
+++ b/demo/config.js
@@ -529,6 +529,10 @@ shakaDemo.Config = class {
         .addNumberInput_('Interstitial preload ahead time',
             'ads.interstitialPreloadAheadTime',
             /* canBeDecimal= */ true,
+            /* canBeZero= */ true)
+        .addNumberInput_('Interstitial cooldown',
+            'ads.interstitialCooldown',
+            /* canBeDecimal= */ true,
             /* canBeZero= */ true);
   }
 

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2585,6 +2585,7 @@ shaka.extern.AccessibilityConfiguration;
  *   disableTrackingEvents: boolean,
  *   disableSnapback: boolean,
  *   interstitialPreloadAheadTime: number,
+ *   interstitialCooldown: number,
  *   disablePlayedLinearAdSkip: boolean,
  *   disableTrackingForPlayedLinearAds: boolean,
  * }}
@@ -2646,6 +2647,13 @@ shaka.extern.AccessibilityConfiguration;
  *   Interstitial preload ahead time, in seconds.
  *   <br>
  *   Defaults to <code>10</code>.
+ * @property {number} interstitialCooldown
+ *   Cooldown period, in seconds, that starts after any SGAI interstitial ad
+ *   break finishes playing. While the cooldown is active, any snapback or the
+ *   next interstitial ad break that would otherwise play is skipped. Set to
+ *   <code>0</code> to disable the cooldown.
+ *   <br>
+ *   Defaults to <code>0</code>.
  * @property {boolean} disablePlayedLinearAdSkip
  *   If true, disables automatic skipping of already-played linear ads.
  *   Normally, played linear ads are force-skipped on replay. When this flag

--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -144,6 +144,13 @@ shaka.ads.InterstitialAdManager = class {
      */
     this.playingAdStartTime_ = null;
 
+    /**
+     * Wall-clock time (ms) when the last SGAI interstitial ad break finished
+     * playing. Used to enforce the interstitialCooldown config.
+     * @private {?number}
+     */
+    this.lastAdCompleteTime_ = null;
+
     /** @private {?shaka.util.Timer} */
     this.playoutLimitTimer_ = null;
 
@@ -201,6 +208,12 @@ shaka.ads.InterstitialAdManager = class {
       const currentInterstitial = this.getCurrentInterstitial_();
       if (currentInterstitial &&
           allowPlayInterstitialNow(currentInterstitial)) {
+        if (this.isInCooldown_()) {
+          // While in cooldown, skip this ad break (snapback or next ad) so it
+          // is not played again once the cooldown expires.
+          this.lastPlayedAd_ = currentInterstitial;
+          return;
+        }
         this.setupAd_(currentInterstitial, /* sequenceLength= */ 1,
             /* adPosition= */ 1, /* initialTime= */ Date.now());
       }
@@ -226,6 +239,12 @@ shaka.ads.InterstitialAdManager = class {
       }
       if (currentInterstitial &&
           allowPlayInterstitialNow(currentInterstitial)) {
+        if (this.isInCooldown_()) {
+          // While in cooldown, skip this ad break (snapback or next ad) so it
+          // is not played again once the cooldown expires.
+          this.lastPlayedAd_ = currentInterstitial;
+          return;
+        }
         this.setupAd_(currentInterstitial, /* sequenceLength= */ 1,
             /* adPosition= */ 1, /* initialTime= */ Date.now());
       }
@@ -467,6 +486,7 @@ shaka.ads.InterstitialAdManager = class {
     this.lastTime_ = null;
     this.lastPlayedAd_ = null;
     this.playingAdStartTime_ = null;
+    this.lastAdCompleteTime_ = null;
     this.usingBaseVideo_ = true;
     this.video_ = this.baseVideo_;
     this.adVideo_ = null;
@@ -877,6 +897,23 @@ shaka.ads.InterstitialAdManager = class {
 
 
   /**
+   * Returns true if we are within the interstitialCooldown window that starts
+   * after an SGAI interstitial ad break finishes playing. While active, any
+   * snapback or next ad break should be skipped.
+   *
+   * @return {boolean}
+   * @private
+   */
+  isInCooldown_() {
+    const cooldown = this.config_ ? this.config_.interstitialCooldown : 0;
+    if (cooldown <= 0 || this.lastAdCompleteTime_ == null) {
+      return false;
+    }
+    return (Date.now() - this.lastAdCompleteTime_) / 1000 < cooldown;
+  }
+
+
+  /**
    * @param {shaka.extern.AdInterstitial} interstitial
    * @param {number} sequenceLength
    * @param {number} adPosition
@@ -995,6 +1032,7 @@ shaka.ads.InterstitialAdManager = class {
       }
 
       if (!this.playingAd_) {
+        this.lastAdCompleteTime_ = Date.now();
         this.sendEvent_(shaka.ads.Utils.AD_BREAK_ENDED,
             (new Map()).set('timeOffset', timeOffset));
       }
@@ -1211,6 +1249,7 @@ shaka.ads.InterstitialAdManager = class {
             ++adPosition, initialTime, oncePlayed);
       }
       if (!this.playingAd_) {
+        this.lastAdCompleteTime_ = Date.now();
         this.sendEvent_(shaka.ads.Utils.AD_BREAK_ENDED,
             (new Map()).set('timeOffset', timeOffset));
         this.playoutLimitTimer_?.stop();

--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -209,9 +209,8 @@ shaka.ads.InterstitialAdManager = class {
       if (currentInterstitial &&
           allowPlayInterstitialNow(currentInterstitial)) {
         if (this.isInCooldown_()) {
-          // While in cooldown, skip this ad break (snapback or next ad) so it
-          // is not played again once the cooldown expires.
-          this.lastPlayedAd_ = currentInterstitial;
+          // Within the cooldown window after the last interstitial finished;
+          // don't initiate a new ad break (snapback or next ad).
           return;
         }
         this.setupAd_(currentInterstitial, /* sequenceLength= */ 1,
@@ -240,9 +239,8 @@ shaka.ads.InterstitialAdManager = class {
       if (currentInterstitial &&
           allowPlayInterstitialNow(currentInterstitial)) {
         if (this.isInCooldown_()) {
-          // While in cooldown, skip this ad break (snapback or next ad) so it
-          // is not played again once the cooldown expires.
-          this.lastPlayedAd_ = currentInterstitial;
+          // Within the cooldown window after the last interstitial finished;
+          // don't initiate a new ad break (snapback or next ad).
           return;
         }
         this.setupAd_(currentInterstitial, /* sequenceLength= */ 1,

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -405,6 +405,7 @@ shaka.util.PlayerConfiguration = class {
       disableTrackingEvents: false,
       disableSnapback: false,
       interstitialPreloadAheadTime: 10,
+      interstitialCooldown: 0,
       disablePlayedLinearAdSkip: false,
       disableTrackingForPlayedLinearAds: false,
     };

--- a/project-words.txt
+++ b/project-words.txt
@@ -205,6 +205,7 @@ Clearkey
 Clearkeys
 Clutz
 codem
+cooldown
 cssnano
 hbbtv
 Conax

--- a/test/ads/interstitial_ad_manager_unit.js
+++ b/test/ads/interstitial_ad_manager_unit.js
@@ -3110,6 +3110,100 @@ describe('Interstitial Ad manager', () => {
     }
   });
 
+  /** @suppress {visibility} */
+  describe('interstitialCooldown', () => {
+    /** @param {number} cooldown */
+    function configureCooldown(cooldown) {
+      const config = shaka.util.PlayerConfiguration.createDefault().ads;
+      // We always support multiple video elements so that we can properly
+      // control timing in unit tests.
+      config.supportsMultipleMediaElements = true;
+      config.interstitialCooldown = cooldown;
+      interstitialAdManager.configure(config);
+    }
+
+    /** @return {shaka.extern.HLSMetadata} */
+    function prerollMetadata() {
+      return {
+        type: 'com.apple.quicktime.HLS',
+        startTime: 0,
+        endTime: null,
+        values: [
+          {
+            key: 'ID',
+            data: 'PREROLL',
+          },
+          {
+            key: 'CUE',
+            data: 'PRE',
+          },
+          {
+            key: 'X-ASSET-URI',
+            data: 'http://foo.bar/test.m3u8',
+          },
+          {
+            key: 'X-RESTRICT',
+            data: 'SKIP,JUMP',
+          },
+        ],
+      };
+    }
+
+    it('skips an interstitial while within the cooldown window', async () => {
+      configureCooldown(60);
+      await interstitialAdManager.addMetadata(prerollMetadata());
+
+      // Pretend an ad break just finished, so the cooldown window is active.
+      interstitialAdManager.lastAdCompleteTime_ = Date.now();
+
+      video.play();
+      video.dispatchEvent(new Event('timeupdate'));
+
+      await shaka.test.Util.shortDelay();
+
+      expect(onEventSpy).not.toHaveBeenCalledWith(
+          jasmine.objectContaining({type: 'ad-break-started'}));
+      expect(onEventSpy).not.toHaveBeenCalledWith(
+          jasmine.objectContaining({type: 'ad-started'}));
+    });
+
+    it('plays an interstitial after the cooldown expires', async () => {
+      configureCooldown(60);
+      await interstitialAdManager.addMetadata(prerollMetadata());
+
+      // Pretend an ad break finished longer ago than the cooldown window.
+      interstitialAdManager.lastAdCompleteTime_ = Date.now() - 61 * 1000;
+
+      video.play();
+      video.dispatchEvent(new Event('timeupdate'));
+
+      await shaka.test.Util.shortDelay();
+
+      expect(onEventSpy).toHaveBeenCalledWith(
+          jasmine.objectContaining({type: 'ad-break-started'}));
+      expect(onEventSpy).toHaveBeenCalledWith(
+          jasmine.objectContaining({type: 'ad-started'}));
+    });
+
+    it('does not skip when the cooldown is disabled', async () => {
+      configureCooldown(0);
+      await interstitialAdManager.addMetadata(prerollMetadata());
+
+      // Even with a recent ad break, a zero cooldown must not suppress ads.
+      interstitialAdManager.lastAdCompleteTime_ = Date.now();
+
+      video.play();
+      video.dispatchEvent(new Event('timeupdate'));
+
+      await shaka.test.Util.shortDelay();
+
+      expect(onEventSpy).toHaveBeenCalledWith(
+          jasmine.objectContaining({type: 'ad-break-started'}));
+      expect(onEventSpy).toHaveBeenCalledWith(
+          jasmine.objectContaining({type: 'ad-started'}));
+    });
+  });
+
   it('don\'t dispatch cue points changed if it is an overlay', async () => {
     /** @type {!shaka.extern.AdInterstitial} */
     const interstitial = {


### PR DESCRIPTION
This pull request introduces a new configuration option, `interstitialCooldown`, to control the cooldown period after an SGAI interstitial ad break finishes playing. This prevents snapbacks or subsequent interstitial ad breaks from playing again within the cooldown window. The changes add support for this option in the configuration UI, player configuration, and interstitial ad manager logic.

**Interstitial Ad Cooldown Feature:**

* Added a new `interstitialCooldown` configuration option to the player configuration, with a default value of `0` (disabled). This option specifies a cooldown period (in seconds) after an SGAI interstitial ad break finishes, during which any snapback or next ad break is skipped. [[1]](diffhunk://#diff-44e00a6728e7ff86a8b5f6873213a64b1c0d6a24bb529111ea83068e2529b0feR408) [[2]](diffhunk://#diff-9ac7cefa529d82513af9ff09186f9a6de19b063416e27c6fe97e834ea223388aR2588) [[3]](diffhunk://#diff-9ac7cefa529d82513af9ff09186f9a6de19b063416e27c6fe97e834ea223388aR2650-R2656)
* Updated the configuration UI in `config.js` to allow setting `interstitialCooldown` via a number input.

**Interstitial Ad Manager Logic:**

* Added tracking of the last completed ad break time and implemented the `isInCooldown_()` method to determine if the cooldown is active. This ensures ad breaks are skipped during the cooldown window. [[1]](diffhunk://#diff-93e813158422095783a2ac2782d8a88fa8627f5c1cd41e091f4ee186da7d41b2R147-R153) [[2]](diffhunk://#diff-93e813158422095783a2ac2782d8a88fa8627f5c1cd41e091f4ee186da7d41b2R899-R915)
* Integrated cooldown checks into ad playback logic, so interstitial ads and snapbacks are skipped if the cooldown is active. [[1]](diffhunk://#diff-93e813158422095783a2ac2782d8a88fa8627f5c1cd41e091f4ee186da7d41b2R211-R216) [[2]](diffhunk://#diff-93e813158422095783a2ac2782d8a88fa8627f5c1cd41e091f4ee186da7d41b2R242-R247)
* Updated the ad manager to record the end time of ad breaks, ensuring accurate cooldown enforcement and proper reset on state changes. [[1]](diffhunk://#diff-93e813158422095783a2ac2782d8a88fa8627f5c1cd41e091f4ee186da7d41b2R1035) [[2]](diffhunk://#diff-93e813158422095783a2ac2782d8a88fa8627f5c1cd41e091f4ee186da7d41b2R1252) [[3]](diffhunk://#diff-93e813158422095783a2ac2782d8a88fa8627f5c1cd41e091f4ee186da7d41b2R489)