### PR TITLE
fix(MSF): Fix stale decoder config and unread accessibility descriptors

### DIFF
--- a/externs/msf_catalog.js
+++ b/externs/msf_catalog.js
@@ -68,19 +68,18 @@ msfCatalog.InitDataList;
 
 
 /**
- * Describes a single accessibility descriptor within a Track entry,
- * as defined in the MSF catalog accessibility field.
- * The schemeId identifies the accessibility scheme (e.g. CEA-608, CEA-708),
- * and the optional value carries the scheme-specific parameters such as
- * channel-to-language assignments.
+ * Describes a single accessibility descriptor within a Track entry
+ * (draft-ietf-moq-msf-01 5.2.44).  The scheme identifies the accessibility
+ * scheme (e.g. CEA-608, CEA-708), and the value carries the scheme-specific
+ * parameters such as channel-to-language assignments.
  *
- * CEA-608 example: { schemeId: "urn:scte:dash:cc:cea-608:2015",
+ * CEA-608 example: { scheme: "urn:scte:dash:cc:cea-608:2015",
  *                    value: "CC1=eng;CC3=spa" }
- * CEA-708 example: { schemeId: "urn:scte:dash:cc:cea-708:2015",
+ * CEA-708 example: { scheme: "urn:scte:dash:cc:cea-708:2015",
  *                    value: "1=lang:eng;2=lang:spa" }
  *
  * @typedef {{
- *   schemeId: string,
+ *   scheme: string,
  *   value: (string|undefined),
  * }}
  */

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -816,11 +816,15 @@ shaka.msf.MSFParser = class {
     const closedCaptions = new Map();
     if (!this.config_.disableText) {
       for (const accessibility of (track.accessibility || [])) {
-        const schemeId = accessibility.schemeId;
+        // draft-ietf-moq-msf-01 5.2.44 names this field 'scheme'.  The
+        // corresponding DASH attribute is 'schemeIdUri', which is where the
+        // wrong name came from; reading it left closedCaptions empty for
+        // every conforming catalog, so embedded captions were never exposed.
+        const scheme = accessibility.scheme;
         const value = accessibility.value;
-        if (schemeId == 'urn:scte:dash:cc:cea-608:2015') {
+        if (scheme == 'urn:scte:dash:cc:cea-608:2015') {
           ManifestParserUtils.parseCEA608Captions(value, closedCaptions);
-        } else if (schemeId == 'urn:scte:dash:cc:cea-708:2015') {
+        } else if (scheme == 'urn:scte:dash:cc:cea-708:2015') {
           ManifestParserUtils.parseCEA708Captions(value, closedCaptions);
         }
       }

--- a/lib/transmuxer/loc_transmuxer.js
+++ b/lib/transmuxer/loc_transmuxer.js
@@ -50,6 +50,14 @@ shaka.transmuxer.LocTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
      *              height: number, width: number}}
      */
     this.hvcInfo_ = null;
+
+    /**
+     * `id` of the stream the cached configs above were parsed from. One
+     * transmuxer instance is reused across an adaptation, so this is what
+     * tells us the cache now describes a different rendition.
+     * @private {?number}
+     */
+    this.configStreamId_ = null;
   }
 
 
@@ -61,6 +69,7 @@ shaka.transmuxer.LocTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
     super.destroy();
     this.avcInfo_ = null;
     this.hvcInfo_ = null;
+    this.configStreamId_ = null;
   }
 
 
@@ -162,6 +171,26 @@ shaka.transmuxer.LocTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
     const MimeUtils = shaka.util.MimeUtils;
 
     const uint8ArrayData = shaka.util.BufferUtils.toUint8(data);
+
+    // Drop the cached decoder configs when the rendition changes.
+    //
+    // MediaSourceEngine keeps one transmuxer per content type, and every LOC
+    // rendition normalises to the same base codec, so an adaptation takes the
+    // ResetMode.NONE path: same SourceBuffer, same transmuxer instance, no
+    // changeType().  The cached parameter sets would otherwise survive it, and
+    // because a switch typically lands mid-GOP the first frames of the new
+    // rendition are non-IDR and cannot refresh them — so the initialization
+    // segment generated for the new stream would describe the OLD rendition's
+    // resolution, and the decoder would be handed samples that do not match
+    // it.
+    //
+    // Clearing here suppresses output until the new rendition's first key
+    // frame, which is the same behaviour as at startup.
+    if (stream.id !== this.configStreamId_) {
+      this.avcInfo_ = null;
+      this.hvcInfo_ = null;
+      this.configStreamId_ = stream.id;
+    }
 
     const streamInfos = [];
     try {

--- a/test/msf/msf_parser_unit.js
+++ b/test/msf/msf_parser_unit.js
@@ -51,6 +51,80 @@ filterDescribe('shaka.msf.MSFParser', isMSFSupported, () => {
     parser.configure(config);
   });
 
+  describe('accessibility descriptors', () => {
+    /**
+     * @param {!Array<!Object>} accessibility
+     * @return {msfCatalog.Track}
+     */
+    function videoTrack(accessibility) {
+      return /** @type {msfCatalog.Track} */ ({
+        name: 'video0',
+        packaging: 'loc',
+        codec: 'avc3.4d401f',
+        role: 'video',
+        framerate: 25,
+        width: 1280,
+        height: 720,
+        isLive: true,
+        accessibility,
+      });
+    }
+
+    /**
+     * @param {msfCatalog.Track} track
+     * @return {Map<string, string>}
+     * @suppress {visibility}
+     */
+    function closedCaptionsOf(track) {
+      parser.processTrack_(track, new Map(), new Map());
+      const streams = parser.videoStreams_;
+      return streams.length ? streams[0].closedCaptions : null;
+    }
+
+    it('reads CEA-608 captions from the scheme field', () => {
+      // draft-ietf-moq-msf-01 5.2.44 names the field 'scheme'.  Reading the
+      // DASH spelling 'schemeIdUri'/'schemeId' instead left this map empty
+      // for every conforming catalog, so embedded captions were advertised
+      // by the publisher and never exposed by the player.
+      const captions = closedCaptionsOf(videoTrack([{
+        scheme: 'urn:scte:dash:cc:cea-608:2015',
+        value: 'CC1=eng',
+      }]));
+
+      expect(captions).not.toBeNull();
+      expect(captions.get('CC1')).toBe('en');
+    });
+
+    it('reads CEA-708 captions from the scheme field', () => {
+      const captions = closedCaptionsOf(videoTrack([{
+        scheme: 'urn:scte:dash:cc:cea-708:2015',
+        value: '1=lang:eng',
+      }]));
+
+      expect(captions).not.toBeNull();
+      expect(captions.size).toBe(1);
+    });
+
+    it('ignores an unknown scheme', () => {
+      const captions = closedCaptionsOf(videoTrack([{
+        scheme: 'urn:example:something-else',
+        value: 'CC1=eng',
+      }]));
+
+      expect(captions).not.toBeNull();
+      expect(captions.size).toBe(0);
+    });
+
+    it('tolerates a track with no accessibility at all', () => {
+      const track = videoTrack([]);
+      delete track['accessibility'];
+
+      const captions = closedCaptionsOf(track);
+      expect(captions).not.toBeNull();
+      expect(captions.size).toBe(0);
+    });
+  });
+
   it('fails when WebTransport is not available', async () => {
     let originalWebTransport = null;
     try {

--- a/test/transmuxer/loc_transmuxer_unit.js
+++ b/test/transmuxer/loc_transmuxer_unit.js
@@ -107,6 +107,96 @@ describe('LocTransmuxer', () => {
     return mdatOf(result.data);
   }
 
+  describe('decoder config cache', () => {
+    /**
+     * @param {number} id
+     * @return {shaka.extern.Stream}
+     */
+    function videoStream(id) {
+      return /** @type {shaka.extern.Stream} */ ({
+        id,
+        type: ContentType.VIDEO,
+        codecs: 'avc3.4d401f',
+        mimeType: 'moq/loc',
+        width: 1920,
+        height: 1080,
+        language: 'und',
+      });
+    }
+
+    // A length-prefixed non-IDR slice: no parameter sets, so it can never
+    // refresh the cache on its own.  This is what the first frames after a
+    // mid-GOP adaptation look like.
+    const nonKeyFrame = new Uint8Array([0, 0, 0, 3, 0x41, 0x9a, 0x02]);
+
+    /**
+     * The cache is the transmuxer's own state, and the only way to observe
+     * which rendition it describes.  Stands in for a key frame having
+     * populated it.
+     *
+     * @suppress {visibility}
+     */
+    function primeAvcInfo() {
+      transmuxer.avcInfo_ = {
+        videoConfig: new Uint8Array([1]),
+        hSpacing: 1,
+        vSpacing: 1,
+        width: 1920,
+        height: 1080,
+      };
+    }
+
+    /**
+     * @return {boolean}
+     * @suppress {visibility}
+     */
+    function hasAvcInfo() {
+      return transmuxer.avcInfo_ != null;
+    }
+
+    /**
+     * @param {shaka.extern.Stream} stream
+     * @return {!Promise}
+     */
+    function transmuxVideo(stream) {
+      return transmuxer.transmux(nonKeyFrame, stream, makeReference(),
+          /* duration= */ 1 / 25, ContentType.VIDEO);
+    }
+
+    it('keeps the cache while the rendition is unchanged', async () => {
+      const stream = videoStream(1);
+      await transmuxVideo(stream);
+
+      primeAvcInfo();
+      await transmuxVideo(stream);
+
+      expect(hasAvcInfo()).toBe(true);
+    });
+
+    it('drops the cache when the rendition changes', async () => {
+      // MediaSourceEngine keeps one transmuxer per content type and every LOC
+      // rendition normalises to the same base codec, so an adaptation reuses
+      // this instance with no changeType().  A switch lands mid-GOP, so the
+      // first frames of the new rendition cannot refresh the cache — and the
+      // initialization segment would describe the previous rendition.
+      await transmuxVideo(videoStream(1));
+      primeAvcInfo();
+
+      await transmuxVideo(videoStream(2));
+
+      expect(hasAvcInfo()).toBe(false);
+    });
+
+    it('emits nothing until the new rendition has a key frame', async () => {
+      await transmuxVideo(videoStream(1));
+      primeAvcInfo();
+
+      const result = /** @type {!shaka.extern.TransmuxerOutput} */ (
+        await transmuxVideo(videoStream(2)));
+      expect(result.data.byteLength).toBe(0);
+    });
+  });
+
   describe('AAC', () => {
     // A plausible stereo AAC-LC raw_data_block: starts with a CPE element,
     // so its first byte is 0x21 and it is NOT an ADTS frame.


### PR DESCRIPTION
Two unrelated defects on the LOC path.

MediaSourceEngine keeps one transmuxer per content type, and every LOC rendition normalises to the same base codec, so an adaptation takes the ResetMode.NONE path: same SourceBuffer, same transmuxer instance, no changeType(). LocTransmuxer's cached parameter sets survived it. A switch typically lands mid-GOP, so the first frames of the new rendition are not key frames and cannot refresh the cache — meaning the initialization segment generated for the new stream described the PREVIOUS rendition's resolution, and the decoder was handed samples that did not match it. Reset the cache when the stream id changes, which suppresses output until the new rendition's first key frame: the same behaviour as at startup.

Accessibility descriptors were read from a field that does not exist. draft-ietf-moq-msf-01 5.2.44 names it 'scheme'; the parser read 'schemeId', which is where the DASH attribute name 'schemeIdUri' leaked in. The closedCaptions map therefore came out empty for every conforming catalog, so a publisher advertising CEA-608 or CEA-708 had its captions silently dropped: no caption track was offered and no text stream was created.

Verified against a live publisher advertising CC1: closedCaptions goes from
empty to {CC1: en}, and an application/cea-608 text stream now appears.

Note the captions are advertised but not yet decoded: ClosedCaptionParser has no parser registered for the moq/loc container, so it falls back to DummyCeaParser. Extracting the SEI messages from a LOC payload is left for a follow-up.