### PR TITLE
fix: Release XHR handlers once the request is done

### DIFF
--- a/lib/net/http_xhr_plugin.js
+++ b/lib/net/http_xhr_plugin.js
@@ -46,12 +46,24 @@ shaka.net.HttpXHRPlugin = class {
       xhr.withCredentials = request.allowCrossSiteCredentials;
       let headers = {};
 
+      // Null out the handlers so older Chrome 38 era browsers GC can
+      // clean up the XHR and its response buffer.
+      const cleanup = () => {
+        xhr.onload = null;
+        xhr.onerror = null;
+        xhr.ontimeout = null;
+        xhr.onabort = null;
+        xhr.onreadystatechange = null;
+        xhr.onprogress = null;
+      };
+
       xhr.onabort = () => {
         reject(new shaka.util.Error(
             shaka.util.Error.Severity.RECOVERABLE,
             shaka.util.Error.Category.NETWORK,
             shaka.util.Error.Code.OPERATION_ABORTED,
             uri, requestType));
+        cleanup();
       };
       xhr.onreadystatechange = (event) => {
         if (xhr.readyState === XMLHttpRequest.HEADERS_RECEIVED) {
@@ -75,6 +87,7 @@ shaka.net.HttpXHRPlugin = class {
               'Wrong error type!');
           reject(error);
         }
+        cleanup();
       };
       xhr.onerror = (event) => {
         reject(new shaka.util.Error(
@@ -82,6 +95,7 @@ shaka.net.HttpXHRPlugin = class {
             shaka.util.Error.Category.NETWORK,
             shaka.util.Error.Code.HTTP_ERROR,
             uri, event, requestType));
+        cleanup();
       };
       xhr.ontimeout = (event) => {
         reject(new shaka.util.Error(
@@ -89,6 +103,7 @@ shaka.net.HttpXHRPlugin = class {
             shaka.util.Error.Category.NETWORK,
             shaka.util.Error.Code.TIMEOUT,
             uri, requestType));
+        cleanup();
       };
       xhr.onprogress = (event) => {
         const currentTime = Date.now();


### PR DESCRIPTION
After 60 seconds of playback the listener count sits at 306 and never comes back down. Every XHR we fire keeps it handlers alive and on a Chromium 38 era set top boxes nothing ever collects them until we encounter a OOM situation
 
This has been difficult to capture on device as when an OOM error occurs devtools will crash too.
I was however able to replicate the behaviour in an emulator (Chromium 41 is the closest build available in the emulator).

For testing I have a custom stripped down demo page (made to run on older browsers) running 60 seconds of https://storage.googleapis.com/shaka-demo-assets/bbb-dark-truths/dash.mpd with network cache disabled.
This once again was run in our custom emulator with the following settings.

<img width="546" height="330" alt="image" src="https://github.com/user-attachments/assets/5bc39696-529a-40a5-bb9a-39d6fd3d4115" />

To fix it I added a cleanup function that nulls out the handler references when the XHR terminates giving the primative GC in these older browsers a fighting chance. 
Same 60 second run afterwards: **306** listeners down to **36**, and the staircase in the memory graph is gone.

The findings below and are representative an average test run

Before: You can see the yellow "staircase" during playback on the memory graph
<img width="1459" height="215" alt="image" src="https://github.com/user-attachments/assets/4b1daae5-3520-4b74-87db-ec6f5757bb83" />

After: The stair case is gone and the GC has no issue cleaning up the listeners during play back
<img width="1607" height="214" alt="Chrome 41 - Listener accumulation fix" src="https://github.com/user-attachments/assets/7bf00dee-1a65-4c6d-a7ff-535c684dc070" />

Below is the performance metrics for comparison 
<img width="739" height="152" alt="image" src="https://github.com/user-attachments/assets/98e7471f-bb95-42e1-b280-47c46274ace3" />
Worth noting that on the Baseline, Peak Heap Size and Heap Size After Run are measured at the same point on the graph it peaks and never comes back down.

Small change but it's the difference between stable playback and an OOM on these boxes.

Fixes https://github.com/shaka-project/shaka-player/issues/10505