### PR TITLE
fix(VTT): guard against payload box smaller than 8 bytes to prevent infinite loop (fixes #10561)

### DIFF
--- a/lib/text/mp4_vtt_parser.js
+++ b/lib/text/mp4_vtt_parser.js
@@ -192,6 +192,12 @@ shaka.text.Mp4VttParser = class {
       do {
         // Read the payload size.
         const payloadSize = reader.readUint32();
+        if (payloadSize < 8) {
+          throw new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.TEXT,
+              shaka.util.Error.Code.INVALID_MP4_VTT);
+        }
         totalSize += payloadSize;
 
         // Skip the type.

--- a/lib/util/data_view_reader.js
+++ b/lib/util/data_view_reader.js
@@ -187,7 +187,7 @@ shaka.util.DataViewReader = class {
    */
   readBytes(bytes, clone) {
     goog.asserts.assert(bytes >= 0, 'Bad call to DataViewReader.readBytes');
-    if (this.position_ + bytes > this.dataView_.byteLength) {
+    if (bytes < 0 || this.position_ + bytes > this.dataView_.byteLength) {
       throw this.outOfBounds_();
     }
 
@@ -212,7 +212,7 @@ shaka.util.DataViewReader = class {
    */
   skip(bytes) {
     goog.asserts.assert(bytes >= 0, 'Bad call to DataViewReader.skip');
-    if (this.position_ + bytes > this.dataView_.byteLength) {
+    if (bytes < 0 || this.position_ + bytes > this.dataView_.byteLength) {
       throw this.outOfBounds_();
     }
     this.position_ += bytes;
@@ -226,7 +226,7 @@ shaka.util.DataViewReader = class {
    */
   rewind(bytes) {
     goog.asserts.assert(bytes >= 0, 'Bad call to DataViewReader.rewind');
-    if (this.position_ < bytes) {
+    if (bytes < 0 || this.position_ < bytes) {
       throw this.outOfBounds_();
     }
     this.position_ -= bytes;

--- a/test/text/mp4_vtt_parser_unit.js
+++ b/test/text/mp4_vtt_parser_unit.js
@@ -224,6 +224,41 @@ describe('Mp4VttParser', () => {
         .toThrow(error);
   });
 
+  it('rejects media segment with payload box smaller than 8 bytes', () => {
+    const error = shaka.test.Util.jasmineError(new shaka.util.Error(
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.TEXT,
+        shaka.util.Error.Code.INVALID_MP4_VTT));
+
+    const parser = new shaka.text.Mp4VttParser();
+    parser.parseInit(vttInitSegment);
+    const time = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 0,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
+
+    // Corrupt a valid media segment by setting payload box size to 0.
+    const corruptedSegment = new Uint8Array(vttSegment);
+    for (let i = 0; i < corruptedSegment.length - 4; i++) {
+      if (corruptedSegment[i] === 0x76 && // 'v'
+          corruptedSegment[i + 1] === 0x74 && // 't'
+          corruptedSegment[i + 2] === 0x74 && // 't'
+          corruptedSegment[i + 3] === 0x63) { // 'c'
+        corruptedSegment[i - 4] = 0;
+        corruptedSegment[i - 3] = 0;
+        corruptedSegment[i - 2] = 0;
+        corruptedSegment[i - 1] = 0;
+        break;
+      }
+    }
+
+    expect(() => parser.parseMedia(corruptedSegment, time, null, []))
+        .toThrow(error);
+  });
+
   function verifyHelper(/** !Array */ expected, /** !Array */ actual) {
     expect(actual).toEqual(expected.map((c) => jasmine.objectContaining(c)));
   }

--- a/test/util/data_view_reader_unit.js
+++ b/test/util/data_view_reader_unit.js
@@ -233,6 +233,24 @@ describe('DataViewReader', () => {
       });
     });
 
+    it('detects when skipping negative bytes', () => {
+      runTest(() => {
+        bigEndianReader.skip(-1);
+      });
+    });
+
+    it('detects when reading negative bytes', () => {
+      runTest(() => {
+        bigEndianReader.readBytes(-1, /* clone= */ false);
+      });
+    });
+
+    it('detects when rewinding negative bytes', () => {
+      runTest(() => {
+        bigEndianReader.rewind(-1);
+      });
+    });
+
     function runTest(test) {
       const expected = Util.jasmineError(new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,


### PR DESCRIPTION
### Summary
Fixes #10561.

In `shaka.text.Mp4VttParser`, when parsing samples in fragmented-MP4 WebVTT segments, payload boxes (such as `vtte` or unknown box types) with `payloadSize < 8` (e.g. `payloadSize == 0`) caused the sample loop to spin infinitely:
- `payloadSize` is read as 0.
- `reader.skip(payloadSize - 8)` attempts to skip `-8` bytes.
- In production builds, `goog.asserts.assert(bytes >= 0)` in `DataViewReader.skip` is compiled out, and `this.position_ + bytes > byteLength` evaluates to `false` for negative `bytes`, causing the reader position to move backwards by 8 bytes (cancelling out the 8 bytes read for size and type).
- `totalSize` accumulates 0, so the loop condition `totalSize < presentation.sampleSize` never terminates, permanently hanging the execution thread.

### Changes
1. `lib/text/mp4_vtt_parser.js`:
   - Enforce that `payloadSize >= 8` before processing box contents; throw `INVALID_MP4_VTT` if `payloadSize < 8`.
2. `lib/util/data_view_reader.js`:
   - In `readBytes`, `skip`, and `rewind`, add runtime check `bytes < 0` throwing out of bounds error even when assertions are compiled out in production builds.
3. Unit tests:
   - `test/text/mp4_vtt_parser_unit.js`: test rejecting media segments containing payload boxes with size < 8.
   - `test/util/data_view_reader_unit.js`: test `skip(-1)`, `readBytes(-1)`, and `rewind(-1)` throwing out of bounds error.
