### PR TITLE
fix(HLS): Avoid TypeError when a media playlist fails during load()

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -9047,6 +9047,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return false;
     }
 
+    if (!this.abrManager_) {
+      // The parser can ask to disable a stream during load(), before the
+      // AbrManager has been created.
+      return false;
+    }
+
     // It only makes sense to disable a stream if we have an alternative else we
     // end up disabling all variants.
     const hasAltStream = this.manifest_.variants.some((variant) => {

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -602,6 +602,22 @@ describe('Player', () => {
         expect(fromAdaptation).toBeFalsy();
       });
 
+      it('does nothing when the AbrManager does not exist yet', async () => {
+        multiVariantManifest();
+
+        await player.load(fakeManifestUri, 0, fakeMimeType);
+
+        const variant = manifest.variants[0];
+        const videoStream = /** @type {shaka.extern.Stream} */ (variant.video);
+
+        // The parser can ask to disable a stream during load(), before the
+        // AbrManager has been created.
+        player.abrManager_ = null;
+
+        expect(player.disableStream(videoStream, disableTimeInSeconds))
+            .toBe(false);
+      });
+
       describe('does not disable stream if there not alternate stream', () => {
         it('single audio multiple videos', async () => {
           manifest = shaka.test.ManifestGenerator.generate((manifest) => {

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -601,7 +601,12 @@ describe('Player', () => {
         expect(forceSwitch).toBeFalsy();
         expect(fromAdaptation).toBeFalsy();
       });
-
+      
+      /** @suppress {accessControls} */
+      function clearAbrManager() {
+        player.abrManager_ = null;
+      }
+      
       it('does nothing when the AbrManager does not exist yet', async () => {
         multiVariantManifest();
 
@@ -612,7 +617,7 @@ describe('Player', () => {
 
         // The parser can ask to disable a stream during load(), before the
         // AbrManager has been created.
-        player.abrManager_ = null;
+        clearAbrManager();
 
         expect(player.disableStream(videoStream, disableTimeInSeconds))
             .toBe(false);

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -601,12 +601,12 @@ describe('Player', () => {
         expect(forceSwitch).toBeFalsy();
         expect(fromAdaptation).toBeFalsy();
       });
-      
+
       /** @suppress {accessControls} */
       function clearAbrManager() {
         player.abrManager_ = null;
       }
-      
+
       it('does nothing when the AbrManager does not exist yet', async () => {
         multiVariantManifest();
 


### PR DESCRIPTION
## Problem

When an HLS media playlist fails to download during `load()`, the parser bans the
stream via `playerInterface.disableStream()` (`lib/hls/hls_parser.js`, inside
`downloadSegmentIndex`). That reaches `Player.disableStream()`, which calls
`chooseVariantAndSwitch_()` → `chooseVariant_()` → `updateAbrManagerVariants_()`,
where `this.abrManager_.setVariants(...)` is dereferenced unconditionally.

`abrManager_` is null during a window inside `load()`:

    this.manifest_ = preloadManager.getManifest();   // manifest_ is now set
    ... await initializeMediaSourceEngineInner_()
    ... await preloadManager.waitForFinish()         // lazy media playlist
                                                     // download happens here
    ... await drm init / drmEngine_.attach()
    this.abrManager_ = abrFactory();                 // abrManager_ created here

`disableStream()` guards on `config_.abr.enabled`, `loadMode_ === DESTROYED`,
`navigator.onLine`, `disableTime` and `manifest_` — but not on `abrManager_`. So
`manifest_` already passes while `abrManager_` is still null, and `load()` rejects
with a raw TypeError instead of a `shaka.util.Error`:

    TypeError: Cannot read properties of null (reading 'setVariants')
        at Player.updateAbrManagerVariants_
        at Player.chooseVariant_
        at Player.chooseVariantAndSwitch_
        at Player.disableStream
        at playerInterface.disableStream
        at downloadSegmentIndex (HlsParser)

Every other `abrManager_` call site in `player.js` is null-guarded; this path is not.

We hit this in production on mobile Chrome (Android), where a brief radio hiccup
fails one media playlist request. Note `disableStream()` returns early when
`!navigator.onLine`, so this only happens on connections the browser still
considers online. Because the rejection is not a `shaka.util.Error`, the
application cannot classify it, and it surfaces as a hard playback error.

Affects 5.1.10 through current `main` (the code is identical in 5.1.22, 5.2.9 and
`main`), so a backport to v5.2 and v5.1 would be useful.

## Fix

Return false from `disableStream()` when there is no AbrManager yet. The parser
already rethrows the original network error when `disableStream()` returns false,
so callers get a proper `shaka.util.Error` instead of a TypeError.

The added test fails without the fix with the same TypeError.