### PR TITLE
fix(Ads): Don't drop SVTA signaling of preloaded assets

### DIFF
--- a/lib/ads/svta_ad_manager.js
+++ b/lib/ads/svta_ad_manager.js
@@ -144,7 +144,7 @@ shaka.ads.SvtaAdManager = class {
    * @param {shaka.extern.HLSMetadata} metadata
    */
   addMetadata(metadata) {
-    if (!this.playbackStarted_) {
+    if (!this.startPlaybackIfNeeded_()) {
       return;
     }
     if (!shaka.ads.SvtaAdManager.validSchemes_.has(metadata.type)) {
@@ -196,7 +196,7 @@ shaka.ads.SvtaAdManager = class {
    */
   addRegion(region) {
     const TXml = shaka.util.TXml;
-    if (!this.playbackStarted_) {
+    if (!this.startPlaybackIfNeeded_()) {
       return;
     }
     if (!shaka.ads.SvtaAdManager.validSchemes_.has(region.schemeIdUri) ||
@@ -279,8 +279,29 @@ shaka.ads.SvtaAdManager = class {
     if (this.playbackStarted_) {
       return;
     }
+    const mediaElement = this.player_.getMediaElement();
+    if (!mediaElement) {
+      return;
+    }
     this.playbackStarted_ = true;
-    this.video_ = this.player_.getMediaElement();
+    this.video_ = mediaElement;
+  }
+
+  /**
+   * This manager is created lazily, when the first signaling is seen, so it
+   * can miss the 'loading' event of the asset that carries that signaling.
+   * That happens with preloaded assets: their regions are flushed to the ad
+   * manager as soon as the load starts, which is after 'loading' has been
+   * dispatched. Start here instead of dropping the signaling.
+   *
+   * @return {boolean} True if the signaling can be processed.
+   * @private
+   */
+  startPlaybackIfNeeded_() {
+    if (!this.playbackStarted_ && this.player_.getAssetUri()) {
+      this.playbackStart_();
+    }
+    return this.playbackStarted_;
   }
 
   /**

--- a/lib/player.js
+++ b/lib/player.js
@@ -1948,6 +1948,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.startTime_ = startTime;
       this.fullyLoaded_ = false;
 
+      // Set the asset URI before anything can observe the load, so that
+      // getAssetUri() is accurate from the 'loading' event onwards, and for
+      // anything the preload manager hands off below (e.g. the timeline
+      // regions of a preloaded asset, which are flushed to the ad manager as
+      // soon as the load starts).
+      this.assetUri_ = assetUri;
+
       // We dispatch the loading event when someone calls |load| because we want
       // to surface the user intent.
       this.dispatchEvent(shaka.Player.makeEvent_(
@@ -2002,7 +2009,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.stats_ =
           preloadManager ? preloadManager.getStats() : new shaka.util.Stats();
 
-      this.assetUri_ = assetUri;
       this.mimeType_ = mimeType || null;
 
       // Make sure that the app knows of the new buffering state.


### PR DESCRIPTION
shaka.ads.SvtaAdManager is created lazily, when the first signaling is seen, and only marks itself active from the player's 'loading' event or from getAssetUri() in its constructor. For a preloaded asset neither is available: the timeline regions of the parsed manifest are flushed to the ad manager inside load(), at setEventHandoffTarget(), which runs after 'loading' has been dispatched and before assetUri_ is assigned. The freshly created manager saw no playback start and addRegion()/addMetadata() dropped the signaling.

This is what a DASH interstitial hits on every ad break whose asset was preloaded: the SVTA2053 EventStream carried inside the ad's own MPD is discarded, so no impression, no quartiles and no complete are reported for that ad.

Assign assetUri_ before dispatching 'loading', so it is accurate for everything that observes the load (getAssetUri() from a 'loading' listener was null until now), and let SvtaAdManager start tracking when the signaling arrives while the asset is loading.