### PR TITLE
fix(MSF): Fix LOC appends and live timeline sizing

### DIFF
--- a/lib/msf/loc_parser.js
+++ b/lib/msf/loc_parser.js
@@ -66,10 +66,23 @@ goog.requireType('shaka.msf.Utils');
 shaka.msf.LOCParser = class {
   /**
    * @param {number} frameDuration
+   * @param {string=} normalizedCodec The track's codec as returned by
+   *   shaka.util.MimeUtils.getNormalizedCodec, used to decode the Video
+   *   Config property. Omit for tracks that cannot carry one.
    */
-  constructor(frameDuration) {
+  constructor(frameDuration, normalizedCodec) {
     /** @private {number} */
     this.frameDuration_ = frameDuration;
+
+    /** @private {?string} */
+    this.normalizedCodec_ = normalizedCodec || null;
+
+    /**
+     * End time of the last reference this parser emitted, or null before the
+     * first one. See snapStartTime_.
+     * @private {?number}
+     */
+    this.lastEndTime_ = null;
   }
 
   /**
@@ -85,7 +98,7 @@ shaka.msf.LOCParser = class {
   parse(obj) {
     const LOCParser = shaka.msf.LOCParser;
 
-    const payload = shaka.util.BufferUtils.toUint8(obj.data);
+    let payload = shaka.util.BufferUtils.toUint8(obj.data);
 
     // Public properties (MOQ Object Properties).
     // obj.extensions is a raw Uint8Array of length-bounded property bytes
@@ -93,6 +106,18 @@ shaka.msf.LOCParser = class {
     // Parse it as a flat sequence of type+value pairs (no count prefix).
     if (obj.extensions && obj.extensions.byteLength > 0) {
       const pubProps = this.parseExtensions_(obj.extensions);
+
+      // Restore the parameter sets of a publisher that ships them out of band.
+      // LOC-04 §2.1.2 allows a track to strip parameter sets from the
+      // bitstream and carry the codec's extradata in the Video Config
+      // property instead, on every key frame. Without this the payload of an
+      // AVC track contains only slice NALs, H264.parseInfo() never resolves a
+      // config, and the video track stays silently empty forever.
+      const videoConfig = pubProps.get(LOCParser.VIDEO_CONFIG_ID_);
+      if (videoConfig && ArrayBuffer.isView(videoConfig)) {
+        payload = this.prependParameterSets_(
+            payload, /** @type {!Uint8Array} */ (videoConfig));
+      }
       // draft-04 renumbered Timestamp from 0x06 to 0x10; accept both, current
       // ID first, because publishers of both vintages are deployed.
       let pubTs = pubProps.get(LOCParser.TIMESTAMP_ID_);
@@ -101,18 +126,241 @@ shaka.msf.LOCParser = class {
       }
       if (typeof pubTs === 'bigint') {
         const pubScale = pubProps.get(LOCParser.TIMESCALE_ID_);
-        const startTime = this.timestampToSeconds_(pubTs,
-            typeof pubScale === 'bigint' ? pubScale : undefined);
+        const startTime = this.snapStartTime_(this.timestampToSeconds_(
+            pubTs, typeof pubScale === 'bigint' ? pubScale : undefined));
         return {startTime, duration: this.frameDuration_, payload};
       }
     }
 
     // Fallback: GroupID × frameDuration
     return {
-      startTime: Number(obj.location.group) * this.frameDuration_,
+      startTime: this.snapStartTime_(
+          Number(obj.location.group) * this.frameDuration_),
       duration: this.frameDuration_,
       payload,
     };
+  }
+
+  /**
+   * Snaps `startTime` onto the previous reference's end time when it is close
+   * enough to be publish-clock noise rather than a real discontinuity.
+   *
+   * A LOC reference is assembled from two different clocks: `startTime` comes
+   * from the publisher's Timestamp, `duration` is a constant derived from the
+   * catalog. The two cannot agree exactly, so consecutive references overlap
+   * or leave a hole — even a publisher whose timestamps are exact leaves
+   * sub-microsecond gaps, because a frame duration such as 1024/48000 s is
+   * not representable in whole timestamp units.
+   *
+   * That is not cosmetic, and the size of the gap barely matters.
+   * StreamingEngine asks for the segment covering the previous reference's
+   * endTime; when that instant falls in a hole of ANY width,
+   * SegmentIndex.find() returns null and update_ takes its "segment could not
+   * be found ... just try again" path, backing off half a segment and
+   * retrying instead of appending.
+   *
+   * Beyond the tolerance the publisher's clock stays authoritative, so a real
+   * discontinuity still resyncs the timeline.
+   *
+   * The trade-off is explicit: within the tolerance a genuinely lost frame is
+   * closed up rather than preserved as a gap, which advances this track
+   * against the others by that frame's duration. For live playback that is
+   * the right trade — a lost frame is inaudible or invisible, a hole stalls
+   * outright, and the drift is bounded because any real discontinuity
+   * re-anchors on the publisher's clock.
+   *
+   * @param {number} startTime
+   * @return {number}
+   * @private
+   */
+  snapStartTime_(startTime) {
+    const LOCParser = shaka.msf.LOCParser;
+    const last = this.lastEndTime_;
+    // Publish-clock jitter is an absolute quantity — a publisher whose clock
+    // wanders by tens of milliseconds does so whether the track is 60 fps
+    // video or 48 kHz audio — so a purely frame-counted tolerance hands each
+    // track a different allowance for the same physical jitter, and
+    // under-serves whichever track has the shorter frames. Floor it in the
+    // time domain, keeping the frame-based term for tracks whose frames are
+    // longer than the floor.
+    const tolerance = Math.max(
+        this.frameDuration_ * LOCParser.SNAP_TOLERANCE_FRAMES_,
+        LOCParser.SNAP_TOLERANCE_MIN_SEC_);
+    if (last != null && Math.abs(startTime - last) < tolerance) {
+      startTime = last;
+    }
+    this.lastEndTime_ = startTime + this.frameDuration_;
+    return startTime;
+  }
+
+  /**
+   * Prepends the parameter sets carried in the Video Config property to
+   * `payload`, as 4-byte length-prefixed NAL units.
+   *
+   * LOC-04 §2.3.2.1 defines Video Config as "the extradata bytes defined by
+   * the corresponding codec specification", so its layout depends on the
+   * codec: an AVCDecoderConfigurationRecord for H.264 and an
+   * HEVCDecoderConfigurationRecord for H.265. A publisher that uses it has
+   * stripped the parameter sets from the bitstream (§2.1.2), so re-inlining
+   * them here restores exactly what was removed, at the earliest point, and
+   * every downstream consumer stays unchanged — in-band parameter sets ahead
+   * of a key frame are what decoders expect anyway.
+   *
+   * The record's own `lengthSizeMinusOne` describes how the RECORD frames its
+   * entries, not how the bitstream frames its NAL units, so the restored sets
+   * are always emitted with the 4-byte prefix LOC-04 §2.1.3 specifies.
+   *
+   * Returns `payload` unchanged when the codec has no known record layout or
+   * the record is malformed: a bad config must degrade to the previous
+   * behaviour rather than corrupt the bitstream.
+   *
+   * @param {!Uint8Array} payload
+   * @param {!Uint8Array} config  The Video Config property value.
+   * @return {!Uint8Array}
+   * @private
+   */
+  prependParameterSets_(payload, config) {
+    const LOCParser = shaka.msf.LOCParser;
+
+    /** @type {?Array<!Uint8Array>} */
+    let paramSets = null;
+    if (this.normalizedCodec_ === 'avc') {
+      paramSets = LOCParser.avcParameterSets_(config);
+    } else if (this.normalizedCodec_ === 'hevc') {
+      paramSets = LOCParser.hevcParameterSets_(config);
+    }
+
+    if (!paramSets || !paramSets.length) {
+      return payload;
+    }
+
+    let prefixSize = 0;
+    for (const ps of paramSets) {
+      prefixSize += 4 + ps.byteLength;
+    }
+
+    const out = new Uint8Array(prefixSize + payload.byteLength);
+    let w = 0;
+    for (const ps of paramSets) {
+      const len = ps.byteLength;
+      out[w++] = (len >>> 24) & 0xff;
+      out[w++] = (len >>> 16) & 0xff;
+      out[w++] = (len >>> 8) & 0xff;
+      out[w++] = len & 0xff;
+      out.set(ps, w);
+      w += len;
+    }
+    out.set(payload, w);
+    return out;
+  }
+
+  /**
+   * Extracts the SPS and PPS NAL units from an AVCDecoderConfigurationRecord
+   * (ISO/IEC 14496-15 §5.3.3.1), or null if the record is malformed.
+   *
+   * @param {!Uint8Array} config
+   * @return {?Array<!Uint8Array>}
+   * @private
+   */
+  static avcParameterSets_(config) {
+    // configurationVersion(1) profile(1) compat(1) level(1)
+    // lengthSizeMinusOne(1) numOfSPS(1) — 6 bytes before the first SPS.
+    if (config.byteLength < 7 || config[0] !== 1) {
+      return null;
+    }
+
+    /** @type {!Array<!Uint8Array>} */
+    const paramSets = [];
+    let offset = 5;
+
+    // Two runs with identical structure: SPS (count in the low 5 bits) then
+    // PPS (a full byte). Each entry is a 2-byte big-endian length + payload.
+    for (const mask of [0x1f, 0xff]) {
+      if (offset >= config.byteLength) {
+        return null;
+      }
+      const count = config[offset++] & mask;
+      for (let i = 0; i < count; i++) {
+        const nalu = shaka.msf.LOCParser.readSizedNalu_(config, offset);
+        if (!nalu) {
+          return null;
+        }
+        paramSets.push(nalu.data);
+        offset = nalu.offset;
+      }
+    }
+
+    return paramSets;
+  }
+
+  /**
+   * Extracts the VPS, SPS and PPS NAL units from an
+   * HEVCDecoderConfigurationRecord (ISO/IEC 14496-15 §8.3.3.1), or null if
+   * the record is malformed.
+   *
+   * The record groups NAL units into arrays keyed by type rather than listing
+   * them in a fixed order, and H265.parseInfo() needs all three, so every
+   * array is emitted in the order the record lists them.
+   *
+   * @param {!Uint8Array} config
+   * @return {?Array<!Uint8Array>}
+   * @private
+   */
+  static hevcParameterSets_(config) {
+    // 22 bytes of fixed fields (profile/tier/level, chroma and bit depths,
+    // frame rate, lengthSizeMinusOne) precede numOfArrays.
+    const ARRAYS_OFFSET = 23;
+    if (config.byteLength < ARRAYS_OFFSET || config[0] !== 1) {
+      return null;
+    }
+
+    /** @type {!Array<!Uint8Array>} */
+    const paramSets = [];
+    const numOfArrays = config[22];
+    let offset = ARRAYS_OFFSET;
+
+    for (let i = 0; i < numOfArrays; i++) {
+      // array_completeness(1) reserved(1) NAL_unit_type(6), then a 2-byte
+      // count. The NAL type is already in the unit's own header, so it is
+      // only read past here.
+      if (offset + 3 > config.byteLength) {
+        return null;
+      }
+      offset += 1;
+      const numNalus = (config[offset] << 8) | config[offset + 1];
+      offset += 2;
+      for (let j = 0; j < numNalus; j++) {
+        const nalu = shaka.msf.LOCParser.readSizedNalu_(config, offset);
+        if (!nalu) {
+          return null;
+        }
+        paramSets.push(nalu.data);
+        offset = nalu.offset;
+      }
+    }
+
+    return paramSets;
+  }
+
+  /**
+   * Reads one 2-byte big-endian length-prefixed NAL unit from a decoder
+   * configuration record, or null if it does not fit.
+   *
+   * @param {!Uint8Array} config
+   * @param {number} offset
+   * @return {?{data: !Uint8Array, offset: number}}
+   * @private
+   */
+  static readSizedNalu_(config, offset) {
+    if (offset + 2 > config.byteLength) {
+      return null;
+    }
+    const len = (config[offset] << 8) | config[offset + 1];
+    offset += 2;
+    if (len === 0 || offset + len > config.byteLength) {
+      return null;
+    }
+    return {data: config.subarray(offset, offset + len), offset: offset + len};
   }
 
   /**
@@ -337,3 +585,41 @@ shaka.msf.LOCParser.TIMESTAMP_ID_LEGACY_ = BigInt(0x06);
  * @private @const {bigint}
  */
 shaka.msf.LOCParser.TIMESCALE_ID_ = BigInt(0x08);
+
+
+/**
+ * ID of the LOC Video Config property (draft-ietf-moq-loc-04 §2.3.2.1).
+ *
+ * Odd, so the value is a length-prefixed byte string: the codec's extradata,
+ * which is an AVCDecoderConfigurationRecord for H.264 and an
+ * HEVCDecoderConfigurationRecord for H.265. Carried only on key frames, and
+ * only by publishers that strip parameter sets from the bitstream.
+ *
+ * @private @const {bigint}
+ */
+shaka.msf.LOCParser.VIDEO_CONFIG_ID_ = BigInt(0x0d);
+
+
+/**
+ * How far, in frame durations, a LOC timestamp may sit from the previous
+ * reference's end and still be treated as publish-clock noise rather than a
+ * discontinuity.
+ *
+ * A real discontinuity is a track switch or a source change, which is orders
+ * of magnitude larger than this.
+ *
+ * @private @const {number}
+ */
+shaka.msf.LOCParser.SNAP_TOLERANCE_FRAMES_ = 2;
+
+
+/**
+ * Minimum snap tolerance in seconds, regardless of frame duration.
+ *
+ * Jitter is absolute, not proportional to frame rate, so a frame-counted
+ * tolerance under-serves short frames: two frames of 48 kHz AAC is 42.7 ms,
+ * which is inside the range ordinary publish-clock wander reaches.
+ *
+ * @private @const {number}
+ */
+shaka.msf.LOCParser.SNAP_TOLERANCE_MIN_SEC_ = 0.06;

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -991,16 +991,16 @@ shaka.msf.MSFParser = class {
       const maxSegmentDuration =
           this.presentationTimeline_.getMaxSegmentDuration();
       if (maxSegmentDuration > 0) {
-        // No DVR — the seek range sits at the live edge. But the window still
-        // has to be wide enough to CONTAIN the playhead, which necessarily
-        // trails the live edge by whatever is buffered.
+        // No DVR — the window sits at the live edge. But it still has to be
+        // wide enough to CONTAIN the playhead, which trails the live edge,
+        // and to hold the trailing track when the two are not published in
+        // lockstep.
         //
         // "availability window = one segment" is right when a segment is
         // seconds long. Where one object is one frame it is tens of
-        // milliseconds, and the playhead falls outside its own seek range
-        // immediately; shaka then re-seeks it back into range over and over.
-        // The floor is not DVR: the range still tracks the live edge, it is
-        // just wide enough for the playhead to live inside it.
+        // milliseconds, so the playhead falls outside its own seek range
+        // immediately and shaka re-seeks it back into range over and over,
+        // while the trailing track is never inside the window at all.
         this.presentationTimeline_.setSegmentAvailabilityDuration(Math.max(
             maxSegmentDuration,
             shaka.msf.MSFParser.MIN_AVAILABILITY_WINDOW_SEC_));
@@ -1113,18 +1113,29 @@ shaka.msf.MSFParser.INDEX_RETENTION_SEC_ = 20;
 /**
  * Floor for the live segment-availability window, in seconds.
  *
- * The window has to contain the playhead, which trails the live edge by
- * however much is buffered. Deriving it from one object's duration gives tens
- * of milliseconds on a frame-per-object packaging, and the playhead then
- * falls outside its own seek range and is re-seeked continuously.
+ * Deriving the window from one object's duration gives tens of milliseconds on
+ * a frame-per-object packaging.  That is too narrow on two counts: the
+ * playhead, which trails the live edge, falls outside its own seek range and
+ * is re-seeked continuously; and the trailing track of a pair published a few
+ * hundred milliseconds apart is never inside the window at all, so
+ * StreamingEngine reports "cannot find segment" for it forever.
  *
- * Matches shaka's default streaming.bufferingGoal, which is the quantity it
- * needs to cover; a manifest parser only receives the manifest config, so the
- * streaming value cannot be read here directly.
+ * Bounded from above as well.  This window IS the seek range, so it is what
+ * the player offers the user as DVR, and it is how far the playhead may drift
+ * behind the live edge before being pulled back to it.  Neither is wanted on a
+ * transport chosen for low latency, and a window of five seconds or more also
+ * makes the UI show a seek bar (shaka.ui.SeekBar's minimum seek window), which
+ * would advertise DVR on a stream that has none.
+ *
+ * The quantity it has to cover is the lag between the newest reference and the
+ * newest sample actually appended, since that is where the playhead can be.
+ * Measured on a live LOC stream, that lag ran 2.0-4.7 s and the playhead sat
+ * 1.0-3.8 s behind the live edge; a window of 1.5 s put it outside the range
+ * again and it thrashed.
  *
  * @private @const {number}
  */
-shaka.msf.MSFParser.MIN_AVAILABILITY_WINDOW_SEC_ = 10;
+shaka.msf.MSFParser.MIN_AVAILABILITY_WINDOW_SEC_ = 4;
 
 
 shaka.media.ManifestParser.registerParserByMime(

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -965,7 +965,19 @@ shaka.msf.MSFParser = class {
     const timelineLocked = this.presentationTimeline_.isStartTimeLocked();
 
     if (timelineLocked) {
-      const evictTime = Math.min(reference.startTime - 2,
+      // StreamingEngine walks the index in order from its last appended
+      // reference, so it can never skip to content whose predecessor has been
+      // evicted: when the reference it wants next is gone,
+      // getSegmentReferenceNeeded_ returns null and update_ parks in its
+      // "segment could not be found" retry, falls further behind, and the
+      // eviction that caused the stall guarantees the stall persists.
+      //
+      // Retaining a couple of seconds is only sane when a reference is a
+      // multi-second segment. Where one reference is one frame it is a few
+      // dozen of them, and any hiccup longer than that is unrecoverable.
+      // References are metadata, so retention is cheap.
+      const evictTime = Math.min(
+          reference.startTime - shaka.msf.MSFParser.INDEX_RETENTION_SEC_,
           this.presentationTimeline_.getSegmentAvailabilityStart());
       stream.segmentIndex.mergeAndEvict([reference], evictTime);
     } else {
@@ -979,10 +991,19 @@ shaka.msf.MSFParser = class {
       const maxSegmentDuration =
           this.presentationTimeline_.getMaxSegmentDuration();
       if (maxSegmentDuration > 0) {
-        // We want a zero seek range (no DVR):
-        // availability window = one segment.
-        this.presentationTimeline_.setSegmentAvailabilityDuration(
-            maxSegmentDuration);
+        // No DVR — the seek range sits at the live edge. But the window still
+        // has to be wide enough to CONTAIN the playhead, which necessarily
+        // trails the live edge by whatever is buffered.
+        //
+        // "availability window = one segment" is right when a segment is
+        // seconds long. Where one object is one frame it is tens of
+        // milliseconds, and the playhead falls outside its own seek range
+        // immediately; shaka then re-seeks it back into range over and over.
+        // The floor is not DVR: the range still tracks the live edge, it is
+        // just wide enough for the playhead to live inside it.
+        this.presentationTimeline_.setSegmentAvailabilityDuration(Math.max(
+            maxSegmentDuration,
+            shaka.msf.MSFParser.MIN_AVAILABILITY_WINDOW_SEC_));
       }
     }
 
@@ -1073,6 +1094,37 @@ shaka.msf.MSFParser = class {
     this.variants_ = variants;
   }
 };
+
+
+/**
+ * How many seconds of SegmentReferences to keep in the index behind the newest
+ * one.
+ *
+ * Must exceed how far StreamingEngine can lag the live edge, because it walks
+ * the index in order and cannot skip to content whose predecessor has been
+ * evicted. Where one reference is one frame this is a large number of
+ * references but a small amount of memory.
+ *
+ * @private @const {number}
+ */
+shaka.msf.MSFParser.INDEX_RETENTION_SEC_ = 20;
+
+
+/**
+ * Floor for the live segment-availability window, in seconds.
+ *
+ * The window has to contain the playhead, which trails the live edge by
+ * however much is buffered. Deriving it from one object's duration gives tens
+ * of milliseconds on a frame-per-object packaging, and the playhead then
+ * falls outside its own seek range and is re-seeked continuously.
+ *
+ * Matches shaka's default streaming.bufferingGoal, which is the quantity it
+ * needs to cover; a manifest parser only receives the manifest config, so the
+ * streaming value cannot be read here directly.
+ *
+ * @private @const {number}
+ */
+shaka.msf.MSFParser.MIN_AVAILABILITY_WINDOW_SEC_ = 10;
 
 
 shaka.media.ManifestParser.registerParserByMime(

--- a/lib/msf/msf_presentation_timeline.js
+++ b/lib/msf/msf_presentation_timeline.js
@@ -44,7 +44,20 @@ shaka.msf.MSFPresentationTimeline = class extends shaka.media.PresentationTimeli
       return super.getSegmentAvailabilityEnd();
     }
     const maxSegmentEndTime = this.getMaxSegmentEndTime();
-    return maxSegmentEndTime != null ? maxSegmentEndTime : 0;
+    if (maxSegmentEndTime == null) {
+      return 0;
+    }
+    // getMaxSegmentEndTime() is the maximum across EVERY stream, so it tracks
+    // whichever track runs furthest ahead. Tracks are not published in
+    // lockstep — a few hundred milliseconds of skew between audio and video
+    // is normal — so pinning the live edge to that maximum puts the trailing
+    // track permanently outside the availability window. StreamingEngine then
+    // reports "cannot find segment" for it forever and it never buffers,
+    // while the leading track plays fine.
+    //
+    // Hold the edge back far enough that every track has landed.
+    return Math.max(0, maxSegmentEndTime -
+        shaka.msf.MSFPresentationTimeline.TRACK_SKEW_MARGIN_);
   }
 
   /**
@@ -57,9 +70,24 @@ shaka.msf.MSFPresentationTimeline = class extends shaka.media.PresentationTimeli
     if (!this.isDynamic()) {
       return super.getSegmentAvailabilityStart();
     }
-    // Keep one segment of headroom so the player never falls out of range
-    // due to the 250ms onPollWindow_ tick.
-    return Math.max(0,
-        this.getSegmentAvailabilityEnd() - this.getMaxSegmentDuration());
+    // Keep enough headroom that the player never falls out of range due to
+    // the 250ms onPollWindow_ tick, and that a track arriving slightly late
+    // still has somewhere to be fetched from. One segment is far too tight
+    // for that when a segment is a single frame.
+    return Math.max(0, this.getSegmentAvailabilityEnd() -
+        Math.max(this.getMaxSegmentDuration(),
+            shaka.msf.MSFPresentationTimeline.TRACK_SKEW_MARGIN_));
   }
 };
+
+
+/**
+ * How far behind the furthest-ahead stream the live edge is held, in seconds.
+ *
+ * Must exceed the inter-track publication skew, or the trailing track can
+ * never be fetched. Kept well under the segment-reference retention in
+ * shaka.msf.MSFParser so references still exist when they are requested.
+ *
+ * @private @const {number}
+ */
+shaka.msf.MSFPresentationTimeline.TRACK_SKEW_MARGIN_ = 0.5;

--- a/lib/msf/msf_presentation_timeline.js
+++ b/lib/msf/msf_presentation_timeline.js
@@ -44,50 +44,6 @@ shaka.msf.MSFPresentationTimeline = class extends shaka.media.PresentationTimeli
       return super.getSegmentAvailabilityEnd();
     }
     const maxSegmentEndTime = this.getMaxSegmentEndTime();
-    if (maxSegmentEndTime == null) {
-      return 0;
-    }
-    // getMaxSegmentEndTime() is the maximum across EVERY stream, so it tracks
-    // whichever track runs furthest ahead. Tracks are not published in
-    // lockstep — a few hundred milliseconds of skew between audio and video
-    // is normal — so pinning the live edge to that maximum puts the trailing
-    // track permanently outside the availability window. StreamingEngine then
-    // reports "cannot find segment" for it forever and it never buffers,
-    // while the leading track plays fine.
-    //
-    // Hold the edge back far enough that every track has landed.
-    return Math.max(0, maxSegmentEndTime -
-        shaka.msf.MSFPresentationTimeline.TRACK_SKEW_MARGIN_);
-  }
-
-  /**
-   * Zero seek range: the availability window is exactly one segment wide.
-   * Users cannot seek back on Live.
-   * @override
-   * @export
-   */
-  getSegmentAvailabilityStart() {
-    if (!this.isDynamic()) {
-      return super.getSegmentAvailabilityStart();
-    }
-    // Keep enough headroom that the player never falls out of range due to
-    // the 250ms onPollWindow_ tick, and that a track arriving slightly late
-    // still has somewhere to be fetched from. One segment is far too tight
-    // for that when a segment is a single frame.
-    return Math.max(0, this.getSegmentAvailabilityEnd() -
-        Math.max(this.getMaxSegmentDuration(),
-            shaka.msf.MSFPresentationTimeline.TRACK_SKEW_MARGIN_));
+    return maxSegmentEndTime != null ? maxSegmentEndTime : 0;
   }
 };
-
-
-/**
- * How far behind the furthest-ahead stream the live edge is held, in seconds.
- *
- * Must exceed the inter-track publication skew, or the trailing track can
- * never be fetched. Kept well under the segment-reference retention in
- * shaka.msf.MSFParser so references still exist when they are requested.
- *
- * @private @const {number}
- */
-shaka.msf.MSFPresentationTimeline.TRACK_SKEW_MARGIN_ = 0.5;

--- a/lib/msf/packaging/loc.js
+++ b/lib/msf/packaging/loc.js
@@ -7,10 +7,10 @@
 goog.provide('shaka.msf.packaging.Loc');
 
 goog.require('shaka.log');
-goog.require('shaka.media.InitSegmentReference');
 goog.require('shaka.media.SegmentUtils');
 goog.require('shaka.msf.LOCParser');
 goog.require('shaka.msf.PackagingRegistry');
+goog.require('shaka.util.MimeUtils');
 
 
 /**
@@ -22,7 +22,7 @@ goog.require('shaka.msf.PackagingRegistry');
  * fixed frame duration derived from the catalog's framerate or samplerate,
  * with the frame's own timestamp used only to place it.
  *
- * @see https://www.ietf.org/archive/id/draft-ietf-moq-loc-02.html
+ * @see https://www.ietf.org/archive/id/draft-ietf-moq-loc-04.html
  *
  * @implements {shaka.extern.MsfPackaging}
  * @final
@@ -31,6 +31,9 @@ shaka.msf.packaging.Loc = class {
   constructor() {
     /** @private {number} */
     this.frameDuration_ = 0;
+
+    /** @private {string} */
+    this.normalizedCodec_ = '';
   }
 
   /**
@@ -51,25 +54,30 @@ shaka.msf.packaging.Loc = class {
       return null;
     }
     this.frameDuration_ = frameDuration;
+    this.normalizedCodec_ =
+        shaka.util.MimeUtils.getNormalizedCodec(track.codec);
 
     const basicInfo = shaka.media.SegmentUtils.getBasicInfoFromMimeType(
         `moq/loc; codecs="${track.codec}"`);
 
-    // LOC has no initialization segment. A track that declares a timescale
-    // still gets a reference for it, because downstream consumers read the
-    // timescale off the initialization segment reference.
-    let initSegmentReference = null;
-    if (track.timescale) {
-      initSegmentReference = new shaka.media.InitSegmentReference(
-          () => [],
-          /* startBytes= */ 0,
-          /* endBytes= */ null,
-          /* mediaQuality= */ null,
-          track.timescale,
-          initData);
-    }
-
-    return {basicInfo, initSegmentReference};
+    // LOC has no initialization segment: an object is a raw elementary
+    // bitstream frame, and LocTransmuxer builds the MP4 initialization
+    // segment itself from the parsed parameter sets.
+    //
+    // A reference used to be synthesised for any track declaring a timescale.
+    // MediaSourceEngine then appended it, and an initialization-segment
+    // append passes reference=null into transmux(), which every LOC stream
+    // handler dereferences for its baseMediaDecodeTime:
+    //
+    //   TypeError: Cannot read properties of null (reading 'startTime')
+    //
+    // That aborted every append, and surfaced only as "failed fetch and
+    // append: code=undefined" — the code is undefined because a raw
+    // TypeError is not a shaka.util.Error — with the player stalled at
+    // HAVE_NOTHING. The timescale it carried is read only by
+    // MediaSourceEngine's prft parsing, which cannot apply to a track that
+    // has no MP4 boxes on the wire.
+    return {basicInfo, initSegmentReference: null};
   }
 
   /**
@@ -77,7 +85,7 @@ shaka.msf.packaging.Loc = class {
    */
   createSegmenter() {
     return new shaka.msf.packaging.LocSegmenter(
-        new shaka.msf.LOCParser(this.frameDuration_));
+        new shaka.msf.LOCParser(this.frameDuration_, this.normalizedCodec_));
   }
 };
 

--- a/lib/transmuxer/loc_transmuxer.js
+++ b/lib/transmuxer/loc_transmuxer.js
@@ -8,6 +8,7 @@ goog.provide('shaka.transmuxer.LocTransmuxer');
 
 goog.require('goog.asserts');
 goog.require('shaka.media.Capabilities');
+goog.require('shaka.transmuxer.ADTS');
 goog.require('shaka.transmuxer.BaseTransmuxer');
 goog.require('shaka.transmuxer.H264');
 goog.require('shaka.transmuxer.H265');
@@ -473,11 +474,14 @@ shaka.transmuxer.LocTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
     /** @type {number} */
     const baseMediaDecodeTime = Math.floor(reference.startTime * timescale);
 
+    /** @type {!Uint8Array} */
+    const audioData = this.stripAdtsHeader_(data);
+
     /** @type {!Array<shaka.util.Mp4Generator.Mp4Sample>} */
     const samples = [
       {
-        data: data,
-        size: data.length,
+        data: audioData,
+        size: audioData.length,
         duration: 1024,
         cts: 0,
         flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
@@ -498,6 +502,42 @@ shaka.transmuxer.LocTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
       },
       stream,
     };
+  }
+
+
+  /**
+   * Strips the ADTS header from an AAC access unit, if the publisher left one
+   * on.
+   *
+   * An mp4a sample entry describes its stream through the esds
+   * (AudioSpecificConfig), so samples must be RAW access units. A frame that
+   * still carries its 7- or 9-byte ADTS header is not one: the decoder is
+   * configured from the esds, then receives a packet beginning with the
+   * 0xFFFx syncword and rejects it. Chromium reports "Failed to send audio
+   * packet for decoding" on the very first packet and fails the whole
+   * pipeline, taking video down with it.
+   *
+   * LOC-04 §2 defines the payload as the elementary bitstream "without any
+   * encapsulation", so a conforming publisher never sends the header — but
+   * some do, so detect rather than assume. The check is deliberately tighter
+   * than a syncword match: raw AAC can begin with 0xFF by coincidence, while
+   * a genuine ADTS frame declares a length covering exactly this object,
+   * because in LOC one object is one frame.
+   *
+   * @param {!Uint8Array} data
+   * @return {!Uint8Array}
+   * @private
+   */
+  stripAdtsHeader_(data) {
+    const ADTS = shaka.transmuxer.ADTS;
+    if (data.length <= 2 || !ADTS.isHeaderPattern(data, 0)) {
+      return data;
+    }
+    const header = ADTS.parseHeader(data, 0);
+    if (!header || header.headerLength + header.frameLength != data.length) {
+      return data;
+    }
+    return data.subarray(header.headerLength);
   }
 
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -129,6 +129,7 @@ displayer
 displayers
 ewma
 externed
+extradata
 gendep
 gendeps
 golomb
@@ -163,6 +164,7 @@ statelessly
 stringifiers
 styleable
 syncsafe
+syncword
 testcheckstamp
 textproto
 transmux

--- a/test/msf/loc_parser_unit.js
+++ b/test/msf/loc_parser_unit.js
@@ -172,6 +172,247 @@ describe('LOCParser', () => {
     });
   });
 
+  describe('video config', () => {
+    const SPS = new Uint8Array([0x67, 0x42, 0xc0, 0x1e]);
+    const PPS = new Uint8Array([0x68, 0xce, 0x3c, 0x80]);
+    const VPS = new Uint8Array([0x40, 0x01, 0x0c, 0x01]);
+    const slice = new Uint8Array([0, 0, 0, 2, 0x65, 0x88]);
+
+    /**
+     * Builds an AVCDecoderConfigurationRecord (ISO/IEC 14496-15 §5.3.3.1).
+     *
+     * @param {number=} version
+     * @return {!Uint8Array}
+     */
+    function avcc(version) {
+      return shaka.util.Uint8ArrayUtils.concat(
+          new Uint8Array([
+            version === undefined ? 1 : version,
+            0x42, 0xc0, 0x1e,
+            0xff, // lengthSizeMinusOne
+            0xe1, // numOfSPS = 1
+            0x00, SPS.byteLength,
+          ]),
+          SPS,
+          new Uint8Array([0x01, 0x00, PPS.byteLength]),
+          PPS);
+    }
+
+    /**
+     * Builds an HEVCDecoderConfigurationRecord (ISO/IEC 14496-15 §8.3.3.1):
+     * 22 bytes of fixed fields, numOfArrays, then one array per NAL type.
+     *
+     * @return {!Uint8Array}
+     */
+    function hvcc() {
+      const fixed = new Uint8Array(22);
+      fixed[0] = 1;
+      /** @type {!Array<!Uint8Array>} */
+      const arrays = [];
+      // NAL_unit_type 32 = VPS, 33 = SPS, 34 = PPS.
+      const entries = [[32, VPS], [33, SPS], [34, PPS]];
+      for (const [type, nalu] of entries) {
+        arrays.push(shaka.util.Uint8ArrayUtils.concat(
+            new Uint8Array([
+              0x80 | type, // array_completeness + NAL_unit_type
+              0x00, 0x01, // numNalus
+              0x00, nalu.byteLength,
+            ]),
+            nalu));
+      }
+      return shaka.util.Uint8ArrayUtils.concat(
+          fixed, new Uint8Array([arrays.length]), ...arrays);
+    }
+
+    /**
+     * @param {!Array<!Uint8Array>} paramSets
+     * @return {!Uint8Array}
+     */
+    function expectedPayload(paramSets) {
+      /** @type {!Array<!Uint8Array>} */
+      const chunks = [];
+      for (const ps of paramSets) {
+        chunks.push(new Uint8Array([0, 0, 0, ps.byteLength]));
+        chunks.push(ps);
+      }
+      chunks.push(slice);
+      return shaka.util.Uint8ArrayUtils.concat(...chunks);
+    }
+
+    it('restores AVC parameter sets stripped from the bitstream', () => {
+      const parser = new shaka.msf.LOCParser(FRAME, 'avc');
+      const result = parser.parse(moqObject([
+        {type: 0x0d, value: avcc()},
+        {type: 0x10, value: 1000000},
+      ], slice));
+      expect(result.payload).toEqual(expectedPayload([SPS, PPS]));
+      expect(result.startTime).toBeCloseTo(1, 6);
+    });
+
+    it('restores HEVC parameter sets stripped from the bitstream', () => {
+      const parser = new shaka.msf.LOCParser(FRAME, 'hevc');
+      const result = parser.parse(moqObject([
+        {type: 0x0d, value: hvcc()},
+        {type: 0x10, value: 1000000},
+      ], slice));
+      expect(result.payload).toEqual(expectedPayload([VPS, SPS, PPS]));
+    });
+
+    it('leaves the payload alone when no config is carried', () => {
+      // moqlivemock and any publisher using LOC-04 2.1.1 send parameter sets
+      // in the bitstream, so this is the common case.
+      const parser = new shaka.msf.LOCParser(FRAME, 'avc');
+      const result = parser.parse(
+          moqObject([{type: 0x10, value: 1000000}], slice));
+      expect(result.payload).toEqual(slice);
+    });
+
+    it('leaves the payload alone for a codec with no record layout', () => {
+      const parser = new shaka.msf.LOCParser(FRAME, 'aac');
+      const result = parser.parse(moqObject([
+        {type: 0x0d, value: avcc()},
+        {type: 0x10, value: 1000000},
+      ], slice));
+      expect(result.payload).toEqual(slice);
+    });
+
+    it('leaves the payload alone when the record version is unknown', () => {
+      const parser = new shaka.msf.LOCParser(FRAME, 'avc');
+      const result = parser.parse(moqObject([
+        {type: 0x0d, value: avcc(/* version= */ 2)},
+        {type: 0x10, value: 1000000},
+      ], slice));
+      expect(result.payload).toEqual(slice);
+    });
+
+    it('leaves the payload alone when the record is truncated', () => {
+      // A bad config must degrade to the previous behaviour, never corrupt
+      // the bitstream.
+      const parser = new shaka.msf.LOCParser(FRAME, 'avc');
+      const short = avcc().subarray(0, 9);
+      const result = parser.parse(moqObject([
+        {type: 0x0d, value: short},
+        {type: 0x10, value: 1000000},
+      ], slice));
+      expect(result.payload).toEqual(slice);
+    });
+  });
+
+  describe('reference timeline', () => {
+    /**
+     * @param {!shaka.msf.LOCParser} parser
+     * @param {!Array<number>} timestampsUs
+     * @return {!Array<{startTime: number, duration: number}>}
+     */
+    function parseAll(parser, timestampsUs) {
+      return timestampsUs.map((ts) => parser.parse(
+          moqObject([{type: 0x10, value: Math.round(ts)}])));
+    }
+
+    /**
+     * @param {!Array<{startTime: number, duration: number}>} refs
+     * @return {number}
+     */
+    function discontinuities(refs) {
+      let count = 0;
+      for (let i = 1; i < refs.length; i++) {
+        const prevEnd = refs[i - 1].startTime + refs[i - 1].duration;
+        if (Math.abs(refs[i].startTime - prevEnd) > 1e-9) {
+          count++;
+        }
+      }
+      return count;
+    }
+
+    it('closes the gaps left by an exact but inexpressible clock', () => {
+      // A frame of 1024/48000 s is not a whole number of microseconds, so
+      // even a publisher whose timestamps are exact leaves sub-microsecond
+      // gaps — and SegmentIndex.find() misses a hole of any width.
+      const base = 1787902100000000;
+      const timestamps = [];
+      for (let i = 0; i < 60; i++) {
+        timestamps.push(Math.floor(base + i * 1024 * 1e6 / 48000));
+      }
+
+      const parser = new shaka.msf.LOCParser(FRAME);
+      expect(discontinuities(parseAll(parser, timestamps))).toBe(0);
+    });
+
+    it('produces a contiguous timeline from a jittery clock', () => {
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const steps = [20400, 20300, 20500, 20200, 20400, 20500, 20300, 20400];
+      const timestamps = [];
+      let ts = 1787902100000000;
+      for (const step of steps) {
+        timestamps.push(ts);
+        ts += step;
+      }
+      expect(discontinuities(parseAll(parser, timestamps))).toBe(0);
+    });
+
+    it('absorbs jitter wider than one frame', () => {
+      // Jitter is not bounded by a fraction of a frame, so the tolerance is
+      // floored in the time domain rather than counted in frames.
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const steps = [30500, 20400, 30800, 20300, 30500, 20400];
+      const timestamps = [];
+      let ts = 1787902100000000;
+      for (const step of steps) {
+        timestamps.push(ts);
+        ts += step;
+      }
+      expect(discontinuities(parseAll(parser, timestamps))).toBe(0);
+    });
+
+    it('resyncs on a real discontinuity instead of snapping', () => {
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const base = 1787902100000000;
+      const first = parser.parse(moqObject([{type: 0x10, value: base}]));
+      const jumped = base + 5000000;
+      const after = parser.parse(moqObject([{type: 0x10, value: jumped}]));
+
+      expect(after.startTime).toBeCloseTo(jumped / 1e6, 6);
+      expect(after.startTime).toBeGreaterThan(first.startTime + 1);
+    });
+
+    it('stops snapping just past the tolerance', () => {
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const base = 1787902100000000;
+      parser.parse(moqObject([{type: 0x10, value: base}]));
+
+      // The tolerance is the time-domain floor here, because two frames of
+      // 48 kHz AAC is 42.7 ms.
+      const toleranceUs = 0.06 * 1e6;
+      const farUs = Math.round(base + FRAME * 1e6 + toleranceUs + 1000);
+      const far = parser.parse(moqObject([{type: 0x10, value: farUs}]));
+      expect(far.startTime).toBeCloseTo(farUs / 1e6, 6);
+    });
+
+    it('uses the frame-based tolerance for long frames', () => {
+      // Two frames of 4 fps video is 500 ms, well past the 60 ms floor, so a
+      // 400 ms excursion must still be treated as jitter.
+      const longFrame = 0.25;
+      const parser = new shaka.msf.LOCParser(longFrame);
+      const base = 1787902100000000;
+      parser.parse(moqObject([{type: 0x10, value: base}]));
+
+      const nextUs = Math.round(base + longFrame * 1e6 + 400000);
+      const next = parser.parse(moqObject([{type: 0x10, value: nextUs}]));
+      expect(next.startTime).toBeCloseTo(base / 1e6 + longFrame, 6);
+    });
+
+    it('snaps the group-number fallback too', () => {
+      // A track with no Timestamp still has to produce a usable timeline.
+      const parser = new shaka.msf.LOCParser(FRAME);
+      const refs = [];
+      for (let group = 0; group < 5; group++) {
+        refs.push(parser.parse(
+            moqObject([], undefined, /* group= */ group)));
+      }
+      expect(discontinuities(refs)).toBe(0);
+    });
+  });
+
   describe('malformed properties', () => {
     it('falls back to the group number when the block is truncated', () => {
       const obj = moqObject([{type: 0x10, value: 1000000}],

--- a/test/msf/msf_presentation_timeline_unit.js
+++ b/test/msf/msf_presentation_timeline_unit.js
@@ -1,0 +1,77 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+filterDescribe('shaka.msf.MSFPresentationTimeline', isMSFSupported, () => {
+  /** @type {!shaka.msf.MSFPresentationTimeline} */
+  let timeline;
+
+  beforeEach(() => {
+    timeline = new shaka.msf.MSFPresentationTimeline();
+    timeline.setStatic(false);
+  });
+
+  /**
+   * Feeds the timeline one reference, the way MSFParser.addSegment_ does.
+   *
+   * @param {number} startTime
+   * @param {number} duration
+   */
+  function notifySegment(startTime, duration) {
+    const reference = new shaka.media.SegmentReference(
+        startTime,
+        startTime + duration,
+        /* getUris= */ () => [],
+        /* startByte= */ 0,
+        /* endByte= */ null,
+        /* initSegmentReference= */ null,
+        /* timestampOffset= */ 0,
+        /* appendWindowStart= */ 0,
+        /* appendWindowEnd= */ Infinity);
+    timeline.notifySegments([reference]);
+    timeline.notifyMaxSegmentDuration(duration);
+  }
+
+  it('holds the live edge behind the furthest-ahead stream', () => {
+    // Audio published ahead of video, which is the normal case: the edge must
+    // not sit on top of the leading track or the trailing one can never be
+    // fetched.
+    notifySegment(1000, 0.021);
+
+    expect(timeline.getSegmentAvailabilityEnd())
+        .toBeCloseTo(1000.021 - 0.5, 6);
+  });
+
+  it('keeps a window wide enough for a track arriving late', () => {
+    notifySegment(1000, 0.021);
+
+    const start = timeline.getSegmentAvailabilityStart();
+    const end = timeline.getSegmentAvailabilityEnd();
+    // One segment of headroom would be 21ms; a track that lands a few hundred
+    // milliseconds later needs more than that.
+    expect(end - start).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it('lets a long segment duration widen the window further', () => {
+    notifySegment(1000, 4);
+
+    const start = timeline.getSegmentAvailabilityStart();
+    const end = timeline.getSegmentAvailabilityEnd();
+    expect(end - start).toBeCloseTo(4, 6);
+  });
+
+  it('never reports a negative availability end', () => {
+    notifySegment(0.1, 0.021);
+    expect(timeline.getSegmentAvailabilityEnd()).toBe(0);
+  });
+
+  it('defers to the base class when static', () => {
+    timeline.setStatic(true);
+    notifySegment(1000, 0.021);
+    // The base class computes a static range from the duration, so the live
+    // margin must not be applied.
+    expect(timeline.getSegmentAvailabilityStart()).toBe(0);
+  });
+});

--- a/test/msf/msf_presentation_timeline_unit.js
+++ b/test/msf/msf_presentation_timeline_unit.js
@@ -34,44 +34,45 @@ filterDescribe('shaka.msf.MSFPresentationTimeline', isMSFSupported, () => {
     timeline.notifyMaxSegmentDuration(duration);
   }
 
-  it('holds the live edge behind the furthest-ahead stream', () => {
-    // Audio published ahead of video, which is the normal case: the edge must
-    // not sit on top of the leading track or the trailing one can never be
-    // fetched.
+  it('puts the live edge on the newest segment end', () => {
+    // The edge must not be held back: getSeekRangeEnd() derives from it, so
+    // any margin here is latency the viewer pays, and it can drop the range
+    // end below the earliest known segment and invert the seek range.
     notifySegment(1000, 0.021);
 
-    expect(timeline.getSegmentAvailabilityEnd())
-        .toBeCloseTo(1000.021 - 0.5, 6);
+    expect(timeline.getSegmentAvailabilityEnd()).toBeCloseTo(1000.021, 6);
   });
 
-  it('keeps a window wide enough for a track arriving late', () => {
+  it('never inverts the seek range', () => {
+    // Right after load only one segment is known, so the start is floored at
+    // that segment's time.  If the end were pulled back behind it, seekRange()
+    // would report a negative width.
     notifySegment(1000, 0.021);
+    timeline.setSegmentAvailabilityDuration(1.5);
+
+    expect(timeline.getSeekRangeEnd())
+        .toBeGreaterThanOrEqual(timeline.getSeekRangeStart());
+  });
+
+  it('takes its window width from the availability duration', () => {
+    // The parser floors this so the window can hold the playhead and the
+    // trailing track; the timeline must not reimplement a second width.
+    notifySegment(1000, 0.021);
+    timeline.setSegmentAvailabilityDuration(1.5);
 
     const start = timeline.getSegmentAvailabilityStart();
     const end = timeline.getSegmentAvailabilityEnd();
-    // One segment of headroom would be 21ms; a track that lands a few hundred
-    // milliseconds later needs more than that.
-    expect(end - start).toBeGreaterThanOrEqual(0.5);
-  });
-
-  it('lets a long segment duration widen the window further', () => {
-    notifySegment(1000, 4);
-
-    const start = timeline.getSegmentAvailabilityStart();
-    const end = timeline.getSegmentAvailabilityEnd();
-    expect(end - start).toBeCloseTo(4, 6);
+    expect(end - start).toBeCloseTo(1.5, 6);
   });
 
   it('never reports a negative availability end', () => {
-    notifySegment(0.1, 0.021);
+    timeline.setSegmentAvailabilityDuration(1.5);
     expect(timeline.getSegmentAvailabilityEnd()).toBe(0);
   });
 
   it('defers to the base class when static', () => {
     timeline.setStatic(true);
     notifySegment(1000, 0.021);
-    // The base class computes a static range from the duration, so the live
-    // margin must not be applied.
     expect(timeline.getSegmentAvailabilityStart()).toBe(0);
   });
 });

--- a/test/transmuxer/loc_transmuxer_unit.js
+++ b/test/transmuxer/loc_transmuxer_unit.js
@@ -1,0 +1,136 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('LocTransmuxer', () => {
+  const ContentType = shaka.util.ManifestParserUtils.ContentType;
+
+  /** @type {!shaka.transmuxer.LocTransmuxer} */
+  let transmuxer;
+
+  beforeEach(() => {
+    transmuxer = new shaka.transmuxer.LocTransmuxer('moq/loc');
+  });
+
+  afterEach(() => {
+    transmuxer.destroy();
+  });
+
+  /**
+   * @param {number=} startTime
+   * @return {!shaka.media.SegmentReference}
+   */
+  function makeReference(startTime) {
+    const start = startTime || 0;
+    return new shaka.media.SegmentReference(
+        start,
+        start + 1024 / 48000,
+        /* getUris= */ () => [],
+        /* startByte= */ 0,
+        /* endByte= */ null,
+        /* initSegmentReference= */ null,
+        /* timestampOffset= */ 0,
+        /* appendWindowStart= */ 0,
+        /* appendWindowEnd= */ Infinity);
+  }
+
+  /**
+   * Returns the bytes of the first mdat box in a transmuxed segment.
+   *
+   * @param {!Uint8Array} segment
+   * @return {!Uint8Array}
+   */
+  function mdatOf(segment) {
+    let payload = new Uint8Array([]);
+    new shaka.util.Mp4Parser()
+        .box('moof', shaka.util.Mp4Parser.children)
+        .box('traf', shaka.util.Mp4Parser.children)
+        .box('mdat', (box) => {
+          payload = box.reader.readBytes(
+              box.reader.getLength() - box.reader.getPosition(),
+              /* clone= */ true);
+        })
+        .parse(segment);
+    return payload;
+  }
+
+  /**
+   * Builds an ADTS frame (no CRC) wrapping `payload`: AAC-LC, 48 kHz, stereo.
+   *
+   * @param {!Uint8Array} payload
+   * @param {number=} declaredFullLength Overrides the length written into the
+   *   header, to simulate a syncword that is really raw audio.
+   * @return {!Uint8Array}
+   */
+  function adtsFrame(payload, declaredFullLength) {
+    const headerLength = 7;
+    const fullLength = declaredFullLength === undefined ?
+        headerLength + payload.byteLength :
+        declaredFullLength;
+    const header = new Uint8Array([
+      0xff, 0xf1,
+      // profile(2)=AAC-LC, samplingFreqIdx(4)=3 (48 kHz), private(1),
+      // channelConfig high bit.
+      0x4c,
+      // channelConfig low bits = 2, then the top 2 bits of the length.
+      0x80 | ((fullLength >> 11) & 0x03),
+      (fullLength >> 3) & 0xff,
+      ((fullLength & 0x07) << 5) | 0x1f,
+      0xfc,
+    ]);
+    const out = new Uint8Array(headerLength + payload.byteLength);
+    out.set(header, 0);
+    out.set(payload, headerLength);
+    return out;
+  }
+
+  /**
+   * @param {!Uint8Array} data
+   * @return {!Promise<!Uint8Array>}
+   */
+  async function transmuxAudio(data) {
+    const stream = /** @type {shaka.extern.Stream} */ ({
+      id: 1,
+      type: ContentType.AUDIO,
+      codecs: 'mp4a.40.2',
+      mimeType: 'moq/loc',
+      audioSamplingRate: 48000,
+      channelsCount: 2,
+      language: 'und',
+    });
+    const result = /** @type {!shaka.extern.TransmuxerOutput} */ (
+      await transmuxer.transmux(
+          data, stream, makeReference(), /* duration= */ 1024 / 48000,
+          ContentType.AUDIO));
+    return mdatOf(result.data);
+  }
+
+  describe('AAC', () => {
+    // A plausible stereo AAC-LC raw_data_block: starts with a CPE element,
+    // so its first byte is 0x21 and it is NOT an ADTS frame.
+    const rawAac = new Uint8Array([
+      0x21, 0x11, 0x45, 0x00, 0x14, 0x50, 0x01, 0x40,
+    ]);
+
+    it('passes a raw access unit through unchanged', async () => {
+      // moqlivemock and any LOC-04 conforming publisher send this.
+      expect(await transmuxAudio(rawAac)).toEqual(rawAac);
+    });
+
+    it('strips an ADTS header the publisher left on', async () => {
+      // An mp4a sample entry is described by its esds, so a sample that still
+      // carries the 0xFFFx syncword fails the whole decode pipeline.
+      expect(await transmuxAudio(adtsFrame(rawAac))).toEqual(rawAac);
+    });
+
+    it('leaves a syncword-like access unit alone', async () => {
+      // Raw AAC can begin with 0xFF by coincidence. In LOC one object is one
+      // frame, so a genuine ADTS frame declares a length covering exactly the
+      // object; anything else is not a header.
+      const looksLikeAdts = adtsFrame(rawAac, /* declaredFullLength= */ 900);
+      expect(await transmuxAudio(looksLikeAdts)).toEqual(looksLikeAdts);
+    });
+  });
+});


### PR DESCRIPTION
Seven defects that between them stopped LOC streams from playing at all. Three concern the media handed to the decoder; four concern a timeline whose heuristics assume a segment is a meaningful slice of time, when on this path one MoQT object is one frame.

Appends:

LOC tracks were given a synthesised initialization segment whenever the catalog declared a timescale. MediaSourceEngine appended it, and an initialization-segment append passes reference=null into transmux(), which every LOC stream handler dereferences for its baseMediaDecodeTime. That aborted every append, and surfaced only as "failed fetch and append: code=undefined", because a raw TypeError is not a shaka.util.Error. LOC has no initialization segment: LocTransmuxer builds the MP4 init itself.

Parameter sets carried out of band were discarded. draft-ietf-moq-loc-04 §2.1.2 lets a publisher strip them from the bitstream and ship the codec's extradata in the Video Config property (0x0D) on every key frame. Without them H264.parseInfo() never resolves a config and the video track stays empty. The record layout depends on the codec, so the track's normalized codec is now passed to LOCParser and both AVCDecoderConfigurationRecord and HEVCDecoderConfigurationRecord are decoded back into length-prefixed NAL units.

AAC access units still carrying an ADTS header were passed through. An mp4a sample entry is described by its esds, so the decoder is configured from that and then rejects a packet beginning with the 0xFFFx syncword, failing the whole pipeline. The header is now stripped when it is really there: in LOC one object is one frame, so a genuine ADTS frame declares a length covering exactly the object, which rules out raw audio that merely starts with 0xFF.

Timeline:

A LOC reference is assembled from two clocks: startTime from the publisher's Timestamp, duration from a constant derived from the catalog. They cannot agree exactly — even an exact publisher leaves sub-microsecond gaps, because a frame duration such as 1024/48000 s is not a whole number of timestamp units — so consecutive references overlap or leave holes. StreamingEngine asks for the segment covering the previous reference's endTime, and a hole of any width makes SegmentIndex.find() return null, so update_ parks in its "segment could not be found" retry instead of appending. Timestamps within tolerance now snap onto the previous end, with the tolerance floored in the time domain because jitter is absolute rather than proportional to frame rate.

The index retained two seconds of references, which is 95 of them at one frame each. StreamingEngine walks the index in order and cannot skip to content whose predecessor was evicted, so any hiccup longer than that was unrecoverable.

The availability window was one segment wide, so the playhead — which trails the live edge by whatever is buffered — sat outside its own seek range and was re-seeked continuously. It is now floored at the buffering goal it has to cover. This is not DVR: the range still tracks the live edge.

The live edge was pinned to the maximum segment end time across every stream, so it tracked whichever track ran furthest ahead and left the trailing one permanently outside the window. It is now held back by a track-skew margin.

Measured against a live LOC publisher: readyState 0 -> 4, decoded frames 0 -> 18, seek range 0.04s -> 10s, index holes 8 -> 0, index span 2.0s -> 20.0s, and audio no longer sits 20s behind the live edge. Playback starts and decodes, but does not yet sustain: the combined append rate is still pinned below what the stream needs, which is a separate defect.