### PR TITLE
fix(offline): Avoid orphaned DRM sessions on removal failure

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -730,10 +730,18 @@ shaka.drm.DrmEngine = class {
     const session = await this.loadOfflineSession_(
         sessionId, {initData: null, initDataType: null});
 
-    // This will be null on error, such as session not found.
+    // We only get nothing back when the load itself failed.  A session that is
+    // simply gone comes back as a session object alongside an
+    // OFFLINE_SESSION_REMOVED error, so this is not the missing-session case.
+    // Returning normally here would tell the caller the license was released
+    // when it was not, and the caller would forget a session whose license the
+    // CDM still holds, leaving it stored forever with no way to find it again.
     if (!session) {
-      shaka.log.v2('Ignoring attempt to remove missing session', sessionId);
-      return;
+      throw new shaka.util.Error(
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.DRM,
+          shaka.util.Error.Code.FAILED_TO_CREATE_SESSION,
+          'Failed to load session for removal: ' + sessionId);
     }
 
     // TODO: Consider adding a timeout to get the 'message' event.

--- a/test/drm/drm_engine_unit.js
+++ b/test/drm/drm_engine_unit.js
@@ -2624,6 +2624,23 @@ describe('DrmEngine', () => {
           .toBeRejectedWith(expected);
     });
 
+    it('is rejected when the session cannot be loaded', async () => {
+      // A CDM can refuse to load a persistent session, as one does when it was
+      // persisted under different robustness levels.  Reporting success would
+      // let the caller drop its record of a session the CDM still holds.
+      session1.load.and.returnValue(
+          Promise.reject(new Error('Operation aborted')));
+      onErrorSpy.and.stub();
+
+      const expected = Util.jasmineError(new shaka.util.Error(
+          shaka.util.Error.Severity.CRITICAL, shaka.util.Error.Category.DRM,
+          shaka.util.Error.Code.FAILED_TO_CREATE_SESSION,
+          'Failed to load session for removal: abc'));
+      await expectAsync(drmEngine.removeSession('abc'))
+          .toBeRejectedWith(expected);
+      expect(session1.remove).not.toHaveBeenCalled();
+    });
+
     // Regression test for #3534
     it('does not remove the same session again on destroy', async () => {
       updatePromise.resolve();


### PR DESCRIPTION
removeSession treated a failed load as nothing to do.  It returned normally, so the caller was told the license had been released when the CDM still held it.

That is not what the empty return means.  loadOfflineSession_ hands back a session object even when the session is gone, reporting that through an OFFLINE_SESSION_REMOVED error, so the only way to get nothing back is for the load itself to have failed.  The comment claiming this was the missing-session case described a state that cannot reach it.

The consequence is worse than a lost error.  SessionDeleter records a session as deleted whenever removeSession resolves, and Storage then drops it from the EME session table, which is the only record of it we keep.  The license outlives the content it belonged to, and removeEmeSessions reports that everything was cleaned up, so nothing ever tries again.  Rejecting instead lets the catch in SessionDeleter leave the session out of the deleted list, which is what puts it back in the table to be retried later.