### PR TITLE
fix(MSF): Don't call BigInt() at load time in LOCParser

### DIFF
--- a/lib/msf/loc_parser.js
+++ b/lib/msf/loc_parser.js
@@ -120,19 +120,21 @@ shaka.msf.LOCParser = class {
       // property instead, on every key frame. Without this the payload of an
       // AVC track contains only slice NALs, H264.parseInfo() never resolves a
       // config, and the video track stays silently empty forever.
-      const videoConfig = pubProps.get(LOCParser.VIDEO_CONFIG_ID_);
+      // The property IDs are declared as numbers and widened at each lookup;
+      // see their declarations at the bottom of this file.
+      const videoConfig = pubProps.get(BigInt(LOCParser.VIDEO_CONFIG_ID_));
       if (videoConfig && ArrayBuffer.isView(videoConfig)) {
         payload = this.prependParameterSets_(
             payload, /** @type {!Uint8Array} */ (videoConfig));
       }
       // draft-04 renumbered Timestamp from 0x06 to 0x10; accept both, current
       // ID first, because publishers of both vintages are deployed.
-      let pubTs = pubProps.get(LOCParser.TIMESTAMP_ID_);
+      let pubTs = pubProps.get(BigInt(LOCParser.TIMESTAMP_ID_));
       if (typeof pubTs !== 'bigint') {
-        pubTs = pubProps.get(LOCParser.TIMESTAMP_ID_LEGACY_);
+        pubTs = pubProps.get(BigInt(LOCParser.TIMESTAMP_ID_LEGACY_));
       }
       if (typeof pubTs === 'bigint') {
-        const pubScale = pubProps.get(LOCParser.TIMESCALE_ID_);
+        const pubScale = pubProps.get(BigInt(LOCParser.TIMESCALE_ID_));
         const startTime = this.snapStartTime_(this.timestampToSeconds_(
             pubTs, typeof pubScale === 'bigint' ? pubScale : undefined));
         return {startTime, duration: this.frameDuration_, payload};
@@ -532,14 +534,27 @@ shaka.msf.LOCParser = class {
 };
 
 
+// The four property IDs below key a Map whose keys are bigint, but they are
+// declared as numbers and widened with BigInt() at each lookup instead of
+// being declared as bigint.  A BigInt() call here would run at load time, and
+// on a platform without BigInt (Tizen 3) it throws before the file finishes
+// evaluating, which Karma reports as an uncaught error and which abandons the
+// entire test run.  The lookups themselves only ever run under an LOCParser,
+// which no such platform constructs.
+//
+// Number() on the map's keys would be the smaller change, but the key is a
+// vi64 sum that can exceed Number.MAX_SAFE_INTEGER, so distinct property types
+// could fold onto one key and overwrite each other's values.
+
+
 /**
  * ID of the LOC Timestamp property (draft-ietf-moq-loc-04 §2.3.1.1).
  *
  * Even, so the value is a bare vi64.
  *
- * @private @const {bigint}
+ * @private @const {number}
  */
-shaka.msf.LOCParser.TIMESTAMP_ID_ = BigInt(0x10);
+shaka.msf.LOCParser.TIMESTAMP_ID_ = 0x10;
 
 
 /**
@@ -549,9 +564,9 @@ shaka.msf.LOCParser.TIMESTAMP_ID_ = BigInt(0x10);
  * deployed. It is read only when the current ID is absent, so a publisher
  * that sends 0x10 is never affected by it.
  *
- * @private @const {bigint}
+ * @private @const {number}
  */
-shaka.msf.LOCParser.TIMESTAMP_ID_LEGACY_ = BigInt(0x06);
+shaka.msf.LOCParser.TIMESTAMP_ID_LEGACY_ = 0x06;
 
 
 /**
@@ -559,9 +574,9 @@ shaka.msf.LOCParser.TIMESTAMP_ID_LEGACY_ = BigInt(0x06);
  *
  * Unchanged across draft-02 and draft-04. Even, so the value is a bare vi64.
  *
- * @private @const {bigint}
+ * @private @const {number}
  */
-shaka.msf.LOCParser.TIMESCALE_ID_ = BigInt(0x08);
+shaka.msf.LOCParser.TIMESCALE_ID_ = 0x08;
 
 
 /**
@@ -572,9 +587,9 @@ shaka.msf.LOCParser.TIMESCALE_ID_ = BigInt(0x08);
  * HEVCDecoderConfigurationRecord for H.265. Carried only on key frames, and
  * only by publishers that strip parameter sets from the bitstream.
  *
- * @private @const {bigint}
+ * @private @const {number}
  */
-shaka.msf.LOCParser.VIDEO_CONFIG_ID_ = BigInt(0x0d);
+shaka.msf.LOCParser.VIDEO_CONFIG_ID_ = 0x0d;
 
 
 /**

--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -267,6 +267,14 @@ window.quarantinedIt = (name, callback) => {
  *   a truthy value, the tests will run, falsy will skip the tests.
  * @param {function()} describeBody The body of the describe() block.  This
  *   function will call before/after/it functions to define tests.
+ *
+ * Only the test and before/after bodies are conditional.  The describe body
+ * itself always runs, on every platform, because that is what declares them.
+ * So a describe body that touches the very thing cond checks for (BigInt, say)
+ * throws on the platforms the suite exists to skip.  Such a throw is caught
+ * here and reported as one failing test, rather than being allowed to escape
+ * into Jasmine's declaration phase, where it aborts the entire run and leaves
+ * the globals below swapped out for every file loaded after this one.
  */
 window.filterDescribe = (describeName, cond, describeBody) => {
   describe(describeName, () => {
@@ -288,10 +296,20 @@ window.filterDescribe = (describeName, cond, describeBody) => {
       };
     }
 
-    describeBody();
-
-    for (const methodName in old) {
-      window[methodName] = old[methodName];
+    try {
+      describeBody();
+    } catch (error) { // eslint-disable-line no-restricted-syntax
+      // The tests declared before the throw are already registered, and are
+      // filtered like any other.  Give the throw itself the same treatment:
+      // a failure where the suite should have run, and a skip where it
+      // should not have.
+      window['it']('should declare its tests', () => {
+        throw error;
+      });
+    } finally {
+      for (const methodName in old) {
+        window[methodName] = old[methodName];
+      }
     }
   });
 };


### PR DESCRIPTION
LOCParser declared four LOC property IDs with BigInt() at module scope. On a platform without BigInt (Tizen 3) that throws while the file is still evaluating, so Karma reports an uncaught error and abandons the whole run: the Tizen job executed 0 of 3676 tests, not just the MSF ones.

Declare the IDs as numbers and widen them with BigInt() at each lookup instead. The lookups only run under an LOCParser, which a platform without BigInt never constructs.

Also stop a throw from a filterDescribe body from taking the run with it. Only the test and before/after bodies are conditional; the describe body runs on every platform, including the ones its condition exists to skip, so a body touching the unsupported feature throws there. That throw escaped into Jasmine's declaration phase and left the swapped-out it/beforeEach globals installed for every file loaded afterward. It is now reported as a single failing spec.