### PR TITLE
fix(VTT): guard against payload box smaller than 8 bytes to prevent infinite loop (fixes #10561)

### DIFF
--- a/lib/text/mp4_vtt_parser.js
+++ b/lib/text/mp4_vtt_parser.js
@@ -192,6 +192,12 @@ shaka.text.Mp4VttParser = class {
       do {
         // Read the payload size.
         const payloadSize = reader.readUint32();
+        if (payloadSize < 8) {
+          throw new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.TEXT,
+              shaka.util.Error.Code.INVALID_MP4_VTT);
+        }
         totalSize += payloadSize;
 
         // Skip the type.

--- a/lib/util/data_view_reader.js
+++ b/lib/util/data_view_reader.js
@@ -187,7 +187,7 @@ shaka.util.DataViewReader = class {
    */
   readBytes(bytes, clone) {
     goog.asserts.assert(bytes >= 0, 'Bad call to DataViewReader.readBytes');
-    if (this.position_ + bytes > this.dataView_.byteLength) {
+    if (bytes < 0 || this.position_ + bytes > this.dataView_.byteLength) {
       throw this.outOfBounds_();
     }
 
@@ -212,7 +212,7 @@ shaka.util.DataViewReader = class {
    */
   skip(bytes) {
     goog.asserts.assert(bytes >= 0, 'Bad call to DataViewReader.skip');
-    if (this.position_ + bytes > this.dataView_.byteLength) {
+    if (bytes < 0 || this.position_ + bytes > this.dataView_.byteLength) {
       throw this.outOfBounds_();
     }
     this.position_ += bytes;
@@ -226,7 +226,7 @@ shaka.util.DataViewReader = class {
    */
   rewind(bytes) {
     goog.asserts.assert(bytes >= 0, 'Bad call to DataViewReader.rewind');
-    if (this.position_ < bytes) {
+    if (bytes < 0 || this.position_ < bytes) {
       throw this.outOfBounds_();
     }
     this.position_ -= bytes;

--- a/test/text/mp4_vtt_parser_unit.js
+++ b/test/text/mp4_vtt_parser_unit.js
@@ -224,6 +224,41 @@ describe('Mp4VttParser', () => {
         .toThrow(error);
   });
 
+  it('rejects media segment with payload box smaller than 8 bytes', () => {
+    const error = shaka.test.Util.jasmineError(new shaka.util.Error(
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.TEXT,
+        shaka.util.Error.Code.INVALID_MP4_VTT));
+
+    const parser = new shaka.text.Mp4VttParser();
+    parser.parseInit(vttInitSegment);
+    const time = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 0,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
+
+    // Corrupt a valid media segment by setting payload box size to 0.
+    const corruptedSegment = new Uint8Array(vttSegment);
+    for (let i = 0; i < corruptedSegment.length - 4; i++) {
+      if (corruptedSegment[i] === 0x76 && // 'v'
+          corruptedSegment[i + 1] === 0x74 && // 't'
+          corruptedSegment[i + 2] === 0x74 && // 't'
+          corruptedSegment[i + 3] === 0x63) { // 'c'
+        corruptedSegment[i - 4] = 0;
+        corruptedSegment[i - 3] = 0;
+        corruptedSegment[i - 2] = 0;
+        corruptedSegment[i - 1] = 0;
+        break;
+      }
+    }
+
+    expect(() => parser.parseMedia(corruptedSegment, time, null, []))
+        .toThrow(error);
+  });
+
   function verifyHelper(/** !Array */ expected, /** !Array */ actual) {
     expect(actual).toEqual(expected.map((c) => jasmine.objectContaining(c)));
   }

--- a/test/util/data_view_reader_unit.js
+++ b/test/util/data_view_reader_unit.js
@@ -233,6 +233,24 @@ describe('DataViewReader', () => {
       });
     });
 
+    it('detects when skipping negative bytes', () => {
+      runTest(() => {
+        bigEndianReader.skip(-1);
+      });
+    });
+
+    it('detects when reading negative bytes', () => {
+      runTest(() => {
+        bigEndianReader.readBytes(-1, /* clone= */ false);
+      });
+    });
+
+    it('detects when rewinding negative bytes', () => {
+      runTest(() => {
+        bigEndianReader.rewind(-1);
+      });
+    });
+
     function runTest(test) {
       const expected = Util.jasmineError(new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,


### PR DESCRIPTION
### Description

Fixes #10561.

When parsing a fragmented MP4 WebVTT segment whose sample contains a payload box with `payloadSize < 8` (e.g. a zero-length box), `Mp4VttParser.parseMedia` enters an infinite loop:
1. `reader.readUint32()` reads the payload size (e.g., 0) and type (4 bytes each, total 8 bytes advanced).
2. Because `payloadSize < 8`, `payloadSize - 8` is negative.
3. In non-`vttc` branches (such as `vtte` or unknown box types), `reader.skip(payloadSize - 8)` is called with a negative number.
4. Because `DataViewReader.skip()` only asserted `bytes >= 0` (which is compiled out in release builds), passing a negative offset moved `reader.position_` backward by 8 bytes, exactly canceling out the header read.
5. `totalSize` does not advance, causing `while (presentation.sampleSize && (totalSize < presentation.sampleSize))` to loop indefinitely and permanently freeze the browser tab (CWE-835).

### Changes
1. **Validation in `Mp4VttParser`**:
   - Every WVTT payload box requires at least 8 bytes for size and 4CC type.
   - If `payloadSize < 8`, immediately throw `shaka.util.Error.Code.INVALID_MP4_VTT` to reject the malformed sample and prevent negative skips.
2. **Runtime bounds checking in `DataViewReader`**:
   - Added `bytes < 0` checks to `readBytes()`, `skip()`, and `rewind()` so out-of-bounds errors (`BUFFER_READ_OUT_OF_BOUNDS`) are consistently thrown even when assertions are stripped in production builds.
3. **Unit Tests**:
   - Added regression test in `test/text/mp4_vtt_parser_unit.js` verifying that a media segment with a sub-8-byte payload box is rejected with `INVALID_MP4_VTT`.
   - Added unit tests in `test/util/data_view_reader_unit.js` verifying that negative counts passed to `skip()`, `readBytes()`, and `rewind()` throw `BUFFER_READ_OUT_OF_BOUNDS`.
