### PR TITLE
wip: Disable gapPadding=0 in HLS tests

### DIFF
--- a/test/hls/hls_parser_integration.js
+++ b/test/hls/hls_parser_integration.js
@@ -36,8 +36,6 @@ describe('HlsParser', () => {
 
     // Disable stall detection, which can interfere with playback tests.
     player.configure('streaming.stallEnabled', false);
-    // Disable gapPadding, which can interfere with playback tests.
-    player.configure('streaming.gapPadding', 0);
 
     // Grab event manager from the uncompiled library:
     eventManager = new shaka.util.EventManager();


### PR DESCRIPTION
The default outside of XBox and Tizen is already 0, so this could only affect Tizen in a lab test run right now.  Do we need it?