### PR TITLE
fix(Ads): Drop interstitials with script URL schemes

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -747,6 +747,17 @@ shaka.ads.InterstitialAdManager = class {
         shaka.log.alwaysWarn('Missing URL in interstitial', interstitial);
         continue;
       }
+      // Interstitial URIs come from manifests and ad decision responses,
+      // which are not trusted input. A javascript: URI assigned to an
+      // unsandboxed iframe src would execute in the publisher's origin, so
+      // drop interstitials whose scheme executes script before any fetch,
+      // playback bookkeeping, or event firing.
+      if (!shaka.ads.InterstitialAdManager.isSafeInterstitialUri_(
+          interstitial.uri)) {
+        shaka.log.alwaysWarn(
+            'Ignoring interstitial with unsupported URI scheme', interstitial);
+        continue;
+      }
       if (!interstitial.mimeType) {
         try {
           const netEngine = this.player_.getNetworkingEngine();
@@ -2630,28 +2641,65 @@ shaka.ads.InterstitialAdManager = class {
   }
 
   /**
+   * Returns the scheme of a URI, or null if it has none.
+   *
+   * Control characters and whitespace are stripped before the scheme is
+   * read, because browsers ignore them when resolving the scheme of a URL.
+   *
+   * @param {string} uri
+   * @return {?string}
+   * @private
+   */
+  static getUriScheme_(uri) {
+    // eslint-disable-next-line no-control-regex
+    const normalizedUri = uri.replace(/[\u0000-\u0020]+/g, '');
+    const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(normalizedUri);
+    if (!schemeMatch) {
+      return null;
+    }
+    return schemeMatch[1].toLowerCase();
+  }
+
+  /**
    * Returns true if a click-through URI is safe to hand to window.open().
    *
    * Click-through URIs come from manifests and ad decision responses, which
    * are not trusted input. window.open() with a javascript: URI executes in
-   * the opener's origin, so restrict click-throughs to http(s). Control
-   * characters and whitespace are stripped before the scheme is read, because
-   * browsers ignore them when resolving the scheme of a URL. A URI with no
-   * scheme is relative and resolves against the page, so it is allowed.
+   * the opener's origin, so restrict click-throughs to http(s). A URI with
+   * no scheme is relative and resolves against the page, so it is allowed.
    *
    * @param {string} uri
    * @return {boolean}
    * @private
    */
   static isSafeClickThroughUri_(uri) {
-    // eslint-disable-next-line no-control-regex
-    const normalizedUri = uri.replace(/[\u0000-\u0020]+/g, '');
-    const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(normalizedUri);
-    if (!schemeMatch) {
-      return true;
-    }
-    const scheme = schemeMatch[1].toLowerCase();
-    return scheme == 'http' || scheme == 'https';
+    const scheme =
+        shaka.ads.InterstitialAdManager.getUriScheme_(uri);
+    return scheme == null || scheme == 'http' || scheme == 'https';
+  }
+
+  /**
+   * Returns true if an interstitial URI is safe to use. Called when
+   * interstitials are added, so that unsafe URIs are never fetched or
+   * assigned to an iframe/img src.
+   *
+   * Interstitial URIs come from manifests and ad decision responses, which
+   * are not trusted input. javascript: and vbscript: URIs execute script in
+   * the publisher's origin when assigned to an unsandboxed iframe src, so
+   * interstitials with those schemes are dropped. Other URIs, including
+   * scheme-less relative URIs, data: URIs (which render in an opaque
+   * origin; VAST HTMLResource creatives become data: URIs, see
+   * shaka.ads.VastInterstitialParser), and custom schemes resolved by
+   * networking plugins, are unaffected.
+   *
+   * @param {string} uri
+   * @return {boolean}
+   * @private
+   */
+  static isSafeInterstitialUri_(uri) {
+    const scheme =
+        shaka.ads.InterstitialAdManager.getUriScheme_(uri);
+    return scheme != 'javascript' && scheme != 'vbscript';
   }
 };
 

--- a/test/ads/interstitial_ad_manager_unit.js
+++ b/test/ads/interstitial_ad_manager_unit.js
@@ -3420,4 +3420,188 @@ describe('Interstitial Ad manager', () => {
           jasmine.objectContaining(eventValue));
     });
   });
+
+  describe('interstitial URI scheme', () => {
+    /**
+     * @param {string} uri
+     * @param {string} mimeType
+     * @return {!shaka.extern.AdInterstitial}
+     */
+    function overlayInterstitialWithUri(uri, mimeType) {
+      return {
+        id: null,
+        groupId: null,
+        startTime: 0,
+        endTime: null,
+        uri: uri,
+        mimeType: mimeType,
+        isSkippable: false,
+        skipOffset: null,
+        skipFor: null,
+        canJump: false,
+        resumeOffset: null,
+        playoutLimit: null,
+        once: true,
+        pre: true,
+        post: false,
+        timelineRange: false,
+        loop: false,
+        overlay: {
+          viewport: {
+            x: 1920,
+            y: 1080,
+          },
+          topLeft: {
+            x: 0,
+            y: 0,
+          },
+          size: {
+            x: 1920,
+            y: 1080,
+          },
+        },
+        displayOnBackground: false,
+        currentVideo: null,
+        background: null,
+        clickThroughUrl: null,
+        tracking: null,
+      };
+    }
+
+    /**
+     * Starts an overlay interstitial with the given URI and MIME type.
+     *
+     * @param {string} uri
+     * @param {string} mimeType
+     */
+    async function startAd(uri, mimeType) {
+      await interstitialAdManager.addInterstitials(
+          [overlayInterstitialWithUri(uri, mimeType)]);
+
+      video.play();
+      video.dispatchEvent(new Event('timeupdate'));
+
+      await shaka.test.Util.shortDelay();
+    }
+
+    it('renders http(s) interstitial URIs into an iframe', async () => {
+      await startAd('https://example.com/ad.html', 'text/html');
+
+      const element = /** @type {HTMLIFrameElement} */(
+        adContainer.querySelector('iframe'));
+      expect(element).not.toBeNull();
+      expect(element.src).toBe('https://example.com/ad.html');
+    });
+
+    it('renders data: interstitial URIs into an iframe', async () => {
+      // VAST HTMLResource creatives are converted into data: URIs, which
+      // render in an opaque origin, so they must keep working.
+      await startAd('data:text/html,<p>ad</p>', 'text/html');
+
+      const element = /** @type {HTMLIFrameElement} */(
+        adContainer.querySelector('iframe'));
+      expect(element).not.toBeNull();
+    });
+
+    it('renders data: image interstitial URIs into an img', async () => {
+      // A valid 1x1 PNG: an invalid image would fire onerror, which removes
+      // the element before the assertion runs.
+      await startAd(
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ' +
+              'AAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+          'image/png');
+
+      const element = /** @type {HTMLImageElement} */(
+        adContainer.querySelector('img'));
+      expect(element).not.toBeNull();
+    });
+
+    it('does not render javascript: interstitial URIs', async () => {
+      // A javascript: URI assigned to an unsandboxed iframe src executes in
+      // the publisher's origin.
+      // eslint-disable-next-line no-script-url
+      await startAd('javascript:alert(1)', 'text/html');
+
+      expect(adContainer.querySelector('iframe')).toBeNull();
+      expect(onEventSpy).not.toHaveBeenCalledWith(
+          jasmine.objectContaining({type: 'ad-started'}));
+      expect(onEventSpy).not.toHaveBeenCalledWith(
+          jasmine.objectContaining({type: 'ad-break-ended'}));
+    });
+
+    it('drops a rejected repeatable interstitial without affecting others',
+        async () => {
+          // once:false entries must not disturb the sequence when dropped.
+          const rejected = overlayInterstitialWithUri(
+              // eslint-disable-next-line no-script-url
+              'javascript:alert(1)', 'text/html');
+          rejected.once = false;
+          const accepted = overlayInterstitialWithUri(
+              'https://example.com/ad.html', 'text/html');
+          accepted.id = 'accepted';
+          await interstitialAdManager.addInterstitials([rejected, accepted]);
+
+          video.play();
+          video.dispatchEvent(new Event('timeupdate'));
+
+          await shaka.test.Util.shortDelay();
+
+          const element = /** @type {HTMLIFrameElement} */(
+            adContainer.querySelector('iframe'));
+          expect(element).not.toBeNull();
+          expect(element.src).toBe('https://example.com/ad.html');
+        });
+
+    it('handles a long run of rejected interstitials without recursion',
+        async () => {
+          // A manifest may repeat many unsafe interstitials; rejecting them
+          // must not recurse or break the sequence.
+          const interstitials = [];
+          for (let i = 0; i < 3000; i++) {
+            const rejected = overlayInterstitialWithUri(
+                // eslint-disable-next-line no-script-url
+                'javascript:alert(1)', 'text/html');
+            rejected.id = 'rejected-' + i;
+            interstitials.push(rejected);
+          }
+          const accepted = overlayInterstitialWithUri(
+              'https://example.com/ad.html', 'text/html');
+          accepted.id = 'accepted';
+          interstitials.push(accepted);
+
+          await interstitialAdManager.addInterstitials(interstitials);
+
+          video.play();
+          video.dispatchEvent(new Event('timeupdate'));
+
+          await shaka.test.Util.shortDelay();
+
+          const element = /** @type {HTMLIFrameElement} */(
+            adContainer.querySelector('iframe'));
+          expect(element).not.toBeNull();
+          expect(element.src).toBe('https://example.com/ad.html');
+        });
+
+    it('skips to the next interstitial after a rejected one', async () => {
+      const rejected = overlayInterstitialWithUri(
+          // eslint-disable-next-line no-script-url
+          'javascript:alert(1)', 'text/html');
+      const accepted = overlayInterstitialWithUri(
+          'https://example.com/ad.html', 'text/html');
+      accepted.id = 'accepted';
+      await interstitialAdManager.addInterstitials([rejected, accepted]);
+
+      video.play();
+      video.dispatchEvent(new Event('timeupdate'));
+
+      await shaka.test.Util.shortDelay();
+
+      const element = /** @type {HTMLIFrameElement} */(
+        adContainer.querySelector('iframe'));
+      expect(element).not.toBeNull();
+      expect(element.src).toBe('https://example.com/ad.html');
+      expect(onEventSpy).not.toHaveBeenCalledWith(
+          jasmine.objectContaining({type: 'ad-break-ended'}));
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Interstitial URIs come from manifests and ad decision responses, which are untrusted input. An overlay interstitial's URI is assigned to `iframe.src` / `img.src` in `InterstitialAdManager` (`setupStaticAd_`). A `javascript:` or `vbscript:` URI executes as script in the publisher's origin when the element is attached.

The click-through path already restricts schemes for the same reason (`isSafeClickThroughUri_`, #10412).

## Change

`addInterstitials` drops an interstitial whose URI scheme is `javascript:` or `vbscript:`, at admission time, next to the existing "Missing URL" skip and before the MIME-type sniff. Dropped interstitials are never fetched, and the rest of the sequence is unaffected.

Relative URIs, `data:` URIs (including those `VastInterstitialParser` produces from VAST `HTMLResource` creatives), and custom schemes resolved by networking plugins are unaffected.

The scheme is read through `shaka.util.URL.getScheme`; `isSafeClickThroughUri_` and `isSafeInterstitialUri_` both call it, on a stripped copy produced by a classification-only helper (`normalizeUri_`). Browsers trim control characters and whitespace when resolving a scheme, so a URI like `\njavascript:...` is classified on the stripped form; the outgoing URI is never modified, and `getScheme` is unchanged for its other callers.

## Tests

Adds an "interstitial URI scheme" block to `test/ads/interstitial_ad_manager_unit.js`:

- https and `data:` URIs still render
- a `javascript:` URI renders no element and emits no ad events
- a rejected interstitial, repeatable or not, does not disturb the rest of the sequence
- a run of 3000 unsafe URIs is dropped without recursion

Validation: karma (ChromeHeadless): Interstitial Ad manager 74/74, NetworkingEngine 70/70, VastInterstitialParser 7/7, URL getScheme 7/7; eslint clean on changed files.
