### PR TITLE
test: Stop disabling gap padding in the HLS tests

### DIFF
--- a/test/hls/hls_parser_integration.js
+++ b/test/hls/hls_parser_integration.js
@@ -36,8 +36,6 @@ describe('HlsParser', () => {
 
     // Disable stall detection, which can interfere with playback tests.
     player.configure('streaming.stallEnabled', false);
-    // Disable gapPadding, which can interfere with playback tests.
-    player.configure('streaming.gapPadding', 0);
 
     // Grab event manager from the uncompiled library:
     eventManager = new shaka.util.EventManager();


### PR DESCRIPTION
gapPadding exists so that a platform can move a gap jump slightly past the start of the buffered range, on devices where landing exactly on the first sample does not reliably resume playback.  Tizen asks for 2 seconds and Xbox for 0.01.  This suite set it to 0 for every device, which switched that workaround off precisely where a gap is being jumped.

The line arrived in #8858, a DASH feature change, alongside an unrelated one that disables stall detection, and its comment is a copy of that one.  Nothing in the change needed it and no test was failing without it, so there is no behavior here to preserve.

The cost is not hypothetical.  A padding-shaped fix for a stall would appear to do nothing in this suite no matter how well it worked in the field, because the suite would be turning it off.  That already happened once while measuring the Safari rendition switch stall: an attempt to give Apple browsers a padding of 0.01 was silently zeroed here, and reported a plausible looking failure rate that measured nothing at all.

Removing it is a no-op everywhere except Tizen and Xbox, since the configured default is 0 and no other device changes it, so nothing on the GitHub runners can move.  Verified on Tizen.