### PR TITLE
fix(offline): Avoid DRM license removal failure

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -317,6 +317,15 @@ shaka.drm.DrmEngine = class {
       mimeTypes.push(audioCapabilities[0].contentType);
     }
 
+    // The license we are about to remove was persisted by a CDM that was
+    // configured with these robustness levels.  Asking for different levels
+    // here can hand us a different CDM instance, and a session persisted by
+    // one CDM cannot be loaded by another, so the removal would quietly fail.
+    const audioRobustness =
+        audioCapabilities.length ? audioCapabilities[0].robustness || '' : '';
+    const videoRobustness =
+        videoCapabilities.length ? videoCapabilities[0].robustness || '' : '';
+
     const makeDrmInfo = (encryptionScheme) => {
       const drmInfo = shaka.util.ManifestParserUtils.createDrmInfo(
           keySystem, encryptionScheme, /* initData= */ null);
@@ -324,6 +333,8 @@ shaka.drm.DrmEngine = class {
       drmInfo.serverCertificate = serverCertificate;
       drmInfo.persistentStateRequired = true;
       drmInfo.sessionType = 'persistent-license';
+      drmInfo.audioRobustness = audioRobustness;
+      drmInfo.videoRobustness = videoRobustness;
       return drmInfo;
     };
     const variant = shaka.util.StreamUtils.createEmptyVariant(mimeTypes);

--- a/test/offline/storage_integration.js
+++ b/test/offline/storage_integration.js
@@ -135,6 +135,10 @@ filterDescribe('Storage', storageSupport, () => {
       // networking engine.  This allows us to use Player.configure in these
       // tests.
       player = new shaka.Player();
+      // The test scheme deliberately keeps license servers out of the manifest,
+      // so they have to come from the player config.  Storage reads that config
+      // from the player, so this has to happen before Storage is constructed.
+      shaka.test.TestScheme.setupPlayer(player, 'sintel-enc');
       storage = new shaka.offline.Storage(player);
     });
 
@@ -148,10 +152,7 @@ filterDescribe('Storage', storageSupport, () => {
     // content.
     // See issue #2218.
 
-    // Quarantined due to http://crbug.com/1019298 where a load cannot happen
-    // immediately after a remove.  This can sometimes be fixed with a delay,
-    // but it is extremely flaky, so these are disabled until the bug is fixed.
-    quarantinedIt('removes persistent license', async () => {
+    it('removes persistent license', async () => {
       const testSchemeMimeType = 'application/x-test-manifest';
 
       // PART 1 - Download and store content that has a persistent license
@@ -182,10 +183,11 @@ filterDescribe('Storage', storageSupport, () => {
 
       // PART 4 - Check that the licenses were removed.
       const p = withDrm(player, manifest, (drm) => {
-        return Promise.all(manifest.offlineSessionIds.map(async (session) => {
-          const notFoundSession = await loadOfflineSession(drm, session);
-          expect(notFoundSession).toBeFalsy();
-        }));
+        // Loading a session that is gone still hands back a MediaKeySession;
+        // what says the license was removed is the error that comes with it,
+        // which withDrm() re-throws once the action is done.
+        return Promise.all(manifest.offlineSessionIds.map(
+            (session) => loadOfflineSession(drm, session)));
       });
       const expected = Util.jasmineError(new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
@@ -194,7 +196,7 @@ filterDescribe('Storage', storageSupport, () => {
       await expectAsync(p).toBeRejectedWith(expected);
     });
 
-    quarantinedIt('defers removing licenses on error', async () => {
+    it('defers removing licenses on error', async () => {
       const testSchemeMimeType = 'application/x-test-manifest';
 
       // PART 1 - Download and store content that has a persistent license
@@ -239,10 +241,11 @@ filterDescribe('Storage', storageSupport, () => {
 
       // PART 6 - Check that the licenses were removed.
       const p = withDrm(player, manifest, (drm) => {
-        return Promise.all(manifest.offlineSessionIds.map(async (session) => {
-          const notFoundSession = await loadOfflineSession(drm, session);
-          expect(notFoundSession).toBeFalsy();
-        }));
+        // Loading a session that is gone still hands back a MediaKeySession;
+        // what says the license was removed is the error that comes with it,
+        // which withDrm() re-throws once the action is done.
+        return Promise.all(manifest.offlineSessionIds.map(
+            (session) => loadOfflineSession(drm, session)));
       });
       const expected = Util.jasmineError(new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,


### PR DESCRIPTION
Removing stored content never released its persistent license.  The content and the manifest went away, and the license stayed in the CDM with nothing left pointing at it.

A persistent session belongs to the CDM instance that created it, and the robustness levels we ask for are part of what decides which instance we get.  initForRemoval is handed the levels the license was stored under, but it used only the content types from them and left the robustness unset, so removal negotiated for a different CDM than storage had used.  That CDM will not load a session it did not create: on a Pixel Tablet, load() rejects with InvalidStateError "Operation aborted (1000003)".  Pass the stored levels through, and the session loads, the license-release message goes to the server, and a later load reports the session as gone.

This is only reachable where the platform supports persistent licenses, which is why it went unnoticed: desktop Chrome reports persistentState false and skips these paths entirely.

Verified on a Pixel Tablet, where the two storage tests covering this pass five runs in a row, and on desktop Chrome, where the full suite is unaffected.

The tests were quarantined in 2019 for http://crbug.com/1019298, a bug since closed, and they describe the opposite symptom to this one, so the reference goes away with the quarantine.  They had also stopped configuring a license server: the test scheme stopped putting one in the manifest in de1a94aba, which the quarantine hid.  Their check that a removed session comes back falsy is updated too, since loading a session that is gone still returns a MediaKeySession, and what reports the removal is the OFFLINE_SESSION_REMOVED error alongside it.