### PR TITLE
fix(Ads): Report an ad that reaches its playout limit as complete

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -1460,9 +1460,21 @@ shaka.ads.InterstitialAdManager = class {
         if (playerStartTime) {
           playoutLimit -= playerStartTime;
         }
+        const limit = playoutLimit;
+        const tolerance =
+            shaka.ads.InterstitialAdManager.PLAYOUT_LIMIT_TOLERANCE_;
         this.playoutLimitTimer_ = new shaka.util.Timer(() => {
-          this.lastOnSkip_();
-        }).tickAfter(playoutLimit);
+          // The playout limit is a cap on the ad's playout, not a skip. An ad
+          // whose own duration is the limit (which is what @maxDuration
+          // signals in DASH) reaches the limit by playing to its end, and this
+          // timer is wall-clock based, so it can reach the limit before the
+          // media does. In that case the ad completed.
+          if (this.video_.ended || this.video_.currentTime >= limit) {
+            complete();
+          } else {
+            this.lastOnSkip_();
+          }
+        }).tickAfter(playoutLimit + tolerance);
         this.player_.configure('playRangeEnd', playoutLimit);
       }
       if (this.player_.getMediaElement() !== this.video_) {
@@ -2701,6 +2713,18 @@ shaka.ads.InterstitialAdManager.Asset;
  * @property {number} DURATION
  */
 shaka.ads.InterstitialAdManager.SkipControl;
+
+
+/**
+ * Extra time, in seconds, given to an ad that is being limited by its playout
+ * limit before it is cut. The limit timer runs on wall-clock time, so without
+ * it an ad whose duration is exactly its playout limit would always be cut a
+ * few frames before its own end.
+ *
+ * @const {number}
+ * @private
+ */
+shaka.ads.InterstitialAdManager.PLAYOUT_LIMIT_TOLERANCE_ = 0.5;
 
 
 /**


### PR DESCRIPTION
The playout limit (DASH @maxDuration, HLS X-PLAYOUT-LIMIT) armed a wall-clock timer that called the skip handler. An ad whose own duration is its playout limit — which is the usual case, since maxDuration is signaled from the ad duration — always loses that race, because the timer starts when the ad is set up while the media still has to load and may rebuffer. The ad was cut a few frames before its own end and reported as skipped: AD_COMPLETE was never dispatched, and neither the SVTA 'complete' beacon nor an EventStream callback Event at the end of the ad ever fired.

Give the media a small tolerance to reach its natural end before the limit is enforced, and when the timer does fire, complete the ad if it has played its content instead of treating it as a skip.