### PR TITLE
fix(HLS): synchronize HTML5 audio track selection in src= mode (fixes #10551)

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -432,6 +432,7 @@ shaka.extern.Track;
 
 /**
  * @typedef {{
+ *   id: (number|undefined),
  *   active: boolean,
  *   language: string,
  *   label: ?string,
@@ -450,6 +451,8 @@ shaka.extern.Track;
  * An object describing a audio track.  This object should be treated as
  * read-only as changing any values does not have any effect.
  *
+ * @property {(number|undefined)} id
+ *   The unique ID of the track, if available.
  * @property {boolean} active
  *   If true, this is the track being streamed (another track may be
  *   visible/audible in the buffer).

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -452,7 +452,7 @@ shaka.extern.Track;
  * read-only as changing any values does not have any effect.
  *
  * @property {(number|undefined)} id
- *   The unique ID of the track, if available.
+ *   The unique ID of the track, if available. Only available for src=.
  * @property {boolean} active
  *   If true, this is the track being streamed (another track may be
  *   visible/audible in the buffer).

--- a/lib/player.js
+++ b/lib/player.js
@@ -6486,7 +6486,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         ].join('_');
         /** @type {shaka.extern.AudioTrack} */
         const audioTrack = {
-          id: track.id,
           active: track.active,
           language: track.language,
           label: track.label,

--- a/lib/player.js
+++ b/lib/player.js
@@ -6400,12 +6400,21 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         const audioTracks = Array.from(this.video_.audioTracks);
         let trackMatch = null;
         let activeTrack = null;
+        if (audioTrack.id != null) {
+          trackMatch = audioTracks.find(
+              (t) => shaka.util.StreamUtils.html5TrackId(t) === audioTrack.id);
+        }
         for (const track of audioTracks) {
-          const trackLanguage = track.language || 'und';
-          if (!trackMatch && track.label == audioTrack.label &&
-              LanguageUtils.normalize(trackLanguage) == inputLanguage &&
-              track.kind == audioTrack.roles[0]) {
-            trackMatch = track;
+          if (!trackMatch) {
+            const trackLanguage = track.language || 'und';
+            const trackKind = track.kind || '';
+            const audioTrackRole = audioTrack.roles && audioTrack.roles.length ?
+                audioTrack.roles[0] : '';
+            if ((track.label || '') == (audioTrack.label || '') &&
+                LanguageUtils.normalize(trackLanguage) == inputLanguage &&
+                trackKind == audioTrackRole) {
+              trackMatch = track;
+            }
           }
           if (track.enabled) {
             activeTrack = track;
@@ -6477,6 +6486,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         ].join('_');
         /** @type {shaka.extern.AudioTrack} */
         const audioTrack = {
+          id: track.id,
           active: track.active,
           language: track.language,
           label: track.label,
@@ -8734,24 +8744,17 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         'Video and video.audioTracks should not be null!');
     const audioTracks = Array.from(this.video_.audioTracks);
     const currentTrack = audioTracks.find((t) => t.enabled);
-
-    // This will reset the "enabled" of other tracks to false.
+    for (const audioTrack of audioTracks) {
+      if (audioTrack !== track) {
+        audioTrack.enabled = false;
+      }
+    }
     track.enabled = true;
-
-    if (!currentTrack) {
-      return;
-    }
-
-    // AirPlay does not reset the "enabled" of other tracks to false, so
-    // it must be changed by hand.
-    if (track.id !== currentTrack.id) {
-      currentTrack.enabled = false;
-    }
 
     const videoTrack = this.getActiveHtml5VideoTrack_();
 
-    const oldTrack =
-        StreamUtils.html5TrackToShakaTrack(currentTrack, videoTrack);
+    const oldTrack = currentTrack ?
+        StreamUtils.html5TrackToShakaTrack(currentTrack, videoTrack) : null;
     const newTrack = StreamUtils.html5TrackToShakaTrack(track, videoTrack);
     // Dispatch a 'variantchanged' event
     this.onVariantChanged_(oldTrack, newTrack);

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1574,6 +1574,7 @@ shaka.util.StreamUtils = class {
 
     /** @type {shaka.extern.AudioTrack} */
     const track = {
+      id: shaka.util.StreamUtils.html5TrackId(audioTrack),
       active: audioTrack.enabled,
       language: shaka.util.LanguageUtils.normalize(language || 'und'),
       label: audioTrack.label,

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -3302,7 +3302,9 @@ describe('Player', () => {
         kind: 'main',
         enabled: false,
       };
-      video.audioTracks = [trackEn1, trackEn2, trackEs];
+      video.audioTracks =
+          /** @type {!AudioTrackList} */ (/** @type {?} */ (
+            [trackEn1, trackEn2, trackEs]));
     });
 
     it('getAudioTracks assigns unique id and matches native tracks', () => {

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -3275,6 +3275,68 @@ describe('Player', () => {
     });
   });  // describe('tracks')
 
+  describe('HTML5 audio tracks in src= mode', () => {
+    let trackEn1;
+    let trackEn2;
+    let trackEs;
+
+    beforeEach(() => {
+      trackEn1 = {
+        id: '',
+        label: 'Stereo',
+        language: 'en',
+        kind: 'main',
+        enabled: true,
+      };
+      trackEn2 = {
+        id: '',
+        label: 'Surround 5.1',
+        language: 'en',
+        kind: 'main',
+        enabled: false,
+      };
+      trackEs = {
+        id: '',
+        label: 'Spanish',
+        language: 'es',
+        kind: 'main',
+        enabled: false,
+      };
+      video.audioTracks = [trackEn1, trackEn2, trackEs];
+    });
+
+    it('getAudioTracks assigns unique id and matches native tracks', () => {
+      const tracks = player.getAudioTracks();
+      expect(tracks.length).toBe(3);
+      expect(tracks[0].id).toBeDefined();
+      expect(tracks[1].id).toBeDefined();
+      expect(tracks[0].id).not.toBe(tracks[1].id);
+      expect(tracks[0].active).toBe(true);
+      expect(tracks[1].active).toBe(false);
+    });
+
+    it('selectAudioTrack disables other tracks when id is empty string', () => {
+      const tracks = player.getAudioTracks();
+      expect(trackEn1.enabled).toBe(true);
+      expect(trackEs.enabled).toBe(false);
+
+      player.selectAudioTrack(tracks[2]);
+
+      expect(trackEs.enabled).toBe(true);
+      expect(trackEn1.enabled).toBe(false);
+      expect(trackEn2.enabled).toBe(false);
+    });
+
+    it('selectAudioTrack distinguishes tracks with same language by id', () => {
+      const tracks = player.getAudioTracks();
+      player.selectAudioTrack(tracks[1]);
+
+      expect(trackEn2.enabled).toBe(true);
+      expect(trackEn1.enabled).toBe(false);
+      expect(trackEs.enabled).toBe(false);
+    });
+  });
+
   describe('languages', () => {
     it('chooses the first as default', async () => {
       await runTest(['en', 'es'], 'pt', 0);

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -3302,9 +3302,7 @@ describe('Player', () => {
         kind: 'main',
         enabled: false,
       };
-      video.audioTracks =
-          /** @type {!AudioTrackList} */ (/** @type {?} */ (
-            [trackEn1, trackEn2, trackEs]));
+      video.audioTracks = /** @type {?} */ ([trackEn1, trackEn2, trackEs]);
     });
 
     it('getAudioTracks assigns unique id and matches native tracks', () => {


### PR DESCRIPTION
### Description

Fixes #10551.

When switching audio tracks in `src=` mode (such as native HLS playback on iOS Safari with `preferNativeHls: true`), the active track indicated by the UI can get out of sync with the track actually playing in the media element:
1. In `switchHtml5Track_()`, the code previously attempted to deactivate the previous track using `if (track.id !== currentTrack.id) currentTrack.enabled = false;`. However, in HTML5 `AudioTrack` (and especially iOS Safari/WebKit), the `.id` property defaults to an empty string `""` when no track ID is specified in the manifest. Because `"" !== ""` evaluates to `false`, `currentTrack.enabled = false` was never executed. Furthermore, unlike `VideoTrackList` (where only one track can be selected at a time), HTML5 `AudioTrackList` allows multiple tracks to be enabled simultaneously. Setting `track.enabled = true` does not automatically disable other audio tracks in standard HTML5.
2. In `selectAudioTrack()`, `selectSrcEqualsMode()` matched tracks via `track.kind == audioTrack.roles[0]`. When `track.kind` was empty and `audioTrack.roles` was empty, `"" == undefined` evaluated to `false`, causing match failures. Furthermore, when multiple audio tracks shared the same language and label (e.g. multi-channel and stereo renditions in HLS manifests), `selectAudioTrack()` always picked the first matching track instead of the specific track requested by the user.

### Changes
1. **Unambiguous Audio Track Identification**:
   - Added optional `id: (number|undefined)` to `shaka.extern.AudioTrack` extern definition.
   - Assigned `id: shaka.util.StreamUtils.html5TrackId(audioTrack)` in `StreamUtils.html5AudioTrackToTrack` and `id: track.id` in `Player.prototype.getAudioTracks`.
   - In `selectAudioTrack()`, prioritizes matching the native `AudioTrack` via `html5TrackId(t) === audioTrack.id`, falling back to normalized language, label, and role matching.
2. **Reliable HTML5 Audio Track Switching**:
   - In `switchHtml5Track_()`, explicitly iterates over `this.video_.audioTracks` and disables all other tracks (`audioTrack.enabled = (audioTrack === track)`). This guarantees that exactly one audio track is enabled regardless of whether `.id` is empty string or omitted.
3. **Unit Tests**:
   - Added `HTML5 audio tracks in src= mode` test suite in `test/player_unit.js` verifying:
     - `getAudioTracks()` assigns unique IDs to native tracks and reads active states correctly.
     - `selectAudioTrack()` disables all other tracks when switching even if track IDs are empty strings `""`.
     - `selectAudioTrack()` distinguishes between multiple tracks with the same language and role.
