### PR TITLE
fix(MSF): Do not tear down a track that was re-subscribed

### DIFF
--- a/lib/msf/request_id_session.js
+++ b/lib/msf/request_id_session.js
@@ -899,6 +899,32 @@ shaka.msf.RequestIdSession = class {
       // Wait for the unsubscribe to complete (or timeout)
       await unsubscribePromise;
 
+      // Only tear down if this alias STILL belongs to the subscription we
+      // cancelled.
+      //
+      // The delay above is a blind half second — there is no unsubscribe
+      // acknowledgement to wait on — and a re-subscribe can complete inside
+      // it.  The relay reuses the same alias for the same track name, so
+      // unregisterAllCallbacks() would then delete the callbacks belonging to
+      // the NEW subscription, silently and permanently: that track stops
+      // receiving objects, nothing raises an error, and nothing ever
+      // re-subscribes it again.
+      //
+      // This is asymmetric between media types.  A video quality switch moves
+      // to a different track NAME, and therefore a different alias, so its
+      // delayed teardown lands on an alias nobody re-registered.  Audio keeps
+      // its name, so the teardown lands on the live subscription every time.
+      //
+      // registerTrackWithAlias() installs a fresh info object on re-subscribe,
+      // so comparing the request ID is a reliable identity check.
+      const current = this.trackRegistry_.getTrackInfoFromAlias(trackAlias);
+      if (current && current.requestId !== requestId) {
+        shaka.log.debug(`Track alias ${trackAlias} was re-subscribed ` +
+            `(requestId ${current.requestId}) while the unsubscribe of ` +
+            `requestId ${requestId} was in flight; leaving it intact`);
+        return;
+      }
+
       // Unregister all callbacks for this track
       this.trackRegistry_.unregisterAllCallbacks(trackAlias);
 

--- a/test/msf/request_id_session_unit.js
+++ b/test/msf/request_id_session_unit.js
@@ -1,0 +1,121 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+filterDescribe('shaka.msf.RequestIdSession', isMSFSupported, () => {
+  /** @type {!shaka.msf.RequestIdSession} */
+  let session;
+  /** @type {!Array<shaka.msf.Utils.Message>} */
+  let sent;
+
+  beforeEach(() => {
+    sent = [];
+
+    // The session listens on both of these for its lifetime, so they must
+    // never resolve or the listen loops spin.
+    const never = () => new Promise(() => {});
+
+    const webTransport = /** @type {!WebTransport} */ (/** @type {?} */ ({
+      incomingUnidirectionalStreams: {getReader: () => ({read: never})},
+      close: () => {},
+    }));
+    const controlStream = /** @type {!shaka.msf.IControlStream} */ (
+      /** @type {?} */ ({
+        send: (msg) => {
+          sent.push(msg);
+          return Promise.resolve();
+        },
+        receive: never,
+        close: () => {},
+      }));
+
+    session = new shaka.msf.RequestIdSession(
+        webTransport, controlStream,
+        /** @type {!shaka.extern.MsfDialect} */ (/** @type {?} */ ({})),
+        /** @type {!shaka.extern.MsfManifestConfiguration} */ (
+          /** @type {?} */ ({})));
+  });
+
+  describe('unsubscribe', () => {
+    const ALIAS = BigInt(10);
+    const NAMESPACE = ['msf', 'clear'];
+    const TRACK = 'audio0';
+
+    /** @type {!shaka.msf.TrackAliasRegistry} */
+    let registry;
+
+    /**
+     * The registry is the session's own state; a subscription can only be
+     * established through a full SUBSCRIBE round trip, which is not what
+     * these tests are about.
+     *
+     * @return {!shaka.msf.TrackAliasRegistry}
+     * @suppress {visibility}
+     */
+    function registryOf() {
+      return /** @type {!shaka.msf.TrackAliasRegistry} */ (
+        session.trackRegistry_);
+    }
+
+    /**
+     * @param {number} requestId
+     */
+    function register(requestId) {
+      registry.registerTrackWithAlias(
+          NAMESPACE, TRACK, BigInt(requestId), ALIAS);
+    }
+
+    /**
+     * @return {boolean}
+     */
+    function hasCallbacks() {
+      const info = registry.getTrackInfoFromAlias(ALIAS);
+      return !!info && info.callbacks.length > 0;
+    }
+
+    beforeEach(() => {
+      registry = registryOf();
+      register(/* requestId= */ 4);
+      registry.registerCallback(ALIAS, () => {});
+    });
+
+    it('tears the track down when nothing re-subscribed', async () => {
+      await session.unsubscribe(ALIAS);
+
+      expect(sent.length).toBe(1);
+      const unsubscribe =
+      /** @type {shaka.msf.Utils.Unsubscribe} */ (sent[0]);
+      expect(unsubscribe.requestId).toBe(BigInt(4));
+      expect(hasCallbacks()).toBe(false);
+    });
+
+    it('leaves a subscription that replaced it during the delay', async () => {
+      // unsubscribe() waits a blind half second for the message to go out,
+      // because there is no acknowledgement.  A re-subscribe can complete
+      // inside that window, and the relay hands out the same alias for the
+      // same track name, so the delayed teardown would kill the NEW
+      // subscription: the track goes silent forever with no error raised.
+      const done = session.unsubscribe(ALIAS);
+
+      // The relay answers a fresh SUBSCRIBE with the same alias.
+      register(/* requestId= */ 6);
+      registry.registerCallback(ALIAS, () => {});
+
+      await done;
+
+      const info = registry.getTrackInfoFromAlias(ALIAS);
+      expect(info.requestId).toBe(BigInt(6));
+      expect(hasCallbacks()).toBe(true);
+    });
+
+    it('rejects for an alias it does not know', async () => {
+      const expected = jasmine.objectContaining({
+        message: jasmine.stringMatching('No track info found'),
+      });
+      await expectAsync(session.unsubscribe(BigInt(99)))
+          .toBeRejectedWith(expected);
+    });
+  });
+});


### PR DESCRIPTION
unsubscribe() sends UNSUBSCRIBE, waits a blind half second — there is no acknowledgement to wait on — and then drops the alias's callbacks. A re-subscribe can complete inside that window, and a relay that hands out the same alias for the same track name will have pointed it at the NEW subscription by then, so the delayed teardown kills the live one: the track stops receiving objects, no error is raised, MediaSource stays open, and nothing ever re-subscribes it again.

The failure is asymmetric between media types. A video quality switch moves to a different track name, and therefore a different alias, so its delayed teardown lands on an alias nobody re-registered. Audio keeps its name, so the teardown lands on the live subscription every time.

After the delay, re-read the registry and skip the teardown if the alias now belongs to a different request ID. registerTrackWithAlias() installs a fresh info object on re-subscribe, so the request ID is a reliable identity check.

Only draft-14 and draft-16 are affected. Draft-17 removed the cancel messages — a subscriber withdraws by resetting the request's bidirectional stream — so the draft-18 session drops its callbacks synchronously and has no window to race in.

Whether the race can happen at all depends on the relay: one that allocates a fresh alias per subscription never reuses an alias during the delay and so never triggers it.