### PR TITLE
fix: Allow getVideoTracks to return compatible tracks across audio groups

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -6610,11 +6610,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         const ArrayUtils = shaka.util.ArrayUtils;
         const MimeUtils = shaka.util.MimeUtils;
 
-        if (!t.videoCodec || t.audioGroupId !== active.audioGroupId ||
-            t.originalAudioId !== active.originalAudioId) {
+        if (!t.videoCodec) {
           return false;
         }
-        if (t.audioId === active.audioId) {
+        if (t.audioId === active.audioId ||
+            (t.audioGroupId != null &&
+             t.audioGroupId === active.audioGroupId &&
+             t.originalAudioId === active.originalAudioId)) {
           return true;
         }
         return t.language === active.language &&
@@ -6658,7 +6660,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         roles: track.videoRoles || [],
         label: track.videoLabel,
       };
-      videoTracksMap.set(id, videoTrack);
+      if (!videoTracksMap.has(id) ||
+          (!videoTracksMap.get(id).active && videoTrack.active)) {
+        videoTracksMap.set(id, videoTrack);
+      }
     }
     return Array.from(videoTracksMap.values());
   }

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -2823,6 +2823,96 @@ describe('Player', () => {
       expect(variant.id).toBe(newTrack.id);
     });
 
+    it('returns video tracks across different audio groups matching active ' +
+        'audio attributes', async () => {
+      const perGroupManifest = shaka.test.ManifestGenerator.generate(
+          (manifest) => {
+            manifest.addVariant(201, (variant) => {
+              variant.bandwidth = 464000;
+              variant.language = 'est';
+              variant.addVideo(1, (stream) => {
+                stream.originalId = 'video-360';
+                stream.bandwidth = 400000;
+                stream.width = 640;
+                stream.height = 360;
+              });
+              variant.addAudio(11, (stream) => {
+                stream.originalId = 'audio-est-64';
+                stream.groupId = 'g360';
+                stream.bandwidth = 64000;
+                stream.language = 'est';
+                stream.label = 'Estonian';
+              });
+            });
+            manifest.addVariant(202, (variant) => {
+              variant.bandwidth = 464000;
+              variant.language = 'rus';
+              variant.addExistingStream(1); // video 360
+              variant.addAudio(12, (stream) => {
+                stream.originalId = 'audio-rus-64';
+                stream.groupId = 'g360';
+                stream.bandwidth = 64000;
+                stream.language = 'rus';
+                stream.label = 'Russian';
+              });
+            });
+            manifest.addVariant(203, (variant) => {
+              variant.bandwidth = 1328000;
+              variant.language = 'est';
+              variant.addVideo(2, (stream) => {
+                stream.originalId = 'video-720';
+                stream.bandwidth = 1200000;
+                stream.width = 1280;
+                stream.height = 720;
+              });
+              variant.addAudio(13, (stream) => {
+                stream.originalId = 'audio-est-128';
+                stream.groupId = 'g720';
+                stream.bandwidth = 128000;
+                stream.language = 'est';
+                stream.label = 'Estonian';
+              });
+            });
+            manifest.addVariant(204, (variant) => {
+              variant.bandwidth = 1328000;
+              variant.language = 'rus';
+              variant.addExistingStream(2); // video 720
+              variant.addAudio(14, (stream) => {
+                stream.originalId = 'audio-rus-128';
+                stream.groupId = 'g720';
+                stream.bandwidth = 128000;
+                stream.language = 'rus';
+                stream.label = 'Russian';
+              });
+            });
+          });
+
+      manifest = perGroupManifest;
+
+      player.configure({
+        preferredAudio: [{language: 'est'}],
+      });
+
+      await player.load(fakeManifestUri, 0, fakeMimeType);
+
+      const videoTracks = player.getVideoTracks();
+      expect(videoTracks.length).toBe(2);
+      const heights = videoTracks.map((t) => t.height).sort((a, b) => a - b);
+      expect(heights).toEqual([360, 720]);
+
+      const activeTrack = videoTracks.find((t) => t.active);
+      expect(activeTrack).not.toBeNull();
+      expect(activeTrack.height).toBe(360);
+
+      const track720 = videoTracks.find((t) => t.height === 720);
+      goog.asserts.assert(track720, 'track720 must exist');
+      player.selectVideoTrack(track720);
+      expect(streamingEngine.switchVariant).toHaveBeenCalled();
+      const selectedVariant =
+          streamingEngine.switchVariant.calls.mostRecent().args[0];
+      expect(selectedVariant.id).toBe(203);
+    });
+
     it('switching audio doesn\'t change selected text track', () => {
       player.configure({
         preferredText: [


### PR DESCRIPTION
### Summary
Fixes #10578 where \Player.getVideoTracks()\ returns only the currently active resolution when each video rendition in an HLS manifest references its own distinct \AUDIO\ group (e.g., multi-audio VOD where audio bitrates scale with video renditions).

### Root Cause
In \Player.getVideoTracks()\, variants were filtered with:
\\\js
if (!t.videoCodec || t.audioGroupId !== active.audioGroupId ||
    t.originalAudioId !== active.originalAudioId) {
  return false;
}
\\\
Because \	.audioGroupId !== active.audioGroupId\ acted as a strict disqualifier before the fallback matching logic (language, label, channelsCount, spatialAudio, audioMimeType, normalized codec, audioRoles), any variant from a different \AUDIO\ group was rejected immediately—even though \selectVideoTrack()\ already supports and expects selecting those variants via the same audio attribute fallback.

### Solution
1. In \Player.getVideoTracks()\, treat matching \udioId\ and matching \(audioGroupId, originalAudioId)\ as fast paths, and fall back to audio attribute compatibility (language, label, channels, codecs, roles).
2. Ensure \ideoTracksMap\ prioritizes active tracks if multiple variants share the same video ID.
3. Added a comprehensive unit test in \	est/player_unit.js\ covering a multi-resolution manifest with distinct audio groups per rendition, verifying that:
   - \getVideoTracks()\ returns all compatible video resolutions.
   - \selectVideoTrack()\ successfully switches across audio groups.

Closes #10578