### PR TITLE
test(UI): Fix test regressions in seek bar tests

### DIFF
--- a/test/ui/ui_unit.js
+++ b/test/ui/ui_unit.js
@@ -2219,11 +2219,7 @@ describe('UI', () => {
         // get it out of the range it is built with.
         controls.seekTo(50, false);
 
-        // The bar is built disabled and is only enabled when the controls go
-        // from hidden to visible, which never happens here because they are
-        // already visible.  A disabled input cannot take focus.
-        seekBar.disabled = false;
-        seekBar.focus();
+        focusForKeyboardTest(seekBar);
       });
 
       /**
@@ -2250,11 +2246,7 @@ describe('UI', () => {
 
       /** @param {string} key */
       function pressKey(key) {
-        seekBar.dispatchEvent(new KeyboardEvent('keydown', {
-          key,
-          bubbles: true,
-          cancelable: true,
-        }));
+        seekBar.dispatchEvent(createKeydownEvent(key));
       }
 
       it('seeks from where the drag left the bar', () => {


### PR DESCRIPTION
PR #10478 introduced two regressions in the tests added there, each of which failed on a different lab platform:
 - Keydown events in the drag tests were not built in a portable way (Tizen)
 - Seek bar focus was not done in a portable way (Chromecast)

---

The seek bar drag tests construct their keydown events with the KeyboardEvent constructor directly. Tizen 3 accepts the init dictionary but leaves event.key undefined, so onControlsKeyDown_ throws a TypeError on event.key.toLowerCase() and all four tests in the suite fail.

createKeydownEvent() already exists for exactly this reason, and the other pressKey() helper in this file uses it. Use it here too.

---

The seek bar drag tests focus the bar by hand, which is the first half of focusForKeyboardTest(): they enable the disabled input and call focus(), but omit the document.activeElement override the helper adds after focus() fails to take.

A Chromecast leaves the bar unfocused, so onControlsKeyDown_ sees no seek bar in the active element and gates off the seek and play/pause shortcuts. Three of the four tests failed there, on both ChromecastGTV and ChromecastStreamer. The fourth presses mute, which is not gated on focus, so it kept working and kept passing.