### PR TITLE
fix(HLS): Avoid a needless abort() on every append in segments mode

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -85,6 +85,15 @@ shaka.media.MediaSourceEngine = class {
      */
     this.sourceBufferTypes_ = new Map();
 
+    /**
+     * The timestamp offset last requested for each SourceBuffer, before the
+     * legacy Edge rounding workaround in setTimestampOffset_ is applied.  The
+     * value read back from the SourceBuffer includes that workaround, so it
+     * cannot be compared against a freshly calculated offset.
+     *
+     * @private {!Map<shaka.util.ManifestParserUtils.ContentType, number>}
+     */
+    this.requestedTimestampOffsets_ = new Map();
 
     /**
      * @private {!Map<shaka.util.ManifestParserUtils.ContentType,
@@ -474,6 +483,7 @@ shaka.media.MediaSourceEngine = class {
     this.textEngine_ = null;
     this.textDisplayer_ = null;
     this.sourceBuffers_.clear();
+    this.requestedTimestampOffsets_.clear();
     this.expectedEncryption_.clear();
     this.clearKeyDecryptors_.clear();
     this.transmuxers_.clear();
@@ -1317,7 +1327,9 @@ shaka.media.MediaSourceEngine = class {
       }
     }
 
-    let timestampOffset = this.sourceBuffers_.get(contentType).timestampOffset;
+    let timestampOffset = this.requestedTimestampOffsets_.has(contentType) ?
+        this.requestedTimestampOffsets_.get(contentType) :
+        this.sourceBuffers_.get(contentType).timestampOffset;
     let mediaTimestamp = null;
 
     // If we buffered to the end of the presentation the MediaSource was put
@@ -1403,7 +1415,9 @@ shaka.media.MediaSourceEngine = class {
           // fixed compensation between the two tracks measured on the first
           // segment. See https://github.com/shaka-project/shaka-player/issues/10341
           const videoTimestampOffset =
-              this.sourceBuffers_.get(ContentType.VIDEO).timestampOffset;
+              this.requestedTimestampOffsets_.has(ContentType.VIDEO) ?
+                  this.requestedTimestampOffsets_.get(ContentType.VIDEO) :
+                  this.sourceBuffers_.get(ContentType.VIDEO).timestampOffset;
           const compensation = await this.audioCompensation_.promise;
           calculatedTimestampOffset = videoTimestampOffset + compensation;
         } else {
@@ -2122,6 +2136,15 @@ shaka.media.MediaSourceEngine = class {
    * @private
    */
   setTimestampOffset_(contentType, timestampOffset) {
+    // Remember what was asked for, before the workaround below skews it.
+    // Callers compare a newly calculated offset against the current one to
+    // decide whether it actually changed, and the value read back from the
+    // SourceBuffer carries the extra 0.001 forever.  Comparing against it
+    // would report a 0.001 difference on every segment of any stream whose
+    // offset is negative, which is every stream whose media timestamps do not
+    // start near zero.
+    this.requestedTimestampOffsets_.set(contentType, timestampOffset);
+
     // Work around for
     // https://github.com/shaka-project/shaka-player/issues/1281:
     // TODO(https://bit.ly/2ttKiBU): follow up when this is fixed in Edge
@@ -2590,6 +2613,7 @@ shaka.media.MediaSourceEngine = class {
       }
       this.transmuxers_.clear();
       this.sourceBuffers_.clear();
+      this.requestedTimestampOffsets_.clear();
       this.clearKeyDecryptors_.clear();
 
       const previousDuration = this.mediaSource_.duration;

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -1073,6 +1073,60 @@ describe('MediaSourceEngine', () => {
 
       expect(videoSourceBuffer.timestampOffset).toBe(0.50);
     });
+
+    // Regression test for the interaction between the legacy Edge rounding
+    // workaround in setTimestampOffset_ and the per-segment recalculation of
+    // the timestamp offset.  The workaround adds 0.001 to any negative offset
+    // before writing it to the SourceBuffer, so reading it back and comparing
+    // it against a freshly calculated offset reported a 0.001 difference on
+    // every segment.  That difference met the "did it change?" threshold, so
+    // every append was preceded by an abort(), which resets MSE's coded frame
+    // processing and makes it drop everything up to the next keyframe.  On
+    // content whose segments are not cut on a GOP boundary, that dropped the
+    // start of every segment and left a gap in the buffered ranges.
+    it('does not re-set an unchanged negative timestampOffset', async () => {
+      const initObject = new Map();
+      initObject.set(ContentType.VIDEO, fakeVideoStream);
+
+      await mediaSourceEngine.init(initObject, /* sequenceMode= */ false,
+          shaka.media.ManifestParser.HLS);
+
+      // Media timestamps that start far from zero, as in an MPEG-TS stream
+      // carrying a real-time clock, so the offset comes out negative.
+      const mediaStart = 92703.440178;
+      spyOn(mediaSourceEngine, 'getTimestampAndDispatchMetadata')
+          .and.callFake((contentType, data, reference) => {
+            return {timestamp: mediaStart + reference.startTime, metadata: []};
+          });
+
+      const expectedOffset = -mediaStart + 0.001;
+
+      /** @param {number} startTime */
+      const appendSegment = async (startTime) => {
+        const reference = dummyReference(startTime, startTime + 10);
+        const append = mediaSourceEngine.appendBuffer(
+            ContentType.VIDEO, buffer, reference, fakeStream,
+            /* hasClosedCaptions= */ false);
+        videoSourceBuffer.updateend();
+        await append;
+      };
+
+      await appendSegment(0);
+
+      // The offset written to the SourceBuffer carries the Edge workaround.
+      expect(videoSourceBuffer.timestampOffset).toBeCloseTo(expectedOffset, 6);
+      videoSourceBuffer.abort.calls.reset();
+
+      // Every later segment resolves to the same offset, so none of them
+      // should abort or touch timestampOffset again.  These have to be
+      // appended one at a time, since each one needs its own updateend.
+      await appendSegment(10);
+      await appendSegment(20);
+      await appendSegment(30);
+
+      expect(videoSourceBuffer.abort).not.toHaveBeenCalled();
+      expect(videoSourceBuffer.timestampOffset).toBeCloseTo(expectedOffset, 6);
+    });
   });
 
   describe('remove', () => {
@@ -1808,6 +1862,7 @@ describe('MediaSourceEngine', () => {
         'initParser', 'destroy', 'appendBuffer', 'remove', 'setTimestampOffset',
         'setAppendWindow', 'bufferStart', 'bufferEnd', 'bufferedAheadOf',
         'storeAndAppendClosedCaptions', 'setModifyCueCallback',
+        'setContainerIsMpegTs',
       ]);
 
       const resolve = () => Promise.resolve();


### PR DESCRIPTION
The legacy Edge workaround in setTimestampOffset_ (issue #1281) adds 0.001 to any negative timestamp offset before writing it to the SourceBuffer. The per-segment recalculation then read that value back and compared it against a freshly calculated offset, so the difference came out as exactly 0.001 on every segment. That met the ">= 0.001" threshold, so every append was preceded by an abort() plus a redundant setTimestampOffset(), for any stream whose media timestamps do not start near zero.

abort() resets MSE's coded frame processing and raises the "need random access point" flag, making the SourceBuffer drop everything up to the next keyframe. On content whose segments are not cut on a GOP boundary that silently removed the start of every segment, leaving a gap in the buffered ranges (sequence mode hid this, since it skips the recalculation entirely).

Compare against the offset that was requested, tracked separately from the value read back from the SourceBuffer, so the Edge workaround stays in place for legacy Edge on Xbox. The same read-back is used to anchor audio to video for muxed content, and is fixed alongside it.