### PR TITLE
fix(Demo): Persist array config values in the URL hash

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -696,11 +696,8 @@ shakaDemo.Config = class {
             /* canBeDecimal= */ false,
             /* canBeZero= */ true,
             /* canBeUnset= */ true)
-        .addCustomTextInput_('Prefetch audio languages', (input) => {
-          shakaDemoMain.configure(
-              'streaming.prefetchAudioLanguages',
-              input.value.split(',').filter(Boolean));
-        })
+        .addArrayStringInput_('Prefetch audio languages',
+            'streaming.prefetchAudioLanguages')
         .addBoolInput_('Disable Audio Prefetch',
             'streaming.disableAudioPrefetch')
         .addBoolInput_('Disable Text Prefetch',

--- a/demo/demo_utils.js
+++ b/demo/demo_utils.js
@@ -14,6 +14,8 @@ shakaDemo.Utils = class {
    * calls the given callback on them so that they can be stored to or read from
    * an URL hash.
    *
+   * Array values are not included here; see |runThroughHashArrayParams|.
+   *
    * @param {function(string, string)} callback A callback to call on each
    *   config value that can be automatically handled. The first parameter is
    *   the hashName (desired name in the hash). The second parameter is the
@@ -25,6 +27,37 @@ shakaDemo.Utils = class {
    *   PlayerConfiguration object.
    */
   static runThroughHashParams(callback, config) {
+    shakaDemo.Utils.runThroughConfig_(callback, config, /* arrays= */ false);
+  }
+
+  /**
+   * Goes through the array values in shaka.extern.PlayerConfiguration, and
+   * calls the given callback on them so that they can be stored to or read from
+   * an URL hash.
+   *
+   * Arrays always use their full path as their hash name, since their contents
+   * are not a stable part of the shape of the config.
+   *
+   * @param {function(string, string)} callback A callback to call on each array
+   *   config value. The first parameter is the hashName (desired name in the
+   *   hash). The second parameter is the configName (the full path of the
+   *   value, as found in the config object).
+   *
+   * @param {!shaka.extern.PlayerConfiguration} config A config object to use
+   *   for reference.
+   */
+  static runThroughHashArrayParams(callback, config) {
+    shakaDemo.Utils.runThroughConfig_(callback, config, /* arrays= */ true);
+  }
+
+  /**
+   * @param {function(string, string)} callback
+   * @param {!shaka.extern.PlayerConfiguration} config
+   * @param {boolean} arrays If true, call the callback on array values only.
+   *   If false, call it on primitive values only.
+   * @private
+   */
+  static runThroughConfig_(callback, config, arrays) {
     // Override the "natural" name for a config value in the hash.
     // This exists for legacy reasons; the previous demo page had some hash
     // values set to names that did not match the names of their corresponding
@@ -45,23 +78,28 @@ shakaDemo.Utils = class {
     // This is to remove ambiguity in situations where there are two objects in
     // the config that share a key with the same name, without wasting space by
     // pointlessly adding namespace information to every value.
+    // Overridden values and array contents are skipped, so that the names of
+    // the other values don't depend on the current contents of the config.
     const added = [];
     const collisions = [];
-    const findCollisions = (object) => {
+    const findCollisions = (object, accumulated) => {
       for (const key in object) {
+        const configName = accumulated + key;
+        const value = object[key];
+        if (overridden.includes(configName) || Array.isArray(value)) {
+          continue;
+        }
         if (added.includes(key) && !collisions.includes(key)) {
           collisions.push(key);
         }
         added.push(key);
 
-        const value = object[key];
-        if (typeof value != 'number' && typeof value != 'string' &&
-            typeof value != 'boolean') {
-          findCollisions(value);
+        if (value && typeof value == 'object') {
+          findCollisions(value, configName + '.');
         }
       }
     };
-    findCollisions(config);
+    findCollisions(config, '');
 
     // TODO: This system for handling name collisions does mean that, if a new
     // collision appears later on, old hashes will become invalid.
@@ -81,10 +119,18 @@ shakaDemo.Utils = class {
         }
 
         const value = object[key];
-        if (typeof value == 'number' || typeof value == 'string' ||
+        if (Array.isArray(value)) {
+          // The contents of an array are not part of the shape of the config,
+          // so an array is handled as a single value, under its full path.
+          if (arrays) {
+            callback(configName, configName);
+          }
+        } else if (typeof value == 'number' || typeof value == 'string' ||
             typeof value == 'boolean') {
-          callback(hashName, configName);
-        } else {
+          if (!arrays) {
+            callback(hashName, configName);
+          }
+        } else if (value && typeof value == 'object') {
           handleConfig(value, configName + '.');
         }
       }

--- a/demo/main.js
+++ b/demo/main.js
@@ -1051,14 +1051,26 @@ shakaDemo.Main = class {
           this.configure(configName, value);
         }
       };
+      const readArrayParam = (hashName, configName) => {
+        if (!params.has(hashName)) {
+          return;
+        }
+        const parsed = shakaDemo.Main.parseArrayParam_(params.get(hashName));
+        if (parsed) {
+          this.configure(configName, parsed);
+        }
+      };
       const config = this.player_.getConfiguration();
       shakaDemo.Utils.runThroughHashParams(readParam, config);
-      const advanced = this.getCurrentConfigValue('drm.advanced');
-      let isAvailable = !!advanced;
-      if (isAvailable && typeof advanced == 'object') {
-        isAvailable = Object.keys(/** @type {!Object} */(advanced)).length > 0;
-      }
-      if (isAvailable) {
+      shakaDemo.Utils.runThroughHashArrayParams(readArrayParam, config);
+      // Note that these are not read as part of |runThroughHashArrayParams|,
+      // since 'drm.advanced' is set per key system, and is stored in the hash
+      // as a single value for all of the common key systems.
+      const hasAdvancedParams = params.has('videoRobustness') ||
+          params.has('audioRobustness') || params.has('sessionType');
+      if (hasAdvancedParams) {
+        const advanced = /** @type {!Object} */(
+          this.getCurrentConfigValue('drm.advanced') || {});
         for (const drmSystem of shakaDemo.Main.commonDrmSystems) {
           if (!advanced[drmSystem]) {
             advanced[drmSystem] = shakaDemo.Main.defaultAdvancedDrmConfig();
@@ -1071,11 +1083,11 @@ shakaDemo.Main = class {
             advanced[drmSystem].audioRobustness =
                 params.get('audioRobustness').split(',');
           }
+          if (params.has('sessionType')) {
+            advanced[drmSystem].sessionType = params.get('sessionType');
+          }
         }
-
-        if (params.has('audioRobustness') || params.has('videoRobustness')) {
-          this.configure('drm.advanced', advanced);
-        }
+        this.configure('drm.advanced', advanced);
       }
     }
     if (params.has('uilang')) {
@@ -1177,22 +1189,6 @@ shakaDemo.Main = class {
               hdrLevel: 'AUTO',
               layout: '',
             })));
-    }
-
-    if (params.has('accessibility.speechToText.languagesToTranslate')) {
-      this.configure('accessibility.speechToText.languagesToTranslate',
-          params.get('accessibility.speechToText.languagesToTranslate')
-              .split(','));
-    }
-
-    if (params.has('manifest.msf.namespaces')) {
-      this.configure('manifest.msf.namespaces',
-          params.get('manifest.msf.namespaces').split(','));
-    }
-
-    if (params.has('drm.preferredKeySystems')) {
-      this.configure('drm.preferredKeySystems',
-          params.get('drm.preferredKeySystems').split(','));
     }
 
     // Add compiled/uncompiled links.
@@ -1725,8 +1721,20 @@ shakaDemo.Main = class {
           params.push(hashName + '=' + currentValue);
         }
       };
+      const setArrayParam = (hashName, configName) => {
+        const currentValue = /** @type {Array<*>} */(
+          this.getCurrentConfigValue(configName));
+        if (!currentValue || !currentValue.length) {
+          // Don't bother saving in the hash unless it's a non-default value.
+          // All arrays in the config default to being empty.
+          return;
+        }
+        params.push(
+            hashName + '=' + shakaDemo.Main.makeArrayParam_(currentValue));
+      };
       const config = this.player_.getConfiguration();
       shakaDemo.Utils.runThroughHashParams(setParam, config);
+      shakaDemo.Utils.runThroughHashArrayParams(setArrayParam, config);
       const advanced = this.getCurrentConfigValue('drm.advanced');
       if (advanced) {
         for (const drmSystem of shakaDemo.Main.commonDrmSystems) {
@@ -1741,6 +1749,9 @@ shakaDemo.Main = class {
               advancedFor.audioRobustness.length) {
               params.push('audioRobustness=' +
                   advancedFor.audioRobustness.join());
+            }
+            if (advancedFor.sessionType) {
+              params.push('sessionType=' + advancedFor.sessionType);
             }
             break;
           }
@@ -1772,20 +1783,6 @@ shakaDemo.Main = class {
     if (prefVideo.length) {
       params.push('preferredVideo=' +
           encodeURIComponent(JSON.stringify(prefVideo)));
-    }
-
-    const otherArrays = [
-      'accessibility.speechToText.languagesToTranslate',
-      'manifest.msf.namespaces',
-      'drm.preferredKeySystems',
-    ];
-
-    for (const key of otherArrays) {
-      const array = /** @type {!Array<string>} */(
-        this.getCurrentConfigValue(key));
-      if (array.length) {
-        params.push(key + '=' + array.join(','));
-      }
     }
 
     if (this.selectedAsset) {
@@ -2179,6 +2176,44 @@ shakaDemo.Main = class {
       this.selectedAsset = ShakaDemoAssetInfo.makeBlankAsset();
       this.showPlayer_();
     }
+  }
+
+  /**
+   * Serializes an array config value, to be stored in the hash.  Arrays of
+   * plain strings are stored as a comma-separated list, for readability;
+   * anything more complex is stored as JSON.
+   *
+   * @param {!Array<*>} array
+   * @return {string}
+   * @private
+   */
+  static makeArrayParam_(array) {
+    const isStringArray = array.every((item) => typeof item == 'string');
+    const value = isStringArray ? array.join(',') : JSON.stringify(array);
+    // The hash is split on ';' and '=' before being decoded, so the value has
+    // to be encoded here.
+    return encodeURIComponent(value);
+  }
+
+  /**
+   * Parses an array config value that was stored in the hash by
+   * |makeArrayParam_|.  Older hashes might contain values that were not
+   * encoded, but those are decoded the same way.
+   *
+   * @param {string} param
+   * @return {?Array<*>} The parsed array, or null if the value was invalid.
+   * @private
+   */
+  static parseArrayParam_(param) {
+    if (param.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(param);
+        return Array.isArray(parsed) ? parsed : null;
+      } catch (e) {
+        return null;
+      }
+    }
+    return param ? param.split(',') : [];
   }
 
   /** @return {!shaka.extern.AdvancedDrmConfiguration} */

--- a/test/demo/demo_unit.js
+++ b/test/demo/demo_unit.js
@@ -92,7 +92,8 @@ describe('Demo', () => {
           .add('accessibility.speechToText.languagesToTranslate')
           .add('drm.preferredKeySystems')
           .add('manifest.msf.namespaces')
-          .add('cmcd.eventTargets');
+          .add('cmcd.eventTargets')
+          .add('streaming.prefetchAudioLanguages');
       // We determine whether a config option has been made or not by looking at
       // which config values have been queried (via the fake main object's
       // |getCurrentConfigValue| method).


### PR DESCRIPTION
The demo's hash serialization only handled primitive config values, and recursed into arrays instead of treating them as a single value.  As a result, array values were not restored on reload (or when copying the URL to another tab), and their contents leaked into the hash as junk params such as "cmcd.eventTargets.0.enabled=true;interval=30;url=...".  Reading those back tried to configure paths like "cmcd.eventTargets.0.url", which restored nothing.  Array contents also took part in the hash name collision detection, so the hash names of unrelated values depended on the current config.

Arrays are now walked as single values, under their full config path, and are stored as a comma-separated list (for arrays of plain strings, which keeps old hashes working) or as JSON otherwise.  This covers every array in the config, instead of the three that were special-cased in main.js: notably cmcd.eventTargets and streaming.prefetchAudioLanguages, which were not persisted at all.

Also fixes drm.advanced, where sessionType was never saved in the hash, and where videoRobustness/audioRobustness were dropped on page load because drm.advanced is still empty at that point.

Finally, the "Prefetch audio languages" input did not call remakeHash() and did not restore its value; it now uses the existing addArrayStringInput_ helper.