### PR TITLE
fix(Ads): ensure complete tracking fires for pod ads ending on pause or teardown (fixes #10545)

### DIFF
--- a/lib/ads/svta_ad_manager.js
+++ b/lib/ads/svta_ad_manager.js
@@ -61,6 +61,15 @@ shaka.ads.SvtaAdManager = class {
      */
     this.adPaused_ = false;
 
+    /**
+     * The last recorded playback position of the media element. Used to
+     * determine whether an ad played to the end if the element is torn down
+     * or reset before or during unload.
+     *
+     * @private {number}
+     */
+    this.lastCurrentTime_ = 0;
+
     /** @private {shaka.util.EventManager} */
     this.eventManager_ = new shaka.util.EventManager();
 
@@ -294,6 +303,7 @@ shaka.ads.SvtaAdManager = class {
     }
     this.playbackStarted_ = true;
     this.video_ = mediaElement;
+    this.lastCurrentTime_ = 0;
   }
 
   /**
@@ -321,10 +331,39 @@ shaka.ads.SvtaAdManager = class {
       return;
     }
     this.playbackStarted_ = false;
+
+    let complete = false;
+    if (this.currentTracking_) {
+      let endTime = this.currentTracking_.endTime;
+      if (!this.player_.isLive() || !endTime) {
+        const seekRange = this.player_.seekRange();
+        endTime = Math.min(
+            seekRange.end, this.currentTracking_.endTime || Infinity);
+      }
+      const duration = endTime - this.currentTracking_.startTime;
+      const tolerance = 0.5;
+      const currentPos = this.video_ && isFinite(this.video_.currentTime) &&
+          this.video_.currentTime > 0 ?
+          this.video_.currentTime : this.lastCurrentTime_;
+      const currentRelativeTime =
+          currentPos - this.currentTracking_.startTime;
+      if ((this.video_ && this.video_.ended) || this.player_.isEnded() ||
+          (duration > 0 && currentRelativeTime >= duration - tolerance)) {
+        complete = true;
+      }
+    }
+
     this.video_ = null;
+    this.lastCurrentTime_ = 0;
     this.playbackEventManager_.removeAll();
     this.trackings_.clear();
-    this.unSetupCurrentTracking_();
+    if (complete) {
+      this.sendEvent_(shaka.ads.Utils.AD_STOPPED);
+      this.sendEvent_(shaka.ads.Utils.AD_COMPLETE);
+      this.unSetupCurrentTracking_(/* complete= */ true);
+    } else {
+      this.unSetupCurrentTracking_();
+    }
     this.trackingEventManager_.removeAll();
 
     if (this.pollTimer_) {
@@ -343,7 +382,8 @@ shaka.ads.SvtaAdManager = class {
     const currentTime = this.video_.currentTime;
     for (const tracking of this.trackings_.values()) {
       if (tracking.startTime <= currentTime && (tracking.endTime &&
-          currentTime <= tracking.endTime) && !this.player_.isEnded()) {
+          currentTime <= tracking.endTime) &&
+          (!this.player_.isEnded() || currentTime < tracking.endTime)) {
         this.currentTracking_ = tracking;
         break;
       }
@@ -469,7 +509,20 @@ shaka.ads.SvtaAdManager = class {
       return false;
     };
 
+    const handleEnded = () => {
+      // 'timeupdate' stops before the very end of the media, so the last
+      // tracking window of a presentation would never reach 100%. Reaching the
+      // end of the media is a completion, not a skip.
+      if (completionPercent_ < 100) {
+        completionPercent_ = 100;
+        this.sendEvent_(shaka.ads.Utils.AD_STOPPED);
+        this.sendEvent_(shaka.ads.Utils.AD_COMPLETE);
+        this.unSetupCurrentTracking_(/* complete= */ true);
+      }
+    };
+
     this.trackingEventManager_.listen(this.video_, 'timeupdate', () => {
+      this.lastCurrentTime_ = this.video_.currentTime;
       const currentTime =
           this.video_.currentTime - this.currentTracking_.startTime;
       const completionRatio = currentTime / duration;
@@ -493,17 +546,19 @@ shaka.ads.SvtaAdManager = class {
       }
     });
 
-    this.trackingEventManager_.listenOnce(this.video_, 'ended', () => {
-      // 'timeupdate' stops before the very end of the media, so the last
-      // tracking window of a presentation would never reach 100%. Reaching the
-      // end of the media is a completion, not a skip.
-      if (completionPercent_ < 100) {
-        completionPercent_ = 100;
-        this.sendEvent_(shaka.ads.Utils.AD_STOPPED);
-        this.sendEvent_(shaka.ads.Utils.AD_COMPLETE);
-        this.unSetupCurrentTracking_(/* complete= */ true);
+    this.trackingEventManager_.listen(this.video_, 'pause', () => {
+      // In interstitials or streams with playRangeEnd, reaching the end fires
+      // 'pause' rather than 'ended'. If the ad reached or came within tolerance
+      // of its end, complete it.
+      const currentRelativeTime =
+          this.video_.currentTime - this.currentTracking_.startTime;
+      const tolerance = 0.5;
+      if (duration > 0 && currentRelativeTime >= duration - tolerance) {
+        handleEnded();
       }
     });
+
+    this.trackingEventManager_.listenOnce(this.video_, 'ended', handleEnded);
   }
 
 

--- a/lib/media/playhead_observer.js
+++ b/lib/media/playhead_observer.js
@@ -80,6 +80,16 @@ shaka.media.PlayheadObserverManager = class {
     });
     this.eventManager_.listen(mediaElement, 'pause', () => {
       this.pollingLoop_.stop();
+      if (isFinite(mediaElement.duration) && mediaElement.duration > 0) {
+        // When playRangeEnd is set or when reaching the end of media, the media
+        // element may pause instead of firing 'ended'. Poll observers with
+        // the duration if playback paused at or near the end so that regions
+        // starting at the presentation end are still entered.
+        const tolerance = 0.5;
+        if (mediaElement.currentTime >= mediaElement.duration - tolerance) {
+          this.pollAllObservers_(/* seeking= */ false, mediaElement.duration);
+        }
+      }
     });
     this.eventManager_.listen(mediaElement, 'seeked', () => {
       this.pollingLoop_.tickNow();

--- a/test/ads/svta_ad_manager_unit.js
+++ b/test/ads/svta_ad_manager_unit.js
@@ -618,5 +618,41 @@ describe('SVTA Ad manager', () => {
       expect(eventTypes().filter(
           (t) => t == shaka.ads.Utils.AD_PAUSED).length).toBe(1);
     });
+
+    it('completes when playback pauses near the end of the tracking window',
+        async () => {
+          await addSimpleTracking();
+          overrideVideoProperty('currentTime', 4.8);
+
+          video.dispatchEvent(new Event('pause'));
+
+          const types = eventTypes();
+          expect(types).toContain(shaka.ads.Utils.AD_COMPLETE);
+          expect(types).not.toContain(shaka.ads.Utils.AD_SKIPPED);
+        });
+
+    it('completes on teardown when tracking reached near the end', async () => {
+      await addSimpleTracking();
+      overrideVideoProperty('currentTime', 4.8);
+
+      video.dispatchEvent(new Event('timeupdate'));
+      svtaAdManager.stop();
+
+      const types = eventTypes();
+      expect(types).toContain(shaka.ads.Utils.AD_COMPLETE);
+      expect(types).not.toContain(shaka.ads.Utils.AD_SKIPPED);
+    });
+
+    it('reports skip on teardown if ad was aborted early', async () => {
+      await addSimpleTracking();
+      overrideVideoProperty('currentTime', 2.0);
+
+      video.dispatchEvent(new Event('timeupdate'));
+      svtaAdManager.stop();
+
+      const types = eventTypes();
+      expect(types).not.toContain(shaka.ads.Utils.AD_COMPLETE);
+      expect(types).toContain(shaka.ads.Utils.AD_SKIPPED);
+    });
   });
 });

--- a/test/media/playhead_observer_unit.js
+++ b/test/media/playhead_observer_unit.js
@@ -65,4 +65,22 @@ describe('PlayheadObserverManager', () => {
 
     expect(pollSpy).toHaveBeenCalledWith(10, true);
   });
+
+  it('polls with the duration when playback pauses near the end', () => {
+    video.currentTime = 19.8;
+    video.duration = 20;
+
+    video.on['pause']();
+
+    expect(pollSpy).toHaveBeenCalledWith(20, false);
+  });
+
+  it('does not poll with duration when playback pauses mid-stream', () => {
+    video.currentTime = 10;
+    video.duration = 20;
+
+    video.on['pause']();
+
+    expect(pollSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Fixes #10545

### Problem
In a DASH interstitial pod (e.g. two 10 s creatives in a 20 s pod), the media element does not fire an HTML5 `ended` event because playback halts via `pause` (when `playRangeEnd` is reached) or teardown/`unload()`.
As a result, tracking points that fall at the end of the presentation were missed on both carriages:
1. **DASH callback `EventStream` carriage**: `PlayheadObserverManager` stops its polling loop on `pause`, and because `ended` never fires, the duration poll introduced in #10546 never executed. The final region callback at the presentation end was never entered.
2. **SVTA ad tracking carriage**: `SvtaAdManager.createSlidingSetupTracking_` only checked for completion on `timeupdate` and `ended`. When playback paused or the interstitial player unloaded, `playbackEnd_()` called `unSetupCurrentTracking_()` without arguments (`complete = false`), tearing down the window as an `AD_SKIPPED` rather than `AD_COMPLETE`.

### Solution
1. **`PlayheadObserverManager`**: In the `pause` listener, check if playback paused at or near the end of media (`mediaElement.currentTime >= mediaElement.duration - tolerance`, with tolerance = 0.5 s). If so, poll observers with `mediaElement.duration` so regions starting at or ending at the presentation boundary are entered.
2. **`SvtaAdManager`**:
   - Keep track of `lastCurrentTime_` to preserve the latest playback position before teardown/abort.
   - Listen to `pause` in `createSlidingSetupTracking_` to complete the window if the ad reached within tolerance of its end.
   - In `playbackEnd_()`, determine whether the ad played to completion before tearing down the tracking window (preventing false `AD_SKIPPED` emissions when the stream is unloaded after playing to its end).
   - In `setupCurrentTracking_()`, allow setting up the tracking window if `currentTime < tracking.endTime`, even if `player_.isEnded()` was temporarily asserted.
3. Added unit tests in `test/media/playhead_observer_unit.js` and `test/ads/svta_ad_manager_unit.js`.
