### PR TITLE
feat(UI): Add captions-style submenu for subtitle size and position

### DIFF
--- a/build/types/ui
+++ b/build/types/ui
@@ -5,6 +5,7 @@
 +../../ui/statistics_button_base.js
 +../../ui/audio_language_selection.js
 +../../ui/autoplay_button.js
++../../ui/caption_style.js
 +../../ui/content_title.js
 +../../ui/externs/ui.js
 +../../ui/externs/watermark.js

--- a/docs/tutorials/ui-customization.md
+++ b/docs/tutorials/ui-customization.md
@@ -84,6 +84,9 @@ The following elements can be added to the UI bar using this configuration value
   The button is visible only if the content has at least one text track.
 * captions-size: adds a button that controls the size of the captions.
   The button is visible only if the content has at least one text track.
+* captions-style: adds a button that controls the style (size and position)
+  of the captions. The button is visible only if the content has at least one
+  text track.
 * skip_next: adds a button to skip to next element in the queue. The button
   is visible only if there is next.
 * skip_previous: adds a button to skip to previous element in the queue. The button
@@ -134,6 +137,9 @@ The following buttons can be added to the overflow menu:
   The button is visible only if the content has at least one text track.
 * captions-size: adds a button that controls the size of the captions.
   The button is visible only if the content has at least one text track.
+* captions-style: adds a button that controls the style (size and position)
+  of the captions. The button is visible only if the content has at least one
+  text track.
 * queue: adds a button that opens a menu listing all items in the playback queue.
   Each item displays its title and, if available, a poster thumbnail. The currently
   playing item is highlighted with a checkmark. The button is visible only if there

--- a/shaka-player.uncompiled.js
+++ b/shaka-player.uncompiled.js
@@ -103,6 +103,7 @@ goog.require('shaka.ui.AudioLanguageSelection');
 goog.require('shaka.ui.AutoPlayNextButton');
 goog.require('shaka.ui.AdInfo');
 goog.require('shaka.ui.AdStatisticsButton');
+goog.require('shaka.ui.CaptionStyle');
 goog.require('shaka.ui.CastButton');
 goog.require('shaka.ui.ChapterSelection');
 goog.require('shaka.ui.ContentTitle');

--- a/test/ui/ui_unit.js
+++ b/test/ui/ui_unit.js
@@ -1052,6 +1052,299 @@ describe('UI', () => {
       });
     });
 
+    describe('captions-style submenu', () => {
+      /** @type {shaka.ui.Controls} */
+      let controls;
+      /** @type {shaka.Player} */
+      let player;
+      /** @type {!jasmine.Spy} */
+      let setPreviewSpy;
+      /** @type {!jasmine.Spy} */
+      let clearPreviewSpy;
+
+      afterEach(() => {
+        if (!('shakaPlayerContainer' in videoContainer.dataset) &&
+            videoContainer.parentElement) {
+          videoContainer.remove();
+        }
+      });
+
+      /**
+       * @param {?shaka.Player} p
+       */
+      function usePreviewTextDisplayer(p) {
+        expect(p).not.toBe(null);
+        const localPlayer = /** @type {!shaka.Player} */(p);
+        /** @type {?} */
+        const textDisplayer = {};
+        setPreviewSpy = textDisplayer.setTextStylePreview =
+            jasmine.createSpy('setTextStylePreview');
+        clearPreviewSpy = textDisplayer.clearTextStylePreview =
+            jasmine.createSpy('clearTextStylePreview');
+        spyOn(localPlayer, 'getTextDisplayer').and.returnValue(
+            /** @type {!shaka.extern.TextDisplayer} */(textDisplayer));
+      }
+
+      /**
+       * @param {!HTMLElement} menu
+       * @param {string} label
+       * @return {!HTMLElement}
+       */
+      function getRadioOption(menu, label) {
+        const buttons = Array.from(
+            menu.querySelectorAll('button[role="menuitemradio"]'));
+        const button = buttons.find((btn) => {
+          const span = btn.querySelector('span');
+          return span && span.textContent == label;
+        });
+        expect(button).not.toBe(undefined);
+        return /** @type {!HTMLElement} */(button);
+      }
+
+      it('creates submenu with root, size, and position pages', async () => {
+        const config = {
+          controlPanelElements: [
+            'captions-style',
+          ],
+          customContextMenu: false,
+        };
+        const ui = await UiUtils.createUIThroughAPI(
+            videoContainer, video, config);
+        controls = ui.getControls();
+        player = controls.getLocalPlayer();
+        usePreviewTextDisplayer(player);
+        controls.showUI();
+
+        const styleButton = UiUtils.getElementByClassName(
+            videoContainer, 'shaka-caption-style-button');
+        expect(styleButton).not.toBe(null);
+        styleButton.click();
+
+        const menu = UiUtils.getElementByClassName(
+            videoContainer, 'shaka-caption-style-menu');
+        expect(menu).not.toBe(null);
+
+        // Root page should contain Size and Position buttons
+        const pageButtons = menu.querySelectorAll(
+            'button[role="menuitem"]');
+        expect(pageButtons.length).toBe(2);
+
+        const sizeNavBtn = /** @type {!HTMLButtonElement} */(pageButtons[0]);
+        const posNavBtn = /** @type {!HTMLButtonElement} */(pageButtons[1]);
+
+        expect(sizeNavBtn.getAttribute('aria-expanded')).toBe('false');
+        expect(posNavBtn.getAttribute('aria-expanded')).toBe('false');
+
+        // Navigate to Size page
+        sizeNavBtn.click();
+        expect(setPreviewSpy).toHaveBeenCalled();
+        expect(sizeNavBtn.getAttribute('aria-expanded')).toBe('true');
+        const sizeOption = getRadioOption(menu, '150%');
+        expect(sizeOption).not.toBe(null);
+
+        // Back button returns to root page and hides preview
+        const backBtn = UiUtils.getElementByClassName(
+            menu, 'shaka-back-to-overflow-button');
+        backBtn.click();
+        expect(clearPreviewSpy).toHaveBeenCalled();
+        expect(menu.classList.contains('shaka-hidden')).toBe(false);
+        expect(sizeNavBtn.getAttribute('aria-expanded')).toBe('false');
+
+        // Navigate to Position page
+        posNavBtn.click();
+        expect(setPreviewSpy).toHaveBeenCalled();
+        expect(posNavBtn.getAttribute('aria-expanded')).toBe('true');
+        const loc = controls.getLocalization();
+        const posOption = getRadioOption(
+            menu, loc.resolve(shaka.ui.Locales.Ids.TOP_CENTER));
+        expect(posOption).not.toBe(null);
+
+        // Selecting position applies configuration and hides preview
+        posOption.click();
+        expect(player.getConfiguration().textDisplayer.positionArea)
+            .toBe(shaka.config.PositionArea.TOP_CENTER);
+        expect(clearPreviewSpy).toHaveBeenCalled();
+      });
+
+      it('updates preview and applies font size', async () => {
+        const config = {
+          controlPanelElements: [
+            'captions-style',
+          ],
+          customContextMenu: false,
+        };
+        const ui = await UiUtils.createUIThroughAPI(
+            videoContainer, video, config);
+        controls = ui.getControls();
+        player = controls.getLocalPlayer();
+        usePreviewTextDisplayer(player);
+        controls.showUI();
+
+        const styleButton = UiUtils.getElementByClassName(
+            videoContainer, 'shaka-caption-style-button');
+        styleButton.click();
+
+        const menu = UiUtils.getElementByClassName(
+            videoContainer, 'shaka-caption-style-menu');
+        const pageButtons = menu.querySelectorAll(
+            'button[role="menuitem"]');
+        const sizeNavBtn = /** @type {!HTMLButtonElement} */(pageButtons[0]);
+        sizeNavBtn.click();
+
+        const sizeOption = getRadioOption(menu, '200%');
+        expect(sizeOption).not.toBe(null);
+
+        // Hover over 200% option updates preview
+        setPreviewSpy.calls.reset();
+        sizeOption.dispatchEvent(new MouseEvent('mouseenter'));
+        expect(setPreviewSpy).toHaveBeenCalled();
+        const previewConfig = setPreviewSpy.calls.mostRecent().args[0];
+        expect(previewConfig.fontScaleFactor).toBe(2);
+
+        // Leave resets preview
+        setPreviewSpy.calls.reset();
+        sizeOption.dispatchEvent(new MouseEvent('mouseleave'));
+        expect(setPreviewSpy).toHaveBeenCalled();
+
+        // Clicking updates player font scale config
+        sizeOption.click();
+        expect(player.getConfiguration().textDisplayer.fontScaleFactor)
+            .toBe(2.0);
+        expect(clearPreviewSpy).toHaveBeenCalled();
+      });
+
+      it('works inside overflowMenuButtons and returns to overflow ' +
+          'menu on back', async () => {
+        const config = {
+          overflowMenuButtons: [
+            'captions-style',
+          ],
+          customContextMenu: false,
+        };
+        const ui = await UiUtils.createUIThroughAPI(
+            videoContainer, video, config);
+        controls = ui.getControls();
+        player = controls.getLocalPlayer();
+        spyOn(player, 'getTextTracks').and.returnValue([
+          /** @type {shaka.extern.TextTrack} */({active: true}),
+        ]);
+        usePreviewTextDisplayer(player);
+        controls.showUI();
+
+        const overflowBtn = UiUtils.getElementByClassName(
+            videoContainer, 'shaka-overflow-menu-button');
+        expect(overflowBtn).not.toBe(null);
+        overflowBtn.click();
+
+        const overflowMenu = UiUtils.getElementByClassName(
+            videoContainer, 'shaka-overflow-menu');
+        expect(overflowMenu).not.toBe(null);
+        expect(overflowMenu.classList.contains('shaka-hidden')).toBe(false);
+
+        const styleButton = UiUtils.getElementByClassName(
+            overflowMenu, 'shaka-caption-style-button');
+        expect(styleButton).not.toBe(null);
+        const currentSpan = styleButton.querySelector(
+            '.shaka-current-selection-span');
+        expect(currentSpan.textContent).toContain('100%');
+        styleButton.click();
+
+        const menu = UiUtils.getElementByClassName(
+            videoContainer, 'shaka-caption-style-menu');
+        expect(menu).not.toBe(null);
+        expect(menu.classList.contains('shaka-hidden')).toBe(false);
+        expect(styleButton.classList.contains('shaka-hidden')).toBe(true);
+
+        // Enter Size page
+        const pageButtons = menu.querySelectorAll(
+            'button[role="menuitem"]');
+        const sizeNavBtn = /** @type {!HTMLButtonElement} */(pageButtons[0]);
+        sizeNavBtn.click();
+        expect(setPreviewSpy).toHaveBeenCalled();
+        expect(menu.classList.contains('shaka-hidden')).toBe(false);
+
+        // Back from Size page returns to CaptionStyle ROOT page without
+        // closing menu
+        const backBtn = UiUtils.getElementByClassName(
+            menu, 'shaka-back-to-overflow-button');
+        backBtn.click();
+        expect(clearPreviewSpy).toHaveBeenCalled();
+        expect(menu.classList.contains('shaka-hidden')).toBe(false);
+        expect(styleButton.classList.contains('shaka-hidden')).toBe(true);
+
+        // Back from ROOT page returns to overflow menu
+        backBtn.click();
+        expect(menu.classList.contains('shaka-hidden')).toBe(true);
+        expect(styleButton.classList.contains('shaka-hidden')).toBe(false);
+        expect(overflowMenu.classList.contains('shaka-hidden')).toBe(false);
+      });
+
+      it('toggles visibility based on active text track presence', async () => {
+        const config = {
+          controlPanelElements: [
+            'captions-style',
+          ],
+          customContextMenu: false,
+        };
+        const ui = await UiUtils.createUIThroughAPI(
+            videoContainer, video, config);
+        controls = ui.getControls();
+        player = controls.getLocalPlayer();
+
+        // Stub text tracks with no active tracks
+        const tracksSpy = spyOn(player, 'getTextTracks').and.returnValue([
+          /** @type {shaka.extern.TextTrack} */({active: false}),
+        ]);
+        controls.showUI();
+
+        const styleButton = UiUtils.getElementByClassName(
+            videoContainer, 'shaka-caption-style-button');
+        expect(styleButton).not.toBe(null);
+        expect(styleButton.classList.contains('shaka-hidden')).toBe(true);
+
+        // When an active text track exists, the button becomes visible
+        tracksSpy.and.returnValue([
+          /** @type {shaka.extern.TextTrack} */({active: true}),
+        ]);
+        player.dispatchEvent(new shaka.util.FakeEvent('textchanged'));
+        expect(styleButton.classList.contains('shaka-hidden')).toBe(false);
+      });
+
+
+      it('retains focus inside menu when scale factor is not in options',
+          async () => {
+            const config = {
+              controlPanelElements: [
+                'captions-style',
+              ],
+              captionsFontScaleFactors: [1, 2],
+              customContextMenu: false,
+            };
+            const ui = await UiUtils.createUIThroughAPI(
+                videoContainer, video, config);
+            controls = ui.getControls();
+            player = controls.getLocalPlayer();
+            player.configure('textDisplayer.fontScaleFactor', 1.25);
+            usePreviewTextDisplayer(player);
+            controls.showUI();
+
+            const styleButton = UiUtils.getElementByClassName(
+                videoContainer, 'shaka-caption-style-button');
+            styleButton.click();
+
+            const menu = UiUtils.getElementByClassName(
+                videoContainer, 'shaka-caption-style-menu');
+            const pageButtons = menu.querySelectorAll(
+                'button[role="menuitem"]');
+            const sizeNavBtn =
+            /** @type {!HTMLButtonElement} */(pageButtons[0]);
+            sizeNavBtn.click();
+
+            expect(menu.contains(document.activeElement)).toBe(true);
+            expect(document.activeElement).not.toBe(document.body);
+          });
+    });
+
     describe('resolutions menu', () => {
       /** @type {!HTMLElement} */
       let resolutionsMenu;

--- a/ui/caption_style.js
+++ b/ui/caption_style.js
@@ -1,0 +1,450 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+goog.provide('shaka.ui.CaptionStyle');
+
+goog.require('shaka.config.PositionArea');
+goog.require('shaka.ui.Controls');
+goog.require('shaka.ui.Enums');
+goog.require('shaka.ui.Icon');
+goog.require('shaka.ui.Locales');
+goog.require('shaka.ui.OverflowMenu');
+goog.require('shaka.ui.SettingsMenu');
+goog.require('shaka.ui.TextPosition');
+goog.require('shaka.ui.Utils');
+goog.require('shaka.util.Dom');
+goog.requireType('shaka.ui.TextStylePreview');
+
+
+/**
+ * Submenu for configuring subtitle style (size, position, etc.).
+ *
+ * @extends {shaka.ui.SettingsMenu}
+ * @final
+ * @export
+ */
+shaka.ui.CaptionStyle = class extends shaka.ui.SettingsMenu {
+  /**
+   * @param {!HTMLElement} parent
+   * @param {!shaka.ui.Controls} controls
+   */
+  constructor(parent, controls) {
+    super(parent, controls,
+        shaka.ui.Enums.MaterialDesignSVGIcons['CLOSED_CAPTIONS_STYLE']);
+
+    this.button.classList.add('shaka-caption-style-button');
+    this.button.classList.add('shaka-tooltip');
+    this.menu.classList.add('shaka-caption-style-menu');
+
+    /** @private {shaka.ui.CaptionStyle.Page_} */
+    this.currentPage_ = shaka.ui.CaptionStyle.Page_.ROOT;
+
+    /** @private {HTMLButtonElement} */
+    this.sizeButton_ = shaka.util.Dom.createButton();
+    this.sizeButton_.classList.add('shaka-overflow-button');
+    this.sizeButton_.setAttribute('role', 'menuitem');
+    this.sizeButton_.setAttribute('aria-haspopup', 'true');
+    this.sizeButton_.setAttribute('aria-expanded', 'false');
+
+    /** @private {shaka.ui.Icon} */
+    this.sizeIcon_ = new shaka.ui.Icon(this.sizeButton_,
+        shaka.ui.Enums.MaterialDesignSVGIcons['CLOSED_CAPTIONS_SIZE']);
+
+    const sizeLabel = shaka.util.Dom.createHTMLElement('label');
+    sizeLabel.classList.add('shaka-overflow-button-label');
+    sizeLabel.classList.add('shaka-overflow-menu-only');
+    sizeLabel.classList.add('shaka-overflow-button-label-inline');
+
+    /** @private {HTMLElement} */
+    this.sizeNameSpan_ = shaka.util.Dom.createHTMLElement('span');
+    sizeLabel.appendChild(this.sizeNameSpan_);
+
+    /** @private {HTMLElement} */
+    this.sizeValueSpan_ = shaka.util.Dom.createHTMLElement('span');
+    this.sizeValueSpan_.classList.add('shaka-current-selection-span');
+    sizeLabel.appendChild(this.sizeValueSpan_);
+    this.sizeButton_.appendChild(sizeLabel);
+
+    this.eventManager.listen(this.sizeButton_, 'click', (e) => {
+      e.stopPropagation();
+      this.showPage_(shaka.ui.CaptionStyle.Page_.SIZE);
+    });
+
+    /** @private {HTMLButtonElement} */
+    this.positionButton_ = shaka.util.Dom.createButton();
+    this.positionButton_.classList.add('shaka-overflow-button');
+    this.positionButton_.setAttribute('role', 'menuitem');
+    this.positionButton_.setAttribute('aria-haspopup', 'true');
+    this.positionButton_.setAttribute('aria-expanded', 'false');
+
+    /** @private {shaka.ui.Icon} */
+    this.positionIcon_ = new shaka.ui.Icon(this.positionButton_,
+        shaka.ui.Enums.MaterialDesignSVGIcons['CLOSED_CAPTIONS_POSITION']);
+
+    const positionLabel = shaka.util.Dom.createHTMLElement('label');
+    positionLabel.classList.add('shaka-overflow-button-label');
+    positionLabel.classList.add('shaka-overflow-menu-only');
+    positionLabel.classList.add('shaka-overflow-button-label-inline');
+
+    /** @private {HTMLElement} */
+    this.positionNameSpan_ = shaka.util.Dom.createHTMLElement('span');
+    positionLabel.appendChild(this.positionNameSpan_);
+
+    /** @private {HTMLElement} */
+    this.positionValueSpan_ = shaka.util.Dom.createHTMLElement('span');
+    this.positionValueSpan_.classList.add('shaka-current-selection-span');
+    positionLabel.appendChild(this.positionValueSpan_);
+    this.positionButton_.appendChild(positionLabel);
+
+    this.eventManager.listen(this.positionButton_, 'click', (e) => {
+      e.stopPropagation();
+      this.showPage_(shaka.ui.CaptionStyle.Page_.POSITION);
+    });
+
+    /** @private {!Array<!HTMLButtonElement>} */
+    this.sizeButtons_ = [];
+
+    /** @private {!Array<!HTMLButtonElement>} */
+    this.positionButtons_ = [];
+
+    this.buildPositionButtons_();
+    this.buildSizeButtons_();
+
+    this.eventManager.listenMulti(
+        this.player,
+        [
+          'loading',
+          'unloading',
+          'configurationchanged',
+          'trackschanged',
+          'textchanged',
+        ], () => {
+          this.updateSelectionsAndLabels_();
+          this.checkAvailability();
+        });
+
+    this.updateLocalizedStrings();
+    this.checkAvailability();
+  }
+
+  /** @override */
+  onBackButtonClick(event) {
+    if (this.currentPage_ !== shaka.ui.CaptionStyle.Page_.ROOT) {
+      this.controls.hideTextStylePreview();
+      const prevPage = this.currentPage_;
+      this.showPage_(shaka.ui.CaptionStyle.Page_.ROOT);
+      if (prevPage === shaka.ui.CaptionStyle.Page_.SIZE) {
+        this.sizeButton_.focus();
+      } else if (prevPage === shaka.ui.CaptionStyle.Page_.POSITION) {
+        this.positionButton_.focus();
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * @param {shaka.ui.CaptionStyle.Page_} page
+   * @private
+   */
+  showPage_(page) {
+    this.currentPage_ = page;
+    this.sizeButton_.setAttribute(
+        'aria-expanded',
+        page === shaka.ui.CaptionStyle.Page_.SIZE ? 'true' : 'false');
+    this.positionButton_.setAttribute(
+        'aria-expanded',
+        page === shaka.ui.CaptionStyle.Page_.POSITION ? 'true' : 'false');
+
+    this.render_();
+
+    if (page === shaka.ui.CaptionStyle.Page_.SIZE ||
+        page === shaka.ui.CaptionStyle.Page_.POSITION) {
+      this.controls.showTextStylePreview();
+      const chosenItem = shaka.ui.Utils.getDescendantIfExists(
+          this.menu, 'shaka-chosen-item');
+      if (chosenItem) {
+        chosenItem.parentElement.focus();
+      } else {
+        const buttons = page === shaka.ui.CaptionStyle.Page_.SIZE ?
+            this.sizeButtons_ : this.positionButtons_;
+        if (buttons.length) {
+          buttons[0].focus();
+        } else {
+          this.backButton.focus();
+        }
+      }
+    } else if (page === shaka.ui.CaptionStyle.Page_.ROOT) {
+      this.sizeButton_.focus();
+    }
+  }
+
+  /**
+   * Clears the menu keeping the back button and populates it for the current
+   * page.
+   * @private
+   */
+  render_() {
+    const LocIds = shaka.ui.Locales.Ids;
+    shaka.ui.Utils.clearMenuKeepingBackButton(this.menu);
+
+    switch (this.currentPage_) {
+      case shaka.ui.CaptionStyle.Page_.ROOT:
+        this.backSpan.textContent =
+            this.localization.resolve(LocIds.SUBTITLE_STYLE);
+        this.menu.appendChild(this.sizeButton_);
+        this.menu.appendChild(this.positionButton_);
+        this.updateSelectionsAndLabels_();
+        break;
+      case shaka.ui.CaptionStyle.Page_.SIZE:
+        this.backSpan.textContent =
+            this.localization.resolve(LocIds.SUBTITLE_SIZE);
+        for (const button of this.sizeButtons_) {
+          this.menu.appendChild(button);
+        }
+        this.updateSelectionsAndLabels_();
+        break;
+      case shaka.ui.CaptionStyle.Page_.POSITION:
+        this.backSpan.textContent =
+            this.localization.resolve(LocIds.SUBTITLE_POSITION);
+        for (const button of this.positionButtons_) {
+          this.menu.appendChild(button);
+        }
+        this.updateSelectionsAndLabels_();
+        break;
+    }
+  }
+
+  /**
+   * Helper to build a list of radio option buttons for a style property.
+   *
+   * @param {!Array<T>} items
+   * @param {function(T): string} getLabel
+   * @param {function(T)} onSelect
+   * @param {function(T):
+   *     !shaka.ui.TextStylePreview.Configuration} getPreviewConfig
+   * @return {!Array<!HTMLButtonElement>}
+   * @template T
+   * @private
+   */
+  createRadioOptionButtons_(items, getLabel, onSelect, getPreviewConfig) {
+    const buttons = [];
+    for (const item of items) {
+      const button = shaka.util.Dom.createButton();
+      button.setAttribute('role', 'menuitemradio');
+      button.setAttribute('aria-checked', 'false');
+      const span = shaka.util.Dom.createHTMLElement('span');
+      span.textContent = getLabel(item);
+      button.appendChild(span);
+
+      this.eventManager.listen(button, 'click', () => {
+        onSelect(item);
+        this.updateSelectionsAndLabels_();
+        this.controls.hideTextStylePreview();
+      });
+
+      shaka.ui.Utils.addHoverAndFocusListeners(
+          this.eventManager, button,
+          () => this.controls.updateTextStylePreview(getPreviewConfig(item)),
+          () => this.controls.resetTextStylePreview());
+
+      buttons.push(button);
+    }
+    return buttons;
+  }
+
+  /** @private */
+  buildSizeButtons_() {
+    this.sizeButtons_ = this.createRadioOptionButtons_(
+        this.controls.getConfig().captionsFontScaleFactors,
+        (factor) => factor * 100 + '%',
+        (factor) =>
+          this.player.configure('textDisplayer.fontScaleFactor', factor),
+        (factor) => ({fontScaleFactor: factor}));
+  }
+
+  /** @private */
+  buildPositionButtons_() {
+    this.positionButtons_ = this.createRadioOptionButtons_(
+        Object.values(shaka.config.PositionArea),
+        (pos) =>
+          shaka.ui.TextPosition.getNameOfPosition(pos, this.localization),
+        (pos) => this.player.configure('textDisplayer.positionArea', pos),
+        (pos) => ({positionArea: pos}));
+  }
+
+  /** @private */
+  updateSelectionsAndLabels_() {
+    const sizeLabel = this.getCurrentSizeLabel_();
+    const positionLabel = this.getCurrentPositionLabel_();
+
+    if (this.currentSelection) {
+      this.currentSelection.textContent =
+          [sizeLabel, positionLabel].filter(Boolean).join(' · ');
+    }
+
+    if (this.sizeValueSpan_) {
+      this.sizeValueSpan_.textContent = sizeLabel;
+    }
+    if (this.positionValueSpan_) {
+      this.positionValueSpan_.textContent = positionLabel;
+    }
+
+    if (this.currentPage_ === shaka.ui.CaptionStyle.Page_.SIZE) {
+      this.updateRadioSelection_(this.sizeButtons_, sizeLabel);
+    } else if (this.currentPage_ === shaka.ui.CaptionStyle.Page_.POSITION) {
+      this.updateRadioSelection_(this.positionButtons_, positionLabel);
+    }
+  }
+
+  /**
+   * @param {!Array<!HTMLButtonElement>} buttons
+   * @param {string} currentLabel
+   * @private
+   */
+  updateRadioSelection_(buttons, currentLabel) {
+    for (const button of buttons) {
+      const checkmarkIcon = shaka.ui.Utils.getDescendantIfExists(
+          button, 'shaka-ui-icon shaka-chosen-item');
+      if (checkmarkIcon) {
+        button.removeChild(checkmarkIcon);
+      }
+      button.setAttribute('aria-checked', 'false');
+      const span = /** @type {HTMLElement} */ (button.querySelector('span'));
+      if (span) {
+        span.classList.remove('shaka-chosen-item');
+        if (span.textContent === currentLabel) {
+          button.appendChild(shaka.ui.Utils.checkmarkIcon());
+          shaka.ui.Utils.setChosenItem(button, span);
+        }
+      }
+    }
+  }
+
+  /**
+   * @return {string}
+   * @private
+   */
+  getCurrentSizeLabel_() {
+    if (!this.player) {
+      return '';
+    }
+    const config = this.player.getConfiguration();
+    const fontScaleFactor = config && config.textDisplayer ?
+        config.textDisplayer.fontScaleFactor : 1;
+    return fontScaleFactor * 100 + '%';
+  }
+
+  /**
+   * @return {string}
+   * @private
+   */
+  getCurrentPositionLabel_() {
+    if (!this.player) {
+      return '';
+    }
+    const config = this.player.getConfiguration();
+    const positionArea = config && config.textDisplayer ?
+        config.textDisplayer.positionArea : shaka.config.PositionArea.DEFAULT;
+    return shaka.ui.TextPosition.getNameOfPosition(
+        positionArea, this.localization);
+  }
+
+  /** @override */
+  checkAvailability() {
+    const tracks = this.player ? (this.player.getTextTracks() || []) : [];
+    const hasTrack = tracks.some((track) => track.active);
+    const available = hasTrack && !this.isSubMenuOpened &&
+        this.controls.getConfig().captionsStyles;
+    shaka.ui.Utils.setDisplay(this.button, available);
+  }
+
+  /** @override */
+  onMenuOpen() {
+    this.showPage_(shaka.ui.CaptionStyle.Page_.ROOT);
+  }
+
+  /** @override */
+  onMenuClose() {
+    this.controls.hideTextStylePreview();
+    this.currentPage_ = shaka.ui.CaptionStyle.Page_.ROOT;
+  }
+
+  /** @override */
+  updateLocalizedStrings() {
+    const LocIds = shaka.ui.Locales.Ids;
+
+    this.backButton.ariaLabel = this.localization.resolve(LocIds.BACK);
+
+    const styleLabel = this.localization.resolve(LocIds.SUBTITLE_STYLE);
+    this.button.ariaLabel = styleLabel;
+    this.nameSpan.textContent = styleLabel;
+
+    this.sizeNameSpan_.textContent =
+        this.localization.resolve(LocIds.SUBTITLE_SIZE);
+    this.positionNameSpan_.textContent =
+        this.localization.resolve(LocIds.SUBTITLE_POSITION);
+
+    // Update position button labels with newly resolved strings.
+    const positions = Object.values(shaka.config.PositionArea);
+    for (let i = 0;
+      i < positions.length && i < this.positionButtons_.length;
+      i++) {
+      const span = this.positionButtons_[i].querySelector('span');
+      if (span) {
+        span.textContent = shaka.ui.TextPosition.getNameOfPosition(
+            positions[i], this.localization);
+      }
+    }
+
+    this.render_();
+  }
+
+  /** @override */
+  release() {
+    this.sizeIcon_ = null;
+    this.positionIcon_ = null;
+    this.sizeButton_ = null;
+    this.positionButton_ = null;
+    this.sizeNameSpan_ = null;
+    this.sizeValueSpan_ = null;
+    this.positionNameSpan_ = null;
+    this.positionValueSpan_ = null;
+    this.sizeButtons_ = [];
+    this.positionButtons_ = [];
+    super.release();
+  }
+};
+
+
+/**
+ * @enum {string}
+ * @private
+ */
+shaka.ui.CaptionStyle.Page_ = {
+  ROOT: 'root',
+  SIZE: 'size',
+  POSITION: 'position',
+};
+
+
+/**
+ * @implements {shaka.extern.IUIElement.Factory}
+ * @final
+ */
+shaka.ui.CaptionStyle.Factory = class {
+  /** @override */
+  create(rootElement, controls) {
+    return new shaka.ui.CaptionStyle(rootElement, controls);
+  }
+};
+
+shaka.ui.OverflowMenu.registerElement(
+    'captions-style', new shaka.ui.CaptionStyle.Factory());
+
+shaka.ui.Controls.registerElement(
+    'captions-style', new shaka.ui.CaptionStyle.Factory());

--- a/ui/enums.js
+++ b/ui/enums.js
@@ -60,3 +60,6 @@ shaka.ui.Enums.MaterialDesignSVGIcons = {
 // Same icon as position for now; aliased to avoid duplicating the path.
 shaka.ui.Enums.MaterialDesignSVGIcons['CLOSED_CAPTIONS_SIZE'] =
     shaka.ui.Enums.MaterialDesignSVGIcons['CLOSED_CAPTIONS_POSITION'];
+
+shaka.ui.Enums.MaterialDesignSVGIcons['CLOSED_CAPTIONS_STYLE'] =
+    shaka.ui.Enums.MaterialDesignSVGIcons['CLOSED_CAPTIONS_POSITION'];

--- a/ui/less/overflow_menu.less
+++ b/ui/less/overflow_menu.less
@@ -221,6 +221,10 @@
     }
   }
 
+  .shaka-overflow-button-label-inline span {
+    margin-left: 0;
+  }
+
   .shaka-chapter-item {
     display: flex;
     align-items: center;

--- a/ui/locales/en.json
+++ b/ui/locales/en.json
@@ -64,6 +64,7 @@
   "SUBTITLES_EXAMPLE": "Subtitles example",
   "SUBTITLE_POSITION": "Subtitle position",
   "SUBTITLE_SIZE": "Subtitle size",
+  "SUBTITLE_STYLE": "Subtitle style",
   "SURROUND": "Surround",
   "TOGGLE_STEREOSCOPIC": "Toggle stereoscopic",
   "TOP_CENTER": "Top center",

--- a/ui/locales/source.json
+++ b/ui/locales/source.json
@@ -243,6 +243,10 @@
     "description": "Label for a button used to indicate a subtitle size.",
     "message": "Subtitle size"
   },
+  "SUBTITLE_STYLE": {
+    "description": "Label for a button used to access subtitle style settings (size, position, etc.).",
+    "message": "Subtitle style"
+  },
   "SURROUND": {
     "description": "Label used to identify a audio track that has surround audio.",
     "message": "Surround"

--- a/ui/settings_menu.js
+++ b/ui/settings_menu.js
@@ -132,7 +132,11 @@ shaka.ui.SettingsMenu = class extends shaka.ui.MenuBase {
     this.backButton = shaka.util.Dom.createButton();
     this.backButton.classList.add('shaka-back-to-overflow-button');
     this.menu.appendChild(this.backButton);
-    this.eventManager.listen(this.backButton, 'click', () => {
+    this.eventManager.listen(this.backButton, 'click', (event) => {
+      if (this.onBackButtonClick(event)) {
+        event.stopPropagation();
+        return;
+      }
       this.controls.hideSettingsMenus();
       this.backButton.focus();
     });
@@ -251,6 +255,18 @@ shaka.ui.SettingsMenu = class extends shaka.ui.MenuBase {
 
   /** @protected */
   onMenuClose() {}
+
+  /**
+   * Called when the back button is clicked. If this method returns true,
+   * the default action of closing the menu is prevented.
+   *
+   * @param {!Event} event
+   * @return {boolean}
+   * @protected
+   */
+  onBackButtonClick(event) {
+    return false;
+  }
 
   /** @override */
   adjustCustomStyle() {

--- a/ui/text_position.js
+++ b/ui/text_position.js
@@ -14,6 +14,7 @@ goog.require('shaka.ui.Locales');
 goog.require('shaka.ui.OverflowMenu');
 goog.require('shaka.ui.TextStyleMenu');
 goog.requireType('shaka.ui.Controls');
+goog.requireType('shaka.ui.Localization');
 
 
 /**
@@ -79,35 +80,48 @@ shaka.ui.TextPosition = class extends shaka.ui.TextStyleMenu {
   }
 
   /**
-   * @param {!shaka.config.PositionArea} position
+   * @param {shaka.config.PositionArea} position
+   * @param {shaka.ui.Localization} localization
+   * @return {string}
+   * @export
+   */
+  static getNameOfPosition(position, localization) {
+    if (!localization) {
+      return '';
+    }
+    const LocIds = shaka.ui.Locales.Ids;
+    switch (position) {
+      case shaka.config.PositionArea.DEFAULT:
+        return localization.resolve(LocIds.DEFAULT);
+      case shaka.config.PositionArea.TOP_LEFT:
+        return localization.resolve(LocIds.TOP_LEFT);
+      case shaka.config.PositionArea.TOP_CENTER:
+        return localization.resolve(LocIds.TOP_CENTER);
+      case shaka.config.PositionArea.TOP_RIGHT:
+        return localization.resolve(LocIds.TOP_RIGHT);
+      case shaka.config.PositionArea.CENTER_LEFT:
+        return localization.resolve(LocIds.CENTER_LEFT);
+      case shaka.config.PositionArea.CENTER:
+        return localization.resolve(LocIds.CENTER);
+      case shaka.config.PositionArea.CENTER_RIGHT:
+        return localization.resolve(LocIds.CENTER_RIGHT);
+      case shaka.config.PositionArea.BOTTOM_LEFT:
+        return localization.resolve(LocIds.BOTTOM_LEFT);
+      case shaka.config.PositionArea.BOTTOM_CENTER:
+        return localization.resolve(LocIds.BOTTOM_CENTER);
+      case shaka.config.PositionArea.BOTTOM_RIGHT:
+        return localization.resolve(LocIds.BOTTOM_RIGHT);
+    }
+    return '';
+  }
+
+  /**
+   * @param {shaka.config.PositionArea} position
    * @return {string}
    * @private
    */
   getNameOfPosition_(position) {
-    const LocIds = shaka.ui.Locales.Ids;
-    switch (position) {
-      case shaka.config.PositionArea.DEFAULT:
-        return this.localization.resolve(LocIds.DEFAULT);
-      case shaka.config.PositionArea.TOP_LEFT:
-        return this.localization.resolve(LocIds.TOP_LEFT);
-      case shaka.config.PositionArea.TOP_CENTER:
-        return this.localization.resolve(LocIds.TOP_CENTER);
-      case shaka.config.PositionArea.TOP_RIGHT:
-        return this.localization.resolve(LocIds.TOP_RIGHT);
-      case shaka.config.PositionArea.CENTER_LEFT:
-        return this.localization.resolve(LocIds.CENTER_LEFT);
-      case shaka.config.PositionArea.CENTER:
-        return this.localization.resolve(LocIds.CENTER);
-      case shaka.config.PositionArea.CENTER_RIGHT:
-        return this.localization.resolve(LocIds.CENTER_RIGHT);
-      case shaka.config.PositionArea.BOTTOM_LEFT:
-        return this.localization.resolve(LocIds.BOTTOM_LEFT);
-      case shaka.config.PositionArea.BOTTOM_CENTER:
-        return this.localization.resolve(LocIds.BOTTOM_CENTER);
-      case shaka.config.PositionArea.BOTTOM_RIGHT:
-        return this.localization.resolve(LocIds.BOTTOM_RIGHT);
-    }
-    return '';
+    return shaka.ui.TextPosition.getNameOfPosition(position, this.localization);
   }
 };
 

--- a/ui/text_style.js
+++ b/ui/text_style.js
@@ -40,6 +40,7 @@ shaka.ui.TextStyleMenu = class extends shaka.ui.SettingsMenu {
           'unloading',
           'configurationchanged',
           'trackschanged',
+          'textchanged',
         ], () => {
           this.updateCurrentSelection_();
           this.checkAvailability();


### PR DESCRIPTION
## Pull Request Type

- [x] Feature

## Related Issue

Discussion in (https://github.com/FreeTubeApp/FreeTube/pull/9120#issuecomment-4480409617)
where adding separate `captions-size` and `captions-position` buttons made the overflow menu too full when subtitles were enabled.

## Description

This PR adds a **Subtitle style** (`captions-style`) submenu to Shaka Player.

Right now, subtitle size and subtitle position are two separate buttons. When I was adding them to FreeTube in [FreeTube#9723](https://github.com/FreeTubeApp/FreeTube/pull/9723), the menu got too full once subtitles were turned on. Making a single submenu for them like YouTube does is a much cleaner option.

What this PR does:
- Adds a single **Subtitle style** button to the player menu with the CC settings icon.
- Shows current values on the menu button (e.g. `100% · Default`).
- Clicking it opens a submenu with **Size** and **Position** options.
- When you hover or focus an option, you can preview the change without saving it (same as [#10077](https://github.com/shaka-project/shaka-player/pull/10077)).
- Clicking the back button inside Size or Position takes you back to Subtitle style instead of closing the whole menu.
- Keyboard focus is properly kept inside the menu even if the player scale isn't in the default options.
- The button only shows up when subtitles are on, and hides when they are off.

## Testing

1. Open a video with subtitles and enable them.
2. Open the player menu and confirm **Subtitle style** is visible with current settings (e.g. `100% · Default`).
3. Click **Subtitle style** and confirm **Size** and **Position** options are shown.
4. Click **Size** (or **Position**) and check that preview works on hover and keyboard focus.
5. Click back and confirm it goes back to Subtitle style without closing the menu.
6. Click back again and confirm it returns to the main player menu.
7. Select an option and confirm the change is saved and updated on the main menu button.
8. Turn off subtitles and confirm the button is hidden.

Before:


https://github.com/user-attachments/assets/8c87aa37-ebfa-426e-9c7b-90dfac0e99be



After:


https://github.com/user-attachments/assets/a46b9010-6007-4071-a017-99e5b5817578



Tests:
- Added 6 unit tests in `test/ui/ui_unit.js`.
- All UI controls tests pass.
- Linter and spell checks pass with 0 errors.

## Desktop

- **OS:** Windows
- **OS Version:** 11

## Additional Context

Grouping size and position into one submenu keeps the player menu clean, matches YouTube's player UX, and leaves room for more subtitle settings in the future without cluttering the menu.

also apologies I linked the wrong PR link in related issue previously, I have corrected it now