### PR TITLE
fix: Parse closed captions after transmuxing

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1500,11 +1500,9 @@ shaka.media.MediaSourceEngine = class {
         this.captionParser_ = this.getCaptionParser(
             bufferType.split(';', 1)[0]);
       }
-      if (transmuxedInitSegment) {
+      if (transmuxedInitSegment || !reference) {
         this.captionParser_.init(
-            transmuxedInitSegment, adaptation, continuityTimeline);
-      } else if (!reference) {
-        this.captionParser_.init(data, adaptation, continuityTimeline);
+            transmuxedInitSegment || data, adaptation, continuityTimeline);
       }
       if (reference) {
         const closedCaptions = this.captionParser_.parseFrom(data);

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1453,28 +1453,14 @@ shaka.media.MediaSourceEngine = class {
             reference ? reference.endTime : null);
       }
     }
-    if (hasClosedCaptions && contentType == ContentType.VIDEO) {
-      if (!this.textEngine_) {
-        this.reinitText(shaka.util.MimeUtils.CEA608_CLOSED_CAPTION_MIMETYPE,
-            /* external= */ false);
-      }
-      if (!this.captionParser_) {
-        const basicType = mimeType.split(';', 1)[0];
-        this.captionParser_ = this.getCaptionParser(basicType);
-      }
-      // If it is the init segment for closed captions, initialize the closed
-      // caption parser.
-      if (!reference) {
-        this.captionParser_.init(data, adaptation, continuityTimeline);
-      } else {
-        const closedCaptions = this.captionParser_.parseFrom(data);
-        if (closedCaptions.length) {
-          this.textEngine_.storeAndAppendClosedCaptions(
-              closedCaptions,
-              timestampOffset);
-        }
-      }
-    }
+    /**
+     * The initialization segment a transmuxer produced on this append, if any.
+     * Closed captions are parsed out of the transmuxed media below, so this is
+     * what describes it, not whatever initialization segment arrived from the
+     * network.
+     * @type {?BufferSource}
+     */
+    let transmuxedInitSegment = null;
 
     if (this.transmuxers_.has(contentType)) {
       const transmuxerOutput =
@@ -1487,11 +1473,46 @@ shaka.media.MediaSourceEngine = class {
         /** @type {!shaka.extern.TransmuxerOutput} */(transmuxerOutput);
         if (output.init != null) {
           const initData = output.init;
+          transmuxedInitSegment = initData;
           this.enqueueOperation_(contentType, () => {
             this.append_(contentType, initData, timestampOffset, stream, true);
           }, reference ? reference.getUris()[0] : null);
         }
         data = output.data;
+      }
+    }
+
+    // Closed captions are parsed AFTER transmuxing, out of what is actually
+    // going to be appended.  Transmuxed containers are always repackaged into
+    // MP4, so one parser covers every path that reaches a SourceBuffer, and a
+    // packaging only has to preserve the SEI NAL units to get captions for
+    // free.  Parsing the pre-transmux bytes instead needed a parser per source
+    // container, and gave nothing at all to containers that carry the
+    // elementary stream raw.
+    if (hasClosedCaptions && contentType == ContentType.VIDEO) {
+      if (!this.textEngine_) {
+        this.reinitText(shaka.util.MimeUtils.CEA608_CLOSED_CAPTION_MIMETYPE,
+            /* external= */ false);
+      }
+      if (!this.captionParser_) {
+        // The SourceBuffer's own type, which is what `data` is by now.
+        const bufferType = this.sourceBufferTypes_.get(contentType) || mimeType;
+        this.captionParser_ = this.getCaptionParser(
+            bufferType.split(';', 1)[0]);
+      }
+      if (transmuxedInitSegment) {
+        this.captionParser_.init(
+            transmuxedInitSegment, adaptation, continuityTimeline);
+      } else if (!reference) {
+        this.captionParser_.init(data, adaptation, continuityTimeline);
+      }
+      if (reference) {
+        const closedCaptions = this.captionParser_.parseFrom(data);
+        if (closedCaptions.length) {
+          this.textEngine_.storeAndAppendClosedCaptions(
+              closedCaptions,
+              timestampOffset);
+        }
       }
     }
 

--- a/lib/transmuxer/h265.js
+++ b/lib/transmuxer/h265.js
@@ -650,12 +650,19 @@ shaka.transmuxer.H265 = class {
           push = false;
           break;
       }
-      if (hvcSample && push) {
+      if (push) {
         nalusData.push(nalu.fullData);
         totalNaluSize += nalu.fullData.byteLength;
       }
     }
-    if (!nalusData.length) {
+    // An access unit with no slice in it is not a sample.  This is checked
+    // after the loop rather than gating the collection above, because the
+    // non-VCL NAL units of an access unit come BEFORE its first slice: an
+    // AUD, then the parameter sets, then the prefix SEI.  Dropping whatever
+    // preceded the slice cost the parameter sets and the SEI messages —
+    // which is where CEA captions live — on any stream without an AUD to set
+    // the flag early.
+    if (!hvcSample || !nalusData.length) {
       return false;
     }
 

--- a/test/transmuxer/h265_unit.js
+++ b/test/transmuxer/h265_unit.js
@@ -1,0 +1,106 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('H265', () => {
+  const H265 = shaka.transmuxer.H265;
+
+  /**
+   * @param {number} type
+   * @param {!Array<number>=} payload
+   * @return {shaka.extern.VideoNalu}
+   */
+  function nalu(type, payload) {
+    const body = payload || [0x00, 0x01];
+    // nal_unit_type(6) in the high bits of the first byte, then
+    // nuh_layer_id(6) and nuh_temporal_id_plus1(3).
+    const fullData = new Uint8Array([(type << 1) & 0x7e, 0x01, ...body]);
+    return /** @type {shaka.extern.VideoNalu} */ ({
+      data: fullData.subarray(2),
+      fullData,
+      type,
+    });
+  }
+
+  /**
+   * Reads back the NAL unit types of the length-prefixed sample the parser
+   * produced.
+   *
+   * @param {!Uint8Array} data
+   * @return {!Array<number>}
+   */
+  function sampleNaluTypes(data) {
+    const types = [];
+    let offset = 0;
+    while (offset + 4 <= data.byteLength) {
+      const size = ((data[offset] << 24) | (data[offset + 1] << 16) |
+          (data[offset + 2] << 8) | data[offset + 3]) >>> 0;
+      offset += 4;
+      types.push((data[offset] & 0x7e) >> 1);
+      offset += size;
+    }
+    return types;
+  }
+
+  // 39 = prefix SEI, 40 = suffix SEI, 32/33/34 = VPS/SPS/PPS,
+  // 35 = AUD, 19 = IDR_W_RADL, 1 = TRAIL_R.
+  const PREFIX_SEI = 39;
+  const SUFFIX_SEI = 40;
+  const VPS = 32;
+  const SPS = 33;
+  const PPS = 34;
+  const AUD = 35;
+  const IDR = 19;
+
+  describe('parseFrame', () => {
+    it('keeps the non-VCL units that precede the first slice', () => {
+      // This is the ordinary access unit layout when there is no AUD: the
+      // parameter sets and the prefix SEI come BEFORE the slice.  CEA
+      // captions live in that SEI, so dropping it loses them.
+      const frame = {data: new Uint8Array(0), isKeyframe: false};
+      const parsed = H265.parseFrame(
+          [nalu(VPS), nalu(SPS), nalu(PPS), nalu(PREFIX_SEI), nalu(IDR)],
+          frame);
+
+      expect(parsed).toBe(true);
+      expect(sampleNaluTypes(frame.data))
+          .toEqual([VPS, SPS, PPS, PREFIX_SEI, IDR]);
+      expect(frame.isKeyframe).toBe(true);
+    });
+
+    it('keeps them when an AUD leads the access unit', () => {
+      const frame = {data: new Uint8Array(0), isKeyframe: false};
+      const parsed = H265.parseFrame(
+          [nalu(AUD), nalu(PREFIX_SEI), nalu(IDR), nalu(SUFFIX_SEI)], frame);
+
+      expect(parsed).toBe(true);
+      expect(sampleNaluTypes(frame.data))
+          .toEqual([AUD, PREFIX_SEI, IDR, SUFFIX_SEI]);
+    });
+
+    it('produces no sample for an access unit with no slice', () => {
+      // Parameter sets on their own are not a frame, and emitting them as one
+      // would put a sample with no picture into the timeline.
+      const frame = {data: new Uint8Array(0), isKeyframe: false};
+      const parsed = H265.parseFrame(
+          [nalu(VPS), nalu(SPS), nalu(PPS), nalu(PREFIX_SEI)], frame);
+
+      expect(parsed).toBe(false);
+    });
+
+    it('produces no sample for an empty access unit', () => {
+      const frame = {data: new Uint8Array(0), isKeyframe: false};
+      expect(H265.parseFrame([], frame)).toBe(false);
+    });
+
+    it('drops NAL unit types that do not belong in a sample', () => {
+      const frame = {data: new Uint8Array(0), isKeyframe: false};
+      // 62 is unspecified; it must not reach the SourceBuffer.
+      H265.parseFrame([nalu(IDR), nalu(62)], frame);
+
+      expect(sampleNaluTypes(frame.data)).toEqual([IDR]);
+    });
+  });
+});


### PR DESCRIPTION
Closed captions were parsed out of the bytes that arrived from the network, before transmuxing. That needed a caption parser per source container, and gave nothing at all to containers that carry the elementary stream raw: ClosedCaptionParser has entries for video/mp4 and video/mp2t, and anything else falls back to DummyCeaParser and silently yields no cues.

Parse them out of what is actually going to be appended instead. Everything that is transmuxed is repackaged into MP4, so one parser now covers every path that reaches a SourceBuffer. A new packaging no longer needs a caption parser of its own — preserving the SEI NAL units through the transmuxer is enough to get captions for free. LOC over MoQ is the immediate case: it has no container to parse and so could never have had one.

This exposed a defect in the HEVC path. H265.parseFrame only started collecting NAL units once it had seen a slice or an AUD, but the non-VCL units of an access unit come before its first slice: an AUD, then the parameter sets, then the prefix SEI. Without an AUD to set the flag early, all of them were dropped from the sample — the parameter sets as well as the SEI messages where CEA captions live. Collect them and check for a slice at the end instead, which keeps the "no slice, no sample" rule.

TsCeaParser stays: SegmentUtils.getBasicInfoFromTs uses it to discover which caption channels an HLS stream carries, and that path inspects a raw TS segment rather than appending it, so no transmuxer is involved.

Covered by the existing CEA-708 integration tests, which assert specific cues and now exercise the transmuxed MP4 for TS instead of the raw TS.