### PR TITLE
fix: Prevent infinite loop on zero-length WVTT payload box

### DIFF
--- a/lib/text/mp4_vtt_parser.js
+++ b/lib/text/mp4_vtt_parser.js
@@ -192,6 +192,13 @@ shaka.text.Mp4VttParser = class {
       do {
         // Read the payload size.
         const payloadSize = reader.readUint32();
+        if (payloadSize < 8) {
+          // A box smaller than its own header makes no forward progress.
+          throw new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.TEXT,
+              shaka.util.Error.Code.INVALID_MP4_VTT);
+        }
         totalSize += payloadSize;
 
         // Skip the type.

--- a/lib/util/data_view_reader.js
+++ b/lib/util/data_view_reader.js
@@ -211,8 +211,9 @@ shaka.util.DataViewReader = class {
    * @export
    */
   skip(bytes) {
-    goog.asserts.assert(bytes >= 0, 'Bad call to DataViewReader.skip');
-    if (this.position_ + bytes > this.dataView_.byteLength) {
+    // A negative count would move the read head backwards, which callers
+    // never intend and which can make parse loops fail to make progress.
+    if (bytes < 0 || this.position_ + bytes > this.dataView_.byteLength) {
       throw this.outOfBounds_();
     }
     this.position_ += bytes;
@@ -225,8 +226,9 @@ shaka.util.DataViewReader = class {
    * @export
    */
   rewind(bytes) {
-    goog.asserts.assert(bytes >= 0, 'Bad call to DataViewReader.rewind');
-    if (this.position_ < bytes) {
+    // A negative count would move the read head forwards, possibly past the
+    // end of the data.
+    if (bytes < 0 || this.position_ < bytes) {
       throw this.outOfBounds_();
     }
     this.position_ -= bytes;

--- a/test/text/mp4_vtt_parser_unit.js
+++ b/test/text/mp4_vtt_parser_unit.js
@@ -214,6 +214,34 @@ describe('Mp4VttParser', () => {
     verifyHelper([], result);
   });
 
+  it('rejects a media segment with a zero-length payload box', () => {
+    const error = shaka.test.Util.jasmineError(new shaka.util.Error(
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.TEXT,
+        shaka.util.Error.Code.INVALID_MP4_VTT));
+
+    // The first payload box of vtt-segment.mp4 is an 8-byte 'vtte' whose
+    // header starts here.  A size of 0 would move the reader backwards by the
+    // header size, making the sample loop spin forever.
+    const boxOffset = 128;
+    const segment = shaka.util.BufferUtils.toUint8(vttSegment.slice());
+    expect(new shaka.util.DataViewReader(
+        segment.subarray(boxOffset),
+        shaka.util.DataViewReader.Endianness.BIG_ENDIAN).readUint32()).toBe(8);
+    segment.set([0, 0, 0, 0], boxOffset);
+
+    const parser = new shaka.text.Mp4VttParser();
+    parser.parseInit(vttInitSegment);
+    const time = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 0,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
+    expect(() => parser.parseMedia(segment, time, null, [])).toThrow(error);
+  });
+
   it('rejects init segment with no vtt', () => {
     const error = shaka.test.Util.jasmineError(new shaka.util.Error(
         shaka.util.Error.Severity.CRITICAL,

--- a/test/util/data_view_reader_unit.js
+++ b/test/util/data_view_reader_unit.js
@@ -233,6 +233,30 @@ describe('DataViewReader', () => {
       });
     });
 
+    it('detects when skipping a negative number of bytes', () => {
+      bigEndianReader.skip(4);
+      runTest(() => {
+        bigEndianReader.skip(-1);
+      });
+      expect(bigEndianReader.getPosition()).toBe(4);
+    });
+
+    it('detects when rewinding past the start', () => {
+      bigEndianReader.skip(4);
+      runTest(() => {
+        bigEndianReader.rewind(5);
+      });
+      expect(bigEndianReader.getPosition()).toBe(4);
+    });
+
+    it('detects when rewinding a negative number of bytes', () => {
+      bigEndianReader.skip(4);
+      runTest(() => {
+        bigEndianReader.rewind(-1);
+      });
+      expect(bigEndianReader.getPosition()).toBe(4);
+    });
+
     function runTest(test) {
       const expected = Util.jasmineError(new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,


### PR DESCRIPTION
A WebVTT-in-MP4 sample whose payload box declares a size of 0 hung the main thread permanently. The sample loop in Mp4VttParser advances by 4 (size) + 4 (type) + skip(payloadSize - 8), i.e. exactly payloadSize bytes, so a size of 0 returned the reader to the offset it started from while totalSize grew by nothing, and the loop condition could never be satisfied. The negative skip was possible because DataViewReader.skip() only guarded its upper bound; the non-negative check was an assertion, which is compiled out of release builds.

Reject a payload box smaller than its own header as INVALID_MP4_VTT, matching what the parser already reports for a short-but-nonzero box, and turn the non-negative assertions in DataViewReader.skip() and rewind() into real BUFFER_READ_OUT_OF_BOUNDS throws so a negative count cannot move the read head the wrong way in a release build either.

Closes #10561