### PR TITLE
fix: Don't fall back to another role when the preferred text role is unmatched

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1766,6 +1766,9 @@ shaka.util.StreamUtils = class {
    * Chooses streams according to the given config.
    * Works both for Stream and Track types due to their similarities.
    *
+   * The language, role and forced preferences are all strict requirements: if
+   * any of them cannot be matched, an empty array is returned.
+   *
    * @param {!Array<!shaka.extern.Stream>|!Array<!shaka.extern.Track>} streams
    * @param {string} preferredLanguage
    * @param {string} preferredRole
@@ -1827,28 +1830,25 @@ shaka.util.StreamUtils = class {
       return stream.forced == preferredForced;
     });
 
-    // Now refine the choice based on role preference.
+    // Now refine the choice based on role preference.  A role preference is a
+    // strict requirement: if no stream carries the requested role, this
+    // preference cannot be satisfied, and the caller is free to move on to the
+    // next entry of its preference list.
     if (preferredRole) {
-      const roleMatches = shaka.util.StreamUtils.filterStreamsByRole_(
-          chosen, preferredRole);
-      if (roleMatches.length) {
-        return roleMatches;
-      } else {
-        shaka.log.warning('No exact match for the text role could be found.');
-      }
-    } else {
-      // Prefer text streams with no roles, if they exist.
-      const noRoleMatches = chosen.filter((stream) => {
-        return stream.roles.length == 0;
-      });
-      if (noRoleMatches.length) {
-        return noRoleMatches;
-      }
+      return shaka.util.StreamUtils.filterStreamsByRole_(chosen, preferredRole);
     }
 
-    // Either there was no role preference, or it could not be satisfied.
-    // Choose an arbitrary role, if there are any, and filter out any other
-    // roles. This ensures we never adapt between roles.
+    // There is no role preference.  Prefer streams with no roles, if they
+    // exist.
+    const noRoleMatches = chosen.filter((stream) => {
+      return stream.roles.length == 0;
+    });
+    if (noRoleMatches.length) {
+      return noRoleMatches;
+    }
+
+    // Every stream has a role.  Choose an arbitrary role, if there are any, and
+    // filter out any other roles. This ensures we never adapt between roles.
 
     const allRoles = chosen.map((stream) => {
       return stream.roles;

--- a/test/util/stream_utils_unit.js
+++ b/test/util/stream_utils_unit.js
@@ -135,7 +135,8 @@ describe('StreamUtils', () => {
       expect(chosen[0].roles.length).toBe(0); // Pick a stream with no role.
     });
 
-    it('ignores no-role streams if there is a preferred role', () => {
+    // Regression test for https://github.com/shaka-project/shaka-player/issues/9993
+    it('chooses nothing if the preferred role is not present', () => {
       manifest = shaka.test.ManifestGenerator.generate((manifest) => {
         manifest.addTextStream(0, (stream) => {
           stream.language = 'en';
@@ -154,8 +155,7 @@ describe('StreamUtils', () => {
           manifest.textStreams,
           'en',
           'main', false); // A role that is not present.
-      expect(chosen.length).toBe(1);
-      expect(chosen[0].roles.length).toBe(1); // Pick a stream with a role.
+      expect(chosen.length).toBe(0);
     });
 
     it('chooses only one role, even if none is preferred', () => {
@@ -290,6 +290,40 @@ describe('StreamUtils', () => {
             {language: 'fi', role: '', format: '', forced: false},
           ]);
       expect(chosen.length).toBe(0);
+    });
+
+    // Regression test for https://github.com/shaka-project/shaka-player/issues/9993
+    it('returns nothing when the language matches but the role does not',
+        () => {
+          manifest = shaka.test.ManifestGenerator.generate((manifest) => {
+            manifest.addTextStream(1, (stream) => {
+              stream.language = 'sv';
+              stream.roles = ['caption'];
+            });
+          });
+
+          const chosen = StreamUtils.filterStreamsByTextPreferences(
+              manifest.textStreams, [
+                {language: 'sv', role: 'main', format: '', forced: false},
+              ]);
+          expect(chosen.length).toBe(0);
+        });
+
+    it('falls back to the next preference if a role does not match', () => {
+      manifest = shaka.test.ManifestGenerator.generate((manifest) => {
+        manifest.addTextStream(1, (stream) => {
+          stream.language = 'sv';
+          stream.roles = ['caption'];
+        });
+      });
+
+      const chosen = StreamUtils.filterStreamsByTextPreferences(
+          manifest.textStreams, [
+            {language: 'sv', role: 'main', format: '', forced: false},
+            {language: 'sv', role: '', format: '', forced: false},
+          ]);
+      expect(chosen.length).toBe(1);
+      expect(chosen[0]).toBe(manifest.textStreams[0]);
     });
 
     it('returns nothing without preferences', () => {


### PR DESCRIPTION
When a preference specified a role, filterStreamsByLanguageAndRole fell back to an arbitrary role if that role was not present, so a preference like {language: 'sv', role: 'main'} still enabled a 'caption' track in Swedish. The role is now a strict requirement, matching how PreferenceBasedCriteria already handles audio and video roles, and what the accessibility tutorial already documents. Callers simply move on to the next entry of preferredText/preferredAudio.

The arbitrary-role fallback is kept when no role is preferred, so adaptation between roles is still prevented (issue #949).

Note: setTextTrackVisibility(true) no longer picks an unrelated track when the configured role does not match.

Closes #9993