### PR TITLE
fix(Transmuxer): Fix infinite loop and dropped frames in MPEG audio

### DIFF
--- a/lib/transmuxer/mp3_transmuxer.js
+++ b/lib/transmuxer/mp3_transmuxer.js
@@ -93,11 +93,8 @@ shaka.transmuxer.Mp3Transmuxer = class extends shaka.transmuxer.BaseTransmuxer {
     while (offset < uint8ArrayData.length) {
       const header = MpegAudio.parseHeader(uint8ArrayData, offset);
       if (!header) {
-        return Promise.reject(new shaka.util.Error(
-            shaka.util.Error.Severity.CRITICAL,
-            shaka.util.Error.Category.MEDIA,
-            shaka.util.Error.Code.TRANSMUXING_FAILED,
-            reference ? reference.getUris()[0] : null));
+        offset++;
+        continue;
       }
       if (!firstHeader) {
         firstHeader = header;

--- a/lib/transmuxer/mpeg_audio.js
+++ b/lib/transmuxer/mpeg_audio.js
@@ -26,6 +26,10 @@ shaka.transmuxer.MpegAudio = class {
   static parseHeader(data, offset) {
     const MpegAudio = shaka.transmuxer.MpegAudio;
 
+    if (!MpegAudio.isHeader(data, offset)) {
+      return null;
+    }
+
     const mpegVersion = (data[offset + 1] >> 3) & 3;
     const mpegLayer = (data[offset + 1] >> 1) & 3;
     const bitRateIndex = (data[offset + 2] >> 4) & 15;
@@ -55,6 +59,10 @@ shaka.transmuxer.MpegAudio = class {
       const frameLength =
         Math.floor((sampleCoefficient * bitRate) / sampleRate + paddingBit) *
         bytesInSlot;
+
+      if (!frameLength || !samplesPerFrame || !sampleRate) {
+        return null;
+      }
 
       const userAgent = navigator.userAgent || '';
       // This affect to Tizen also for example.

--- a/lib/transmuxer/mpeg_ts_transmuxer.js
+++ b/lib/transmuxer/mpeg_ts_transmuxer.js
@@ -152,29 +152,37 @@ shaka.transmuxer.MpegTsTransmuxer = class {
           reference ? reference.getUris()[0] : null));
     }
 
-    let transmuxData = new Uint8Array([]);
-
+    // MPEG audio frames are not aligned with the PES packets, so join the
+    // payloads and parse them as a single elementary stream. Otherwise the
+    // frames that straddle a PES boundary would be dropped, and their leading
+    // bytes in the next payload could be mistaken for a frame of their own.
+    /** @type {!Array<!Uint8Array>} */
+    const payloads = [];
     for (const audioData of tsParser.getAudioData()) {
-      const data = audioData.data;
-      if (!data) {
+      if (!audioData.data) {
         continue;
       }
-      let offset = 0;
-      while (offset < data.length) {
-        const header = MpegAudio.parseHeader(data, offset);
-        if (!header) {
-          offset++;
-          continue;
-        }
-        if (offset + header.frameLength <= data.length) {
-          transmuxData = Uint8ArrayUtils.concat(transmuxData,
-              data.subarray(offset, offset + header.frameLength));
-        }
-        offset += header.frameLength;
+      payloads.push(audioData.data);
+    }
+    const audioStream = Uint8ArrayUtils.concatRange(payloads);
+
+    /** @type {!Array<!Uint8Array>} */
+    const frames = [];
+    let offset = 0;
+    while (offset < audioStream.length) {
+      const header = MpegAudio.parseHeader(audioStream, offset);
+      if (!header) {
+        offset++;
+        continue;
       }
+      if (offset + header.frameLength <= audioStream.length) {
+        frames.push(
+            audioStream.subarray(offset, offset + header.frameLength));
+      }
+      offset += header.frameLength;
     }
 
-    return Promise.resolve(transmuxData);
+    return Promise.resolve(Uint8ArrayUtils.concatRange(frames));
   }
 };
 

--- a/lib/transmuxer/ts_transmuxer.js
+++ b/lib/transmuxer/ts_transmuxer.js
@@ -625,6 +625,7 @@ shaka.transmuxer.TsTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
   getMp3StreamInfo_(tsParser, stream, duration, reference) {
     const MpegAudio = shaka.transmuxer.MpegAudio;
     const timescale = shaka.util.TsParser.Timescale;
+    const Uint8ArrayUtils = shaka.util.Uint8ArrayUtils;
 
     /** @type {!Array<shaka.util.Mp4Generator.Mp4Sample>} */
     const samples = [];
@@ -633,35 +634,42 @@ shaka.transmuxer.TsTransmuxer = class extends shaka.transmuxer.BaseTransmuxer {
 
     let firstPts = null;
 
+    // MPEG audio frames are not aligned with the PES packets, so join the
+    // payloads and parse them as a single elementary stream. Otherwise the
+    // frames that straddle a PES boundary would be dropped, and their leading
+    // bytes in the next payload could be mistaken for a frame of their own.
+    /** @type {!Array<!Uint8Array>} */
+    const payloads = [];
     for (const audioData of tsParser.getAudioData()) {
-      const data = audioData.data;
-      if (!data) {
+      if (!audioData.data) {
         continue;
       }
       if (firstPts == null && audioData.pts !== null) {
         firstPts = audioData.pts;
       }
-      let offset = 0;
-      while (offset < data.length) {
-        const header = MpegAudio.parseHeader(data, offset);
-        if (!header) {
-          offset++;
-          continue;
-        }
-        if (!firstHeader) {
-          firstHeader = header;
-        }
-        if (offset + header.frameLength <= data.length) {
-          samples.push({
-            data: data.subarray(offset, offset + header.frameLength),
-            size: header.frameLength,
-            duration: MpegAudio.MPEG_AUDIO_SAMPLE_PER_FRAME,
-            cts: 0,
-            flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
-          });
-        }
-        offset += header.frameLength;
+      payloads.push(audioData.data);
+    }
+    const data = Uint8ArrayUtils.concatRange(payloads);
+    let offset = 0;
+    while (offset < data.length) {
+      const header = MpegAudio.parseHeader(data, offset);
+      if (!header) {
+        offset++;
+        continue;
       }
+      if (!firstHeader) {
+        firstHeader = header;
+      }
+      if (offset + header.frameLength <= data.length) {
+        samples.push({
+          data: data.subarray(offset, offset + header.frameLength),
+          size: header.frameLength,
+          duration: MpegAudio.MPEG_AUDIO_SAMPLE_PER_FRAME,
+          cts: 0,
+          flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
+        });
+      }
+      offset += header.frameLength;
     }
     if (!firstHeader || firstPts == null) {
       throw new shaka.util.Error(

--- a/test/transmuxer/mpeg_audio_unit.js
+++ b/test/transmuxer/mpeg_audio_unit.js
@@ -1,0 +1,52 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('MpegAudio', () => {
+  const MpegAudio = shaka.transmuxer.MpegAudio;
+
+  it('parses a MPEG-1 Layer II header', () => {
+    const data = new Uint8Array([0xff, 0xfc, 0xc4, 0x00]);
+    const header = MpegAudio.parseHeader(data, 0);
+    expect(header).toEqual({
+      sampleRate: 48000,
+      channelCount: 2,
+      frameLength: 768,
+      samplesPerFrame: 1152,
+    });
+  });
+
+  it('rejects data without a sync word', () => {
+    // These bytes appear between frames in real MPEG audio streams. Without a
+    // sync word check they look like a header of a reserved layer, whose frame
+    // length is 0, which made the transmuxers loop forever. See #10419.
+    const data = new Uint8Array([0x7c, 0xf9, 0xb8, 0xdc]);
+    expect(MpegAudio.parseHeader(data, 0)).toBe(null);
+    expect(MpegAudio.isHeader(data, 0)).toBe(false);
+    expect(MpegAudio.probe(data, 0)).toBe(false);
+  });
+
+  it('never returns a header with an empty frame length', () => {
+    // Exhaustively check every possible header, so that no input can make a
+    // caller advance by 0 bytes.
+    const data = new Uint8Array(4);
+    data[0] = 0xff;
+    for (let b1 = 0xe0; b1 <= 0xff; b1++) {
+      data[1] = b1;
+      for (let b2 = 0; b2 <= 0xff; b2++) {
+        data[2] = b2;
+        for (let b3 = 0; b3 <= 0xff; b3 += 0x40) {
+          data[3] = b3;
+          const header = MpegAudio.parseHeader(data, 0);
+          if (header) {
+            expect(header.frameLength).toBeGreaterThan(0);
+            expect(header.samplesPerFrame).toBeGreaterThan(0);
+            expect(header.sampleRate).toBeGreaterThan(0);
+          }
+        }
+      }
+    }
+  });
+});

--- a/test/transmuxer/mpeg_ts_transmuxer_unit.js
+++ b/test/transmuxer/mpeg_ts_transmuxer_unit.js
@@ -1,0 +1,187 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('MpegTsTransmuxer', () => {
+  /** MPEG-1 Layer II, 48 kHz, stereo, 256 kbit/s. */
+  const FRAME_LENGTH = 768;
+  const AUDIO_PID = 0x100;
+  const PMT_PID = 0x1000;
+
+  /**
+   * @param {number} count
+   * @return {!Uint8Array}
+   */
+  function makeElementaryStream(count) {
+    const data = new Uint8Array(count * FRAME_LENGTH);
+    for (let i = 0; i < count; i++) {
+      const offset = i * FRAME_LENGTH;
+      data[offset] = 0xff;
+      data[offset + 1] = 0xfc;
+      data[offset + 2] = 0xc4;
+      data[offset + 3] = 0x00;
+      // Leave the rest as zeros, so that no false sync word can appear.
+    }
+    return data;
+  }
+
+  /**
+   * @param {number} pid
+   * @param {boolean} start
+   * @param {number} continuityCounter
+   * @param {!Uint8Array} payload At most 184 bytes.
+   * @return {!Uint8Array}
+   */
+  function makeTsPacket(pid, start, continuityCounter, payload) {
+    goog.asserts.assert(payload.length <= 184, 'payload too long');
+    const packet = new Uint8Array(188);
+    packet[0] = 0x47;
+    packet[1] = (start ? 0x40 : 0x00) | ((pid >> 8) & 0x1f);
+    packet[2] = pid & 0xff;
+    const stuffing = 184 - payload.length;
+    if (stuffing) {
+      // Adaptation field followed by a payload.
+      packet[3] = 0x30 | (continuityCounter & 0xf);
+      packet[4] = stuffing - 1;
+      if (stuffing > 1) {
+        packet[5] = 0x00;
+        packet.fill(0xff, 6, 4 + stuffing);
+      }
+    } else {
+      packet[3] = 0x10 | (continuityCounter & 0xf);
+    }
+    packet.set(payload, 4 + stuffing);
+    return packet;
+  }
+
+  /** @return {!Uint8Array} */
+  function makePat() {
+    const section = new Uint8Array([
+      0x00, // pointer_field
+      0x00, // table_id
+      0xb0, 0x0d, // section_syntax_indicator + section_length (13)
+      0x00, 0x01, // transport_stream_id
+      0xc1, 0x00, 0x00, // version, section numbers
+      0x00, 0x01, // program_number
+      0xe0 | ((PMT_PID >> 8) & 0x1f), PMT_PID & 0xff,
+      0x00, 0x00, 0x00, 0x00, // CRC32 (not verified by the parser)
+    ]);
+    return makeTsPacket(0, true, 0, section);
+  }
+
+  /** @return {!Uint8Array} */
+  function makePmt() {
+    const section = new Uint8Array([
+      0x00, // pointer_field
+      0x02, // table_id
+      0xb0, 0x12, // section_syntax_indicator + section_length (18)
+      0x00, 0x01, // program_number
+      0xc1, 0x00, 0x00, // version, section numbers
+      0xe0 | ((AUDIO_PID >> 8) & 0x1f), AUDIO_PID & 0xff, // PCR PID
+      0xf0, 0x00, // program_info_length
+      // ISO/IEC 13818-3 audio (MPEG-2 halved sample rate audio).
+      0x04,
+      0xe0 | ((AUDIO_PID >> 8) & 0x1f), AUDIO_PID & 0xff,
+      0xf0, 0x00, // ES_info_length
+      0x00, 0x00, 0x00, 0x00, // CRC32 (not verified by the parser)
+    ]);
+    return makeTsPacket(PMT_PID, true, 0, section);
+  }
+
+  /**
+   * @param {!Uint8Array} payload
+   * @param {number} pts
+   * @return {!Uint8Array}
+   */
+  function makePes(payload, pts) {
+    const header = new Uint8Array(14);
+    header[0] = 0x00;
+    header[1] = 0x00;
+    header[2] = 0x01;
+    header[3] = 0xc0; // stream_id: audio
+    const packetLength = payload.length + 8;
+    header[4] = (packetLength >> 8) & 0xff;
+    header[5] = packetLength & 0xff;
+    header[6] = 0x80;
+    header[7] = 0x80; // PTS present
+    header[8] = 0x05; // PES_header_data_length
+    header[9] = 0x20 | ((pts >> 29) & 0x0e) | 0x01;
+    header[10] = (pts >> 22) & 0xff;
+    header[11] = ((pts >> 14) & 0xfe) | 0x01;
+    header[12] = (pts >> 7) & 0xff;
+    header[13] = ((pts << 1) & 0xfe) | 0x01;
+    return shaka.util.Uint8ArrayUtils.concat(header, payload);
+  }
+
+  /**
+   * Builds a TS with MPEG audio split into PES packets of |pesPayloadSize|
+   * bytes, which is deliberately not a multiple of the frame length.
+   *
+   * @param {!Uint8Array} elementaryStream
+   * @param {number} pesPayloadSize
+   * @return {!Uint8Array}
+   */
+  function makeTs(elementaryStream, pesPayloadSize) {
+    const packets = [makePat(), makePmt()];
+    let continuityCounter = 0;
+    let pts = 900000;
+    for (let i = 0; i < elementaryStream.length; i += pesPayloadSize) {
+      const pes = makePes(
+          elementaryStream.subarray(i, i + pesPayloadSize), pts);
+      pts += 90000;
+      for (let j = 0; j < pes.length; j += 184) {
+        packets.push(makeTsPacket(AUDIO_PID, j == 0, continuityCounter++,
+            pes.subarray(j, j + 184)));
+      }
+    }
+    return shaka.util.Uint8ArrayUtils.concatRange(packets);
+  }
+
+  /** @type {!shaka.transmuxer.MpegTsTransmuxer} */
+  let transmuxer;
+  /** @type {shaka.extern.Stream} */
+  let stream;
+  /** @type {!shaka.media.SegmentReference} */
+  let reference;
+
+  beforeEach(() => {
+    transmuxer = new shaka.transmuxer.MpegTsTransmuxer('video/mp2t');
+    stream = /** @type {shaka.extern.Stream} */ ({
+      id: 1,
+      originalId: '1',
+      type: 'audio',
+      mimeType: 'video/mp2t',
+      codecs: 'mp4a.40.34',
+      language: 'und',
+      drmInfos: [],
+      keyIds: new Set(),
+    });
+    reference = /** @type {!shaka.media.SegmentReference} */ ({
+      discontinuitySequence: 0,
+      startTime: 0,
+      endTime: 10,
+      getUris: () => ['test://segment'],
+    });
+  });
+
+  afterEach(() => {
+    transmuxer.destroy();
+  });
+
+  it('keeps frames that straddle a PES boundary', async () => {
+    const elementaryStream = makeElementaryStream(40);
+    // 500 is not a multiple of 768, so most frames cross a PES boundary.
+    const ts = makeTs(elementaryStream, 500);
+
+    const output = await transmuxer.transmux(
+        ts, stream, reference, 10, 'audio');
+
+    // The output must be the elementary stream, unchanged.  Before this was
+    // fixed, the frames that straddled a PES boundary were dropped and their
+    // leading bytes in the next payload were emitted as a truncated frame of
+    // their own.
+    expect(shaka.util.BufferUtils.equal(output, elementaryStream)).toBe(true);
+  });
+});

--- a/test/transmuxer/mpeg_ts_transmuxer_unit.js
+++ b/test/transmuxer/mpeg_ts_transmuxer_unit.js
@@ -175,8 +175,9 @@ describe('MpegTsTransmuxer', () => {
     // 500 is not a multiple of 768, so most frames cross a PES boundary.
     const ts = makeTs(elementaryStream, 500);
 
-    const output = await transmuxer.transmux(
-        ts, stream, reference, 10, 'audio');
+    // This transmuxer produces a raw MPEG audio stream, not an MP4.
+    const output = /** @type {!Uint8Array} */ (await transmuxer.transmux(
+        ts, stream, reference, 10, 'audio'));
 
     // The output must be the elementary stream, unchanged.  Before this was
     // fixed, the frames that straddled a PES boundary were dropped and their


### PR DESCRIPTION
`MpegAudio.parseHeader()` did not check the sync word, so arbitrary bytes could be parsed as a header of a reserved layer, whose frame length is 0. The callers, which scan through the data looking for frames, then advanced by 0 bytes forever while pushing an empty sample on every iteration, hanging the page and exhausting memory.

MPEG audio frames are also not aligned with the PES packets, but the TS transmuxers parsed each payload on its own. Every frame straddling a PES boundary was dropped, and its leading bytes in the next payload were emitted as a truncated frame, which broke decoding. The payloads are now joined and parsed as a single elementary stream.

Also resync instead of rejecting the whole segment when a raw MP3 segment has trailing bytes that are not a frame, such as an ID3v1 tag.

Fixes https://github.com/shaka-project/shaka-player/issues/10419