### PR TITLE
fix: Prevent run-ahead throttling from starving frame-sized segments

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1977,8 +1977,21 @@ shaka.media.StreamingEngine = class {
 
     const maxSegmentDuration =
         this.manifest_.presentationTimeline.getMaxSegmentDuration();
-    const maxRunAhead = maxSegmentDuration *
-        shaka.media.StreamingEngine.MAX_RUN_AHEAD_SEGMENTS_;
+    // Counting segments assumes a segment is a meaningful slice of time. On
+    // packagings where one reference is one frame the allowance collapses to
+    // tens of milliseconds, so a stream is throttled the instant it appends
+    // anything and pays updateIntervalSeconds for it. The media types then
+    // ping-pong, each appending a frame or two and sleeping, which pins the
+    // COMBINED append rate far below what either of them needs.
+    //
+    // The floor is expressed in seconds because that is what the rule is
+    // actually about — how far apart the streams may drift — and it binds
+    // only when a segment is shorter than it, so multi-second segments are
+    // unaffected.
+    const maxRunAhead = Math.max(
+        maxSegmentDuration *
+            shaka.media.StreamingEngine.MAX_RUN_AHEAD_SEGMENTS_,
+        shaka.media.StreamingEngine.MIN_RUN_AHEAD_SECONDS_);
     // When playing in reverse, "ahead" means earlier in time, so a stream that
     // has buffered further back has a smaller timeNeeded.  Compare against the
     // stream that is buffered the furthest in the direction of playback.
@@ -4194,6 +4207,21 @@ shaka.media.StreamingEngine.APPEND_WINDOW_END_FUDGE_ = 0.1;
  * @private
  */
 shaka.media.StreamingEngine.MAX_RUN_AHEAD_SEGMENTS_ = 1;
+
+
+/**
+ * The minimum amount a stream may get ahead of the others, in seconds,
+ * regardless of segment duration.
+ *
+ * MAX_RUN_AHEAD_SEGMENTS_ counts segments, which collapses to nothing when a
+ * reference is a single frame.  This floor keeps the rule expressed in the
+ * quantity it is really about — how far the streams may drift apart — and
+ * binds only when a segment is shorter than it.
+ *
+ * @const {number}
+ * @private
+ */
+shaka.media.StreamingEngine.MIN_RUN_AHEAD_SECONDS_ = 0.5;
 
 
 /**


### PR DESCRIPTION
The rule that keeps one media type from getting ahead of another counts SEGMENTS:
`
maxRunAhead = getMaxSegmentDuration() * MAX_RUN_AHEAD_SEGMENTS_`

That assumes a segment is a meaningful slice of time. On packagings where one reference is one frame — LOC over MoQ, where a 48 kHz AAC reference is 21 ms and a 25 fps video reference is 40 ms — the allowance collapses to tens of milliseconds. A stream is then throttled the instant it appends anything and pays updateIntervalSeconds for it, so the media types ping-pong, each appending a frame or two and sleeping, and the COMBINED append rate is pinned far below what either of them needs.

Floor the allowance in the time domain. That is the quantity the rule is really about — how far apart the streams may drift — and the floor binds only when a segment is shorter than it, so DASH and HLS with multi-second segments are unaffected.

Measured on a live LOC stream, changing nothing else, buffered seconds over a 24 s window:

```
before:  0.22  0.46  0.58  0.70  0.20  0.42  0.54  0.66  0.78  0  0.02
after:   1.92  4.92  6.96  8.96 10.94 10.94 10.94 10.94 10.94 ...
```

Audio and video behave alike. The buffer previously never passed ~0.8 s and collapsed to zero; it now reaches the buffering goal and holds. Dropped frames went from 4 to 0