### PR TITLE
fix(MSF): Report the end of a MoQT session instead of a catalog timeout

### DIFF
--- a/lib/msf/drafts/draft18/session.js
+++ b/lib/msf/drafts/draft18/session.js
@@ -61,7 +61,35 @@ shaka.msf.draft18.Session = class {
     /** @private {!Map<bigint, !shaka.msf.Utils.ObjectCallback>} */
     this.fetchCallbacks_ = new Map();
 
+    this.watchForSessionEnd_();
     this.startListeningForStreams_();
+  }
+
+  /**
+   * A session the peer hangs up on resets every stream on it at once, and
+   * each of those failures would otherwise be logged as an error of its own.
+   * Watch the transport instead: once the session is gone, its stream errors
+   * are expected, and the reason the session ended is the one worth reporting.
+   *
+   * @private
+   */
+  watchForSessionEnd_() {
+    const onEnd = (reason) => {
+      if (!this.isClosing_) {
+        this.isClosing_ = true;
+        shaka.log.warning(`MoQT session ended: ${reason}`);
+      }
+    };
+    this.webTransport_.closed.then(
+        (info) => {
+          const closeInfo = /** @type {{closeCode: number, reason: string}} */ (
+            info || {closeCode: 0, reason: ''});
+          onEnd(`code ${closeInfo.closeCode}` +
+              (closeInfo.reason ? `: ${closeInfo.reason}` : ''));
+        },
+        (error) => {
+          onEnd(String(error));
+        });
   }
 
   /** @override */
@@ -334,15 +362,11 @@ shaka.msf.draft18.Session = class {
         }
 
         this.handleIncomingStream_(stream).catch((error) => {
-          if (!this.isClosing_) {
-            shaka.log.error('Error handling incoming stream:', error);
-          }
+          this.logStreamFailure_('Error handling incoming stream', error);
         });
       }
     } catch (error) {
-      if (!this.isClosing_) {
-        shaka.log.error('Error listening for incoming streams:', error);
-      }
+      this.logStreamFailure_('Stopped listening for incoming streams', error);
     }
   }
 
@@ -368,11 +392,29 @@ shaka.msf.draft18.Session = class {
         shaka.log.warning(`Unknown stream type: ${streamType}`);
       }
     } catch (error) {
-      if (!this.isClosing_) {
-        shaka.log.error('Error processing incoming stream:', error);
-      }
+      this.logStreamFailure_('Incoming stream ended', error);
     } finally {
       reader.close();
+    }
+  }
+
+  /**
+   * Streams end for reasons that are not a failure of ours: the peer resets
+   * one it no longer needs, and every stream on a session fails at once when
+   * the session goes away, which the session itself already reports. Neither
+   * is worth an error in the log.
+   *
+   * @param {string} context
+   * @param {*} error
+   * @private
+   */
+  logStreamFailure_(context, error) {
+    const isSessionGone = this.isClosing_ ||
+        (error && error['source'] == 'session');
+    if (isSessionGone) {
+      shaka.log.debug(`${context}:`, error);
+    } else {
+      shaka.log.warning(`${context}:`, error);
     }
   }
 

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -211,13 +211,35 @@ shaka.msf.MSFParser = class {
       startTime: null,
     };
 
+    // A session the server hangs up on never answers, so wait for the end of
+    // the session as well as for the catalog: the reason the session gives is
+    // worth reporting, and waiting out the timeout for it is not.
+    const sessionEnded = this.msfTransport_.waitForSessionEnd().then(
+        (reason) => {
+          throw new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.MANIFEST,
+              shaka.util.Error.Code.MSF_CONNECTION_CLOSED,
+              reason);
+        });
+
     let catalog;
     try {
       catalog = await shaka.util.Functional.promiseWithTimeout(
-          /* seconds= */ 10, this.catalogPromise_.promise);
+          /* seconds= */ 10,
+          Promise.race([this.catalogPromise_.promise, sessionEnded]));
     } catch (error) {
       if (error instanceof shaka.util.Error) {
         throw error;
+      }
+      if (error) {
+        // The timeout rejects with nothing at all, so anything here is the
+        // failure that the subscription or the transport itself reported.
+        throw new shaka.util.Error(
+            shaka.util.Error.Severity.CRITICAL,
+            shaka.util.Error.Category.MANIFEST,
+            shaka.util.Error.Code.MSF_CONNECTION_CLOSED,
+            String(error));
       }
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,

--- a/lib/msf/msf_transport.js
+++ b/lib/msf/msf_transport.js
@@ -42,6 +42,16 @@ shaka.msf.MSFTransport = class {
 
     /** @private {?shaka.extern.MsfCodec} */
     this.codec_ = null;
+
+    /**
+     * Resolves with the reason the MoQT session ended. A session the peer
+     * hangs up on -- one whose SETUP it rejects, say -- fails everything in
+     * flight with the same opaque WebTransport error, so the reason the
+     * session itself gives is the only useful one.
+     *
+     * @private {{promise: !Promise<string>, resolve: function(string)}}
+     */
+    this.sessionEnded_ = Promise.withResolvers();
   }
 
   /**
@@ -136,6 +146,7 @@ shaka.msf.MSFTransport = class {
     }
 
     this.webTransport_ = webTransport;
+    this.watchForSessionEnd_(webTransport);
     shaka.log.info(`Connection established with ${dialect.getName()}`);
 
     this.codec_ = dialect.getCodec();
@@ -169,6 +180,34 @@ shaka.msf.MSFTransport = class {
     shaka.log.v1(
         `WebTransport connection established offering ${protocols.join(', ')}`);
     return webTransport;
+  }
+
+  /**
+   * @param {!WebTransport} webTransport
+   * @private
+   */
+  watchForSessionEnd_(webTransport) {
+    webTransport.closed.then(
+        (info) => {
+          const closeInfo = /** @type {{closeCode: number, reason: string}} */ (
+            info || {closeCode: 0, reason: ''});
+          this.sessionEnded_.resolve(
+              `session closed with code ${closeInfo.closeCode}` +
+              (closeInfo.reason ? `: ${closeInfo.reason}` : ''));
+        },
+        (error) => {
+          this.sessionEnded_.resolve(String(error));
+        });
+  }
+
+  /**
+   * Resolves with the reason the MoQT session ended, and stays pending while
+   * it is alive.
+   *
+   * @return {!Promise<string>}
+   */
+  waitForSessionEnd() {
+    return this.sessionEnded_.promise;
   }
 
   /**

--- a/lib/msf/request_id_session.js
+++ b/lib/msf/request_id_session.js
@@ -76,6 +76,7 @@ shaka.msf.RequestIdSession = class {
      */
     this.messageHandlers_ = new Map();
 
+    this.watchForSessionEnd_();
     this.startListeningForStreams_();
     this.listenForControlMessages_();
   }
@@ -240,6 +241,33 @@ shaka.msf.RequestIdSession = class {
   }
 
   /**
+   * A session the peer hangs up on resets every stream on it at once, and
+   * each of those failures would otherwise be logged as an error of its own.
+   * Watch the transport instead: once the session is gone, its stream errors
+   * are expected, and the reason the session ended is the one worth reporting.
+   *
+   * @private
+   */
+  watchForSessionEnd_() {
+    const onEnd = (reason) => {
+      if (!this.isClosing_) {
+        this.isClosing_ = true;
+        shaka.log.warning(`MoQT session ended: ${reason}`);
+      }
+    };
+    this.webTransport_.closed.then(
+        (info) => {
+          const closeInfo = /** @type {{closeCode: number, reason: string}} */ (
+            info || {closeCode: 0, reason: ''});
+          onEnd(`code ${closeInfo.closeCode}` +
+              (closeInfo.reason ? `: ${closeInfo.reason}` : ''));
+        },
+        (error) => {
+          onEnd(String(error));
+        });
+  }
+
+  /**
    * Start listening for incoming unidirectional streams
    *
    * @return {!Promise}
@@ -263,11 +291,15 @@ shaka.msf.RequestIdSession = class {
 
         // Handle the stream in a separate task
         this.handleIncomingStream_(stream).catch((error) => {
-          shaka.log.error('Error handling incoming stream:', error);
+          if (!this.isClosing_) {
+            shaka.log.error('Error handling incoming stream:', error);
+          }
         });
       }
     } catch (error) {
-      shaka.log.error('Error listening for incoming streams:', error);
+      if (!this.isClosing_) {
+        shaka.log.error('Error listening for incoming streams:', error);
+      }
     }
   }
 

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -883,6 +883,14 @@ shaka.util.Error.Code = {
    */
   'MSF_CATALOG_TIMEOUT': 4064,
 
+  /**
+   * The MoQT session ended before the content could be loaded. A server that
+   * rejects something the client sent hangs up rather than answering, so this
+   * is what an unhappy server looks like from here.
+   * <br> error.data[0] is the reason the session ended.
+   */
+  'MSF_CONNECTION_CLOSED': 4065,
+
   // RETIRED: 'INCONSISTENT_BUFFER_STATE': 5000,
   // RETIRED: 'INVALID_SEGMENT_INDEX': 5001,
   // RETIRED: 'SEGMENT_DOES_NOT_EXIST': 5002,

--- a/test/msf/draft18_session_unit.js
+++ b/test/msf/draft18_session_unit.js
@@ -46,6 +46,9 @@ filterDescribe('shaka.msf.draft18.Session', isMSFSupported, () => {
       incomingUnidirectionalStreams: {getReader: () => ({read: never})},
       createBidirectionalStream: () =>
         Promise.resolve(fakeBidirectionalStream()),
+      // The session watches this to know when the peer has gone away, so it
+      // must stay pending for the length of a test.
+      closed: never(),
       close: () => {},
     }));
 

--- a/test/msf/msf_parser_unit.js
+++ b/test/msf/msf_parser_unit.js
@@ -51,6 +51,75 @@ filterDescribe('shaka.msf.MSFParser', isMSFSupported, () => {
     parser.configure(config);
   });
 
+  describe('a session the server hangs up on', () => {
+    /** @type {?} */
+    let realTransport;
+
+    beforeEach(() => {
+      // A namespace in the configuration is what sends the parser straight to
+      // the catalog subscription instead of waiting for an announcement.
+      config.msf.namespaces = ['msf', 'clear'];
+      parser.configure(config);
+      realTransport = shaka.msf['MSFTransport'];
+    });
+
+    afterEach(() => {
+      shaka.msf['MSFTransport'] = realTransport;
+    });
+
+    /**
+     * A transport whose session ends with the given reason while the catalog
+     * subscription is still waiting for an answer, which is what a server
+     * that rejects something the client sent looks like from here.
+     *
+     * @param {string} reason
+     */
+    function transportThatEnds(reason) {
+      shaka.msf['MSFTransport'] = class {
+        /** @return {!Promise} */
+        connect() {
+          return Promise.resolve({});
+        }
+
+        /**
+         * The subscription dies with the session, but its WebTransport error
+         * says nothing about why; the session's reason does.
+         *
+         * @return {!Promise}
+         */
+        subscribeTrack() {
+          return new Promise(() => {});
+        }
+
+        /** @return {!Promise<string>} */
+        waitForSessionEnd() {
+          return Promise.resolve(reason);
+        }
+
+        /** */
+        configure() {}
+
+        /** */
+        release() {}
+      };
+    }
+
+    it('reports why the session ended instead of a catalog timeout',
+        async () => {
+          const reason = 'WebTransportError: Connection lost.';
+          transportThatEnds(reason);
+
+          const expected = shaka.test.Util.jasmineError(new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.MANIFEST,
+              shaka.util.Error.Code.MSF_CONNECTION_CLOSED,
+              reason));
+
+          await expectAsync(parser.start('moqt://relay.example/live',
+              playerInterface)).toBeRejectedWith(expected);
+        });
+  });
+
   describe('accessibility descriptors', () => {
     /**
      * @param {!Array<!Object>} accessibility

--- a/test/msf/request_id_session_unit.js
+++ b/test/msf/request_id_session_unit.js
@@ -19,6 +19,9 @@ filterDescribe('shaka.msf.RequestIdSession', isMSFSupported, () => {
 
     const webTransport = /** @type {!WebTransport} */ (/** @type {?} */ ({
       incomingUnidirectionalStreams: {getReader: () => ({read: never})},
+      // The session watches this to know when the peer has gone away, so it
+      // must stay pending for the length of a test.
+      closed: never(),
       close: () => {},
     }));
     const controlStream = /** @type {!shaka.msf.IControlStream} */ (


### PR DESCRIPTION
A server that rejects something the client sent does not answer it: it hangs up. Everything in flight then fails at once with the same opaque WebTransport error, so the catalog subscription's failure said nothing, surfaced as MSF_CATALOG_TIMEOUT ten seconds later, and the real reason only ever appeared as three stack traces in the console.

Watch the transport for the end of the session and report that instead, as the new MSF_CONNECTION_CLOSED error carrying the reason the session gives, and let the sessions themselves know when the peer has gone away so the stream failures that follow are logged as what they are.

Found against a draft-18 relay that closes the session as a protocol violation when the client sends its SETUP; with the reason in hand that diagnosis takes one load instead of a packet capture.