### PR TITLE
test: Run the offline DRM tests on Android again

### DIFF
--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -85,12 +85,6 @@ filterDescribe('Offline', supportsStorage, () => {
           pending('Widevine persistent licenses are not supported');
           return;
         }
-        if (deviceDetected.getDeviceType() ===
-            shaka.device.IDevice.DeviceType.MOBILE) {
-          pending('Skipping offline DRM tests on Android - crbug.com/1108158');
-          return;
-        }
-
         shaka.test.TestScheme.setupPlayer(player, 'sintel-enc');
 
         storage.configure('offline.usePersistentLicense', true);
@@ -122,12 +116,6 @@ filterDescribe('Offline', supportsStorage, () => {
           pending('Widevine and PlayReady are not supported');
           return;
         }
-        if (deviceDetected.getDeviceType() ===
-            shaka.device.IDevice.DeviceType.MOBILE) {
-          pending('Skipping offline DRM tests on Android - crbug.com/1108158');
-          return;
-        }
-
         if (deviceDetected.getDeviceName() === 'Xbox') {
           // This skip dates from when the content used Axinom's license
           // server, which refused an Xbox One because its security level is


### PR DESCRIPTION
These were skipped on any device reporting as mobile, for crbug.com/1108158, which is from 2020.  It no longer reproduces.

Measured on a Pixel 8a, Chrome 152 on Android, reporting device type MOBILE so the skip was genuinely in force beforehand: with it removed, both specs passed in four separate runs, storing, playing back and deleting protected content under a persistent license and under a temporary one.

A Pixel Tablet passed them too, though it reports as desktop and so was never subject to the skip in the first place, which is worth noting on its own: Chrome in desktop mode on Android evaded this ban entirely.