### PR TITLE
fix(Mp4Parser): Don't hang on a 64-bit largesize of 0

### DIFF
--- a/lib/util/mp4_parser.js
+++ b/lib/util/mp4_parser.js
@@ -225,9 +225,11 @@ shaka.util.Mp4Parser = class {
       // If the box is longer than the remaining parts of the file, e.g. the
       // mp4 is improperly formatted, or this was a partial range request that
       // ended in the middle of a box, just skip to the end.
-      const skipLength = Math.min(
+      // A malformed size (e.g. a 64-bit largesize of 0) can make this
+      // negative, which would move the read head backwards and loop forever.
+      const skipLength = Math.max(0, Math.min(
           start + size - reader.getPosition(),
-          reader.getLength() - reader.getPosition());
+          reader.getLength() - reader.getPosition()));
       reader.skip(skipLength);
     }
   }

--- a/test/util/mp4_parser_unit.js
+++ b/test/util/mp4_parser_unit.js
@@ -304,6 +304,19 @@ describe('Mp4Parser', () => {
       expect(box3).toHaveBeenCalled();
     });
 
+    it('does not loop forever on a 64-bit largesize of 0', () => {
+      // A largesize of 0 is invalid; it must not drive the read head
+      // backwards, which used to hang the parser.  See #10542.
+      const badBox = new Uint8Array([
+        0x00, 0x00, 0x00, 0x01, // size == 1, so a largesize follows
+        0x6D, 0x6F, 0x6F, 0x66, // type 'moof' (undefined in this parser)
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, // largesize == 0
+      ]);
+
+      expect(() => new shaka.util.Mp4Parser().parse(badBox)).not.toThrow();
+    });
+
     it('skips undefined top level boxes', () => {
       // By leaving a single box undefined, it should not interfere
       // with the other boxes (on the same level) from being read.


### PR DESCRIPTION
A box with size == 1 and a largesize of 0 made the skip for an undefined box negative, moving the read head backwards instead of forwards, so parse() looped over the same header forever and blocked the main thread. DataViewReader.skip() only guards the upper bound, and its assert is compiled out of release builds.

Clamp the skip to zero. parseNext() always consumes at least the 8-byte header, so this is the only path that could move the read head backwards; with it clamped, progress is monotonic for any malformed size.

Closes #10542