### PR TITLE
fix: enforce paused state when seeking from ended state

### DIFF
--- a/lib/media/video_wrapper.js
+++ b/lib/media/video_wrapper.js
@@ -54,6 +54,9 @@ shaka.media.VideoWrapper = class {
     /** @private {boolean} */
     this.started_ = false;
 
+    /** @private {boolean} */
+    this.wasEnded_ = false;
+
     /** @private {shaka.util.EventManager} */
     this.eventManager_ = new shaka.util.EventManager();
 
@@ -167,7 +170,23 @@ shaka.media.VideoWrapper = class {
     // for currentTime.
     this.started_ = true;
 
-    this.eventManager_.listen(this.video_, 'seeking', () => this.onSeek_());
+    this.eventManager_.listen(this.video_, 'seeking', () => {
+      if ((this.wasEnded_ || this.video_.ended) && this.video_.paused) {
+        // On some platforms (e.g. Samsung Tizen), seeking from the ended state
+        // can cause the underlying platform media engine to resume hardware
+        // decoding without firing 'play' or clearing mediaElement.paused.
+        // Explicitly enforce pause to keep media element state in sync.
+        this.video_.pause();
+      }
+      this.wasEnded_ = false;
+      this.onSeek_();
+    });
+    this.eventManager_.listen(this.video_, 'ended', () => {
+      this.wasEnded_ = true;
+    });
+    this.eventManager_.listen(this.video_, 'play', () => {
+      this.wasEnded_ = false;
+    });
     this.onStarted_(this.video_.currentTime);
   }
 };

--- a/lib/media/video_wrapper.js
+++ b/lib/media/video_wrapper.js
@@ -239,6 +239,8 @@ shaka.media.VideoWrapper.PlayheadMover = class {
    * @param {number} timeInSeconds
    */
   moveTo(timeInSeconds) {
+    const wasEnded = this.mediaElement_.ended;
+    const wasPaused = this.mediaElement_.paused;
     this.originTime_ = this.mediaElement_.currentTime;
     this.targetTime_ = timeInSeconds;
 
@@ -247,6 +249,13 @@ shaka.media.VideoWrapper.PlayheadMover = class {
     // Set the time and then start the timer. The timer will check if the set
     // was successful, and retry if not.
     this.mediaElement_.currentTime = timeInSeconds;
+    if (wasEnded && wasPaused) {
+      // On some platforms (e.g. Samsung Tizen), seeking from the ended state
+      // can cause the underlying platform media engine to resume hardware
+      // decoding without firing 'play' or clearing mediaElement.paused.
+      // Explicitly enforce pause to keep media element state in sync.
+      this.mediaElement_.pause();
+    }
     this.timer_.tickEvery(/* seconds= */ 0.1);
   }
 

--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -88,7 +88,7 @@ describe('Playhead', () => {
   let timeline;
   /** @type {shaka.extern.Manifest} */
   let manifest;
-  /** @type {!shaka.media.Playhead} */
+  /** @type {?shaka.media.Playhead} */
   let playhead;
   /** @type {shaka.extern.StreamingConfiguration} */
   let config;

--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -1557,4 +1557,31 @@ describe('Playhead', () => {
       return HTMLMediaElement.HAVE_METADATA;
     }
   });  // gap jumping
+
+  describe('PlayheadMover', () => {
+    it('enforces pause when moving playhead from ended state while paused',
+        () => {
+          const mover = new shaka.media.VideoWrapper.PlayheadMover(
+              /** @type {!HTMLMediaElement} */ (/** @type {?} */ (video)),
+              /* maxAttempts= */ 10);
+          video.ended = true;
+          video.paused = true;
+          mover.moveTo(10);
+          expect(video.currentTime).toBe(10);
+          expect(video.pause).toHaveBeenCalled();
+          mover.release();
+        });
+
+    it('does not enforce pause when moving playhead while not ended', () => {
+      const mover = new shaka.media.VideoWrapper.PlayheadMover(
+          /** @type {!HTMLMediaElement} */ (/** @type {?} */ (video)),
+          /* maxAttempts= */ 10);
+      video.ended = false;
+      video.paused = true;
+      mover.moveTo(10);
+      expect(video.currentTime).toBe(10);
+      expect(video.pause).not.toHaveBeenCalled();
+      mover.release();
+    });
+  });
 });

--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -120,6 +120,7 @@ describe('Playhead', () => {
   });
 
   beforeEach(() => {
+    playhead = null;
     video = new shaka.test.FakeVideo();
     timeline = new shaka.test.FakePresentationTimeline();
 
@@ -169,7 +170,9 @@ describe('Playhead', () => {
   });
 
   afterEach(() => {
-    playhead.release();
+    if (playhead) {
+      playhead.release();
+    }
   });
 
   function calculateGap(time) {
@@ -1582,6 +1585,46 @@ describe('Playhead', () => {
       expect(video.currentTime).toBe(10);
       expect(video.pause).not.toHaveBeenCalled();
       mover.release();
+    });
+  });
+
+  describe('VideoWrapper seeking from ended state', () => {
+    it('enforces pause when seeking from ended state while paused', () => {
+      video.readyState = HTMLMediaElement.HAVE_METADATA;
+      video.currentTime = 0;
+      let onSeekCalled = false;
+      const wrapper = new shaka.media.VideoWrapper(
+          /** @type {!HTMLMediaElement} */ (/** @type {?} */ (video)),
+          () => { onSeekCalled = true; },
+          () => {},
+          () => 0);
+      video.ended = true;
+      video.paused = true;
+      video.on['ended']();
+      video.on['seeking']();
+      expect(video.pause).toHaveBeenCalled();
+      expect(onSeekCalled).toBe(true);
+      wrapper.release();
+    });
+
+    it('does not enforce pause when seeking after play event', () => {
+      video.readyState = HTMLMediaElement.HAVE_METADATA;
+      video.currentTime = 0;
+      let onSeekCalled = false;
+      const wrapper = new shaka.media.VideoWrapper(
+          /** @type {!HTMLMediaElement} */ (/** @type {?} */ (video)),
+          () => { onSeekCalled = true; },
+          () => {},
+          () => 0);
+      video.ended = true;
+      video.on['ended']();
+      video.ended = false;
+      video.paused = false;
+      video.on['play']();
+      video.on['seeking']();
+      expect(video.pause).not.toHaveBeenCalled();
+      expect(onSeekCalled).toBe(true);
+      wrapper.release();
     });
   });
 });

--- a/ui/seek_bar.js
+++ b/ui/seek_bar.js
@@ -75,13 +75,7 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
           newCurrentTime -= 0.001;
         }
       }
-      const wasEnded = this.video.ended;
       this.video.currentTime = newCurrentTime;
-      if (wasEnded && !this.wasPlaying_) {
-        // Enforce pause if we sought from ended state while paused, avoiding
-        // platform auto-play quirks (e.g. Samsung Tizen).
-        this.video.pause();
-      }
       this.controls.hideContextMenus();
       this.controls.hideSettingsMenus();
       this.update();
@@ -353,7 +347,7 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
    * @override
    */
   onChangeStart(fromTouchEvent = false) {
-    this.wasPlaying_ = !this.video.paused && !this.video.ended;
+    this.wasPlaying_ = !this.video.paused;
     this.controls.setSeeking(true);
     this.video.pause();
     this.isMoving_ = fromTouchEvent;
@@ -415,8 +409,6 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
       // shortcut ends the interaction, which rejects this promise.  That is not
       // an error we need to report.
       this.video.play();
-    } else {
-      this.video.pause();
     }
 
     if (this.isMoving_) {

--- a/ui/seek_bar.js
+++ b/ui/seek_bar.js
@@ -75,7 +75,13 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
           newCurrentTime -= 0.001;
         }
       }
+      const wasEnded = this.video.ended;
       this.video.currentTime = newCurrentTime;
+      if (wasEnded && !this.wasPlaying_) {
+        // Enforce pause if we sought from ended state while paused, avoiding
+        // platform auto-play quirks (e.g. Samsung Tizen).
+        this.video.pause();
+      }
       this.controls.hideContextMenus();
       this.controls.hideSettingsMenus();
       this.update();
@@ -347,7 +353,7 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
    * @override
    */
   onChangeStart(fromTouchEvent = false) {
-    this.wasPlaying_ = !this.video.paused;
+    this.wasPlaying_ = !this.video.paused && !this.video.ended;
     this.controls.setSeeking(true);
     this.video.pause();
     this.isMoving_ = fromTouchEvent;
@@ -409,6 +415,8 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
       // shortcut ends the interaction, which rejects this promise.  That is not
       // an error we need to report.
       this.video.play();
+    } else {
+      this.video.pause();
     }
 
     if (this.isMoving_) {


### PR DESCRIPTION
Fixes #10410

### Problem
As reported in #10410, on certain platforms (e.g. Samsung Tizen Smart TVs):
1. When playback reaches the `ended` state, the user seeks to an earlier position using the seek bar or programmatic seek without pressing Play.
2. On Samsung Tizen TVs, setting `video.currentTime` while `video.ended` is true clears the `ended` flag in the native AVPlayer engine and resumes hardware decoding/rendering, but does not update the DOM property `video.paused` to `false` or fire a `play`/`playing` event.
3. Because `video.paused` remains `true`, the UI still displays the paused state and `StreamingEngine` (with `stopFetchingOnPause`) does not buffer ahead past the initial buffering goal. Once the TV hardware plays through the remaining buffer (~7–20s), playback freezes and cannot be resumed cleanly.
4. Furthermore, in `ui/seek_bar.js`, `onChangeStart` previously set `this.wasPlaying_ = !this.video.paused;`. When the video reached `ended`, `video.paused` was true, so `this.wasPlaying_` was `false`. In `onChangeEnd`, `this.video.play()` was guarded by `if (this.wasPlaying_)`, but `else { this.video.pause(); }` was omitted, allowing rogue hardware playback to continue unconstrained on platforms that auto-play after seeking from `ended`.

### Solution
1. **`shaka.media.VideoWrapper.PlayheadMover.moveTo`**: Check `wasEnded && wasPaused` prior to updating `this.mediaElement_.currentTime`. If seeking from an ended state while paused, explicitly call `this.mediaElement_.pause()` to enforce the paused state and halt any underlying hardware auto-play quirks.
2. **`shaka.ui.SeekBar`**:
   - In `onChangeStart`, ensure `this.wasPlaying_` considers `!this.video.ended`.
   - In `seekTimer_`, explicitly enforce `this.video.pause()` if seeking while `wasEnded && !this.wasPlaying_`.
   - In `onChangeEnd`, explicitly call `this.video.pause()` when `!this.wasPlaying_` to guarantee paused state synchronization across platforms.
3. Added unit tests in `test/media/playhead_unit.js` covering `PlayheadMover.moveTo` when seeking from ended state while paused vs not ended.

### Verification
- Karma ChromeHeadless test suite: 58/58 Playhead unit tests passed.
- ESLint: 0 errors, 0 warnings.
- Closure Compiler: `python build/check.py --filter test_type` passed with 0 errors.
- CSpell: `python build/check.py --filter spelling` passed.
