### PR TITLE
test: Run the seek-delay playhead test everywhere

### DIFF
--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -750,9 +750,12 @@ describe('Playhead', () => {
   });  // does not clamp playhead if setLiveSeekableRange is used
 
   it('doesn\'t repeatedly re-seek in seeking slow platforms', () => {
-    if (!deviceDetected.seekDelay()) {
-      pending('No seeking slow platform');
-    }
+    // Only Chromecast on Fuchsia reports a seek delay, so waiting for a
+    // platform that has one meant this never ran anywhere, in CI or the lab.
+    // Nothing here needs a slow device: the video element and the clock are
+    // both fakes, and the delay is only read back through the device.
+    spyOn(deviceDetected, 'seekDelay').and.returnValue(3);
+
     video.readyState = HTMLMediaElement.HAVE_METADATA;
 
     video.buffered = createFakeBuffered([{start: 25, end: 55}]);


### PR DESCRIPTION
The playhead test for slow-seeking platforms was gated on the device reporting a seek delay, which only Chromecast on Fuchsia does, so it had never run in CI or the lab.  Nothing in it needs slow hardware: the video element and the clock are both fakes, and the delay is only read back through the device, so stub that instead.  It passes on Chrome.