### PR TITLE
fix(Ads): Report the last ad of a pod as complete

### DIFF
--- a/lib/ads/svta_ad_manager.js
+++ b/lib/ads/svta_ad_manager.js
@@ -470,6 +470,18 @@ shaka.ads.SvtaAdManager = class {
         this.unSetupCurrentTracking_(/* complete= */ true);
       }
     });
+
+    this.trackingEventManager_.listenOnce(this.video_, 'ended', () => {
+      // 'timeupdate' stops before the very end of the media, so the last
+      // tracking window of a presentation would never reach 100%. Reaching the
+      // end of the media is a completion, not a skip.
+      if (completionPercent_ < 100) {
+        completionPercent_ = 100;
+        this.sendEvent_(shaka.ads.Utils.AD_STOPPED);
+        this.sendEvent_(shaka.ads.Utils.AD_COMPLETE);
+        this.unSetupCurrentTracking_(/* complete= */ true);
+      }
+    });
   }
 
 

--- a/lib/media/playhead_observer.js
+++ b/lib/media/playhead_observer.js
@@ -87,6 +87,15 @@ shaka.media.PlayheadObserverManager = class {
         this.pollingLoop_.tickEvery(/* seconds= */ 0.25);
       }
     });
+    this.eventManager_.listen(mediaElement, 'ended', () => {
+      // The end of the media fires 'pause' too, which has already stopped the
+      // polling loop, so the last poll landed short of the end. Poll once more
+      // using the duration, so that regions that start at the very end of the
+      // presentation are still entered. Using the duration rather than the
+      // current time also covers media that ends a few milliseconds before its
+      // declared duration.
+      this.pollAllObservers_(/* seeking= */ false, mediaElement.duration);
+    });
   }
 
   /** @override */
@@ -128,10 +137,14 @@ shaka.media.PlayheadObserverManager = class {
 
   /**
    * @param {boolean} seeking
+   * @param {number=} position The position to poll with, in seconds. Ignored
+   *   when it is not a finite number, in which case the current time of the
+   *   media element is used.
    * @private
    */
-  pollAllObservers_(seeking) {
-    const currentTime = this.mediaElement_.currentTime;
+  pollAllObservers_(seeking, position) {
+    const currentTime = isFinite(position) ?
+        Number(position) : this.mediaElement_.currentTime;
     for (const observer of this.observers_) {
       observer.poll(currentTime, seeking);
     }

--- a/test/ads/svta_ad_manager_unit.js
+++ b/test/ads/svta_ad_manager_unit.js
@@ -507,4 +507,55 @@ describe('SVTA Ad manager', () => {
       expect(onEventSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('tracking', () => {
+    /**
+     * @param {string} name
+     * @param {number} value
+     */
+    function overrideVideoProperty(name, value) {
+      Object.defineProperty(video, name, {
+        value,
+        configurable: true,
+      });
+    }
+
+    beforeEach(() => {
+      spyOn(player, 'isLive').and.returnValue(false);
+      spyOn(player, 'isEnded').and.returnValue(false);
+      spyOn(player, 'seekRange').and.returnValue({start: 0, end: 20});
+      overrideVideoProperty('duration', 20);
+      overrideVideoProperty('currentTime', 1);
+    });
+
+    // 'timeupdate' stops before the very end of the media, so a tracking
+    // window that ends with the presentation would never reach 100% and would
+    // be torn down as a skip instead of a completion.
+    // https://github.com/shaka-project/shaka-player/issues/10545
+    it('completes when the media ends', async () => {
+      const metadata = {
+        type: 'urn:svta:advertising-wg:ad-creative-signaling',
+        startTime: 0,
+        endTime: 5,
+        values: [
+          {
+            key: 'X-AD-CREATIVE-SIGNALING',
+            data: window.btoa(JSON.stringify(creativeSignalingSimple)),
+          },
+        ],
+      };
+      await svtaAdManager.addMetadata(metadata);
+
+      const eventTypes = () => onEventSpy.calls.allArgs().map((args) => {
+        return args[0].type;
+      });
+
+      expect(eventTypes()).not.toContain(shaka.ads.Utils.AD_COMPLETE);
+
+      video.dispatchEvent(new Event('ended'));
+
+      expect(eventTypes()).toContain(shaka.ads.Utils.AD_COMPLETE);
+      expect(eventTypes()).not.toContain(shaka.ads.Utils.AD_SKIPPED);
+    });
+  });
 });

--- a/test/media/playhead_observer_unit.js
+++ b/test/media/playhead_observer_unit.js
@@ -1,0 +1,68 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('PlayheadObserverManager', () => {
+  /** @type {!shaka.test.FakeVideo} */
+  let video;
+  /** @type {!shaka.media.PlayheadObserverManager} */
+  let manager;
+  /** @type {!jasmine.Spy} */
+  let pollSpy;
+
+  beforeEach(() => {
+    video = new shaka.test.FakeVideo();
+    // Start paused so that the manager does not schedule its polling loop; we
+    // drive the polls from the events under test.
+    video.paused = true;
+
+    manager = new shaka.media.PlayheadObserverManager(
+        /** @type {!HTMLMediaElement} */(/** @type {?} */(video)));
+
+    pollSpy = jasmine.createSpy('poll');
+    const observer = /** @type {!shaka.media.IPlayheadObserver} */ ({
+      poll: shaka.test.Util.spyFunc(pollSpy),
+      release: () => {},
+    });
+    manager.manage(observer);
+  });
+
+  afterEach(() => {
+    manager.release();
+  });
+
+  // The end of the media also fires 'pause', which stops the polling loop, so
+  // the last poll of the loop lands short of the end. Without a poll on
+  // 'ended', a region that starts at the very end of the presentation is never
+  // entered.
+  it('polls with the duration when playback ends', () => {
+    video.currentTime = 19.9;
+    video.duration = 20;
+
+    video.on['ended']();
+
+    expect(pollSpy).toHaveBeenCalledTimes(1);
+    expect(pollSpy).toHaveBeenCalledWith(20, false);
+  });
+
+  it('polls with the current time when the duration is not finite', () => {
+    video.currentTime = 19.9;
+    video.duration = Infinity;
+
+    video.on['ended']();
+
+    expect(pollSpy).toHaveBeenCalledTimes(1);
+    expect(pollSpy).toHaveBeenCalledWith(19.9, false);
+  });
+
+  it('polls with the current time on seek', () => {
+    video.currentTime = 10;
+    video.duration = 20;
+
+    manager.notifyOfSeek(/* seeking= */ true);
+
+    expect(pollSpy).toHaveBeenCalledWith(10, true);
+  });
+});


### PR DESCRIPTION
The end of the media fires 'pause' and 'ended', and nothing observes the playhead at the final instant, so a tracking point that falls at the end of the presentation is never reached. In a pod that is exactly the last creative's `complete`.

Poll the playhead observers once more on 'ended', using the duration, so that a region starting at the presentation end is still entered; this also fixes a DASH EventStream event at the end of any VoD presentation. In the SVTA manager, treat the end of the media as a completion of the current tracking window rather than letting it be torn down as a skip.

Closes #10545