### PR TITLE
fix(device): Ban changeType on Opera for macOS

### DIFF
--- a/lib/device/default_browser.js
+++ b/lib/device/default_browser.js
@@ -34,6 +34,13 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
         return parseInt(edge[1], /* base= */ 10);
       }
 
+      // Opera reports both as well, as in "Chrome/140.0.0.0 ... OPR/125.0",
+      // and for the same reason, its own version is the one to report.
+      const opera = navigator.userAgent.match(/OPR\/(\d+)/);
+      if (opera) {
+        return parseInt(opera[1], /* base= */ 10);
+      }
+
       // Looking for something like "Chrome/106.0.0.0" or Firefox/135.0
       const match = navigator.userAgent.match(/(Chrome|Firefox)\/(\d+)/);
       if (match) {
@@ -49,12 +56,29 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
       // Chromium-based Edge contains "Edg/version" (no "e").
       if (navigator.userAgent.match(/Edge?\//)) {
         return 'Edge';
+      } else if (navigator.userAgent.includes('OPR/')) {
+        // Opera is Chromium and says "Chrome" too, so it has to be checked
+        // first, the same way Edge is.
+        return 'Opera';
       } else if (navigator.userAgent.includes('Chrome')) {
         return 'Chrome';
       } else if (navigator.userAgent.includes('Firefox')) {
         return 'Firefox';
       }
       return 'Unknown';
+    });
+
+    /** @private {!shaka.util.Lazy<boolean>} */
+    this.isMac_ = new shaka.util.Lazy(() => {
+      // Try the newer standard first.
+      if (navigator.userAgentData && navigator.userAgentData.platform) {
+        return navigator.userAgentData.platform.toLowerCase() == 'macos';
+      }
+      // Fall back to the old API, with less strict matching.
+      if (!navigator.platform) {
+        return false;
+      }
+      return navigator.platform.toLowerCase().includes('mac');
     });
 
     /** @private {!shaka.util.Lazy<boolean>} */
@@ -119,6 +143,23 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
       return this.isWindows_.value();
     }
     return false;
+  }
+
+  /**
+   * @override
+   */
+  supportsContainerChangeType() {
+    // Opera on macOS accepts changeType and then cannot decode across the
+    // splice.  Playback of content spliced from VP9 to H.264 in one source
+    // buffer stops just before the boundary, with VideoToolbox refusing to
+    // create a session for the second format: error -12906 out of
+    // VTDecompressionSessionCreate().  It is specific to this pairing, since
+    // the same content plays on Opera on Linux and on every other browser on
+    // macOS.
+    if (this.deviceName_.value() === 'Opera' && this.isMac_.value()) {
+      return false;
+    }
+    return super.supportsContainerChangeType();
   }
 
   /**

--- a/lib/device/default_browser.js
+++ b/lib/device/default_browser.js
@@ -202,6 +202,9 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
               'com.microsoft.playready.recommendation',
           };
           break;
+        // Opera is Chromium, and took this branch as "Chrome" before it was
+        // named separately.
+        case 'Opera':
         case 'Chrome':
           config.drm.keySystemsMapping = {
             'com.microsoft.playready':

--- a/test/cast/cast_receiver_integration.js
+++ b/test/cast/cast_receiver_integration.js
@@ -12,6 +12,7 @@
 const castReceiverIntegrationSupport =
     () => deviceDetected.getDeviceName() === 'Chrome' ||
       deviceDetected.getDeviceName() === 'Edge' ||
+      deviceDetected.getDeviceName() === 'Opera' ||
       deviceDetected.getDeviceType() === shaka.device.IDevice.DeviceType.CAST;
 filterDescribe('CastReceiver', castReceiverIntegrationSupport, () => {
   const CastReceiver = shaka.cast.CastReceiver;

--- a/test/cast/cast_receiver_unit.js
+++ b/test/cast/cast_receiver_unit.js
@@ -12,6 +12,7 @@
 const castReceiverSupport =
     () => deviceDetected.getDeviceName() === 'Chrome' ||
       deviceDetected.getDeviceName() === 'Edge' ||
+      deviceDetected.getDeviceName() === 'Opera' ||
       deviceDetected.getDeviceType() === shaka.device.IDevice.DeviceType.CAST;
 filterDescribe('CastReceiver', castReceiverSupport, () => {
   const CastReceiver = shaka.cast.CastReceiver;


### PR DESCRIPTION
Opera on macOS accepts changeType and then cannot decode across the splice.  Content spliced from VP9 to H.264 inside one source buffer plays until just before the boundary and stops there, with VideoToolbox refusing to create a session for the second format: error -12906 out of VTDecompressionSessionCreate().

It is specific to that pairing.  "support multi type variants" failed 4 runs in 5 on Opera on macOS and was the only failure that browser had in a full suite run.  The same content plays on Opera on Linux, and on Chrome, Edge and Firefox on macOS.  A trace showed every run, passing and failing alike, making the same two changeType calls with the same types, so the calls were not what differed; what differed was whether the decoder won a race, and the playhead stopped at the same place in the media each time rather than after the same amount of wall time.

Ban changeType on Opera for macOS, so the player splits the presentation at the container boundary instead of splicing in place. To enable this, add Opera detection to lib/device/.

Before this change, we got the -12906 error in 4 of 5 test runs.  With this change, it goes to 0 in 20.