### PR TITLE
fix(HLS): Support legacy X-CUE for interstitials

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -2447,14 +2447,16 @@ shaka.ads.InterstitialAdManager = class {
   }
 
   /**
-   * Parses the CUE attribute (ONCE/PRE/POST) from HLS metadata.
+   * Parses the CUE attribute (ONCE/PRE/POST) from HLS metadata. X-CUE was
+   * the provisional name and is supported as a fallback for compatibility.
    *
    * @param {shaka.extern.HLSMetadata} hlsMetadata
    * @return {{once: boolean, pre: boolean, post: boolean}}
    * @private
    */
   parseCue_(hlsMetadata) {
-    const cue = this.getMetadataValue_(hlsMetadata, 'CUE');
+    const cue = this.getMetadataValue_(hlsMetadata, 'CUE') ||
+        this.getMetadataValue_(hlsMetadata, 'X-CUE');
     return {
       once: cue != null && cue.includes('ONCE'),
       pre: cue != null && cue.includes('PRE'),

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -4795,7 +4795,10 @@ shaka.hls.HlsParser = class {
           const promise = this.playerInterface_.onMetadata(
               type, startTime, endTime, values);
           let waitForPromise = false;
-          const cue = values.find((v) => v.key == 'CUE');
+          // X-CUE was the provisional name for CUE. Continue to accept it
+          // for compatibility with manifests authored against older drafts.
+          const cue = values.find((v) => v.key == 'CUE') ||
+              values.find((v) => v.key == 'X-CUE');
           if (cue) {
             const data = /** @type {string} */(cue.data);
             if (data.includes('PRE')) {

--- a/test/ads/interstitial_ad_manager_unit.js
+++ b/test/ads/interstitial_ad_manager_unit.js
@@ -104,6 +104,29 @@ describe('Interstitial Ad manager', () => {
           jasmine.objectContaining(eventValue1));
     });
 
+    it('supports legacy X-CUE', async () => {
+      const metadata = {
+        type: 'com.apple.hls.interstitial',
+        startTime: 0,
+        endTime: null,
+        values: [
+          {key: 'ID', data: 'PREROLL'},
+          {key: 'X-CUE', data: 'PRE,ONCE'},
+          {key: 'X-ASSET-URI', data: 'http://foo.bar/test.m3u8'},
+        ],
+      };
+
+      await interstitialAdManager.addMetadata(metadata);
+
+      expect(interstitialAdManager.getInterstitials()).toEqual([
+        jasmine.objectContaining({
+          pre: true,
+          post: false,
+          once: true,
+        }),
+      ]);
+    });
+
     it('supports multiple interstitials', async () => {
       const metadata = {
         type: 'com.apple.quicktime.HLS',

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -7119,6 +7119,35 @@ describe('HlsParser', () => {
       expect(onMetadataSpy).toHaveBeenCalledWith(metadataType, 5, 35, values);
     });
 
+    it('supports legacy X-CUE for interstitials', async () => {
+      const mediaPlaylist = [
+        '#EXTM3U\n',
+        '#EXT-X-TARGETDURATION:5\n',
+        '#EXT-X-PROGRAM-DATE-TIME:2000-01-01T00:00:00.00Z\n',
+        '#EXTINF:5,\n',
+        'video1.ts\n',
+        '#EXT-X-DATERANGE:ID="1",CLASS="com.apple.hls.interstitial",',
+        'START-DATE="2000-01-01T00:00:05.00Z",',
+        'X-ASSET-URI="fake",X-CUE="PRE,ONCE"\n',
+      ].join('');
+
+      fakeNetEngine
+          .setResponseText('test:/master', mediaPlaylist)
+          .setResponseValue('test:/video1.ts', tsSegmentData);
+
+      await parser.start('test:/master', playerInterface);
+
+      expect(onMetadataSpy).toHaveBeenCalledOnceWith(
+          'com.apple.hls.interstitial', 5, null, [
+            jasmine.objectContaining({key: 'ID', data: '1'}),
+            jasmine.objectContaining({
+              key: 'X-ASSET-URI',
+              data: 'test:/fake',
+            }),
+            jasmine.objectContaining({key: 'X-CUE', data: 'PRE,ONCE'}),
+          ]);
+    });
+
     it('supports 1970-01-01T00:00:00.000Z', async () => {
       const mediaPlaylist = [
         '#EXTM3U\n',


### PR DESCRIPTION
Before revision 12, `X-CUE` was used. This was later standardized in RFC8216bis as `CUE`.

This is supported by HLS.js too, see https://github.com/video-dev/hls.js/blob/a31697ff31976526125e4259698882d45391dedd/src/loader/date-range.ts#L117

For a demo stream, check:

```
POST https://hlspresso.green-mode-c2f7.workers.dev/api/v1/sessions
```

```json
{
  "url": "https://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM.m3u8",
  "interstitials": [{
    "time": 0,
    "assets": [{
      "type": "VAST",
      "url": "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&correlator={random}"
    }]
  }]
}
```