### PR TITLE
feat(MSF): Add AV1 support to the LOC transmuxer

### DIFF
--- a/build/types/msf
+++ b/build/types/msf
@@ -29,4 +29,5 @@
 +../../lib/msf/drafts/draft18/messages.js
 +../../lib/msf/drafts/draft18/session.js
 
++../../lib/transmuxer/av1.js
 +../../lib/transmuxer/loc_transmuxer.js

--- a/build/types/transmuxer-worker
+++ b/build/types/transmuxer-worker
@@ -6,6 +6,7 @@
 +../../lib/device/apple_browser.js
 +../../lib/device/default_browser.js
 +@devices
++../../lib/transmuxer/av1.js
 +../../lib/transmuxer/loc_transmuxer.js
 +../../lib/transmuxer/transmuxer_worker.js
 +@transmuxer

--- a/lib/msf/loc_parser.js
+++ b/lib/msf/loc_parser.js
@@ -199,8 +199,9 @@ shaka.msf.LOCParser = class {
    *
    * LOC-04 §2.3.2.1 defines Video Config as "the extradata bytes defined by
    * the corresponding codec specification", so its layout depends on the
-   * codec: an AVCDecoderConfigurationRecord for H.264 and an
-   * HEVCDecoderConfigurationRecord for H.265. A publisher that uses it has
+   * codec: an AVCDecoderConfigurationRecord for H.264, an
+   * HEVCDecoderConfigurationRecord for H.265, and an
+   * AV1CodecConfigurationRecord for AV1. A publisher that uses it has
    * stripped the parameter sets from the bitstream (§2.1.2), so re-inlining
    * them here restores exactly what was removed, at the earliest point, and
    * every downstream consumer stays unchanged — in-band parameter sets ahead
@@ -209,6 +210,11 @@ shaka.msf.LOCParser = class {
    * The record's own `lengthSizeMinusOne` describes how the RECORD frames its
    * entries, not how the bitstream frames its NAL units, so the restored sets
    * are always emitted with the 4-byte prefix LOC-04 §2.1.3 specifies.
+   *
+   * AV1 is the exception to that framing: OBUs are self-delimiting, carrying
+   * their own type and size, and a temporal unit is a bare concatenation of
+   * them. A length prefix would be read as an OBU header and desynchronise
+   * the whole unit, so the sequence header OBUs are concatenated raw.
    *
    * Returns `payload` unchanged when the codec has no known record layout or
    * the record is malformed: a bad config must degrade to the previous
@@ -228,6 +234,8 @@ shaka.msf.LOCParser = class {
       paramSets = LOCParser.avcParameterSets_(config);
     } else if (this.normalizedCodec_ === 'hevc') {
       paramSets = LOCParser.hevcParameterSets_(config);
+    } else if (this.normalizedCodec_ === 'av01') {
+      return LOCParser.prependAv1ConfigObus_(payload, config);
     }
 
     if (!paramSets || !paramSets.length) {
@@ -253,6 +261,39 @@ shaka.msf.LOCParser = class {
     out.set(payload, w);
     return out;
   }
+
+  /**
+   * Prepends the configOBUs of an AV1CodecConfigurationRecord to `payload`.
+   *
+   * The record (AV1 ISOBMFF binding §2.3.3) is four fixed bytes describing the
+   * decoder requirements, followed by configOBUs — the sequence header OBU,
+   * byte for byte as it would appear in the bitstream. Only those trailing
+   * bytes belong in the temporal unit; the fixed four are a container-level
+   * summary and would decode as a stray OBU.
+   *
+   * Returns `payload` unchanged when the record is malformed or carries no
+   * OBUs, so a bad config degrades to the previous behaviour.
+   *
+   * @param {!Uint8Array} payload
+   * @param {!Uint8Array} config
+   * @return {!Uint8Array}
+   * @private
+   */
+  static prependAv1ConfigObus_(payload, config) {
+    // marker(1) = 1 and version(7) = 1, i.e. 0x81, then three more fixed
+    // bytes. Anything shorter, or with a different marker/version, is not a
+    // record this code can read.
+    if (config.byteLength <= 4 || config[0] !== 0x81) {
+      return payload;
+    }
+
+    const configObus = config.subarray(4);
+    const out = new Uint8Array(configObus.byteLength + payload.byteLength);
+    out.set(configObus, 0);
+    out.set(payload, configObus.byteLength);
+    return out;
+  }
+
 
   /**
    * Extracts the SPS and PPS NAL units from an AVCDecoderConfigurationRecord

--- a/lib/transmuxer/av1.js
+++ b/lib/transmuxer/av1.js
@@ -1,0 +1,629 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.provide('shaka.transmuxer.AV1');
+
+goog.require('shaka.util.ExpGolomb');
+
+
+/**
+ * AV1 utils.
+ *
+ * An AV1 access unit is a "temporal unit": a flat sequence of Open Bitstream
+ * Units (OBUs), each self-delimiting through its own header. There are no
+ * start codes and no length prefixes, and — unlike H.264/H.265 — no emulation
+ * prevention bytes, so an OBU payload can be read as a raw bit stream.
+ *
+ * @see https://aomediacodec.github.io/av1-spec/av1-spec.pdf
+ * @see https://aomediacodec.github.io/av1-isobmff/ (av1C)
+ */
+shaka.transmuxer.AV1 = class {
+  /**
+   * Splits a temporal unit into its OBUs.
+   *
+   * @param {!Uint8Array} data
+   * @return {!Array<shaka.transmuxer.AV1.Obu>}
+   */
+  static parseObus(data) {
+    const AV1 = shaka.transmuxer.AV1;
+
+    /** @type {!Array<shaka.transmuxer.AV1.Obu>} */
+    const obus = [];
+    let offset = 0;
+
+    while (offset < data.byteLength) {
+      const start = offset;
+      const headerByte = data[offset++];
+
+      // obu_forbidden_bit must be 0. Anything else means we have lost sync,
+      // and continuing would emit garbage OBUs.
+      if (headerByte & 0x80) {
+        break;
+      }
+
+      const type = (headerByte & 0x78) >> 3;
+      const hasExtension = (headerByte & 0x04) != 0;
+      const hasSizeField = (headerByte & 0x02) != 0;
+
+      if (hasExtension) {
+        if (offset >= data.byteLength) {
+          break;
+        }
+        offset++;
+      }
+
+      let payloadSize;
+      if (hasSizeField) {
+        const leb128 = AV1.readLeb128_(data, offset);
+        if (!leb128) {
+          break;
+        }
+        payloadSize = leb128.value;
+        offset = leb128.offset;
+      } else {
+        // Only the last OBU of a temporal unit may omit its size field, in
+        // which case it runs to the end of the unit.
+        payloadSize = data.byteLength - offset;
+      }
+
+      const payloadEnd = offset + payloadSize;
+      if (payloadEnd > data.byteLength) {
+        // Malformed: the declared size runs past the temporal unit.
+        break;
+      }
+
+      obus.push({
+        type,
+        data: data.subarray(offset, payloadEnd),
+        fullData: data.subarray(start, payloadEnd),
+      });
+      offset = payloadEnd;
+    }
+
+    return obus;
+  }
+
+  /**
+   * Reads the sequence header of a temporal unit and returns the properties
+   * needed to describe the stream, or null when the unit carries none.
+   *
+   * Only key frames carry a sequence header, so callers must cache the result
+   * and reuse it for the inter frames that follow.
+   *
+   * @param {!Array<shaka.transmuxer.AV1.Obu>} obus
+   * @return {?shaka.transmuxer.AV1.Info}
+   */
+  static parseInfo(obus) {
+    const AV1 = shaka.transmuxer.AV1;
+    if (!obus.length) {
+      return null;
+    }
+    const sequenceHeader = obus.find((obu) => {
+      return obu.type == AV1.OBU_TYPE_SEQUENCE_HEADER_;
+    });
+    if (!sequenceHeader) {
+      return null;
+    }
+
+    const parsed = AV1.parseSequenceHeader_(sequenceHeader.data);
+    if (!parsed) {
+      return null;
+    }
+
+    return {
+      width: parsed.width,
+      height: parsed.height,
+      reducedStillPicture: parsed.reducedStillPicture,
+      videoConfig: AV1.buildAv1C_(parsed, sequenceHeader.fullData),
+    };
+  }
+
+  /**
+   * Returns whether a temporal unit codes a shown key frame.
+   *
+   * `uncompressed_header()` (AV1 §5.9.2) puts `show_existing_frame` and
+   * `frame_type` in the first three bits of a frame header, so this needs no
+   * state from the sequence header beyond `reduced_still_picture_header` —
+   * which suppresses both fields and makes every frame a key frame.
+   *
+   * @param {!Array<shaka.transmuxer.AV1.Obu>} obus
+   * @param {boolean} reducedStillPicture
+   * @return {boolean}
+   */
+  static isKeyframe(obus, reducedStillPicture) {
+    const AV1 = shaka.transmuxer.AV1;
+
+    for (const obu of obus) {
+      if (obu.type != AV1.OBU_TYPE_FRAME_ &&
+          obu.type != AV1.OBU_TYPE_FRAME_HEADER_) {
+        continue;
+      }
+      if (reducedStillPicture) {
+        return true;
+      }
+      if (!obu.data.byteLength) {
+        return false;
+      }
+      const firstByte = obu.data[0];
+      // show_existing_frame f(1) — a repeat of an already decoded frame, which
+      // codes no picture of its own and is never a key frame here.
+      if (firstByte & 0x80) {
+        return false;
+      }
+      // frame_type f(2), where 0 is KEY_FRAME.
+      return ((firstByte & 0x60) >> 5) == AV1.FRAME_TYPE_KEY_;
+    }
+
+    return false;
+  }
+
+  /**
+   * Builds an AV1CodecConfigurationRecord (the payload of an `av1C` box).
+   *
+   * The record is four fixed bytes describing the decoder requirements,
+   * followed by `configOBUs` — the sequence header itself. The OBU bytes are
+   * copied verbatim rather than re-serialised from the parsed fields, because
+   * a sequence header carries data this parser does not model (operating
+   * points, timing info, trailing bits), and the decoder is configured from
+   * these bytes.
+   *
+   * @param {shaka.transmuxer.AV1.SequenceHeader} header
+   * @param {!Uint8Array} sequenceHeaderObu
+   * @return {!Uint8Array}
+   * @private
+   */
+  static buildAv1C_(header, sequenceHeaderObu) {
+    const record = new Uint8Array(4 + sequenceHeaderObu.byteLength);
+    // marker f(1) = 1, version f(7) = 1
+    record[0] = 0x81;
+    // seq_profile f(3), seq_level_idx_0 f(5)
+    record[1] = ((header.seqProfile & 0x07) << 5) | (header.seqLevelIdx & 0x1f);
+    // seq_tier_0 f(1), high_bitdepth f(1), twelve_bit f(1), monochrome f(1),
+    // chroma_subsampling_x f(1), chroma_subsampling_y f(1),
+    // chroma_sample_position f(2)
+    record[2] =
+        (header.seqTier << 7) |
+        (header.highBitdepth << 6) |
+        (header.twelveBit << 5) |
+        (header.monochrome << 4) |
+        (header.subsamplingX << 3) |
+        (header.subsamplingY << 2) |
+        (header.chromaSamplePosition & 0x03);
+    // reserved f(3) = 0, initial_presentation_delay_present f(1) = 0,
+    // reserved f(4) = 0.  We do not signal a presentation delay: it is
+    // optional, and the frames arrive one per LOC object in decode order.
+    record[3] = 0x00;
+    record.set(sequenceHeaderObu, 4);
+    return record;
+  }
+
+  /**
+   * Parses `sequence_header_obu()` (AV1 §5.5.1).
+   *
+   * @param {!Uint8Array} data  The OBU payload, without its header.
+   * @return {?shaka.transmuxer.AV1.SequenceHeader}
+   * @private
+   */
+  static parseSequenceHeader_(data) {
+    const AV1 = shaka.transmuxer.AV1;
+    if (!data.byteLength) {
+      return null;
+    }
+    const reader = AV1.makeReader_(data);
+
+    const seqProfile = AV1.readBits_(reader, 3);
+    AV1.readBits_(reader, 1); // still_picture
+    const reducedStillPicture = AV1.readBits_(reader, 1) == 1;
+
+    let seqLevelIdx = 0;
+    let seqTier = 0;
+
+    if (reducedStillPicture) {
+      seqLevelIdx = AV1.readBits_(reader, 5);
+    } else {
+      let decoderModelInfoPresent = false;
+      let bufferDelayLength = 0;
+      const timingInfoPresent = AV1.readBits_(reader, 1) == 1;
+      if (timingInfoPresent) {
+        // timing_info(): num_units_in_display_tick f(32), time_scale f(32)
+        AV1.skipBits_(reader, 64);
+        const equalPictureInterval = AV1.readBits_(reader, 1) == 1;
+        if (equalPictureInterval) {
+          AV1.skipUvlc_(reader); // num_ticks_per_picture_minus_1
+        }
+        decoderModelInfoPresent = AV1.readBits_(reader, 1) == 1;
+        if (decoderModelInfoPresent) {
+          bufferDelayLength = AV1.readBits_(reader, 5) + 1;
+          AV1.skipBits_(reader, 32); // num_units_in_decoding_tick
+          // buffer_removal_time_length_minus_1 f(5),
+          // frame_presentation_time_length_minus_1 f(5)
+          AV1.skipBits_(reader, 10);
+        }
+      }
+      const initialDisplayDelayPresent = AV1.readBits_(reader, 1) == 1;
+      const operatingPointsCnt = AV1.readBits_(reader, 5) + 1;
+      for (let i = 0; i < operatingPointsCnt; i++) {
+        AV1.skipBits_(reader, 12); // operating_point_idc[i]
+        const levelIdx = AV1.readBits_(reader, 5);
+        // Levels above 7 (i.e. 4.0 and up) are the only ones that define a
+        // tier; below that the tier is implicitly Main.
+        const tier = levelIdx > 7 ? AV1.readBits_(reader, 1) : 0;
+        if (i == 0) {
+          seqLevelIdx = levelIdx;
+          seqTier = tier;
+        }
+        if (decoderModelInfoPresent) {
+          // decoder_model_present_for_this_op[i]
+          if (AV1.readBits_(reader, 1) == 1) {
+            // operating_parameters_info(i): decoder_buffer_delay f(n),
+            // encoder_buffer_delay f(n), low_delay_mode_flag f(1)
+            AV1.skipBits_(reader, 2 * bufferDelayLength + 1);
+          }
+        }
+        if (initialDisplayDelayPresent) {
+          if (AV1.readBits_(reader, 1) == 1) {
+            AV1.readBits_(reader, 4); // initial_display_delay_minus_1[i]
+          }
+        }
+      }
+    }
+
+    const frameWidthBits = AV1.readBits_(reader, 4) + 1;
+    const frameHeightBits = AV1.readBits_(reader, 4) + 1;
+    const width = AV1.readBits_(reader, frameWidthBits) + 1;
+    const height = AV1.readBits_(reader, frameHeightBits) + 1;
+
+    if (!reducedStillPicture) {
+      if (AV1.readBits_(reader, 1) == 1) { // frame_id_numbers_present_flag
+        // delta_frame_id_length_minus_2 f(4),
+        // additional_frame_id_length_minus_1 f(3)
+        AV1.skipBits_(reader, 7);
+      }
+    }
+
+    // use_128x128_superblock, enable_filter_intra, enable_intra_edge_filter
+    AV1.skipBits_(reader, 3);
+
+    if (!reducedStillPicture) {
+      // enable_interintra_compound, enable_masked_compound,
+      // enable_warped_motion, enable_dual_filter
+      AV1.skipBits_(reader, 4);
+      const enableOrderHint = AV1.readBits_(reader, 1) == 1;
+      if (enableOrderHint) {
+        // enable_jnt_comp, enable_ref_frame_mvs
+        AV1.skipBits_(reader, 2);
+      }
+      let seqForceScreenContentTools = AV1.SELECT_SCREEN_CONTENT_TOOLS_;
+      if (AV1.readBits_(reader, 1) == 0) { // seq_choose_screen_content_tools
+        seqForceScreenContentTools = AV1.readBits_(reader, 1);
+      }
+      if (seqForceScreenContentTools > 0) {
+        if (AV1.readBits_(reader, 1) == 0) { // seq_choose_integer_mv
+          AV1.readBits_(reader, 1); // seq_force_integer_mv
+        }
+      }
+      if (enableOrderHint) {
+        AV1.readBits_(reader, 3); // order_hint_bits_minus_1
+      }
+    }
+
+    // enable_superres, enable_cdef, enable_restoration
+    AV1.skipBits_(reader, 3);
+
+    // ── color_config() (AV1 §5.5.2) ──────────────────────────────────────
+    const highBitdepth = AV1.readBits_(reader, 1);
+    let twelveBit = 0;
+    let bitDepth = highBitdepth ? 10 : 8;
+    if (seqProfile == 2 && highBitdepth) {
+      twelveBit = AV1.readBits_(reader, 1);
+      bitDepth = twelveBit ? 12 : 10;
+    }
+    const monochrome = seqProfile == 1 ? 0 : AV1.readBits_(reader, 1);
+
+    let colorPrimaries = AV1.CP_UNSPECIFIED_;
+    let transferCharacteristics = AV1.TC_UNSPECIFIED_;
+    let matrixCoefficients = AV1.MC_UNSPECIFIED_;
+    if (AV1.readBits_(reader, 1) == 1) { // color_description_present_flag
+      colorPrimaries = AV1.readBits_(reader, 8);
+      transferCharacteristics = AV1.readBits_(reader, 8);
+      matrixCoefficients = AV1.readBits_(reader, 8);
+    }
+
+    let subsamplingX = 1;
+    let subsamplingY = 1;
+    let chromaSamplePosition = AV1.CSP_UNKNOWN_;
+
+    if (monochrome) {
+      AV1.readBits_(reader, 1); // color_range
+    } else if (colorPrimaries == AV1.CP_BT_709_ &&
+        transferCharacteristics == AV1.TC_SRGB_ &&
+        matrixCoefficients == AV1.MC_IDENTITY_) {
+      // Lossless sRGB: 4:4:4 with an implied full color range.
+      subsamplingX = 0;
+      subsamplingY = 0;
+    } else {
+      AV1.readBits_(reader, 1); // color_range
+      if (seqProfile == 0) {
+        // Main profile is 4:2:0 only.
+        subsamplingX = 1;
+        subsamplingY = 1;
+      } else if (seqProfile == 1) {
+        // High profile is 4:4:4 only.
+        subsamplingX = 0;
+        subsamplingY = 0;
+      } else if (bitDepth == 12) {
+        subsamplingX = AV1.readBits_(reader, 1);
+        subsamplingY = subsamplingX ? AV1.readBits_(reader, 1) : 0;
+      } else {
+        // Professional profile below 12 bits is 4:2:2 only.
+        subsamplingX = 1;
+        subsamplingY = 0;
+      }
+      if (subsamplingX && subsamplingY) {
+        chromaSamplePosition = AV1.readBits_(reader, 2);
+      }
+    }
+
+    // A header that ran past the end of the OBU was truncated, or was never a
+    // sequence header at all. Either way the fields above are meaningless, and
+    // an av1C built from them would misconfigure the decoder.
+    if (reader.overrun || width <= 1 || height <= 1) {
+      return null;
+    }
+
+    return {
+      seqProfile,
+      seqLevelIdx,
+      seqTier,
+      highBitdepth,
+      twelveBit,
+      monochrome,
+      subsamplingX,
+      subsamplingY,
+      chromaSamplePosition,
+      width,
+      height,
+      reducedStillPicture,
+    };
+  }
+
+  /**
+   * Reads an unsigned LEB128 value (AV1 §4.10.5).
+   *
+   * @param {!Uint8Array} data
+   * @param {number} offset
+   * @return {?{value: number, offset: number}}
+   * @private
+   */
+  static readLeb128_(data, offset) {
+    let value = 0;
+    for (let i = 0; i < 8; i++) {
+      if (offset >= data.byteLength) {
+        return null;
+      }
+      const byte = data[offset++];
+      // Multiply rather than shift: the spec allows up to 56 significant bits,
+      // and JavaScript's bitwise operators would truncate to 32.
+      value += (byte & 0x7f) * Math.pow(2, i * 7);
+      if (!(byte & 0x80)) {
+        return {value, offset};
+      }
+    }
+    // More than 8 bytes is malformed.
+    return null;
+  }
+
+  /**
+   * Wraps an ExpGolomb in a bit budget.
+   *
+   * A sequence header is a chain of conditionally present fields, so a
+   * truncated one is not detected by any single read — the parser simply keeps
+   * asking for bits that are not there. ExpGolomb answers those by recursing
+   * on itself until the stack gives out, so the budget is tracked here, and
+   * once it is spent every read returns 0 and `overrun` stays set for the
+   * caller to reject the whole header.
+   *
+   * @param {!Uint8Array} data
+   * @return {shaka.transmuxer.AV1.Reader}
+   * @private
+   */
+  static makeReader_(data) {
+    return {
+      gb: new shaka.util.ExpGolomb(data),
+      bitsLeft: data.byteLength * 8,
+      overrun: false,
+    };
+  }
+
+  /**
+   * Reads `count` bits, at most 16 at a time so the result of a read can never
+   * be interpreted as a negative 32-bit integer.
+   *
+   * @param {shaka.transmuxer.AV1.Reader} reader
+   * @param {number} count
+   * @return {number}
+   * @private
+   */
+  static readBits_(reader, count) {
+    if (count > reader.bitsLeft) {
+      reader.overrun = true;
+      reader.bitsLeft = 0;
+      return 0;
+    }
+    reader.bitsLeft -= count;
+
+    let value = 0;
+    while (count > 0) {
+      const chunk = Math.min(count, 16);
+      value = (value * Math.pow(2, chunk)) + reader.gb.readBits(chunk);
+      count -= chunk;
+    }
+    return value;
+  }
+
+  /**
+   * Skips `count` bits.
+   *
+   * @param {shaka.transmuxer.AV1.Reader} reader
+   * @param {number} count
+   * @private
+   */
+  static skipBits_(reader, count) {
+    shaka.transmuxer.AV1.readBits_(reader, count);
+  }
+
+  /**
+   * Skips a variable length unsigned integer (AV1 §4.10.3).
+   *
+   * @param {shaka.transmuxer.AV1.Reader} reader
+   * @private
+   */
+  static skipUvlc_(reader) {
+    const AV1 = shaka.transmuxer.AV1;
+    let leadingZeros = 0;
+    while (leadingZeros < 32 && AV1.readBits_(reader, 1) == 0) {
+      if (reader.overrun) {
+        return;
+      }
+      leadingZeros++;
+    }
+    if (leadingZeros < 32) {
+      AV1.skipBits_(reader, leadingZeros);
+    }
+  }
+};
+
+
+/**
+ * One Open Bitstream Unit.
+ *
+ * `data` is the OBU payload alone; `fullData` also covers the header and the
+ * size field, which is what an `av1C` configOBUs entry needs.
+ *
+ * @typedef {{
+ *   type: number,
+ *   data: !Uint8Array,
+ *   fullData: !Uint8Array,
+ * }}
+ */
+shaka.transmuxer.AV1.Obu;
+
+
+/**
+ * @typedef {{
+ *   width: number,
+ *   height: number,
+ *   reducedStillPicture: boolean,
+ *   videoConfig: !Uint8Array,
+ * }}
+ */
+shaka.transmuxer.AV1.Info;
+
+
+/**
+ * A bit reader with a budget. `overrun` latches once a read has asked for more
+ * bits than the buffer holds.
+ *
+ * @typedef {{
+ *   gb: !shaka.util.ExpGolomb,
+ *   bitsLeft: number,
+ *   overrun: boolean,
+ * }}
+ */
+shaka.transmuxer.AV1.Reader;
+
+
+/**
+ * @typedef {{
+ *   seqProfile: number,
+ *   seqLevelIdx: number,
+ *   seqTier: number,
+ *   highBitdepth: number,
+ *   twelveBit: number,
+ *   monochrome: number,
+ *   subsamplingX: number,
+ *   subsamplingY: number,
+ *   chromaSamplePosition: number,
+ *   width: number,
+ *   height: number,
+ *   reducedStillPicture: boolean,
+ * }}
+ */
+shaka.transmuxer.AV1.SequenceHeader;
+
+
+/**
+ * @private @const {number}
+ */
+shaka.transmuxer.AV1.OBU_TYPE_SEQUENCE_HEADER_ = 1;
+
+
+/**
+ * @private @const {number}
+ */
+shaka.transmuxer.AV1.OBU_TYPE_FRAME_HEADER_ = 3;
+
+
+/**
+ * @private @const {number}
+ */
+shaka.transmuxer.AV1.OBU_TYPE_FRAME_ = 6;
+
+
+/**
+ * @private @const {number}
+ */
+shaka.transmuxer.AV1.FRAME_TYPE_KEY_ = 0;
+
+
+/**
+ * Sentinel meaning "decide per frame" for seq_force_screen_content_tools.
+ *
+ * @private @const {number}
+ */
+shaka.transmuxer.AV1.SELECT_SCREEN_CONTENT_TOOLS_ = 2;
+
+
+/**
+ * @private @const {number}
+ */
+shaka.transmuxer.AV1.CP_BT_709_ = 1;
+
+
+/**
+ * @private @const {number}
+ */
+shaka.transmuxer.AV1.CP_UNSPECIFIED_ = 2;
+
+
+/**
+ * @private @const {number}
+ */
+shaka.transmuxer.AV1.TC_UNSPECIFIED_ = 2;
+
+
+/**
+ * @private @const {number}
+ */
+shaka.transmuxer.AV1.TC_SRGB_ = 13;
+
+
+/**
+ * @private @const {number}
+ */
+shaka.transmuxer.AV1.MC_IDENTITY_ = 0;
+
+
+/**
+ * @private @const {number}
+ */
+shaka.transmuxer.AV1.MC_UNSPECIFIED_ = 2;
+
+
+/**
+ * @private @const {number}
+ */
+shaka.transmuxer.AV1.CSP_UNKNOWN_ = 0;

--- a/lib/transmuxer/loc_transmuxer.js
+++ b/lib/transmuxer/loc_transmuxer.js
@@ -9,6 +9,7 @@ goog.provide('shaka.transmuxer.LocTransmuxer');
 goog.require('goog.asserts');
 goog.require('shaka.media.Capabilities');
 goog.require('shaka.transmuxer.ADTS');
+goog.require('shaka.transmuxer.AV1');
 goog.require('shaka.transmuxer.BaseTransmuxer');
 goog.require('shaka.transmuxer.H264');
 goog.require('shaka.transmuxer.H265');
@@ -52,6 +53,13 @@ shaka.transmuxer.LocTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
     this.hvcInfo_ = null;
 
     /**
+     * Cached result of AV1.parseInfo(), populated from the first temporal unit
+     * that carries a sequence header OBU. Reused for all subsequent frames.
+     * @private {?shaka.transmuxer.AV1.Info}
+     */
+    this.av1Info_ = null;
+
+    /**
      * `id` of the stream the cached configs above were parsed from. One
      * transmuxer instance is reused across an adaptation, so this is what
      * tells us the cache now describes a different rendition.
@@ -69,6 +77,7 @@ shaka.transmuxer.LocTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
     super.destroy();
     this.avcInfo_ = null;
     this.hvcInfo_ = null;
+    this.av1Info_ = null;
     this.configStreamId_ = null;
   }
 
@@ -189,6 +198,7 @@ shaka.transmuxer.LocTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
     if (stream.id !== this.configStreamId_) {
       this.avcInfo_ = null;
       this.hvcInfo_ = null;
+      this.av1Info_ = null;
       this.configStreamId_ = stream.id;
     }
 
@@ -204,6 +214,10 @@ shaka.transmuxer.LocTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
             break;
           case 'hevc':
             streamInfo = this.getHvcStreamInfo_(
+                uint8ArrayData, stream, duration, reference);
+            break;
+          case 'av01':
+            streamInfo = this.getAv1StreamInfo_(
                 uint8ArrayData, stream, duration, reference);
             break;
         }
@@ -486,6 +500,85 @@ shaka.transmuxer.LocTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
 
 
   /**
+   * Builds the StreamInfo for an AV1 temporal unit.
+   *
+   * Unlike AVC/HEVC there is nothing to reframe: LOC carries the temporal unit
+   * exactly as the encoder produced it — no start codes, no length prefixes —
+   * and that is also what an `av01` sample is, so the payload becomes one
+   * sample unchanged.  The OBUs are only walked to find the sequence header
+   * and the frame type.
+   *
+   * @param {!Uint8Array} data
+   * @param {shaka.extern.Stream} stream
+   * @param {number} duration
+   * @param {?shaka.media.SegmentReference} reference
+   * @return {?shaka.util.Mp4Generator.StreamInfo}
+   * @private
+   */
+  getAv1StreamInfo_(data, stream, duration, reference) {
+    const AV1 = shaka.transmuxer.AV1;
+
+    /** @type {number} */
+    const timescale = shaka.transmuxer.LocTransmuxer.VIDEO_TIMESCALE_;
+
+    const obus = AV1.parseObus(data);
+
+    // A sequence header OBU rides in the key frames only, so cache it and let
+    // the inter frames that follow reuse it.
+    const parsedInfo = AV1.parseInfo(obus);
+    if (parsedInfo) {
+      this.av1Info_ = parsedInfo;
+      stream.height = parsedInfo.height;
+      stream.width = parsedInfo.width;
+    }
+
+    if (!this.av1Info_) {
+      return null;
+    }
+
+    const isKeyframe =
+        AV1.isKeyframe(obus, this.av1Info_.reducedStillPicture);
+
+    /** @type {number} */
+    const baseMediaDecodeTime = Math.floor(reference.startTime * timescale);
+
+    /** @type {number} */
+    const sampleDuration =
+        Math.floor((reference.endTime - reference.startTime) * timescale);
+
+    /** @type {!Array<shaka.util.Mp4Generator.Mp4Sample>} */
+    const samples = [
+      {
+        data,
+        size: data.byteLength,
+        duration: sampleDuration,
+        cts: 0,
+        flags: isKeyframe ?
+            shaka.transmuxer.TransmuxerUtils.VIDEO_KEYFRAME_FLAGS :
+            shaka.transmuxer.TransmuxerUtils.VIDEO_NON_KEYFRAME_FLAGS,
+      },
+    ];
+
+    return {
+      id: stream.id,
+      type: shaka.util.ManifestParserUtils.ContentType.VIDEO,
+      codecs: 'av01',
+      timescale,
+      duration,
+      // AV1 signals no sample aspect ratio in its sequence header, so there is
+      // nothing for a pasp box to carry.
+      mediaConfig: this.av1Info_.videoConfig,
+      data: {
+        sequenceNumber: this.frameIndex,
+        baseMediaDecodeTime,
+        samples,
+      },
+      stream,
+    };
+  }
+
+
+  /**
    * @param {!Uint8Array} data
    * @param {shaka.extern.Stream} stream
    * @param {number} duration
@@ -657,6 +750,7 @@ shaka.transmuxer.LocTransmuxer.SUPPORTED_AUDIO_CODECS_ = [
 shaka.transmuxer.LocTransmuxer.SUPPORTED_VIDEO_CODECS_ = [
   'avc',
   'hevc',
+  'av01',
 ];
 
 shaka.transmuxer.TransmuxerEngine.registerTransmuxer(

--- a/lib/util/mp4_generator.js
+++ b/lib/util/mp4_generator.js
@@ -261,6 +261,8 @@ shaka.util.Mp4Generator = class {
           bytes = this.avc1_(streamInfo);
         } else if (streamInfo.codecs.includes('hvc1')) {
           bytes = this.hvc1_(streamInfo);
+        } else if (streamInfo.codecs.includes('av01')) {
+          bytes = this.av01_(streamInfo);
         }
         break;
       case ContentType.AUDIO:
@@ -281,11 +283,12 @@ shaka.util.Mp4Generator = class {
   }
 
   /**
-   * Generate a video sample entry box (shared implementation for AVC1 / HVC1)
+   * Generate a video sample entry box (shared implementation for AVC1 / HVC1
+   * / AV01)
    *
    * @param {shaka.util.Mp4Generator.StreamInfo} streamInfo
-   * @param {string} boxName  'avc1' | 'hvc1'
-   * @param {string} configBoxName  'avcC' | 'hvcC'
+   * @param {string} boxName  'avc1' | 'hvc1' | 'av01'
+   * @param {string} configBoxName  'avcC' | 'hvcC' | 'av1C'
    * @return {!Uint8Array}
    * @private
    */
@@ -335,6 +338,17 @@ shaka.util.Mp4Generator = class {
    */
   hvc1_(streamInfo) {
     return this.videoSampleEntry_(streamInfo, 'hvc1', 'hvcC');
+  }
+
+  /**
+   * Generate an AV01 box
+   *
+   * @param {shaka.util.Mp4Generator.StreamInfo} streamInfo
+   * @return {!Uint8Array}
+   * @private
+   */
+  av01_(streamInfo) {
+    return this.videoSampleEntry_(streamInfo, 'av01', 'av1C');
   }
 
   /**

--- a/project-words.txt
+++ b/project-words.txt
@@ -252,21 +252,24 @@ aach
 aacl
 aacp
 abgr
+altmpd
 apic
-appl
 apos
+appl
 arib
 assetid
 atsc
-avcc
 audiodescription
+avcc
 bipred
+bitdepth
 bmff
 bsid
 buffersource
 cabac
 cbcs
 cdat
+cdef
 cdna
 cehx
 cenc
@@ -289,7 +292,6 @@ cwip
 demuxer
 dfxp
 dinf
-dualmono
 dops
 dovi
 downmixing
@@ -301,6 +303,7 @@ dtsh
 dtsx
 dtsz
 dtvcc
+dualmono
 dvav
 dvcc
 dvhe
@@ -330,6 +333,7 @@ imagetype
 imsa
 imsc
 inband
+interintra
 isom
 isrc
 keyids
@@ -360,6 +364,7 @@ mksa
 monoscopic
 moof
 moov
+mpdpatch
 mpegts
 mpegurl
 mspr
@@ -376,6 +381,7 @@ nalu
 nalus
 nclx
 notsmooth
+obus
 packetized
 pasp
 payl
@@ -394,9 +400,9 @@ radl
 rbsp
 regionanchor
 rltb
-samplerate
 saio
 saiz
+samplerate
 sbgp
 schi
 schm
@@ -430,15 +436,16 @@ subcues
 subframes
 subt
 subviewer
+superres
 talb
 tblr
 tbpm
 tbrl
-tdrc
-tenc
 tcmp
 tcom
 tcop
+tdrc
+tenc
 tfdt
 tfhd
 tfrf
@@ -468,9 +475,9 @@ udta
 ufid
 unalignable
 unskippable
-mpdpatch
 urlparam
 uslt
+uvlc
 valu
 vdms
 vexu
@@ -492,7 +499,6 @@ wvtt
 wxxx
 xlink
 xsdate
-altmpd
 xyzx
 
 # vr

--- a/shaka-player.uncompiled.js
+++ b/shaka-player.uncompiled.js
@@ -83,6 +83,7 @@ goog.require('shaka.transmuxer.AacTransmuxer');
 goog.require('shaka.transmuxer.Ac3');
 goog.require('shaka.transmuxer.Ac3Transmuxer');
 goog.require('shaka.transmuxer.ADTS');
+goog.require('shaka.transmuxer.AV1');
 goog.require('shaka.transmuxer.Ec3');
 goog.require('shaka.transmuxer.Ec3Transmuxer');
 goog.require('shaka.transmuxer.H264');

--- a/test/msf/loc_parser_unit.js
+++ b/test/msf/loc_parser_unit.js
@@ -224,6 +224,25 @@ describe('LOCParser', () => {
           fixed, new Uint8Array([arrays.length]), ...arrays);
     }
 
+    // The sequence header OBU and av1C fixed bytes of moqlivemock's
+    // assets/test10s/video_600kbps_av1.mp4.
+    const sequenceHeaderObu = new Uint8Array([
+      0x0a, 0x0b,
+      0x00, 0x00, 0x00, 0x2d, 0x4c, 0xff, 0xb3, 0xc6, 0xaf, 0x98, 0x04,
+    ]);
+    const frameObu = new Uint8Array([0x32, 0x03, 0x10, 0x00, 0x96]);
+
+    /**
+     * Builds an AV1CodecConfigurationRecord: four fixed bytes, then the
+     * sequence header OBU as configOBUs.
+     *
+     * @return {!Uint8Array}
+     */
+    function av1c() {
+      return shaka.util.Uint8ArrayUtils.concat(
+          new Uint8Array([0x81, 0x05, 0x0c, 0x00]), sequenceHeaderObu);
+    }
+
     /**
      * @param {!Array<!Uint8Array>} paramSets
      * @return {!Uint8Array}
@@ -256,6 +275,40 @@ describe('LOCParser', () => {
         {type: 0x10, value: 1000000},
       ], slice));
       expect(result.payload).toEqual(expectedPayload([VPS, SPS, PPS]));
+    });
+
+    it('restores an AV1 sequence header stripped from the bitstream', () => {
+      // AV1 OBUs are self-delimiting, so configOBUs is concatenated raw: a
+      // 4-byte length prefix would be read as an OBU header and desynchronise
+      // the temporal unit.
+      const parser = new shaka.msf.LOCParser(FRAME, 'av01');
+      const result = parser.parse(moqObject([
+        {type: 0x0d, value: av1c()},
+        {type: 0x10, value: 1000000},
+      ], frameObu));
+      expect(result.payload).toEqual(
+          shaka.util.Uint8ArrayUtils.concat(sequenceHeaderObu, frameObu));
+    });
+
+    it('leaves the payload alone when the av1C is truncated', () => {
+      const parser = new shaka.msf.LOCParser(FRAME, 'av01');
+      const result = parser.parse(moqObject([
+        // The four fixed bytes alone carry no configOBUs.
+        {type: 0x0d, value: av1c().subarray(0, 4)},
+        {type: 0x10, value: 1000000},
+      ], frameObu));
+      expect(result.payload).toEqual(frameObu);
+    });
+
+    it('leaves the payload alone when the av1C marker is wrong', () => {
+      const parser = new shaka.msf.LOCParser(FRAME, 'av01');
+      const bad = av1c();
+      bad[0] = 0x01; // marker cleared, version 1
+      const result = parser.parse(moqObject([
+        {type: 0x0d, value: bad},
+        {type: 0x10, value: 1000000},
+      ], frameObu));
+      expect(result.payload).toEqual(frameObu);
     });
 
     it('leaves the payload alone when no config is carried', () => {

--- a/test/transmuxer/av1_unit.js
+++ b/test/transmuxer/av1_unit.js
@@ -1,0 +1,231 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('AV1', () => {
+  const AV1 = shaka.transmuxer.AV1;
+
+  /**
+   * The sequence header OBU of moqlivemock's
+   * assets/test10s/video_600kbps_av1.mp4, copied out of the first coded key
+   * frame: 1280x720, profile 0 (Main), level 5, 8-bit, 4:2:0.
+   *
+   * Header byte 0x0a is obu_type=1 (OBU_SEQUENCE_HEADER) with
+   * obu_has_size_field=1, and 0x0b is the 11-byte payload size.
+   *
+   * @const {!Uint8Array}
+   */
+  const sequenceHeaderObu = new Uint8Array([
+    0x0a, 0x0b,
+    0x00, 0x00, 0x00, 0x2d, 0x4c, 0xff, 0xb3, 0xc6, 0xaf, 0x98, 0x04,
+  ]);
+
+  /**
+   * Builds an OBU_FRAME whose uncompressed header begins with `firstByte`.
+   *
+   * @param {number} firstByte
+   * @return {!Uint8Array}
+   */
+  function frameObu(firstByte) {
+    // 0x32: obu_type=6 (OBU_FRAME), obu_has_size_field=1.
+    return new Uint8Array([0x32, 0x03, firstByte, 0x00, 0x96]);
+  }
+
+  /**
+   * @param {...!Uint8Array} parts
+   * @return {!Uint8Array}
+   */
+  function concat(...parts) {
+    return shaka.util.Uint8ArrayUtils.concat(...parts);
+  }
+
+  // The first byte of the uncompressed header packs show_existing_frame f(1),
+  // frame_type f(2) and show_frame f(1) into its top nibble.
+  const keyFrameHeaderByte = 0x10; // 0, KEY_FRAME (0), shown
+  const interFrameHeaderByte = 0x30; // 0, INTER_FRAME (1), shown
+  const showExistingHeaderByte = 0x80; // show_existing_frame = 1
+
+  describe('parseObus', () => {
+    it('splits a temporal unit into its OBUs', () => {
+      const obus = AV1.parseObus(
+          concat(sequenceHeaderObu, frameObu(keyFrameHeaderByte)));
+
+      expect(obus.length).toBe(2);
+      expect(obus[0].type).toBe(1);
+      expect(obus[0].data.byteLength).toBe(11);
+      expect(obus[0].fullData).toEqual(sequenceHeaderObu);
+      expect(obus[1].type).toBe(6);
+      expect(obus[1].data.byteLength).toBe(3);
+    });
+
+    it('skips the extension byte', () => {
+      // 0x0e adds obu_extension_flag to the sequence header type, so a
+      // temporal_id/spatial_id byte precedes the size field.
+      const extended = concat(
+          new Uint8Array([0x0e, 0x00, 0x0b]), sequenceHeaderObu.subarray(2));
+
+      const obus = AV1.parseObus(extended);
+      expect(obus.length).toBe(1);
+      expect(obus[0].type).toBe(1);
+      expect(obus[0].data).toEqual(sequenceHeaderObu.subarray(2));
+    });
+
+    it('runs an OBU with no size field to the end of the unit', () => {
+      // 0x08 clears obu_has_size_field, which only the last OBU may do.
+      const unsized =
+          concat(new Uint8Array([0x08]), sequenceHeaderObu.subarray(2));
+
+      const obus = AV1.parseObus(unsized);
+      expect(obus.length).toBe(1);
+      expect(obus[0].data.byteLength).toBe(11);
+    });
+
+    it('reads a multi-byte leb128 size', () => {
+      const payload = new Uint8Array(200);
+      // 200 = 0xc8 -> leb128 0xc8 0x01.
+      const obus =
+          AV1.parseObus(concat(new Uint8Array([0x32, 0xc8, 0x01]), payload));
+
+      expect(obus.length).toBe(1);
+      expect(obus[0].data.byteLength).toBe(200);
+    });
+
+    it('stops at an OBU that runs past the end of the unit', () => {
+      const truncated =
+          concat(sequenceHeaderObu, new Uint8Array([0x32, 0x40, 0x10]));
+
+      const obus = AV1.parseObus(truncated);
+      expect(obus.length).toBe(1);
+      expect(obus[0].type).toBe(1);
+    });
+
+    it('stops when obu_forbidden_bit is set', () => {
+      const obus = AV1.parseObus(
+          concat(sequenceHeaderObu, new Uint8Array([0x80, 0x00])));
+
+      expect(obus.length).toBe(1);
+    });
+
+    it('returns nothing for an empty unit', () => {
+      expect(AV1.parseObus(new Uint8Array([]))).toEqual([]);
+    });
+  });
+
+  describe('parseInfo', () => {
+    it('reads the sequence header', () => {
+      const obus = AV1.parseObus(
+          concat(sequenceHeaderObu, frameObu(keyFrameHeaderByte)));
+      const info = AV1.parseInfo(obus);
+
+      goog.asserts.assert(info, 'Should have parsed the sequence header');
+      expect(info.width).toBe(1280);
+      expect(info.height).toBe(720);
+      expect(info.reducedStillPicture).toBe(false);
+    });
+
+    it('builds the av1C record', () => {
+      const obus = AV1.parseObus(sequenceHeaderObu);
+      const info = AV1.parseInfo(obus);
+      goog.asserts.assert(info, 'Should have parsed the sequence header');
+
+      // The four fixed bytes are the ones the source file carries in its own
+      // av1C box: marker+version, then profile 0 / level 5, then Main tier,
+      // 8-bit, colour, 4:2:0 with an unknown chroma sample position.
+      expect(info.videoConfig.subarray(0, 4))
+          .toEqual(new Uint8Array([0x81, 0x05, 0x0c, 0x00]));
+      // configOBUs is the sequence header OBU copied verbatim.
+      expect(info.videoConfig.subarray(4)).toEqual(sequenceHeaderObu);
+    });
+
+    it('returns null without a sequence header', () => {
+      const obus = AV1.parseObus(frameObu(interFrameHeaderByte));
+      expect(AV1.parseInfo(obus)).toBe(null);
+    });
+
+    it('returns null for a truncated sequence header', () => {
+      // A header that runs off the end reads as zeros, which would otherwise
+      // describe a 1x1 stream.
+      const obus = AV1.parseObus(new Uint8Array([0x0a, 0x02, 0x00, 0x00]));
+      expect(AV1.parseInfo(obus)).toBe(null);
+    });
+  });
+
+  describe('isKeyframe', () => {
+    it('accepts a key frame', () => {
+      const obus = AV1.parseObus(
+          concat(sequenceHeaderObu, frameObu(keyFrameHeaderByte)));
+      expect(AV1.isKeyframe(obus, /* reducedStillPicture= */ false)).toBe(true);
+    });
+
+    it('rejects an inter frame', () => {
+      const obus = AV1.parseObus(frameObu(interFrameHeaderByte));
+      expect(AV1.isKeyframe(obus, /* reducedStillPicture= */ false))
+          .toBe(false);
+    });
+
+    it('rejects a show_existing_frame header', () => {
+      const obus = AV1.parseObus(frameObu(showExistingHeaderByte));
+      expect(AV1.isKeyframe(obus, /* reducedStillPicture= */ false))
+          .toBe(false);
+    });
+
+    it('reads the first frame OBU, not a later one', () => {
+      // A temporal unit with more than one frame is decided by the first.
+      const obus = AV1.parseObus(concat(
+          frameObu(interFrameHeaderByte), frameObu(keyFrameHeaderByte)));
+      expect(AV1.isKeyframe(obus, /* reducedStillPicture= */ false))
+          .toBe(false);
+    });
+
+    it('treats every frame of a reduced still picture as a key frame', () => {
+      // reduced_still_picture_header suppresses show_existing_frame and
+      // frame_type, so the bits that would read as INTER_FRAME are picture
+      // data.
+      const obus = AV1.parseObus(frameObu(interFrameHeaderByte));
+      expect(AV1.isKeyframe(obus, /* reducedStillPicture= */ true)).toBe(true);
+    });
+
+    it('rejects a unit with no frame OBU', () => {
+      const obus = AV1.parseObus(sequenceHeaderObu);
+      expect(AV1.isKeyframe(obus, /* reducedStillPicture= */ false))
+          .toBe(false);
+    });
+  });
+
+  describe('real bitstream', () => {
+    // The first 20 bytes of the first coded frame of
+    // assets/test10s/video_600kbps_av1.mp4: the sequence header OBU followed
+    // by the start of a 10209-byte OBU_FRAME.
+    it('reads a key frame temporal unit', () => {
+      const unit = new Uint8Array([
+        0x0a, 0x0b, 0x00, 0x00, 0x00, 0x2d, 0x4c, 0xff, 0xb3, 0xc6,
+        0xaf, 0x98, 0x04,
+        // OBU_FRAME, leb128 size 10209, then the uncompressed header.
+        0x32, 0xe1, 0x4f, 0x10, 0x00, 0x96, 0xc0,
+      ]);
+
+      const obus = AV1.parseObus(unit);
+      // The frame OBU declares more bytes than this excerpt holds, so only the
+      // sequence header survives the size check.
+      expect(obus.length).toBe(1);
+
+      const info = AV1.parseInfo(obus);
+      goog.asserts.assert(info, 'Should have parsed the sequence header');
+      expect(info.width).toBe(1280);
+      expect(info.height).toBe(720);
+    });
+
+    it('reads an inter frame header', () => {
+      // The start of the second coded frame: OBU_FRAME, size 429.
+      const obus = AV1.parseObus(concat(
+          new Uint8Array([0x32, 0x05, 0x30, 0x02, 0x00, 0x09, 0x24])));
+
+      expect(obus.length).toBe(1);
+      expect(obus[0].type).toBe(6);
+      expect(AV1.isKeyframe(obus, /* reducedStillPicture= */ false))
+          .toBe(false);
+    });
+  });
+});

--- a/test/transmuxer/loc_transmuxer_unit.js
+++ b/test/transmuxer/loc_transmuxer_unit.js
@@ -241,7 +241,13 @@ describe('LocTransmuxer', () => {
             /* duration= */ 1 / 25, ContentType.VIDEO));
     }
 
-    it('supports the codec', () => {
+    it('supports the codec', async () => {
+      if (!await shaka.test.Util.isTypeSupported(
+          'video/mp4; codecs="av01.0.05M.08"',
+          /* width= */ 1280, /* height= */ 720)) {
+        pending('Codec AV1 is not supported by the platform.');
+      }
+
       expect(transmuxer.isSupported(
           'moq/loc; codecs="av01.0.05M.08"', ContentType.VIDEO)).toBe(true);
     });

--- a/test/transmuxer/loc_transmuxer_unit.js
+++ b/test/transmuxer/loc_transmuxer_unit.js
@@ -197,6 +197,118 @@ describe('LocTransmuxer', () => {
     });
   });
 
+  describe('AV1', () => {
+    // The sequence header OBU of moqlivemock's
+    // assets/test10s/video_600kbps_av1.mp4: 1280x720, profile 0, level 5,
+    // 8-bit 4:2:0.  moqlivemock sends it in-band ahead of every key frame,
+    // exactly as it appears here.
+    const sequenceHeaderObu = new Uint8Array([
+      0x0a, 0x0b,
+      0x00, 0x00, 0x00, 0x2d, 0x4c, 0xff, 0xb3, 0xc6, 0xaf, 0x98, 0x04,
+    ]);
+
+    // OBU_FRAME, 3-byte payload.  The first byte of the uncompressed header
+    // packs show_existing_frame f(1), frame_type f(2) and show_frame f(1).
+    const keyFrameObu = new Uint8Array([0x32, 0x03, 0x10, 0x00, 0x96]);
+    const interFrameObu = new Uint8Array([0x32, 0x03, 0x30, 0x00, 0x96]);
+
+    const keyFrameUnit =
+        shaka.util.Uint8ArrayUtils.concat(sequenceHeaderObu, keyFrameObu);
+
+    /**
+     * @param {number=} id
+     * @return {shaka.extern.Stream}
+     */
+    function av1Stream(id) {
+      return /** @type {shaka.extern.Stream} */ ({
+        id: id || 1,
+        type: ContentType.VIDEO,
+        codecs: 'av01.0.05M.08',
+        mimeType: 'moq/loc',
+        language: 'und',
+      });
+    }
+
+    /**
+     * @param {!Uint8Array} data
+     * @param {shaka.extern.Stream=} stream
+     * @return {!Promise<!shaka.extern.TransmuxerOutput>}
+     */
+    function transmuxAv1(data, stream) {
+      return /** @type {!Promise<!shaka.extern.TransmuxerOutput>} */ (
+        transmuxer.transmux(
+            data, stream || av1Stream(), makeReference(),
+            /* duration= */ 1 / 25, ContentType.VIDEO));
+    }
+
+    it('supports the codec', () => {
+      expect(transmuxer.isSupported(
+          'moq/loc; codecs="av01.0.05M.08"', ContentType.VIDEO)).toBe(true);
+    });
+
+    it('passes the temporal unit through as one sample', async () => {
+      // LOC carries the temporal unit exactly as an av01 sample wants it, so
+      // nothing is reframed: no start codes to strip, no length prefixes to
+      // add, and the sequence header OBU stays in the sample.
+      const result = await transmuxAv1(keyFrameUnit);
+      expect(mdatOf(result.data)).toEqual(keyFrameUnit);
+    });
+
+    it('takes the resolution from the sequence header', async () => {
+      const stream = av1Stream();
+      await transmuxAv1(keyFrameUnit, stream);
+
+      expect(stream.width).toBe(1280);
+      expect(stream.height).toBe(720);
+    });
+
+    it('builds an av01 sample entry with an av1C box', async () => {
+      const result = await transmuxAv1(keyFrameUnit);
+      goog.asserts.assert(result.init, 'Should have an init segment');
+
+      let av1C = null;
+      new shaka.util.Mp4Parser()
+          .box('moov', shaka.util.Mp4Parser.children)
+          .box('trak', shaka.util.Mp4Parser.children)
+          .box('mdia', shaka.util.Mp4Parser.children)
+          .box('minf', shaka.util.Mp4Parser.children)
+          .box('stbl', shaka.util.Mp4Parser.children)
+          .fullBox('stsd', shaka.util.Mp4Parser.sampleDescription)
+          .box('av01', shaka.util.Mp4Parser.visualSampleEntry)
+          .box('av1C', (box) => {
+            av1C = box.reader.readBytes(
+                box.reader.getLength() - box.reader.getPosition(),
+                /* clone= */ true);
+          })
+          .parse(result.init);
+
+      goog.asserts.assert(av1C, 'Should have found an av1C box');
+      expect(av1C).toEqual(shaka.util.Uint8ArrayUtils.concat(
+          new Uint8Array([0x81, 0x05, 0x0c, 0x00]), sequenceHeaderObu));
+    });
+
+    it('emits nothing before the first sequence header', async () => {
+      // An inter frame carries no sequence header, so there is nothing to
+      // describe the stream with yet.
+      const result = await transmuxAv1(interFrameObu);
+      expect(result.data.byteLength).toBe(0);
+    });
+
+    it('reuses the cached sequence header for inter frames', async () => {
+      await transmuxAv1(keyFrameUnit);
+
+      const result = await transmuxAv1(interFrameObu);
+      expect(mdatOf(result.data)).toEqual(interFrameObu);
+    });
+
+    it('drops the cache when the rendition changes', async () => {
+      await transmuxAv1(keyFrameUnit, av1Stream(1));
+
+      const result = await transmuxAv1(interFrameObu, av1Stream(2));
+      expect(result.data.byteLength).toBe(0);
+    });
+  });
+
   describe('AAC', () => {
     // A plausible stereo AAC-LC raw_data_block: starts with a CPE element,
     // so its first byte is 0x21 and it is NOT an ADTS frame.


### PR DESCRIPTION
av01 tracks were dropped by the manifest filter because the LOC transmuxer had no AV1 path at all: nothing in lib/transmuxer/ or Mp4Generator knew the codec.

Add an OBU parser (lib/transmuxer/av1.js) that walks a temporal unit, reads the sequence header for the fields an av1C needs, and detects key frames from the first three bits of a frame header. Generate the av01 sample entry and its av1C box, and wire the codec through LocTransmuxer.

Unlike AVC/HEVC there is nothing to reframe: LOC carries the temporal unit exactly as an av01 sample wants it, so the payload becomes one sample untouched. The Video Config property is handled for AV1 too, concatenating the record's configOBUs raw — OBUs are self-delimiting, so a length prefix would be read as an OBU header.

The sequence header is parsed under its own bit budget rather than with a bare ExpGolomb, which recurses until the stack gives out once its buffer is exhausted — exactly what a truncated header does.