### PR TITLE
fix: Try every preferredText entry when choosing the text track

### DIFF
--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -816,27 +816,15 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
    */
   chooseTextStream_(initialVariant) {
     let textStream = null;
-    const preferredText = this.config_.preferredText;
-
-    // Try each preferred text entry in order
-    for (const pref of preferredText) {
-      if (!pref.language) {
-        continue;
-      }
-      const subset = shaka.util.StreamUtils.filterStreamsByLanguageAndRole(
-          this.manifest_.textStreams,
-          pref.language,
-          pref.role,
-          pref.forced);
-      if (subset.length) {
-        textStream = subset[0];
-        break;
-      }
+    let subset = shaka.util.StreamUtils.filterStreamsByTextPreferences(
+        this.manifest_.textStreams, this.config_.preferredText);
+    if (subset.length) {
+      textStream = subset[0];
     }
 
     if (!textStream && initialVariant?.audio &&
         this.config_.accessibility.handleForcedSubtitlesAutomatically) {
-      const subset = shaka.util.StreamUtils.filterStreamsByLanguageAndRole(
+      subset = shaka.util.StreamUtils.filterStreamsByLanguageAndRole(
           this.manifest_.textStreams,
           initialVariant.audio.language,
           /* preferredRole= */ '',

--- a/lib/player.js
+++ b/lib/player.js
@@ -994,18 +994,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     shaka.util.PlayerConfiguration.addDeprecatedConfigFields(criteriaConfig);
     this.currentAdaptationSetCriteria_.configure(criteriaConfig);
 
-    /** @private {string} */
-    this.currentTextLanguage_ =
-        this.config_.preferredText[0]?.language || '';
-
-    /** @private {string} */
-    this.currentTextRole_ =
-        this.config_.preferredText[0]?.role || '';
-
-    /** @private {boolean} */
-    this.currentTextForced_ =
-        this.config_.preferredText[0]?.forced || false;
-
     /** @private {!Array<function(): (!Promise | undefined)>} */
     this.cleanupOnUnload_ = [];
 
@@ -3106,15 +3094,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // depending on the config.
     this.setupLcevc_(this.config_, isLcevcDualTrack);
 
-    this.currentTextLanguage_ =
-        (this.config_.preferredText[0] &&
-        this.config_.preferredText[0].language) || '';
-    this.currentTextRole_ =
-        (this.config_.preferredText[0] &&
-        this.config_.preferredText[0].role) || '';
-    this.currentTextForced_ =
-        this.config_.preferredText[0]?.forced || false;
-
     shaka.Player.applyPlayRange_(this.manifest_.presentationTimeline,
         this.config_.playRangeStart,
         this.config_.playRangeEnd);
@@ -3856,22 +3835,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return;
     }
 
-    const preferredText = this.config_.preferredText;
-
-    // Try each preferred text entry in order
-    for (const pref of preferredText) {
-      if (!pref.language) {
-        continue;
-      }
-      const subset = shaka.util.StreamUtils.filterStreamsByLanguageAndRole(
-          textTracks,
-          pref.language,
-          pref.role,
-          pref.forced);
-      if (subset.length) {
-        this.selectTextTrack(subset[0]);
-        return;
-      }
+    let subset = shaka.util.StreamUtils.filterStreamsByTextPreferences(
+        textTracks, this.config_.preferredText);
+    if (subset.length) {
+      this.selectTextTrack(subset[0]);
+      return;
     }
 
     if (this.video_ && this.video_.audioTracks &&
@@ -3879,7 +3847,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const audioTracks = Array.from(this.video_.audioTracks);
       const activeAudio = audioTracks.find((t) => t.enabled);
       if (activeAudio) {
-        const subset = shaka.util.StreamUtils.filterStreamsByLanguageAndRole(
+        subset = shaka.util.StreamUtils.filterStreamsByLanguageAndRole(
             textTracks,
             activeAudio.language,
             /* preferredRole= */ '',
@@ -6117,12 +6085,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.streamingEngine_.switchTextStream(stream);
       this.onTextChanged_();
       this.setTextDisplayerLanguage_();
-
-      // Workaround for
-      // https://github.com/shaka-project/shaka-player/issues/1299
-      // When track is selected, back-propagate the language to
-      // currentTextLanguage_.
-      this.currentTextLanguage_ = stream.language;
       this.setTextTrackVisibility_(true);
     };
     const selectSrcEqualsMode = () => {
@@ -6919,11 +6881,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         } else {
           // Find the text stream that best matches the user's preferences.
           const streams =
-                shaka.util.StreamUtils.filterStreamsByLanguageAndRole(
-                    this.manifest_.textStreams,
-                    this.currentTextLanguage_,
-                    this.currentTextRole_,
-                    this.currentTextForced_);
+                shaka.util.StreamUtils.filterStreamsByTextPreferences(
+                    this.manifest_.textStreams, this.config_.preferredText);
 
           // It is possible that there are no streams to play.
           if (streams.length > 0) {
@@ -8658,7 +8617,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
   /**
    * Choose a text stream from all possible text streams while taking into
-   * account user preference.
+   * account user preference.  Each entry of preferredText is tried in order,
+   * and the first one that matches any text stream wins.
    *
    * @param {!shaka.extern.Variant} initialVariant
    * @return {?shaka.extern.Stream}
@@ -8666,11 +8626,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    */
   chooseTextStream_(initialVariant) {
     let textStream = null;
-    let subset = shaka.util.StreamUtils.filterStreamsByLanguageAndRole(
-        this.manifest_.textStreams,
-        this.currentTextLanguage_,
-        this.currentTextRole_,
-        this.currentTextForced_);
+    let subset = shaka.util.StreamUtils.filterStreamsByTextPreferences(
+        this.manifest_.textStreams, this.config_.preferredText);
     if (subset.length) {
       textStream = subset[0];
     }

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1862,6 +1862,35 @@ shaka.util.StreamUtils = class {
 
 
   /**
+   * Choose the streams that best match the given text preferences.  Each
+   * preference is tried in order, and the first one that matches any stream
+   * wins.
+   *
+   * Works both for Stream and Track types due to their similarities.
+   *
+   * @param {!Array<!shaka.extern.Stream>|!Array<!shaka.extern.Track>} streams
+   * @param {!Array<!shaka.extern.TextPreference>} preferences
+   * @return {!Array<!shaka.extern.Stream>|!Array<!shaka.extern.Track>}
+   */
+  static filterStreamsByTextPreferences(streams, preferences) {
+    for (const pref of preferences) {
+      if (!pref.language) {
+        continue;
+      }
+      const subset = shaka.util.StreamUtils.filterStreamsByLanguageAndRole(
+          streams,
+          pref.language,
+          pref.role || '',
+          pref.forced || false);
+      if (subset.length) {
+        return subset;
+      }
+    }
+    return [];
+  }
+
+
+  /**
    * Filter Streams by role.
    * Works both for Stream and Track types due to their similarities.
    *

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -3226,6 +3226,35 @@ describe('Player', () => {
       }));
     });
 
+    it('chooses the first available configured text language at start',
+        async () => {
+          player.configure({
+            preferredText: [
+              {
+                language: 'fi',
+                role: '',
+                format: '',
+                forced: false,
+              },
+              {
+                language: 'en',
+                role: 'commentary',
+                format: '',
+                forced: false,
+              },
+            ],
+          });
+
+          await player.load(fakeManifestUri, 0, fakeMimeType);
+
+          // The first preference is not available, so the second one is used.
+          expect(getActiveTextTrack()).toEqual(jasmine.objectContaining({
+            id: 52,
+            language: 'en',
+            roles: ['commentary'],
+          }));
+        });
+
     it('chooses a variant with preferred audio label', async () => {
       expect(getActiveVariantTrack().label).toBe(null);
 

--- a/test/util/stream_utils_unit.js
+++ b/test/util/stream_utils_unit.js
@@ -243,6 +243,62 @@ describe('StreamUtils', () => {
         });
   });
 
+  describe('filterStreamsByTextPreferences', () => {
+    beforeEach(() => {
+      manifest = shaka.test.ManifestGenerator.generate((manifest) => {
+        manifest.addTextStream(1, (stream) => {
+          stream.language = 'en';
+        });
+        manifest.addTextStream(2, (stream) => {
+          stream.language = 'es';
+        });
+      });
+    });
+
+    it('uses the first preference that matches', () => {
+      const chosen = StreamUtils.filterStreamsByTextPreferences(
+          manifest.textStreams, [
+            {language: 'fi', role: '', format: '', forced: false},
+            {language: 'es', role: '', format: '', forced: false},
+          ]);
+      expect(chosen.length).toBe(1);
+      expect(chosen[0]).toBe(manifest.textStreams[1]);
+    });
+
+    it('supports preferences without role and forced', () => {
+      const chosen = StreamUtils.filterStreamsByTextPreferences(
+          manifest.textStreams, [
+            /** @type {shaka.extern.TextPreference} */ ({language: 'en'}),
+          ]);
+      expect(chosen.length).toBe(1);
+      expect(chosen[0]).toBe(manifest.textStreams[0]);
+    });
+
+    it('skips preferences without a language', () => {
+      const chosen = StreamUtils.filterStreamsByTextPreferences(
+          manifest.textStreams, [
+            {language: '', role: 'caption', format: '', forced: false},
+            {language: 'en', role: '', format: '', forced: false},
+          ]);
+      expect(chosen.length).toBe(1);
+      expect(chosen[0]).toBe(manifest.textStreams[0]);
+    });
+
+    it('returns nothing when no preference matches', () => {
+      const chosen = StreamUtils.filterStreamsByTextPreferences(
+          manifest.textStreams, [
+            {language: 'fi', role: '', format: '', forced: false},
+          ]);
+      expect(chosen.length).toBe(0);
+    });
+
+    it('returns nothing without preferences', () => {
+      const chosen = StreamUtils.filterStreamsByTextPreferences(
+          manifest.textStreams, []);
+      expect(chosen.length).toBe(0);
+    });
+  });
+
   describe('getDecodingInfosForVariants', () => {
     it('for multiplexed content', async () => {
       manifest = shaka.test.ManifestGenerator.generate((manifest) => {


### PR DESCRIPTION
Only the first entry of `preferredText` was taken into account when choosing the initial text track in the MSE path, so a preference list whose first entry is unavailable ended up with the captions off instead of falling back to the next entry.

`Player.chooseTextStream_` still read the pre- #9542 `currentTextLanguage_` / `currentTextRole_` / `currentTextForced_` fields, which were only seeded from `preferredText[0]`. Those fields are now gone, and all three text selection paths (MSE, src= and the preload manager) share a single `StreamUtils.filterStreamsByTextPreferences` helper that tries each preference in order.

The helper also defaults `role` and `forced` per entry. The already-migrated loops passed them through untouched, and since `forced` is always a boolean on streams and tracks, a partial preference such as `{language: 'en'}` compared `false == undefined` and matched nothing — which meant no text track was selected at all in src=.

Closes #10544