### PR TITLE
fix: Reduce unnecessary error calls

### DIFF
--- a/lib/util/abortable_operation.js
+++ b/lib/util/abortable_operation.js
@@ -168,11 +168,10 @@ shaka.util.AbortableOperation = class {
     // Silence uncaught rejection errors, which may otherwise occur any place
     // we don't explicitly handle aborted operations.
     newPromise.promise.catch(() => {});
-    const abortError = shaka.util.AbortableOperation.abortError();
 
     // If called before "this" completes, just abort "this".
     let abort = () => {
-      newPromise.reject(abortError);
+      newPromise.reject(shaka.util.AbortableOperation.abortError());
       return this.abort();
     };
 
@@ -182,7 +181,7 @@ shaka.util.AbortableOperation = class {
           // If "this" is not abortable(), or if abort() is called after "this"
           // is complete but before the next stage in the chain begins, we
           // should stop right away.
-          newPromise.reject(abortError);
+          newPromise.reject(shaka.util.AbortableOperation.abortError());
           return;
         }
 


### PR DESCRIPTION
I noticed that there were a lot of slowish `shaka.util.Error` calls happening during seemingly good playback.

<img width="2814" height="686" alt="error-util-calls" src="https://github.com/user-attachments/assets/f74d2b68-c088-4f6a-9d0e-180ae7a01595" />

It turns out that we are creating a new shaka error object on every `shaka.util.AbortableOperation.chain` call whether its aborted or not. This is bad for performance as `.stack` does a whole JS frame walk which can be slow, especially on older browsers.

For testing I have a custom stripped down demo page (made to run on older browsers) running 60 seconds of `https://storage.googleapis.com/shaka-demo-assets/bbb-dark-truths/dash.mpd` with network cache disabled.

I have done some testing in a custom emulator running Chromium 41 on my M4 Macbook Pro using the following settings.

<img width="546" height="330" alt="emulator-settings" src="https://github.com/user-attachments/assets/158ea596-4986-4826-9811-2e7a50068ad7" />

These are my findings below and are representative of the aveage test run

Generally good improvements across the board

<img width="668" height="230" alt="image" src="https://github.com/user-attachments/assets/eef5628f-820a-415f-9c07-7d600e21d383" />

With the GC looking a lot happier too. Less events over the test run generally 

Before
<img width="358" height="337" alt="image" src="https://github.com/user-attachments/assets/0670900d-1840-463d-b3cc-62f9182e1ad7" />


After
<img width="354" height="252" alt="image" src="https://github.com/user-attachments/assets/5fbacea8-2ada-48e9-8148-6c94f7857b38" />


No behavior changes. A promise still only settles once, so only one abort error was ever used anyway. 
We just build it at abort time instead of up front.

Fixes https://github.com/shaka-project/shaka-player/issues/10500