### PR TITLE
fix(Ads): Do not report a resume for an ad's first playout

### DIFF
--- a/lib/ads/svta_ad_manager.js
+++ b/lib/ads/svta_ad_manager.js
@@ -52,6 +52,15 @@ shaka.ads.SvtaAdManager = class {
     /** @private {?shaka.extern.AdTrackingInfo} */
     this.currentTracking_ = null;
 
+    /**
+     * True when the current tracking window has seen a pause that has not been
+     * resumed yet. Used to avoid reporting a resume for the initial play of an
+     * ad, which is already covered by impression and start.
+     *
+     * @private {boolean}
+     */
+    this.adPaused_ = false;
+
     /** @private {shaka.util.EventManager} */
     this.eventManager_ = new shaka.util.EventManager();
 
@@ -371,6 +380,7 @@ shaka.ads.SvtaAdManager = class {
     }
     this.trackingEventManager_.removeAll();
     this.currentTracking_ = null;
+    this.adPaused_ = false;
   }
 
   /**
@@ -387,10 +397,22 @@ shaka.ads.SvtaAdManager = class {
       this.sendEvent_(shaka.ads.Utils.AD_ERROR,
           (new Map()).set('originalEvent', e));
     });
+    this.adPaused_ = false;
     this.trackingEventManager_.listen(this.video_, 'play', () => {
+      // Only report a resume when the ad was actually paused before. The
+      // initial play of an interstitial happens while the tracking window is
+      // being opened, and it is already covered by impression and start.
+      if (!this.adPaused_) {
+        return;
+      }
+      this.adPaused_ = false;
       this.sendEvent_(shaka.ads.Utils.AD_RESUMED);
     });
     this.trackingEventManager_.listen(this.video_, 'pause', () => {
+      if (this.adPaused_) {
+        return;
+      }
+      this.adPaused_ = true;
       this.sendEvent_(shaka.ads.Utils.AD_PAUSED);
     });
     this.trackingEventManager_.listen(this.video_, 'volumechange', () => {

--- a/test/ads/svta_ad_manager_unit.js
+++ b/test/ads/svta_ad_manager_unit.js
@@ -557,5 +557,66 @@ describe('SVTA Ad manager', () => {
       expect(eventTypes()).toContain(shaka.ads.Utils.AD_COMPLETE);
       expect(eventTypes()).not.toContain(shaka.ads.Utils.AD_SKIPPED);
     });
+
+    /**
+     * @return {!Promise}
+     */
+    async function addSimpleTracking() {
+      const metadata = {
+        type: 'urn:svta:advertising-wg:ad-creative-signaling',
+        startTime: 0,
+        endTime: 5,
+        values: [
+          {
+            key: 'X-AD-CREATIVE-SIGNALING',
+            data: window.btoa(JSON.stringify(creativeSignalingSimple)),
+          },
+        ],
+      };
+      await svtaAdManager.addMetadata(metadata);
+    }
+
+    /** @return {!Array<string>} */
+    function eventTypes() {
+      return onEventSpy.calls.allArgs().map((args) => args[0].type);
+    }
+
+    // An interstitial starts a fresh playout, so 'play' fires as the tracking
+    // window opens. That is not a resume; it is already covered by the
+    // impression and start beacons.
+    // https://github.com/shaka-project/shaka-player/issues/10562
+    it('does not report a resume without a preceding pause', async () => {
+      await addSimpleTracking();
+
+      video.dispatchEvent(new Event('play'));
+
+      expect(eventTypes()).not.toContain(shaka.ads.Utils.AD_RESUMED);
+    });
+
+    it('reports a resume after a pause', async () => {
+      await addSimpleTracking();
+
+      video.dispatchEvent(new Event('play'));
+      video.dispatchEvent(new Event('pause'));
+      video.dispatchEvent(new Event('play'));
+
+      const types = eventTypes();
+      expect(types.filter((t) => t == shaka.ads.Utils.AD_PAUSED).length)
+          .toBe(1);
+      expect(types.filter((t) => t == shaka.ads.Utils.AD_RESUMED).length)
+          .toBe(1);
+      expect(types.indexOf(shaka.ads.Utils.AD_PAUSED))
+          .toBeLessThan(types.indexOf(shaka.ads.Utils.AD_RESUMED));
+    });
+
+    it('ignores repeated pause events', async () => {
+      await addSimpleTracking();
+
+      video.dispatchEvent(new Event('pause'));
+      video.dispatchEvent(new Event('pause'));
+
+      expect(eventTypes().filter(
+          (t) => t == shaka.ads.Utils.AD_PAUSED).length).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
SVTA2053-1 §4.3.2 defines `resume` as being sent "when a user action has caused the ad to begin again after previously being paused or stopped". The tracking setup wired the media element's `play` event straight to AD_RESUMED, so an interstitial -- which starts a fresh playout as its tracking window opens -- fired a resume beacon at t=0 of its first creative with no preceding pause, inflating resume counts by exactly one per interstitial. The beginning of playout is already covered by `impression` and `start`.

Track whether the current ad was actually paused, and only report AD_RESUMED when it was. Also ignore repeated `pause` events so pause and resume stay paired.

Closes #10562