### PR TITLE
feat(text): enhance SRT parser with full Aegisub alignment, styling, and robust formatting

### DIFF
--- a/lib/text/srt_text_parser.js
+++ b/lib/text/srt_text_parser.js
@@ -46,20 +46,25 @@ shaka.text.SrtTextParser = class extends shaka.text.VttTextParser {
   srt2webvtt_(data) {
     let result = 'WEBVTT\n\n';
 
-    // Supports no cues
-    if (data == '') {
-      return result;
-    }
+    // Remove UTF-8 BOM if present
+    let srt = data.replace(/^\uFEFF/, '');
 
     // remove dos newlines
-    let srt = data.replace(/\r+/g, '');
+    srt = srt.replace(/\r+/g, '');
     // trim white space start and end
     srt = srt.trim();
 
-    // get cues
-    const cuelist = srt.split('\n\n');
+    // Supports no cues
+    if (srt === '') {
+      return result;
+    }
+
+    // get cues (split on blank lines, allowing whitespace on empty lines)
+    const cuelist = srt.split(/\n\s*\n/);
     for (const cue of cuelist) {
-      result += this.convertSrtCue_(cue);
+      if (cue.trim()) {
+        result += this.convertSrtCue_(cue);
+      }
     }
 
     return result;
@@ -90,7 +95,7 @@ shaka.text.SrtTextParser = class extends shaka.text.VttTextParser {
     }
 
     // 2. Parse time line (start --> end [settings])
-    const timeRegex = /^([\d:,]+)\s*-->\s*([\d:,]+)(.*)?$/;
+    const timeRegex = /^([\d:,.]+)\s*-->\s*([\d:,.]+)(.*)?$/;
     const match = lines[0].match(timeRegex);
     if (!match) {
       return '';
@@ -98,27 +103,56 @@ shaka.text.SrtTextParser = class extends shaka.text.VttTextParser {
 
     const start = this.normalizeTime_(match[1]);
     const end = this.normalizeTime_(match[2]);
-    let settings = '';
+    let settings = match[3] ? match[3].trim() : '';
+    if (settings) {
+      settings = ' ' + settings;
+    }
 
     // 3. Combine remaining lines as cue text
     let text = lines.slice(1).join('\n');
 
-    // 4. Aegisub alignment {\anX} → WebVTT line & align settings
-    const alignMatch = text.match(/{\\an(\d)}/);
-    if (alignMatch) {
-      const map = {
-        1: 'line:-1 align:left',
-        2: 'line:-1 align:center',
-        3: 'line:-1 align:right',
-        7: 'line:0 align:left',
-        8: 'line:0 align:center',
-        9: 'line:0 align:right',
+    // 4. Aegisub alignment {\anX} or legacy SSA {\aX} → WebVTT settings
+    const anMatch = text.match(/{[^{}]*?\\an([1-9])(?![0-9])[^{}]*}/);
+    if (anMatch) {
+      const anMap = {
+        '1': 'line:-1 align:left',
+        '2': 'line:-1 align:center',
+        '3': 'line:-1 align:right',
+        '4': 'line:50% align:left',
+        '5': 'line:50% align:center',
+        '6': 'line:50% align:right',
+        '7': 'line:0 align:left',
+        '8': 'line:0 align:center',
+        '9': 'line:0 align:right',
       };
-      settings += map[alignMatch[1]] ? ` ${map[alignMatch[1]]}` : '';
+      const alignSetting = anMap[anMatch[1]];
+      if (alignSetting) {
+        settings += ` ${alignSetting}`;
+      }
+    } else {
+      const aMatch =
+          text.match(/{[^{}]*?\\a(10|11|[1-35-79])(?![0-9])[^{}]*}/);
+      if (aMatch) {
+        const aMap = {
+          '1': 'line:-1 align:left',
+          '2': 'line:-1 align:center',
+          '3': 'line:-1 align:right',
+          '5': 'line:0 align:left',
+          '6': 'line:0 align:center',
+          '7': 'line:0 align:right',
+          '9': 'line:50% align:left',
+          '10': 'line:50% align:center',
+          '11': 'line:50% align:right',
+        };
+        const alignSetting = aMap[aMatch[1]];
+        if (alignSetting) {
+          settings += ` ${alignSetting}`;
+        }
+      }
     }
 
     // 5. Aegisub position {\pos(x,y)} → WebVTT position & line
-    const posMatch = text.match(/{\\pos\((\d+),(\d+)\)}/);
+    const posMatch = text.match(/{[^{}]*?\\pos\((\d+),(\d+)\)[^{}]*}/);
     if (posMatch) {
       // Convert coordinates to percentages (approximation)
       const x = Math.min(100, Math.round(parseFloat(posMatch[1]) / 19.2));
@@ -126,19 +160,53 @@ shaka.text.SrtTextParser = class extends shaka.text.VttTextParser {
       settings += ` position:${x}% line:${y}%`;
     }
 
-    // 6. Remove all remaining Aegisub/unsupported tags
+    // 6. Convert Aegisub and SRT inline style tags
+    text = text.replace(/{([^{}]*)}/g, (_, inner) => {
+      const lower = inner.trim().toLowerCase();
+      if (lower === 'b') {
+        return '<b>';
+      }
+      if (lower === '/b') {
+        return '</b>';
+      }
+      if (lower === 'i') {
+        return '<i>';
+      }
+      if (lower === '/i') {
+        return '</i>';
+      }
+      if (lower === 'u') {
+        return '<u>';
+      }
+      if (lower === '/u') {
+        return '</u>';
+      }
+      if (inner.startsWith('\\')) {
+        let tagHtml = '';
+        if (/\\b([1-9]\d{2,}|1)(?![0-9])/i.test(inner)) {
+          tagHtml += '<b>';
+        } else if (/\\b(0|(?![a-zA-Z0-9]))/i.test(inner)) {
+          tagHtml += '</b>';
+        }
+        if (/\\i1(?![0-9])/i.test(inner)) {
+          tagHtml += '<i>';
+        } else if (/\\i(0|(?![a-zA-Z0-9]))/i.test(inner)) {
+          tagHtml += '</i>';
+        }
+        if (/\\u1(?![0-9])/i.test(inner)) {
+          tagHtml += '<u>';
+        } else if (/\\u(0|(?![a-zA-Z0-9]))/i.test(inner)) {
+          tagHtml += '</u>';
+        }
+        return tagHtml;
+      }
+      return '';
+    });
+
+    // 7. Remove all remaining Aegisub/unsupported tags
     text = text.replace(/{\\.*?}/g, '');
 
-    // 7. Convert basic SRT style tags {b}{/b}, {i}{/i}, {u}{/u} → HTML
-    text = text
-        .replace(/{b}/gi, '<b>')
-        .replace(/{\/b}/gi, '</b>')
-        .replace(/{i}/gi, '<i>')
-        .replace(/{\/i}/gi, '</i>')
-        .replace(/{u}/gi, '<u>')
-        .replace(/{\/u}/gi, '</u>');
-
-    // 8. Convert <font color="#XXXXXX"> → <c.colorName> (WebVTT spec)
+    // 8. Convert <font color="..."> → <c.colorName> (WebVTT spec)
     text = this.convertColors_(text);
 
     // 9. Return formatted WebVTT cue
@@ -147,22 +215,34 @@ shaka.text.SrtTextParser = class extends shaka.text.VttTextParser {
 
   /**
    * Normalize timestamp for WebVTT
-   * Supports MM:SS,mmm → 00:MM:SS.mmm
+   * Supports:
+   *   H:MM:SS,mmm -> 0H:MM:SS.mmm
+   *   M:SS,mmm -> 00:0M:SS.mmm
+   *   MM:SS,mmm -> 00:MM:SS.mmm
    *
    * @param {string} time
    * @return {string}
    * @private
    */
   normalizeTime_(time) {
-    if (/^\d{2}:\d{2},\d{3}$/.test(time)) {
-      return '00:' + time.replace(',', '.');
+    time = time.replace(',', '.');
+    const parts = time.split(':');
+    if (parts.length === 2) {
+      // M:SS.mmm or MM:SS.mmm -> 00:MM:SS.mmm
+      const minutes = parts[0].padStart(2, '0');
+      return `00:${minutes}:${parts[1]}`;
+    } else if (parts.length === 3) {
+      // H:MM:SS.mmm -> 0H:MM:SS.mmm
+      const hours = parts[0].padStart(2, '0');
+      return `${hours}:${parts[1]}:${parts[2]}`;
     }
-    return time.replace(',', '.');
+    return time;
   }
 
   /**
-   * Convert SRT <font color="#XXXXXX"> or <font color="name"> tags
-   * into WebVTT <c.colorName>. Unknown colors are removed safely.
+   * Convert SRT <font ... color="#XXXXXX" ...> or
+   * <font ... color="name" ...> tags into WebVTT <c.colorName>.
+   * Unknown colors are removed safely.
    *
    * @param {string} text
    * @return {string}
@@ -171,20 +251,26 @@ shaka.text.SrtTextParser = class extends shaka.text.VttTextParser {
   convertColors_(text) {
     const openColors = [];
 
-    text = text.replace(/<font color=["']?([^"'>]+)["']?>/gi, (_, color) => {
-      const key = color.toLowerCase();
-      const colorName = shaka.text.Utils.getColorName(key);
-      if (colorName) {
-        openColors.push(colorName);
-        return `<c.${colorName}>`;
+    text = text.replace(/<font(\s+[^>]*)?>/gi, (_, attrs) => {
+      if (attrs) {
+        const colorMatch = attrs.match(/color=["']?([^"'\s>]+)["']?/i);
+        if (colorMatch) {
+          const key = colorMatch[1].toLowerCase();
+          const colorName = shaka.text.Utils.getColorName(key);
+          if (colorName) {
+            openColors.push(colorName);
+            return `<c.${colorName}>`;
+          }
+        }
       }
+      openColors.push(null);
       return '';
     });
 
     text = text.replace(/<\/font>/gi, () => {
       if (openColors.length) {
-        openColors.pop();
-        return '</c>';
+        const colorName = openColors.pop();
+        return colorName ? '</c>' : '';
       }
       return '';
     });

--- a/test/text/srt_text_parser_unit.js
+++ b/test/text/srt_text_parser_unit.js
@@ -218,6 +218,212 @@ describe('SrtTextParser', () => {
         });
   });
 
+  it('supports Aegisub middle and top alignments', () => {
+    verifyHelper(
+        [
+          {
+            startTime: 10,
+            endTime: 20,
+            payload: 'Middle-left',
+            line: 50,
+            lineInterpretation: Cue.lineInterpretation.PERCENTAGE,
+            textAlign: 'left',
+          },
+          {
+            startTime: 20,
+            endTime: 30,
+            payload: 'Middle-center',
+            line: 50,
+            lineInterpretation: Cue.lineInterpretation.PERCENTAGE,
+            textAlign: 'center',
+          },
+          {
+            startTime: 30,
+            endTime: 40,
+            payload: 'Middle-right',
+            line: 50,
+            lineInterpretation: Cue.lineInterpretation.PERCENTAGE,
+            textAlign: 'right',
+          },
+          {
+            startTime: 40,
+            endTime: 50,
+            payload: 'Top-center',
+            line: 0,
+            lineInterpretation: Cue.lineInterpretation.LINE_NUMBER,
+            textAlign: 'center',
+          },
+        ],
+        '1\n' +
+        '00:00:10,000 --> 00:00:20,000\n' +
+        '{\\an4}Middle-left\n\n' +
+        '2\n' +
+        '00:00:20,000 --> 00:00:30,000\n' +
+        '{\\an5}Middle-center\n\n' +
+        '3\n' +
+        '00:00:30,000 --> 00:00:40,000\n' +
+        '{\\an6}Middle-right\n\n' +
+        '4\n' +
+        '00:00:40,000 --> 00:00:50,000\n' +
+        '{\\an8}Top-center\n',
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
+  });
+
+  it('supports legacy SSA alignments', () => {
+    verifyHelper(
+        [
+          {
+            startTime: 10,
+            endTime: 20,
+            payload: 'SSA bottom-left',
+            line: -1,
+            lineInterpretation: Cue.lineInterpretation.LINE_NUMBER,
+            textAlign: 'left',
+          },
+          {
+            startTime: 20,
+            endTime: 30,
+            payload: 'SSA top-center',
+            line: 0,
+            lineInterpretation: Cue.lineInterpretation.LINE_NUMBER,
+            textAlign: 'center',
+          },
+          {
+            startTime: 30,
+            endTime: 40,
+            payload: 'SSA middle-center',
+            line: 50,
+            lineInterpretation: Cue.lineInterpretation.PERCENTAGE,
+            textAlign: 'center',
+          },
+        ],
+        '1\n' +
+        '00:00:10,000 --> 00:00:20,000\n' +
+        '{\\a1}SSA bottom-left\n\n' +
+        '2\n' +
+        '00:00:20,000 --> 00:00:30,000\n' +
+        '{\\a6}SSA top-center\n\n' +
+        '3\n' +
+        '00:00:30,000 --> 00:00:40,000\n' +
+        '{\\a10}SSA middle-center\n',
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
+  });
+
+  it('supports Aegisub inline styles and multi-attribute fonts', () => {
+    verifyHelper(
+        [
+          {
+            startTime: 10,
+            endTime: 20,
+            payload: '',
+            nestedCues: [
+              {
+                startTime: 10,
+                endTime: 20,
+                payload: 'Aegisub bold',
+                fontWeight: Cue.fontWeight.BOLD,
+              },
+              {
+                startTime: 10,
+                endTime: 20,
+                payload: ' regular',
+              },
+            ],
+          },
+          {
+            startTime: 20,
+            endTime: 30,
+            payload: '',
+            nestedCues: [
+              {
+                startTime: 20,
+                endTime: 30,
+                payload: 'Aegisub italic',
+                fontStyle: Cue.fontStyle.ITALIC,
+              },
+            ],
+          },
+          {
+            startTime: 30,
+            endTime: 40,
+            payload: '',
+            nestedCues: [
+              {
+                startTime: 30,
+                endTime: 40,
+                payload: 'Aegisub underline',
+                textDecoration: [Cue.textDecoration.UNDERLINE],
+              },
+            ],
+          },
+          {
+            startTime: 40,
+            endTime: 50,
+            payload: '',
+            nestedCues: [
+              {
+                startTime: 40,
+                endTime: 50,
+                payload: 'Multi-attr font',
+                color: 'red',
+              },
+            ],
+          },
+        ],
+        '1\n' +
+        '00:00:10,000 --> 00:00:20,000\n' +
+        '{\\b1}Aegisub bold{\\b0} regular\n\n' +
+        '2\n' +
+        '00:00:20,000 --> 00:00:30,000\n' +
+        '{\\i1}Aegisub italic{\\i0}\n\n' +
+        '3\n' +
+        '00:00:30,000 --> 00:00:40,000\n' +
+        '{\\u1}Aegisub underline{\\u0}\n\n' +
+        '4\n' +
+        '00:00:40,000 --> 00:00:50,000\n' +
+        '<font face="Arial" color="red" size="2">Multi-attr font</font>',
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
+  });
+
+  it('supports single-digit hour timestamps, BOM, and blank lines', () => {
+    verifyHelper(
+        [
+          {startTime: 3620, endTime: 3640, payload: 'Hour padded'},
+          {startTime: 20, endTime: 30, payload: 'Whitespace trimmed'},
+        ],
+        '\uFEFF1\n' +
+        '1:00:20,000 --> 1:00:40,000\n' +
+        'Hour padded\n \n' +
+        '2\n' +
+        '00:20,000 --> 00:30,000\n' +
+        'Whitespace trimmed\n',
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
+  });
+
   /**
    * @param {!Array} cues
    * @param {string} text


### PR DESCRIPTION
### Summary of Changes
Enhances `shaka.text.SrtTextParser` to provide robust SRT subtitle parsing with extended Aegisub/SSA features and formatting resilience:
1. **Full Aegisub Alignment Mapping**: Added missing middle alignments `{\an4}` (middle-left `line:50% align:left`), `{\an5}` (middle-center `line:50% align:center`), and `{\an6}` (middle-right `line:50% align:right`).
2. **Legacy SubStation Alpha (SSA) Alignment Support**: Added legacy `{\a1}` ~ `{\a11}` tag support (`\a1..\a3` bottom, `\a5..\a7` top, `\a9..\a11` middle).
3. **Aegisub Inline Styles**: Supports Aegisub style overrides (`{\b1}`/`{\b0}`, `{\i1}`/`{\i0}`, `{\u1}`/`{\u0}`) by converting them to standard HTML tags (`<b>`, `<i>`, `<u>`) prior to stripping unsupported override tags.
4. **Flexible Font Color Tag Parsing**: Updated `<font>` regex to correctly handle font tags that contain additional attributes (such as `face`, `size`) in any order (e.g. `<font face="Arial" color="red">`), while preserving safe removal of unknown colors and nested font tags without tag stack corruption.
5. **Robust Timestamp & Blank Line Parsing**:
   - Strips leading UTF-8 Byte Order Mark (BOM `\uFEFF`).
   - Normalizes single-digit hour timestamps (`1:00:20,000` -> `01:00:20.000`) and minute-only timestamps (`00:20,000` -> `00:00:20.000`) to conform with WebVTT time syntax.
   - Allows whitespace on empty lines separating subtitle cues.
6. **Unit Tests**: Added comprehensive test cases covering Aegisub alignments, legacy SSA alignments, inline styling, multi-attribute fonts, single-digit timestamps, and BOM cues.

### Verification
- Ran all unit tests on ChromeHeadless:
  `python build/test.py --browsers ChromeHeadless --filter SrtTextParser --quick --uncompiled` -> 10/10 passed (exit code 0).
- Closure compiler type check: `python build/check.py --filter test_type` (passed).
- CSpell: `python build/check.py --filter spelling` (passed).
- Complete check: `python build/check.py --filter complete` (passed).
- Linter: `npx eslint lib/text/srt_text_parser.js test/text/srt_text_parser_unit.js` (0 errors, 0 warnings).
