### PR TITLE
test: Update Safari comments on multitype variants test

### DIFF
--- a/test/dash/dash_parser_integration.js
+++ b/test/dash/dash_parser_integration.js
@@ -139,13 +139,23 @@ describe('DashParser', () => {
             deviceDetected.getDeviceName() === 'Tizen') {
       pending('Disabled on Tizen.');
     }
+
+    // Safari stalls at the second container boundary.  Measured 2026-09-01,
+    // 5 runs out of 5: playback gets through the VP9 section and the H.264
+    // one, then stops at 4.30 of 4.90 seconds, just past the splice back to
+    // VP9 at 4.204, with readyState falling to 1 and no error raised.  It is
+    // starvation at the boundary rather than the decoding errors this was
+    // originally disabled for, so the reason is recorded here rather than
+    // left pointing at issue #2746.
     const BrowserEngine = shaka.device.IDevice.BrowserEngine;
     if (deviceDetected.getBrowserEngine() === BrowserEngine.WEBKIT) {
-      pending('Disabled on Safari.');
+      pending('Disabled on Safari: stalls at the second container boundary.');
     }
+
     if (!await Util.isTypeSupported('video/webm; codecs="vp9"')) {
       pending('Codec VP9 is not supported by the platform.');
     }
+
     await player.load('/base/test/test/assets/dash-multitype-variant/dash.mpd');
     await video.play();
     expect(player.isLive()).toBe(false);


### PR DESCRIPTION
Safari is banned from the multitype variants test.  The ban cited issue #2746 and random decoding errors, borrowed from a change that disabled this test on several devices at once.  That is not what Safari does.

Measured with the ban lifted, 5 runs out of 5 on macOS Safari: playback gets through the VP9 section and the H.264 one, then stops at 4.30 of 4.90 seconds, just past the splice back to VP9 at 4.204, with readyState falling to 1 and no error raised at all.  It starves at the boundary rather than failing to decode.

The ban stays, since it does fail every time, but it now says what it is for.  Worth contrasting with Opera on macOS, which failed at the first boundary with a real decode error and was fixed by taking it off changeType; Safari is already off changeType and still stalls, so it is a different problem.